### PR TITLE
Fix for 321

### DIFF
--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="ValidationTests.fs" />
     <Compile Include="FormattingPropertyTests.fs" />
     <Compile Include="SpecialConstructsTests.fs" />
+    <Compile Include="FormatAstTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas\Fantomas.fsproj" />

--- a/src/Fantomas.Tests/FormatAstTests.fs
+++ b/src/Fantomas.Tests/FormatAstTests.fs
@@ -1,0 +1,19 @@
+module Fantomas.Tests.FormatAstTests
+
+open NUnit.Framework
+open FsUnit
+
+open Fantomas.CodeFormatter
+open Fantomas.FormatConfig
+open Fantomas.Tests.TestHelper
+
+[<Test>]
+let ``Format the ast works correctly with no source code``() =
+    let inputExp =
+        "()" |> Input
+        |> toSynExprs
+        |> List.head
+    
+    fromSynExpr inputExp
+    |> function Input x -> x.TrimEnd('\r', '\n')
+    |> should equal "()"

--- a/src/Fantomas/CodeFormatterImpl.fs
+++ b/src/Fantomas/CodeFormatterImpl.fs
@@ -350,7 +350,10 @@ let isValidFSharpCode formatContext =
     
 let formatWith ast formatContext config =
     let moduleName = Path.GetFileNameWithoutExtension formatContext.FileName
-    let input = Some formatContext.Source
+    let input =
+        if String.IsNullOrWhiteSpace formatContext.Source then None
+        else Some formatContext.Source
+        
     // Use '\n' as the new line delimiter consistently
     // It would be easier for F# parser
     let sourceCode = defaultArg input String.Empty


### PR DESCRIPTION
Only wrap formatContext.Source with an option when there is a string present.
Also added a test for this and refactored some test code to be reusable.