### PR TITLE
Fix for abstract member declaration with optional param

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -116,7 +116,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(CacheFilesExist)' == 'true' ">
-      <!-- If the restire file doesn't exist we need to restore, otherwise only if hashes don't match -->
+      <!-- If the restore file doesn't exist we need to restore, otherwise only if hashes don't match -->
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(ProjectsRestoredHash)' ">false</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>

--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -121,6 +121,30 @@ type Shape2D(x0: float, y0: float) =
 """
 
 [<Test>]
+let ``abstract member declaration``() =
+    formatSourceString false """
+type A =
+    abstract B: ?p1:(float * int) -> unit
+    abstract C: ?p1:float * int -> unit
+    abstract D: ?p1:(int -> int) -> unit
+    abstract E: ?p1:float -> unit
+    abstract F: ?p1:float * ?p2:float -> unit
+    abstract G: p1:float * ?p2:float -> unit
+    abstract H: float * ?p2:float -> unit
+    """ config
+    |> prepend newline
+    |> should equal """
+type A =
+    abstract B: ?p1:(float * int) -> unit
+    abstract C: ?p1:float * int -> unit
+    abstract D: ?p1:(int -> int) -> unit
+    abstract E: ?p1:float -> unit
+    abstract F: ?p1:float * ?p2:float -> unit
+    abstract G: p1:float * ?p2:float -> unit
+    abstract H: float * ?p2:float -> unit
+"""
+
+[<Test>]
 let ``class declaration``() =
     formatSourceString false """
 type BaseClass = class

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1489,18 +1489,14 @@ and genTypeList astContext node =
     match node with
     | [] -> sepNone
     | (t, [ArgInfo(ats, so, isOpt)])::ts -> 
-        let hasBracket = not ts.IsEmpty
         let gt =
             match t with
-            | TTuple _ ->
-                opt sepColonFixed so (if isOpt then (sprintf "?%s" >> (!-)) else (!-)) 
-                +> genType astContext hasBracket t 
-            | TFun _ ->
-                // Fun is grouped by brackets inside 'genType astContext true t'
-                opt sepColonFixed so (if isOpt then (sprintf "?%s" >> (!-)) else (!-)) 
-                +> genType astContext true t
-            | _ -> 
-                opt sepColonFixed so (!-) +> genType astContext false t
+            | TTuple _ -> not ts.IsEmpty
+            | TFun _ -> true // Fun is grouped by brackets inside 'genType astContext true t'
+            | _ -> false
+            |> fun hasBracket ->
+                opt sepColonFixed so (if isOpt then (sprintf "?%s" >> (!-)) else (!-))
+                +> genType astContext hasBracket t
         genOnelinerAttributes astContext ats
         +> gt +> ifElse ts.IsEmpty sepNone (autoNln (sepArrow +> genTypeList astContext ts))
 


### PR DESCRIPTION
Fixes an issue in an abstract member declaration where the only parameter is a non-tuple, non-function, optional param. Formatting was dropping the `?` on the parameter.

For example:
```fsharp
type A =
    abstract B: ?p:float -> unit
```
would format to
```fsharp
type A =
    abstract B: p:float -> unit
```

The issue was in the printer: the `_` wildcard case was not account for the `isOpt` boolean. When making the wildcard account for `isOpt`, I noticed all three matches were the same except for the `hasBracket` bool, so I moved only that bool to the matching statement and sent to the same printing code underneath.

Added some test cases that account for both the fix and the changed code. Members `B` and `C` exercise the `TTuple` case for optional parameters, and member `D` exercises the `TFun` case for an optional parameter. Member `E` is the specific test for this fix, and the rest are additional tests as I didn't see anything that matched them in the existing tests.

Let me know if there is anything that needs to be changed!