### PR TITLE
Fix 269

### DIFF
--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -48,6 +48,21 @@ let alu = "GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGG\
 """
 
 [<Test>]
+let ``multiline string piped``() =
+    formatSourceString false """
+let f a b =
+    a "
+" |> b
+    """ config
+    |> prepend newline
+    |> should equal """
+let f a b =
+    a "
+"
+    |> b
+"""
+
+[<Test>]
 let ``preserve uncommon literals``() =
     formatSourceString false """
 let a = 0xFFy

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -16,6 +16,8 @@ module List =
 /// Check whether an expression should be broken into multiple lines. 
 /// Notice that order of patterns matters due to non-disjoint property.
 let rec multiline synExpr = 
+    let isConstMultiline (Unresolved(_, _, s)) = String.normalizeNewLine s |> String.exists ((=)'\n')
+    
     match synExpr with
     | ConstExpr _
     | NullExpr
@@ -54,6 +56,8 @@ let rec multiline synExpr =
 
     | Tuple es ->
         List.exists multiline es
+
+    | App(e, (ConstExpr c :: _)) -> multiline e || isConstMultiline c
 
     // An infix app is multiline if it contains at least two new line infix ops
     | InfixApps(e, es) ->


### PR DESCRIPTION
Fix #269.

Although example from issue is formatted as
```
let f a b =
    a "
"
    |> b
```

which can look like unnecessary newline, but it is because of general rule "always break line before |>" in Fantomas.