### PR TITLE
Added --framework to install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To install you probably need to uninstall the current version from the official 
 
 Install from MyGet:
 
-> dotnet tool install -g fantomas-tool --add-source https://www.myget.org/F/fantomas/api/v3/index.json --version 2.9.1-latest
+> dotnet tool install -g fantomas-tool --add-source https://www.myget.org/F/fantomas/api/v3/index.json --framework netcoreapp2.1 --version 2.9.1-latest
 
 Note that the `--version` is important, check the latest version [at MyGet](https://www.myget.org/feed/fantomas/package/nuget/fantomas-tool).
 Your can check your current version with `fantomas --version` (since December 2018).


### PR DESCRIPTION
You need the `--framework` setting if you are on .NET Core 2.2 of higher. 