### PR TITLE
Use qualified name for inputPath and outputPath

### DIFF
--- a/src/Fantomas.Cmd/Program.fs
+++ b/src/Fantomas.Cmd/Program.fs
@@ -58,12 +58,14 @@ let time f =
     printfn "Time taken: %O s" sw.Elapsed
     res
 
+[<RequireQualifiedAccess>]
 type InputPath = 
     | File of string 
     | Folder of string 
     | StdIn of string
     | Unspecified
 
+[<RequireQualifiedAccess>]
 type OutputPath =
     | IO of string
     | StdOut
@@ -99,8 +101,8 @@ let main _args =
     let force = ref true
     let profile = ref false
 
-    let outputPath = ref Notknown
-    let inputPath = ref Unspecified
+    let outputPath = ref OutputPath.Notknown
+    let inputPath = ref InputPath.Unspecified
 
     let fsi = ref false
     let stdIn = ref false
@@ -123,19 +125,19 @@ let main _args =
 
     let handleOutput s =
         if not !stdOut then
-            outputPath := IO s
+            outputPath := OutputPath.IO s
 
     let handleStdOut() =
         stdOut := true
-        outputPath := StdOut
+        outputPath := OutputPath.StdOut
 
     let handleInput s = 
         if !stdIn then
-            inputPath := StdIn s
+            inputPath := InputPath.StdIn s
         elif Directory.Exists(s) then
-           inputPath := Folder s
+           inputPath := InputPath.Folder s
         elif File.Exists s && isFSharpFile s then
-           inputPath := File s
+           inputPath := InputPath.File s
         else
             eprintfn "Input path should be a file or a folder."
             exit 1
@@ -265,7 +267,7 @@ let main _args =
     | :? InvalidOperationException ->
         // Currently only support UTF8
         Console.InputEncoding <- Text.Encoding.UTF8
-        inputPath := StdIn(stdin.ReadToEnd())
+        inputPath := InputPath.StdIn(stdin.ReadToEnd())
 
     let processFile inputFile outputFile config =
         if inputFile <> outputFile then
@@ -289,22 +291,22 @@ let main _args =
             processFile i o config)
 
     match !inputPath, !outputPath with
-    | Unspecified, _ ->
+    | InputPath.Unspecified, _ ->
         eprintfn "Input path is missing..."
         exit 1
-    | Folder p1, Notknown -> processFolder p1 p1
-    | File p1, Notknown -> processFile p1 p1 config
-    | File p1, IO p2 ->
+    | InputPath.Folder p1, OutputPath.Notknown -> processFolder p1 p1
+    | InputPath.File p1, OutputPath.Notknown -> processFile p1 p1 config
+    | InputPath.File p1, OutputPath.IO p2 ->
         processFile p1 p2 config
-    | Folder p1, IO p2 -> processFolder p1 p2
-    | StdIn s, IO p ->
+    | InputPath.Folder p1, OutputPath.IO p2 -> processFolder p1 p2
+    | InputPath.StdIn s, OutputPath.IO p ->
         stringToFile s p config
-    | StdIn s, Notknown
-    | StdIn s, StdOut ->
+    | InputPath.StdIn s, OutputPath.Notknown
+    | InputPath.StdIn s, OutputPath.StdOut ->
         stringToStdOut s config
-    | File p, StdOut -> 
+    | InputPath.File p, OutputPath.StdOut -> 
         fileToStdOut p config
-    | Folder p, StdOut ->
+    | InputPath.Folder p, OutputPath.StdOut ->
         allFiles !recurse p
         |> Seq.iter (fun p -> fileToStdOut p config)
     0


### PR DESCRIPTION
Sorry to bother you for such a trivial PR.

It just tries to add qualified name in matching values of `InputPath` and `OutputPath`, for example:

```
let outputPath = ref Notknown
```

becomes

```
let outputPath = ref OutputPath.Notknown
```

because I've learned from [here](https://www.ikriv.com/dev/misc/fsharp/fs_enums) that the compiler will not warn if there are ambiguities (it simply uses the most recent suitable value), so there would possibly exist ambiguities (in future, not now).

I'm still (re)learning F# and do not know much, so feel free to reject if you find anything inappropriate.

Many thanks.