### PR TITLE
Add build image for AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Fantomas
 
 F# source code formatter, inspired by [scalariform](https://github.com/mdr/scalariform) for Scala, [ocp-indent](https://github.com/OCamlPro/ocp-indent) for OCaml and [PythonTidy](https://github.com/acdha/PythonTidy) for Python.
 
-[![Build Status](https://travis-ci.org/dungpa/fantomas.png)](https://travis-ci.org/dungpa/fantomas)
+[![Build Status Travis](https://travis-ci.org/dungpa/fantomas.png)](https://travis-ci.org/dungpa/fantomas)
+[![Build Status AppVeyor](https://ci.appveyor.com/api/projects/status/github/dungpa/fantomas)](https://ci.appveyor.com/project/dungpa/fantomas)
 
 ## Purpose
 This project aims at formatting F# source files based on a given configuration.


### PR DESCRIPTION
Main motivation for this is that the link to AppVeyor contains an artifact of the build.
Useful for trying out early builds.