### PR TITLE
Fix 383

### DIFF
--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -330,3 +330,47 @@ let ``should support rational powers on units of measures``() =
 [<Measure>]
 type X = cm^(1/2) / W
 """
+
+[<Test>]
+let ``should split constructor and function call correctly, double formatting`` () =
+    let original = """
+let update msg model =
+    let res =
+        match msg with
+        | AMessage -> { model with AFieldWithAVeryVeryVeryLooooooongName = 10 }.RecalculateTotal()
+        | AnotherMessage -> model
+    res
+"""
+
+    let afterFirstFormat = formatSourceString false original config 
+    
+    formatSourceString false afterFirstFormat config
+    |> prepend newline
+    |> should equal """
+let update msg model =
+    let res =
+        match msg with
+        | AMessage ->
+            { model with AFieldWithAVeryVeryVeryLooooooongName = 10 }
+                .RecalculateTotal()
+        | AnotherMessage -> model
+    res
+"""
+
+[<Test>]
+let ``record with with function call should be on newline, even though short`` () =
+    formatSourceString false """
+let x =  { Value = 36 }.Times(9)
+    
+match b with
+| _ -> { Value = 42 }.Times(8) 
+"""  config
+    |> prepend newline
+    |> should equal """
+let x =
+    { Value = 36 }.Times(9)
+
+match b with
+| _ ->
+    { Value = 42 }.Times(8)
+"""

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -333,6 +333,8 @@ type X = cm^(1/2) / W
 
 [<Test>]
 let ``should split constructor and function call correctly, double formatting`` () =
+    let config80 = { config with PageWidth = 80 }
+    
     let original = """
 let update msg model =
     let res =
@@ -342,9 +344,9 @@ let update msg model =
     res
 """
 
-    let afterFirstFormat = formatSourceString false original config 
+    let afterFirstFormat = formatSourceString false original config80 
     
-    formatSourceString false afterFirstFormat config
+    formatSourceString false afterFirstFormat config80
     |> prepend newline
     |> should equal """
 let update msg model =
@@ -358,7 +360,7 @@ let update msg model =
 """
 
 [<Test>]
-let ``record with with function call should be on newline, even though short`` () =
+let ``updated record with function call should be on newline, even though short`` () =
     formatSourceString false """
 let x =  { Value = 36 }.Times(9)
     
@@ -367,8 +369,7 @@ match b with
 """  config
     |> prepend newline
     |> should equal """
-let x =
-    { Value = 36 }.Times(9)
+let x = { Value = 36 }.Times(9)
 
 match b with
 | _ ->

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1098,7 +1098,14 @@ and genInterfaceImpl astContext (InterfaceImpl(t, bs, range)) =
 
 and genClause astContext hasBar (Clause(p, e, eo)) = 
     ifElse hasBar sepBar sepNone +> genPat astContext p 
-    +> optPre (!- " when ") sepNone eo (genExpr astContext) +> sepArrow +> preserveBreakNln astContext e
+    +> optPre (!- " when ") sepNone eo (genExpr astContext) +> sepArrow +> (fun ctx ->
+        let alreadyMultiline = checkPreserveBreakForExpr e ctx
+        match alreadyMultiline, e with
+        | false, SynExpr.App(_,_,SynExpr.DotGet(SynExpr.Record(_, copyInfo,recordFields,_), _, LongIdentWithDots(lid), range),_,_) ->
+            (breakNln astContext true e) ctx
+        | _ ->
+            (breakNln astContext alreadyMultiline e) ctx
+    )
 
 /// Each multiline member definition has a pre and post new line. 
 and genMemberDefnList astContext (*(interfaceRange:Microsoft.FSharp.Compiler.Range.range)*) = function

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -35,6 +35,35 @@ let rec multiline synExpr =
     | IfThenElse _ ->
         true
 
+    | Ast.SynExpr.DotGet(Ast.SynExpr.Record(_, _,_,_), _, Ast.LongIdentWithDots(_,_), _) ->
+        // f.ex { model with AFieldWithAVeryVeryVeryLooooooongName = 10 }.RecalculateTotal()
+        
+    //| Ast.SynExpr.DotGet(Ast.SynExpr.Record(_, copyInfo,recordFields,_), _, Ast.LongIdentWithDots(lid,_), range) ->
+        // length record + length dotget > config.ColumnLength
+//        let lidLength =
+//            lid
+//            |> List.fold (fun acc (Ident(idt)) ->
+//                idt.Length
+//            ) 0
+//            
+//        let recordName =
+//            copyInfo
+//            |> Option.map ((fun (rexp,blck) ->
+//                match rexp with
+//                | Ast.SynExpr.Ident idt -> idt.idText.Length
+//                | _ -> 0
+//            ))
+//            
+//        let recordFieldLength =
+//            recordFields
+//            |> List.fold (fun acc rf ->
+//                match rf with
+//                | (LongIdentWithDots(idt), _), _, _ ->
+//                    idt.Length
+//            ) 0
+//            
+        true
+        
     | Paren e
     | SingleExpr(_, e)
     | TypedExpr(_, e, _)
@@ -57,7 +86,8 @@ let rec multiline synExpr =
     | Tuple es ->
         List.exists multiline es
 
-    | App(e, (ConstExpr c :: _)) -> multiline e || isConstMultiline c
+    | App(e, (ConstExpr c :: _)) ->
+        multiline e || isConstMultiline c
 
     // An infix app is multiline if it contains at least two new line infix ops
     | InfixApps(e, es) ->

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -35,35 +35,6 @@ let rec multiline synExpr =
     | IfThenElse _ ->
         true
 
-    | Ast.SynExpr.DotGet(Ast.SynExpr.Record(_, _,_,_), _, Ast.LongIdentWithDots(_,_), _) ->
-        // f.ex { model with AFieldWithAVeryVeryVeryLooooooongName = 10 }.RecalculateTotal()
-        
-    //| Ast.SynExpr.DotGet(Ast.SynExpr.Record(_, copyInfo,recordFields,_), _, Ast.LongIdentWithDots(lid,_), range) ->
-        // length record + length dotget > config.ColumnLength
-//        let lidLength =
-//            lid
-//            |> List.fold (fun acc (Ident(idt)) ->
-//                idt.Length
-//            ) 0
-//            
-//        let recordName =
-//            copyInfo
-//            |> Option.map ((fun (rexp,blck) ->
-//                match rexp with
-//                | Ast.SynExpr.Ident idt -> idt.idText.Length
-//                | _ -> 0
-//            ))
-//            
-//        let recordFieldLength =
-//            recordFields
-//            |> List.fold (fun acc rf ->
-//                match rf with
-//                | (LongIdentWithDots(idt), _), _, _ ->
-//                    idt.Length
-//            ) 0
-//            
-        true
-        
     | Paren e
     | SingleExpr(_, e)
     | TypedExpr(_, e, _)


### PR DESCRIPTION
The compromise here is that `{ foo with Bar = ""}.Someting()` will always go on a newline when after arrow in pattern match. Even though expr is short.