### PR TITLE
Upgrade to 452

### DIFF
--- a/src/Fantomas.Cmd/Fantomas.Cmd.fsproj
+++ b/src/Fantomas.Cmd/Fantomas.Cmd.fsproj
@@ -2,9 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
     <Version>2.8.1</Version>
     <AssemblyName>dotnet-fantomas</AssemblyName>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
     <Version>2.8.1</Version>
     <NoWarn>FS0988</NoWarn>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <Version>2.8.1</Version>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
I'm on a fresh Windows machine and it is no longer possible to download the developer pack for .NET 4.5.
[See list](https://www.microsoft.com/net/download/visual-studio-sdks).

4.5 is also end of life for a while now.