### PR TITLE
Add spaces around ".." operator

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -220,13 +220,13 @@ type MyClassDerived2(y: int) =
 type MyClassBase2(x: int) =
     let mutable z = x * x
     do
-        for i in 1..z do
+        for i in 1 .. z do
             printf "%d " i
 
 type MyClassDerived2(y: int) =
     inherit MyClassBase2(y * 2)
     do
-        for i in 1..y do
+        for i in 1 .. y do
             printf "%d " i
 """
 

--- a/src/Fantomas.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Tests/ComputationExpressionTests.fs
@@ -45,7 +45,7 @@ let comp =
     |> should equal """
 let comp =
     eventually {
-        for x in 1..2 do
+        for x in 1 .. 2 do
             printfn " x = %d" x
         return 3 + 4
     }
@@ -70,10 +70,10 @@ let rec inorder tree =
     |> should equal """
 let s1 =
     seq {
-        for i in 1..10 -> i * i
+        for i in 1 .. 10 -> i * i
     }
 
-let s2 = seq { 0..10..100 }
+let s2 = seq { 0 .. 10 .. 100 }
 
 let rec inorder tree =
     seq {
@@ -94,7 +94,7 @@ let factors number =
     |> Seq.filter (fun x -> number % x = 0L)""" config
     |> prepend newline
     |> should equal """
-let factors number = { 2L..number / 2L } |> Seq.filter (fun x -> number % x = 0L)
+let factors number = { 2L .. number / 2L } |> Seq.filter (fun x -> number % x = 0L)
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Tests/ControlStructureTests.fs
@@ -158,7 +158,7 @@ let ``range expressions``() =
     |> prepend newline
     |> should equal """
 let function2() =
-    for i in 1..2..10 do
+    for i in 1 .. 2 .. 10 do
         printf "%d " i
     printfn ""
 

--- a/src/Fantomas.Tests/DataStructureTests.fs
+++ b/src/Fantomas.Tests/DataStructureTests.fs
@@ -118,9 +118,9 @@ let list0to3 = [0 .. 3]""" config
     |> prepend newline
     |> should equal """
 let listOfSquares =
-    [ for i in 1..10 -> i * i ]
+    [ for i in 1 .. 10 -> i * i ]
 
-let list0to3 = [ 0..3 ]
+let list0to3 = [ 0 .. 3 ]
 """
 
 [<Test>]
@@ -132,12 +132,12 @@ let a3 = [| for n in 1 .. 100 do if isPrime n then yield n |]""" config
     |> prepend newline
     |> should equal """
 let a1 =
-    [| for i in 1..10 -> i * i |]
+    [| for i in 1 .. 10 -> i * i |]
 
-let a2 = [| 0..99 |]
+let a2 = [| 0 .. 99 |]
 
 let a3 =
-    [| for n in 1..100 do
+    [| for n in 1 .. 100 do
         if isPrime n then yield n |]
 """
 

--- a/src/Fantomas.Tests/FormattingSelectionTests.fs
+++ b/src/Fantomas.Tests/FormattingSelectionTests.fs
@@ -221,7 +221,7 @@ let a3 =
     [| for n in 1 .. 100 do if isPrime n then yield n |]""" config
     |> should equal """
 let a3 =
-    [| for n in 1..100 do
+    [| for n in 1 .. 100 do
         if isPrime n then yield n |]"""
 
 [<Test>]
@@ -244,7 +244,7 @@ let comp =
     |> should equal """
 let comp =
     eventually {
-        for x in 1..2 do
+        for x in 1 .. 2 do
             printfn " x = %d" x
         return 3 + 4
     }"""

--- a/src/Fantomas.Tests/KeepNewlineAfterTests.fs
+++ b/src/Fantomas.Tests/KeepNewlineAfterTests.fs
@@ -126,7 +126,7 @@ let x =
     |> prepend newline
     |> should equal """
 let x =
-    [| 1..2 |]
+    [| 1 .. 2 |]
     |> Array.mapi (fun _ _ ->
         let num =
             ""

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -100,7 +100,7 @@ let x =
     |> prepend newline
     |> should equal """
 let x =
-    [| 1..2 |]
+    [| 1 .. 2 |]
     |> Array.mapi (fun _ _ ->
         let num = "".PadLeft(9)
         num)

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -190,3 +190,16 @@ let ``should not add newline before = operator after |>``() =
     |> should equal """1
 |> max 0 = 1
 """
+
+[<Test>]
+let ``should add space around .. operator``() =
+    formatSourceString false """[1..10]""" config
+    |> should equal """[ 1 .. 10 ]
+"""
+
+
+[<Test>]
+let ``should add space around .. .. operators``() =
+    formatSourceString false """[10 .. -1 .. 1]""" config
+    |> should equal """[ 10 .. -1 .. 1 ]
+"""

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -400,7 +400,7 @@ type SparseMatrix() =
 
 let matrix1 = new SparseMatrix()
 
-for i in 1..1000 do
+for i in 1 .. 1000 do
     matrix1.[i, i] <- float i * float i
 """
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -852,10 +852,10 @@ and genExpr astContext synExpr =
             genExpr astContext e -- "?" +> sepOpenT +> col sepSpace es (genExpr astContext) +> sepCloseT
 
     | App(Var "..", [e1; e2]) ->
-        let expr = genExpr astContext e1 -- ".." +> genExpr astContext e2
+        let expr = genExpr astContext e1 +> sepSpace -- ".." +> sepSpace +> genExpr astContext e2
         ifElse astContext.IsNakedRange expr (sepOpenS +> expr +> sepCloseS)
     | App(Var ".. ..", [e1; e2; e3]) -> 
-        let expr = genExpr astContext e1 -- ".." +> genExpr astContext e2 -- ".." +> genExpr astContext e3
+        let expr = genExpr astContext e1 +> sepSpace -- ".." +> sepSpace +> genExpr astContext e2 +> sepSpace -- ".." +> sepSpace +> genExpr astContext e3
         ifElse astContext.IsNakedRange expr (sepOpenS +> expr +> sepCloseS)
     // Separate two prefix ops by spaces
     | PrefixApp(s1, PrefixApp(s2, e)) -> !- (sprintf "%s %s" s1 s2) +> genExpr astContext e

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -437,7 +437,7 @@ let internal sortAndDeduplicate by l (ctx : Context) =
     else l
 
 /// Don't put space before and after these operators
-let internal NoSpaceInfixOps = set [".."; "?"]
+let internal NoSpaceInfixOps = set ["?"]
 
 /// Always break into newlines on these operators
 let internal NewLineInfixOps = set ["|>"; "||>"; "|||>"; ">>"; ">>="]


### PR DESCRIPTION
Fix #456

Change globally all ranges `1..10` to `1 .. 10`. Based on official docs, I think it is correct formatting:

https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/loops-for-in-expression

https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/lists