### PR TITLE
Removing chessie from projects to test.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -86,14 +86,14 @@ let externalProjectsToTest = [
       Tag = "5.1.0"
       SourceSubDirectory = "src"
       BuildConfigurationFn = configureBuildCommandFromDefaultFakeBuildScripts }
+    ]
+
+let externalProjectsToTestFailing = [
     { GitUrl = @"https://github.com/fsprojects/Chessie"
       DirectoryName = "Chessie"
       Tag = "master"
       SourceSubDirectory = "src"
       BuildConfigurationFn = configureBuildCommandFromDefaultFakeBuildScripts }
-]
-
-let externalProjectsToTestFailing = [
     { GitUrl = @"https://github.com/fscheck/FsCheck"
       DirectoryName = "FsCheck"
       Tag = "master"


### PR DESCRIPTION
Chessie is currently not building on CI.
Latest tag uses an old version of paket and is not an option.
Removing Chessie for now.