### PR TITLE
Fix CLI tool install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,12 @@ This is available in the [Visual Studio Gallery](http://visualstudiogallery.msdn
 You can also use Fantomas extension in Ivan's [fsharp-vs-commands](https://github.com/itowlson/fsharp-vs-commands) project.
 
 ### Command line tool / API 
-You can fork this repo and compile the project with F# 3.0/.NET framework 4.0. 
-Alternatively, Fantomas is also available via [a NuGet package](https://www.nuget.org/packages/FantomasCLI/) which contains both the library and the command line interface.
+Use this command to install Fantomas as a dotnet SDK global tool:
+
+```
+dotnet tool install -g fantomas-tool
+```
+
 For detailed guidelines, please read [Fantomas: How to use](docs/Documentation.md#using-the-command-line-tool).
 
 ### FAKE build system


### PR DESCRIPTION
It took me a while to install the tool because the README contained an outdated link (I guess FantomasCLI is not supported anymore) and I had to find Florian's blog post to remember the name of the package.

Other information from the README seems to be outdated too. If the preferred way now is to install `fantomas-tool`, should mentions to VS be deleted?