### PR TITLE
Added back internals visible in code.

### DIFF
--- a/src/Fantomas/AssemblyInfo.fs
+++ b/src/Fantomas/AssemblyInfo.fs
@@ -1,0 +1,9 @@
+namespace System
+open System.Runtime.CompilerServices
+
+[<assembly: InternalsVisibleToAttribute("Fantomas.Tests")>]
+
+do ()
+
+module internal AssemblyVersionInformation =
+    let [<Literal>] InternalsVisibleTo = "Fantomas.Tests"

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -6,11 +6,7 @@
     <Description>Source code formatter for F#</Description>
   </PropertyGroup>
   <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
     <None Include="paket.references" />
     <Compile Include="Dbg.fs" />
     <Compile Include="Utils.fs" />


### PR DESCRIPTION
In https://github.com/fsprojects/fantomas/pull/375 I removed the AssemblyInfo.fs file entirely and marked the internals visible in the fsproj.

I now regret that decision and changed it back.