### PR TITLE
Fix: Print comment after '{' in Record signature.

### DIFF
--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -564,3 +564,33 @@ module Maintoc =
 This is a very long line in a multi-line string, so long in fact that it is longer than that page width to which I am trying to constrain everything, and so it goes bang.
 \"\"\" ]   }
 "
+
+[<Test>]
+let ``record type signature with line comment, 517`` () =
+    formatSourceString true """
+module RecordSignature
+/// Represents simple XML elements.
+type Element =
+    { /// The attribute collection.
+      Attributes: IDictionary<Name, string>;
+
+      /// The children collection.
+      Children: seq<INode>;
+
+      /// The qualified name.
+      Name: Name }
+"""  config
+    |> prepend newline
+    |> should equal """
+module RecordSignature
+/// Represents simple XML elements.
+type Element =
+    { /// The attribute collection.
+      Attributes: IDictionary<Name, string>
+
+      /// The children collection.
+      Children: seq<INode>
+
+      /// The qualified name.
+      Name: Name }
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1415,7 +1415,7 @@ and genSigTypeDefn astContext (SigTypeDef(ats, px, ao, tds, tcs, tdr, ms, s, pre
     | SigSimple(TDSRRecord(ao', fs)) ->
         typeName +> sepEq 
         +> indent +> sepNln +> opt sepNln ao' genAccess +> sepOpenS 
-        +> atCurrentColumn (col sepSemiNln fs (genField astContext "")) +> sepCloseS
+        +> atCurrentColumn (leaveLeftBrace tdr.Range +> col sepSemiNln fs (genField astContext "")) +> sepCloseS
         +> colPre sepNln sepNln ms (genMemberSig astContext)
         +> unindent 
 


### PR DESCRIPTION
Fixes #517 