### PR TITLE
Removed unused open statements.

### DIFF
--- a/src/Fantomas.Tests/ActivePatternTests.fs
+++ b/src/Fantomas.Tests/ActivePatternTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/AttributeTests.fs
+++ b/src/Fantomas.Tests/AttributeTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open FsUnit
 
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open FsUnit
 
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/ComparisonTests.fs
+++ b/src/Fantomas.Tests/ComparisonTests.fs
@@ -2,11 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.FormatConfig
-open Fantomas.CodeFormatter
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 // the current behavior results in a compile error since the = is moved to the next line and not correctly indented

--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Tests/ComputationExpressionTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Tests/ControlStructureTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/DataStructureTests.fs
+++ b/src/Fantomas.Tests/DataStructureTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/FormatAstTests.fs
+++ b/src/Fantomas.Tests/FormatAstTests.fs
@@ -2,9 +2,6 @@ module Fantomas.Tests.FormatAstTests
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
-open Fantomas.FormatConfig
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/FormattingPropertyTests.fs
+++ b/src/Fantomas.Tests/FormattingPropertyTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open System
 open Fantomas
-open Fantomas.FormatConfig
 open FsCheck
 open FsUnit
 open Microsoft.FSharp.Compiler.Ast

--- a/src/Fantomas.Tests/FormattingSelectionOnlyTests.fs
+++ b/src/Fantomas.Tests/FormattingSelectionOnlyTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/FormattingSelectionTests.fs
+++ b/src/Fantomas.Tests/FormattingSelectionTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Tests/FunctionDefinitionTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/InterfaceTests.fs
+++ b/src/Fantomas.Tests/InterfaceTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -2,8 +2,6 @@ module Fantomas.Tests.LetBindingTests
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/ModuleTests.fs
+++ b/src/Fantomas.Tests/ModuleTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/PipingTests.fs
+++ b/src/Fantomas.Tests/PipingTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 // the current behavior results in a compile error since the |> is merged to the last line 

--- a/src/Fantomas.Tests/PreserveEOLTests.fs
+++ b/src/Fantomas.Tests/PreserveEOLTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 let config =  { config with PreserveEndOfLine = true; PageWidth = 20 }

--- a/src/Fantomas.Tests/QuotationTests.fs
+++ b/src/Fantomas.Tests/QuotationTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 // the current behavior results in a compile error since "(string * string) list" is converted to "string * string list"

--- a/src/Fantomas.Tests/SpecialConstructsTests.fs
+++ b/src/Fantomas.Tests/SpecialConstructsTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/StructTests.fs
+++ b/src/Fantomas.Tests/StructTests.fs
@@ -2,8 +2,6 @@ module Fantomas.Tests.StructTests
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -1,12 +1,10 @@
 ﻿module Fantomas.Tests.TestHelper
 
 open FsUnit
-
 open System
 open Fantomas.FormatConfig
 open Fantomas
 open Microsoft.FSharp.Compiler.SourceCodeServices
-open Microsoft.FSharp.Compiler.ErrorLogger
 open Microsoft.FSharp.Compiler.Ast
 open Microsoft.FSharp.Compiler.Range
 

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/TypeProviderTests.fs
+++ b/src/Fantomas.Tests/TypeProviderTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/UnionTests.fs
+++ b/src/Fantomas.Tests/UnionTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/ValidationTests.fs
+++ b/src/Fantomas.Tests/ValidationTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas.Tests/VerboseSyntaxConversionTests.fs
+++ b/src/Fantomas.Tests/VerboseSyntaxConversionTests.fs
@@ -2,8 +2,6 @@
 
 open NUnit.Framework
 open FsUnit
-
-open Fantomas.CodeFormatter
 open Fantomas.Tests.TestHelper
 
 [<Test>]

--- a/src/Fantomas/CodeFormatter.fs
+++ b/src/Fantomas/CodeFormatter.fs
@@ -1,7 +1,6 @@
 ﻿namespace Fantomas
 
 open Fantomas
-open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.Range
 
 [<Sealed>]

--- a/src/Fantomas/CodeFormatter.fsx
+++ b/src/Fantomas/CodeFormatter.fsx
@@ -9,13 +9,9 @@
 #load "CodeFormatterImpl.fs"
 #load "CodeFormatter.fs"
 
-open Fantomas.TokenMatcher
 open Fantomas.FormatConfig
-open Fantomas.SourceParser
-open Fantomas.CodePrinter
 open Fantomas.CodeFormatter
 open Microsoft.FSharp.Compiler.Range
-open Microsoft.FSharp.Compiler.Interactive.Shell
 open Microsoft.FSharp.Compiler.Interactive.Shell.Settings
 open Fantomas
 

--- a/src/Fantomas/CodeFormatterImpl.fs
+++ b/src/Fantomas/CodeFormatterImpl.fs
@@ -6,7 +6,6 @@ open System.Diagnostics
 open System.Collections.Generic
 open System.Text.RegularExpressions
 
-open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.Ast
 open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler.SourceCodeServices

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1,9 +1,7 @@
 ﻿module internal Fantomas.CodePrinter
 
 open System
-open System.Collections.Generic
 open Microsoft.FSharp.Compiler.Ast
-
 open Fantomas
 open Fantomas.FormatConfig
 open Fantomas.SourceParser

--- a/src/Fantomas/FormatConfig.fs
+++ b/src/Fantomas/FormatConfig.fs
@@ -3,7 +3,6 @@
 open System
 open System.IO
 open System.Collections.Generic
-open System.Text.RegularExpressions
 open System.CodeDom.Compiler
 
 open Microsoft.FSharp.Compiler.Range


### PR DESCRIPTION
The latest Rider EAP now shows warnings if a file contains unused open statements.

![image](https://user-images.githubusercontent.com/2621499/48131017-d6b1a580-e28e-11e8-91fa-ff8dcb0e4e73.png)

This bothers me so I'd like to see them removed.