### PR TITLE
Add anon records formatting

### DIFF
--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -262,28 +262,16 @@ type MyExc =
 """
 
 [<Test>]
-let ``anon record expression``() =
-    formatSourceString false """
-let r : {| Foo : int; Bar : string |} =
-    {| Foo = 123
-       Bar = "" |}
-"""  config
-  |> prepend newline
-  |> should equal """
+let ``anon record``() =
+    shouldNotChangeAfterFormat """
 let r : {| Foo : int; Bar : string |} =
     {| Foo = 123
        Bar = "" |}
 """
 
 [<Test>]
-let `` anon record struct expression``() =
-    formatSourceString false """
-let r : struct {| Foo : int; Bar : string |} =
-    struct {| Foo = 123
-              Bar = "" |}
-"""  config
-  |> prepend newline
-  |> should equal """
+let `` anon record - struct``() =
+    shouldNotChangeAfterFormat """
 let r : struct {| Foo : int; Bar : string |} =
     struct {| Foo = 123
               Bar = "" |}

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -264,13 +264,13 @@ type MyExc =
 [<Test>]
 let ``anon record expression``() =
     formatSourceString false """
-let r =
+let r : {| Foo : int; Bar : string |} =
     {| Foo = 123
        Bar = "" |}
 """  config
   |> prepend newline
   |> should equal """
-let r =
+let r : {| Foo : int; Bar : string |} =
     {| Foo = 123
        Bar = "" |}
 """
@@ -278,13 +278,13 @@ let r =
 [<Test>]
 let `` anon record struct expression``() =
     formatSourceString false """
-let r =
+let r : struct {| Foo : int; Bar : string |} =
     struct {| Foo = 123
               Bar = "" |}
 """  config
   |> prepend newline
   |> should equal """
-let r =
+let r : struct {| Foo : int; Bar : string |} =
     struct {| Foo = 123
               Bar = "" |}
 """

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -260,3 +260,31 @@ type MyExc =
           X = 1
           Y = 2 }
 """
+
+[<Test>]
+let ``anon record expression``() =
+    formatSourceString false """
+let r =
+    {| Foo = 123
+       Bar = "" |}
+"""  config
+  |> prepend newline
+  |> should equal """
+let r =
+    {| Foo = 123
+       Bar = "" |}
+"""
+
+[<Test>]
+let `` anon record struct expression``() =
+    formatSourceString false """
+let r =
+    struct {| Foo = 123
+              Bar = "" |}
+"""  config
+  |> prepend newline
+  |> should equal """
+let r =
+    struct {| Foo = 123
+              Bar = "" |}
+"""

--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -130,3 +130,8 @@ let fromSynExpr expr =
                     [SynModuleDecl.DoExpr(NoSequencePointAtDoBinding, expr, zero)], PreXmlDocEmpty, [], None,
                     zero)], (true, true)))
     Input (tryFormatAST ast None formatConfig)
+
+let shouldNotChangeAfterFormat source =
+    formatSourceString false source config
+    |> prepend newline
+    |> should equal source

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1058,6 +1058,11 @@ and genType astContext outerBracket t =
         | TWithGlobalConstraints(TFuns ts, tcs) -> col sepArrow ts loop +> colPre (!- " when ") wordAnd tcs (genTypeConstraint astContext)        
         | TWithGlobalConstraints(t, tcs) -> loop t +> colPre (!- " when ") wordAnd tcs (genTypeConstraint astContext)
         | TLongIdent s -> ifElse astContext.IsCStylePattern (genTypeByLookup astContext t) (!- s)
+        | TAnonRecord(isStruct, fields) ->
+            ifElse isStruct !- "struct " sepNone
+            +> sepOpenAnonRecd
+            +> col sepSemi fields (genAnonRecordFieldType astContext)
+            +> sepCloseAnonRecd
         | t -> failwithf "Unexpected type: %O" t
 
     and loopTTupleList = function
@@ -1073,6 +1078,9 @@ and genType astContext outerBracket t =
     | TFuns ts -> ifElse outerBracket (sepOpenT +> col sepArrow ts loop +> sepCloseT) (col sepArrow ts loop)
     | TTuple ts -> ifElse outerBracket (sepOpenT +> loopTTupleList ts +> sepCloseT) (loopTTupleList ts)
     | _ -> loop t
+  
+and genAnonRecordFieldType astContext (AnonRecordFieldType(s, t)) =
+    !- s +> sepColon +> (genType astContext false t)
   
 and genPrefixTypes astContext = function
     | [] -> sepNone

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -295,13 +295,21 @@ let internal sepOpenAFixed = !- "[|"
 /// closing token of list
 let internal sepCloseAFixed = !- "|]"
 
-/// opening token of sequence
+/// opening token of sequence or record
 let internal sepOpenS (ctx : Context) = 
     if ctx.Config.SpaceAroundDelimiter then str "{ " ctx else str "{" ctx 
 
-/// closing token of sequence
+/// closing token of sequence or record
 let internal sepCloseS (ctx : Context) = 
     if ctx.Config.SpaceAroundDelimiter then str " }" ctx else str "}" ctx
+
+/// opening token of anon record
+let internal sepOpenAnonRecd (ctx : Context) =
+    if ctx.Config.SpaceAroundDelimiter then str "{| " ctx else str "{|" ctx 
+
+/// closing token of anon record
+let internal sepCloseAnonRecd (ctx : Context) =
+    if ctx.Config.SpaceAroundDelimiter then str " |}" ctx else str "|}" ctx
 
 /// opening token of sequence
 let internal sepOpenSFixed = !- "{"

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -808,6 +808,11 @@ let (|Record|_|) = function
         Some(inheritOpt, xs, Option.map fst eo)
     | _ -> None
 
+let (|AnonRecord|_|) = function
+    | SynExpr.AnonRecd(isStruct, copyInfo, fields, _) ->
+        Some(isStruct, fields, Option.map fst copyInfo)
+    | _ -> None
+
 let (|ObjExpr|_|) = function
     | SynExpr.ObjExpr(t, eio, bd, ims, _, range) ->
         Some (t, eio, bd, ims, range)
@@ -1206,6 +1211,8 @@ let (|Val|) (ValSpfn(ats, IdentOrKeyword(OpNameFull s), tds, t, vi, _, _, px, ao
 // Misc
 
 let (|RecordFieldName|) ((LongIdentWithDots s, _) : RecordFieldName, eo : SynExpr option, _) = (s, eo)
+
+let (|AnonRecordFieldName|) ((Ident s): Ident, e: SynExpr) = (s, e)
 
 let (|PatRecordFieldName|) ((LongIdent s1, Ident s2), p) = (s1, s2, p)
 

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1170,6 +1170,11 @@ let (|TLongIdent|_|) = function
         Some s
     | _ -> None
 
+let (|TAnonRecord|_|) = function
+    | SynType.AnonRecd(isStruct, fields, _) ->
+        Some(isStruct, fields)
+    | _ -> None
+
 // Type parameter
 
 type SingleTyparConstraintKind = 
@@ -1213,6 +1218,7 @@ let (|Val|) (ValSpfn(ats, IdentOrKeyword(OpNameFull s), tds, t, vi, _, _, px, ao
 let (|RecordFieldName|) ((LongIdentWithDots s, _) : RecordFieldName, eo : SynExpr option, _) = (s, eo)
 
 let (|AnonRecordFieldName|) ((Ident s): Ident, e: SynExpr) = (s, e)
+let (|AnonRecordFieldType|) ((Ident s): Ident, t: SynType) = (s, t)
 
 let (|PatRecordFieldName|) ((LongIdent s1, Ident s2), p) = (s1, s2, p)
 


### PR DESCRIPTION
Avoids exceptions when trying to format anon records and adds code printing for the new expressions and types.

Please note: printed anon records types may exceed desired line length with this implementation.