### PR TITLE
Restore caret position on undo / redo

### DIFF
--- a/src/Fantomas.VisualStudio/Commands/CommandBase.cs
+++ b/src/Fantomas.VisualStudio/Commands/CommandBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
 namespace Hestia.FSharpCommands.Commands
@@ -12,6 +13,11 @@ namespace Hestia.FSharpCommands.Commands
         public IWpfTextView TextView { get; set; }
 
         public Services Services { get; set; }
+
+        public ITextBuffer TextBuffer
+        {
+            get { return TextView.TextBuffer; }
+        }
 
         public abstract void Execute();
     }

--- a/src/Fantomas.VisualStudio/Services.cs
+++ b/src/Fantomas.VisualStudio/Services.cs
@@ -4,21 +4,39 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
 
 namespace Hestia.FSharpCommands
 {
     public class Services
     {
         private readonly IEditorOptionsFactoryService _editorOptionsFactory;
+        private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
+        private readonly ITextBufferUndoManagerProvider _textBufferUndoManagerProvider;
 
-        public Services(IEditorOptionsFactoryService editorOptionsFactory)
+        public Services(
+            IEditorOptionsFactoryService editorOptionsFactory, 
+            IEditorOperationsFactoryService editorOperatiosnFactoryService,
+            ITextBufferUndoManagerProvider textBufferUndoManagerProvider)
         {
             _editorOptionsFactory = editorOptionsFactory;
+            _editorOperationsFactoryService = editorOperatiosnFactoryService;
+            _textBufferUndoManagerProvider = textBufferUndoManagerProvider;
         }
 
         public IEditorOptionsFactoryService EditorOptionsFactory
         {
             get { return _editorOptionsFactory; }
+        }
+
+        public ITextBufferUndoManagerProvider TextBufferUndoManagerProvider
+        {
+            get { return _textBufferUndoManagerProvider; }
+        }
+
+        public IEditorOperationsFactoryService EditorOperationsFactoryService
+        {
+            get { return _editorOperationsFactoryService; }
         }
     }
 }

--- a/src/Fantomas.VisualStudio/TextViewHookHelper.cs
+++ b/src/Fantomas.VisualStudio/TextViewHookHelper.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Hestia.FSharpCommands
@@ -18,12 +19,20 @@ namespace Hestia.FSharpCommands
     {
         private readonly IVsEditorAdaptersFactoryService _adaptersFactory;
         private readonly IEditorOptionsFactoryService _editorOptionsFactory;
+        private readonly IEditorOperationsFactoryService _editorOperationsFactorySerivce;
+        private readonly ITextBufferUndoManagerProvider _textBufferUndoManagerProvider;
 
         [ImportingConstructor]
-        public TextViewHookHelper(IVsEditorAdaptersFactoryService adaptersFactory, IEditorOptionsFactoryService editorOptionsFactory)
+        public TextViewHookHelper(
+            IVsEditorAdaptersFactoryService adaptersFactory, 
+            IEditorOptionsFactoryService editorOptionsFactory,
+            IEditorOperationsFactoryService editorOperationsFactoryService,
+            ITextBufferUndoManagerProvider textBufferUndoManagerProvider)
         {
             _adaptersFactory = adaptersFactory;
             _editorOptionsFactory = editorOptionsFactory;
+            _editorOperationsFactorySerivce = editorOperationsFactoryService;
+            _textBufferUndoManagerProvider = textBufferUndoManagerProvider;
         }
 
         public void TextViewCreated(IWpfTextView wpfTextView)
@@ -40,7 +49,7 @@ namespace Hestia.FSharpCommands
 
         private Services GetServices()
         {
-            return new Services(_editorOptionsFactory);
+            return new Services(_editorOptionsFactory, _editorOperationsFactorySerivce, _textBufferUndoManagerProvider);
         }
     }
 }


### PR DESCRIPTION
This change will wrap the format operations inside of an
ITextUndoTransaction that tracks the caret position.  This will cause
the caret position to be consistent across Visual Studio undo / redo
operations.  Before the caret would jump wildly around because Visual
Studio made no attempt to track it and just picked a set offset in the
ITextBuffer.

Note that this will restore the caret position to the exact position it
was in before and after the format operation.  It is possible that for
format selection you may want to put the caret at the start of the
selection for undo.  If that is the case then you need to adjust the
caret to the start of the selection before calling
AddBeforeTextBufferUndoChangePrimitive.  There is no way to say "track
position X" instead it will just track wherever the caret is when this
call is made.

closes #44
