### PR TITLE
Remove obsolete README mention of fantomas.vssdk.sln

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,4 @@
 Fantomas projects
-=========================
+=================
 
- - The main solution `fantomas.sln` consists of core library and command line tool. You need an NUnit test runner to be able to run unit tests.
- - The other solution `fantomas.vssdk.sln` contains core library, command line tool and VS extension. The VS extension project requires Visual Studio 2012 SDK.
-
+The main solution `fantomas.sln` consists of core library and command line tool. You need an NUnit test runner to be able to run unit tests.


### PR DESCRIPTION
`fantomas.vssdk.sln`  is gone.