### PR TITLE
Fixed querying of ITextDocument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ ipch/
 # Visual Studio profiler
 *.psess
 *.vsp
+*.vspx
 
 # ReSharper is a .NET coding add-in
 _ReSharper*

--- a/src/Fantomas.VisualStudio/Commands/FormatCommand.cs
+++ b/src/Fantomas.VisualStudio/Commands/FormatCommand.cs
@@ -130,10 +130,17 @@ namespace Hestia.FSharpCommands.Commands
             return source;
         }
 
-        private static bool IsSignatureFile(ITextBuffer buffer)
+        private bool IsSignatureFile(ITextBuffer buffer)
         {
-            ITextDocument document = buffer.Properties.GetProperty<ITextDocument>(typeof(ITextDocument));
-            var fileExtension = Path.GetExtension(document.FilePath);
+            ITextDocument textDocument;
+            if (!Services.TextDocumentFactoryService.TryGetTextDocument(buffer, out textDocument))
+            {
+                // If this isn't backed by an actual document then it can't be considered 
+                // a signature file
+                return false;
+            }
+
+            var fileExtension = Path.GetExtension(textDocument.FilePath);
             // There isn't a distinct content type for FSI files, so we have to use the file extension
             var isSignatureFile = ".fsi".Equals(fileExtension, StringComparison.OrdinalIgnoreCase);
             return isSignatureFile;

--- a/src/Fantomas.VisualStudio/Services.cs
+++ b/src/Fantomas.VisualStudio/Services.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Text;
 
 namespace Hestia.FSharpCommands
 {
@@ -13,15 +14,18 @@ namespace Hestia.FSharpCommands
         private readonly IEditorOptionsFactoryService _editorOptionsFactory;
         private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
         private readonly ITextBufferUndoManagerProvider _textBufferUndoManagerProvider;
+        private readonly ITextDocumentFactoryService _textDocumentFactoryService;
 
         public Services(
             IEditorOptionsFactoryService editorOptionsFactory, 
             IEditorOperationsFactoryService editorOperatiosnFactoryService,
-            ITextBufferUndoManagerProvider textBufferUndoManagerProvider)
+            ITextBufferUndoManagerProvider textBufferUndoManagerProvider,
+            ITextDocumentFactoryService textDocumentFactoryService)
         {
             _editorOptionsFactory = editorOptionsFactory;
             _editorOperationsFactoryService = editorOperatiosnFactoryService;
             _textBufferUndoManagerProvider = textBufferUndoManagerProvider;
+            _textDocumentFactoryService = textDocumentFactoryService;
         }
 
         public IEditorOptionsFactoryService EditorOptionsFactory
@@ -37,6 +41,11 @@ namespace Hestia.FSharpCommands
         public IEditorOperationsFactoryService EditorOperationsFactoryService
         {
             get { return _editorOperationsFactoryService; }
+        }
+
+        public ITextDocumentFactoryService TextDocumentFactoryService
+        {
+            get { return _textDocumentFactoryService; }
         }
     }
 }

--- a/src/Fantomas.VisualStudio/TextViewHookHelper.cs
+++ b/src/Fantomas.VisualStudio/TextViewHookHelper.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudio.Text;
 
 namespace Hestia.FSharpCommands
 {
@@ -21,18 +22,21 @@ namespace Hestia.FSharpCommands
         private readonly IEditorOptionsFactoryService _editorOptionsFactory;
         private readonly IEditorOperationsFactoryService _editorOperationsFactorySerivce;
         private readonly ITextBufferUndoManagerProvider _textBufferUndoManagerProvider;
+        private readonly ITextDocumentFactoryService _textDocumentFactoryService;
 
         [ImportingConstructor]
         public TextViewHookHelper(
             IVsEditorAdaptersFactoryService adaptersFactory, 
             IEditorOptionsFactoryService editorOptionsFactory,
             IEditorOperationsFactoryService editorOperationsFactoryService,
-            ITextBufferUndoManagerProvider textBufferUndoManagerProvider)
+            ITextBufferUndoManagerProvider textBufferUndoManagerProvider,
+            ITextDocumentFactoryService textDocumentFactoryService)
         {
             _adaptersFactory = adaptersFactory;
             _editorOptionsFactory = editorOptionsFactory;
             _editorOperationsFactorySerivce = editorOperationsFactoryService;
             _textBufferUndoManagerProvider = textBufferUndoManagerProvider;
+            _textDocumentFactoryService = textDocumentFactoryService;
         }
 
         public void TextViewCreated(IWpfTextView wpfTextView)
@@ -49,7 +53,7 @@ namespace Hestia.FSharpCommands
 
         private Services GetServices()
         {
-            return new Services(_editorOptionsFactory, _editorOperationsFactorySerivce, _textBufferUndoManagerProvider);
+            return new Services(_editorOptionsFactory, _editorOperationsFactorySerivce, _textBufferUndoManagerProvider, _textDocumentFactoryService);
         }
     }
 }


### PR DESCRIPTION
The IsSignatureFile method was incorrectly querying for the
ITextDocument related to a given ITextBuffer.  The main problem is there
is no guarantee that an ITextBuffer has an associated ITextDocument
value.  For the most part ITextDocument represents physical files on the
disk while ITextBuffer represents something being editted in Visual
Studio.  Most things being edited in Visual Studio have a backing
physical file but not everything.  When this method was called on such a
file it would result in an exception.

A secondary minor issue is the proper way to query for ITextDocument is
to use ITextDocumentFactoryService.TryGetTextDocument.  Even though they
are very unlikely to ever change this, the use of typeof(ITextDocument)
as the key to the property bag is not a supported operation.
TryGetTextDocument also handles some extreme corner cases (like a
disposed ITextDocument).   It's just a safer API to use.
