### PR TITLE
Fix for preserve EOL feature

### DIFF
--- a/src/Fantomas.Tests/PreserveEOLTests.fs
+++ b/src/Fantomas.Tests/PreserveEOLTests.fs
@@ -455,3 +455,19 @@ let ``keep multiple pipes with pEOL``() =
     | 1 -> 2
     | _ -> 3
 """
+
+[<Test>]
+let ``newline handling in directives``() =
+    formatSourceString false """
+#if NOT_DEFINED
+let x = 1
+let y = 2
+#endif
+"""  config
+    |> should equal """
+#if NOT_DEFINED
+
+let x = 1
+let y = 2
+#endif
+"""

--- a/src/Fantomas.Tests/PreserveEOLTests.fs
+++ b/src/Fantomas.Tests/PreserveEOLTests.fs
@@ -401,3 +401,57 @@ let rainbow =
       b3 = "3"
     }
 """
+
+
+[<Test>]
+let ``keep single pipe with pEOL``() =
+    formatSourceString false """
+    try
+        ()
+    with
+    | :? _ ->
+        ()
+    let y = 4
+    """ config
+    |> should equal """
+    try
+        ()
+    with
+    | :? _ ->
+        ()
+    let y = 4
+"""
+
+[<Test>]
+let ``remove single pipe without pEOL``() =
+    formatSourceString false """
+    try
+        ()
+    with 
+    | :? _ -> 
+        ()
+    let y = 4
+"""     { config with PreserveEndOfLine = false }
+    |> prepend newline
+    |> should equal """
+try 
+    ()
+with :? _ -> ()
+
+let y = 4
+"""
+
+[<Test>]
+let ``keep multiple pipes with pEOL``() =
+    formatSourceString false """
+    match ts with
+    | 0
+    | 1 -> 2
+    | _ -> 3
+    """ config
+    |> should equal """
+    match ts with
+    | 0
+    | 1 -> 2
+    | _ -> 3
+"""

--- a/src/Fantomas/TokenMatcher.fs
+++ b/src/Fantomas/TokenMatcher.fs
@@ -618,8 +618,9 @@ let integrateComments isPreserveEOL (originalText : string) (newText : string) =
                 else
                     addText Environment.NewLine
                     addText line
-            ) lines 
+            ) lines
 
+            if isPreserveEOL then addText Environment.NewLine
             loop moreOrigTokens newTokens
 
         | (LineCommentChunk true (commentTokensText, moreOrigTokens)), [] ->


### PR DESCRIPTION
the code formatted with ```preserveEOL``` feature will be broken and cannot compile, that PR should fix related issues.

P.S: PR #271  have to be accepted before, because a part of changes is based upon.