### PR TITLE
Add braces when dealing with a lazy keyword.

### DIFF
--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -41,6 +41,7 @@
     <Compile Include="FormatAstTests.fs" />
     <Compile Include="LetBindingTests.fs" />
     <Compile Include="NoTrailingSpacesTests.fs" />
+    <Compile Include="LazyTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas\Fantomas.fsproj" />

--- a/src/Fantomas.Tests/LazyTests.fs
+++ b/src/Fantomas.Tests/LazyTests.fs
@@ -1,0 +1,18 @@
+module Fantomas.Tests.LazyTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Tests.TestHelper
+
+[<Test>]
+let ``lazy should wrap with ()``() =
+    formatSourceString false """
+let v = // <- Lazy "1"
+    lazy
+        1 |> string""" config
+    |> fun x -> x
+    |> prepend newline
+    |> should equal """
+let v = // <- Lazy "1"
+    lazy (1 |> string)
+"""

--- a/src/Fantomas/CodeFormatter.fsx
+++ b/src/Fantomas/CodeFormatter.fsx
@@ -321,11 +321,9 @@ let list1 = ["1"]
 let list2 = ["2"]
 
 """
-let list = 
-    list1 
-    @ list2 
-    @ ["a"; "b"] 
-    @ List.map id ["a"; "b"]
+let v = // <- Lazy "1"
+    lazy
+        1 |> string
 """
 |> formatSrc
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -473,6 +473,12 @@ and genTuple astContext es =
         ))
 
 and genExpr astContext = function
+    | SingleExpr(Lazy, e) -> 
+        // Always add braces when dealing with lazy
+        str "lazy "
+        +> ifElse (hasParenthesis e) id sepOpenT 
+        +> genExpr astContext e 
+        +> ifElse (hasParenthesis e) id sepCloseT
     | SingleExpr(kind, e) -> str kind +> genExpr astContext e
     | ConstExpr(c) -> genConst c
     | NullExpr -> !- "null"


### PR DESCRIPTION
Should fix #335.
Does always wrap lazy values with `(` `)`. I am ok with this, not sure if always correct.