### PR TITLE
Fix recursive namespaces and fix recursive modules with access modifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ stylecop.*
 *.dbmdl
 lib/*.xml
 Generated_Code #added for RIA/Silverlight projects
+.ionide
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ However, the [library project](src/Fantomas) and [command line interface](src/Fa
 
 ## Testing and validation
 We have tried to be careful in testing the project.
-There are 326 unit tests and 30 validated test examples, 
+There are 329 unit tests and 30 validated test examples, 
 but it seems some corner cases of the language haven't been covered.
 Feel free to suggests tests if they haven't been handled correctly.
 

--- a/src/Fantomas.Tests/ModuleTests.fs
+++ b/src/Fantomas.Tests/ModuleTests.fs
@@ -298,3 +298,15 @@ module rec Test =
 module rec Test =
     let test = 42
 """
+
+[<Test>]
+let ``should retain order when access and rec present in module declaration``() =
+    formatSourceString false """
+module private rec Test =
+    let test = 42
+    """ config
+    |> prepend newline
+    |> should equal """
+module private rec Test =
+    let test = 42
+"""

--- a/src/Fantomas.Tests/ModuleTests.fs
+++ b/src/Fantomas.Tests/ModuleTests.fs
@@ -172,6 +172,52 @@ module WidgetsModule =
 """
 
 [<Test>]
+let ``should retain rec in namespace``() =
+    formatSourceString false """
+namespace rec Test
+
+type Add = Expr * Expr
+
+type Expr =
+    | Add of Add
+    | Value of int
+    """ config
+    |> prepend newline
+    |> should equal """
+namespace rec Test
+
+type Add = Expr * Expr
+
+type Expr =
+    | Add of Add
+    | Value of int
+"""
+
+[<Test>]
+let ``should retain rec in nested module``() =
+    formatSourceString false """
+namespace Test
+
+module rec Expression =
+    type Add = Expr * Expr
+
+    type Expr =
+        | Add of Add
+        | Value of int
+    """ config
+    |> prepend newline
+    |> should equal """
+namespace Test
+
+module rec Expression =
+    type Add = Expr * Expr
+    
+    type Expr =
+        | Add of Add
+        | Value of int
+"""
+
+[<Test>]
 let ``should preserve global keyword``() =
     formatSourceString false """
 namespace global

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -181,7 +181,10 @@ and genModuleDecl astContext = function
         failwithf "NamespaceFragment hasn't been implemented yet: %O" m
     | NestedModule(ats, px, ao, s, isRecursive, mds) -> 
         genPreXmlDoc px
-        +> genAttributes astContext ats +> ifElse isRecursive (!- "module rec ") (!- "module ") +> opt sepSpace ao genAccess -- s +> sepEq
+        +> genAttributes astContext ats
+        +> (!- "module ")
+        +> opt sepSpace ao genAccess
+        +> ifElse isRecursive (!- "rec ") sepNone -- s +> sepEq
         +> indent +> sepNln +> genModuleDeclList astContext mds +> unindent
 
     | Open(s) ->

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -84,20 +84,22 @@ and genParsedHashDirective (ParsedHashDirective(h, s)) =
 
     !- "#" -- h +> sepSpace +> col sepSpace s printArgument
 
-and genModuleOrNamespace astContext (ModuleOrNamespace(ats, px, ao, s, mds, isModule)) =
+and genModuleOrNamespace astContext (ModuleOrNamespace(ats, px, ao, s, mds, isRecursive, isModule)) =
     genPreXmlDoc px
     +> genAttributes astContext ats
     +> ifElse (String.Equals(s, astContext.TopLevelModuleName, StringComparison.InvariantCultureIgnoreCase)) sepNone 
          (ifElse isModule (!- "module ") (!- "namespace ")
-            +> opt sepSpace ao genAccess +> ifElse (s = "") (!- "global") (!- s) +> rep 2 sepNln)
+            +> opt sepSpace ao genAccess
+            +> ifElse isRecursive (!- "rec ") sepNone
+            +> ifElse (s = "") (!- "global") (!- s) +> rep 2 sepNln)
     +> genModuleDeclList astContext mds
 
-and genSigModuleOrNamespace astContext (SigModuleOrNamespace(ats, px, ao, s, mds, isModule)) =
+and genSigModuleOrNamespace astContext (SigModuleOrNamespace(ats, px, ao, s, mds, isRecursive, isModule)) =
     genPreXmlDoc px
     +> genAttributes astContext ats
     +> ifElse (String.Equals(s, astContext.TopLevelModuleName, StringComparison.InvariantCultureIgnoreCase)) sepNone 
-          (ifElse isModule (!- "module ") (!- "namespace ")
-    +> opt sepSpace ao genAccess -- s +> rep 2 sepNln)
+            (ifElse isModule (!- "module ") (!- "namespace ")
+                +> opt sepSpace ao genAccess -- s +> rep 2 sepNln)
     +> genSigModuleDeclList astContext mds
 
 and genModuleDeclList astContext = function
@@ -177,9 +179,9 @@ and genModuleDecl astContext = function
         !- "module " -- s1 +> sepEq +> sepSpace -- s2
     | NamespaceFragment(m) ->
         failwithf "NamespaceFragment hasn't been implemented yet: %O" m
-    | NestedModule(ats, px, ao, s, isRec, mds) -> 
+    | NestedModule(ats, px, ao, s, isRecursive, mds) -> 
         genPreXmlDoc px
-        +> genAttributes astContext ats +> ifElse isRec (!- "module rec ") (!- "module ") +> opt sepSpace ao genAccess -- s +> sepEq
+        +> genAttributes astContext ats +> ifElse isRecursive (!- "module rec ") (!- "module ") +> opt sepSpace ao genAccess -- s +> sepEq
         +> indent +> sepNln +> genModuleDeclList astContext mds +> unindent
 
     | Open(s) ->

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -193,11 +193,11 @@ let (|ParsedImplFileInput|) (ParsedImplFileInput.ParsedImplFileInput(_, _, _, _,
 let (|ParsedSigFileInput|) (ParsedSigFileInput.ParsedSigFileInput(_, _, _, hs, mns)) =
     (hs, mns)
 
-let (|ModuleOrNamespace|) (SynModuleOrNamespace.SynModuleOrNamespace(LongIdent s, _, isModule, mds, px, ats, ao, _)) =
-    (ats, px, ao, s, mds, isModule)
+let (|ModuleOrNamespace|) (SynModuleOrNamespace.SynModuleOrNamespace(LongIdent s, isRecursive, isModule, mds, px, ats, ao, _)) =
+    (ats, px, ao, s, mds, isRecursive, isModule)
 
-let (|SigModuleOrNamespace|) (SynModuleOrNamespaceSig.SynModuleOrNamespaceSig(LongIdent s, _, isModule, mds, px, ats, ao, _)) =
-    (ats, px, ao, s, mds, isModule)
+let (|SigModuleOrNamespace|) (SynModuleOrNamespaceSig.SynModuleOrNamespaceSig(LongIdent s, isRecursive, isModule, mds, px, ats, ao, _)) =
+    (ats, px, ao, s, mds, isRecursive, isModule)
 
 // Attribute
 


### PR DESCRIPTION
Provides a fix for issue #292.

Additionally, provides a fix for printing recursive modules with access modifier. `module internal rec Test =` was being rewritten as `module rec internal Test =` in v2.8.1.

I also added `.ionide` to the .gitignore.

Let me know if anything needs changed!