### PR TITLE
[VS] F5 support now works out of the box

### DIFF
--- a/src/Fantomas.VisualStudio/Fantomas.VisualStudio.csproj
+++ b/src/Fantomas.VisualStudio/Fantomas.VisualStudio.csproj
@@ -19,6 +19,9 @@
     <AssemblyName>Fantomas.VisualStudio</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
In its current form the fantomas.vssdk solution cannot be debugged out
of the box.  By default Visual Studio will generate all of the .csproj
entries that are necessary for debugging a VSIX into the .csproj.user
file.  This file is correctly excluded in the .gitignore file.  But this
means anyone cloning this project cannot use F5 until they manually
change the debugging information.

Also the information that Visual Studio generates into the .csproj.user
file is not correct.  It assumes a very specific path to Visual Studio.
It will fail if the developer has Visual Studio on a different drive or
x86 vs x64 box.  The version I added will work across all Visual Studio
installs
