### PR TITLE
single line comment trivia treated same as new line trivia (partial fix for issue #513)

### DIFF
--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -278,3 +278,19 @@ let ``should keep space before :`` () =
     |> fun formatted -> formatSourceString false formatted config
     |> should equal "let refl<'a> : Teq<'a, 'a> = Teq(id, id)
 "
+
+[<Test>]
+let ``trivia before simple sequence doesn't force remaining to get offset by last expression column index`` () =
+    // https://github.com/fsprojects/fantomas/issues/513
+    formatSourceString false """let a() =
+    let q = 1
+
+    q
+    b
+"""  config
+    |> should equal """let a() =
+    let q = 1
+
+    q
+    b
+"""

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -280,7 +280,7 @@ let ``should keep space before :`` () =
 "
 
 [<Test>]
-let ``NewLine trivia before simple sequence doesn't force remaining to get offset by last expression column index`` () =
+let ``newline trivia before simple sequence doesn't force remaining to get offset by last expression column index`` () =
     // https://github.com/fsprojects/fantomas/issues/513
     formatSourceString false """let a() =
     let q = 1
@@ -296,7 +296,7 @@ let ``NewLine trivia before simple sequence doesn't force remaining to get offse
 """
 
 [<Test>]
-let ``Comment trivia before simple sequence doesn't force remaining to get offset by last expression column index`` () =
+let ``comment trivia before simple sequence doesn't force remaining to get offset by last expression column index`` () =
     // https://github.com/fsprojects/fantomas/issues/513
     formatSourceString false """let a() =
     let q = 1

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -280,7 +280,7 @@ let ``should keep space before :`` () =
 "
 
 [<Test>]
-let ``trivia before simple sequence doesn't force remaining to get offset by last expression column index`` () =
+let ``NewLine trivia before simple sequence doesn't force remaining to get offset by last expression column index`` () =
     // https://github.com/fsprojects/fantomas/issues/513
     formatSourceString false """let a() =
     let q = 1
@@ -291,6 +291,22 @@ let ``trivia before simple sequence doesn't force remaining to get offset by las
     |> should equal """let a() =
     let q = 1
 
+    q
+    b
+"""
+
+[<Test>]
+let ``Comment trivia before simple sequence doesn't force remaining to get offset by last expression column index`` () =
+    // https://github.com/fsprojects/fantomas/issues/513
+    formatSourceString false """let a() =
+    let q = 1
+    // comment
+    q
+    b
+"""  config
+    |> should equal """let a() =
+    let q = 1
+    // comment
     q
     b
 """

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1066,8 +1066,9 @@ and genExpr astContext synExpr =
             +> indent +> sepNln +> genExpr astContext e2 +> unindent)    
 
     | SequentialSimple es | Sequentials es ->
-        // This is one of those weird situations where the newlines need to printed before atCurrentColumn
-        // If the newline would be printed in a AtCurrentColumn block that code would be started too far of.
+        // This is one situations where the newlines/trivium need to printed before atCurrentColumn due to compiler restriction (last tested 4.7)
+        // If the trivia would be printed in a AtCurrentColumn block that code would be started too far off,
+        // and thus, engender compile errors.
         // See :
         // * https://github.com/fsprojects/fantomas/issues/478
         // * https://github.com/fsprojects/fantomas/issues/513

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -726,7 +726,7 @@ and genTuple astContext es =
             if i = 0 then f e else noIndentBreakNlnFun f e
         ))
 
-and genExpr astContext synExpr = 
+and genExpr astContext synExpr =
     let appNlnFun e =
         match e with
         | CompExpr _
@@ -1065,14 +1065,15 @@ and genExpr astContext synExpr =
         atCurrentColumn (kw "TRY" !-"try " +> indent +> sepNln +> genExpr astContext e1 +> unindent +> kw "FINALLY" !+~"finally" 
             +> indent +> sepNln +> genExpr astContext e2 +> unindent)    
 
-    | SequentialSimple es -> atCurrentColumn (colAutoNlnSkip0 sepSemiNln es (genExpr astContext))
-    // It seems too annoying to use sepSemiNln
-    | Sequentials es ->
+    | SequentialSimple es | Sequentials es ->
         // This is one of those weird situations where the newlines need to printed before atCurrentColumn
         // If the newline would be printed in a AtCurrentColumn block that code would be started too far of.
-        // See https://github.com/fsprojects/fantomas/issues/478
+        // See :
+        // * https://github.com/fsprojects/fantomas/issues/478
+        // * https://github.com/fsprojects/fantomas/issues/513
+
         firstNewline es +> atCurrentColumn (col sepSemiNln es (genExpr astContext))
-    
+
     | IfThenElse(e1, e2, None) -> 
         atCurrentColumn (!- "if " +> ifElse (checkBreakForExpr e1) (genExpr astContext e1 ++ "then") (genExpr astContext e1 +- "then") 
                          -- " " +> preserveBreakNln astContext e2)

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1072,7 +1072,7 @@ and genExpr astContext synExpr =
         // * https://github.com/fsprojects/fantomas/issues/478
         // * https://github.com/fsprojects/fantomas/issues/513
 
-        firstNewline es +> atCurrentColumn (col sepSemiNln es (genExpr astContext))
+        firstNewlineOrComment es +> atCurrentColumn (col sepSemiNln es (genExpr astContext))
 
     | IfThenElse(e1, e2, None) -> 
         atCurrentColumn (!- "if " +> ifElse (checkBreakForExpr e1) (genExpr astContext e1 ++ "then") (genExpr astContext e1 +- "then") 

--- a/src/Fantomas/TriviaContext.fs
+++ b/src/Fantomas/TriviaContext.fs
@@ -5,13 +5,13 @@ open Fantomas
 open Fantomas.Context
 open Fantomas.TriviaTypes
 
-let firstNewline (es: SynExpr list) (ctx: Context) =
+let firstNewlineOrComment (es: SynExpr list) (ctx: Context) =
     es
     |> List.tryHead
     |> Option.bind (fun e -> TriviaHelpers.findByRange ctx.Trivia e.Range)
     |> fun cb ->
         match cb with
-        | Some ({ ContentBefore = TriviaContent.Newline::rest } as tn) ->
+        | Some ({ ContentBefore = (TriviaContent.Newline|TriviaContent.Comment _) as head ::rest } as tn) ->
             let updatedTriviaNodes =
                 ctx.Trivia
                 |> List.map (fun t ->
@@ -21,6 +21,6 @@ let firstNewline (es: SynExpr list) (ctx: Context) =
                 )
 
             let ctx' = { ctx with Trivia = updatedTriviaNodes }
-            printTriviaContent Newline ctx'
+            printTriviaContent head ctx'
         | _ -> sepNone ctx
 


### PR DESCRIPTION
This seems to run the tests green and fix the minimal case of #513, it doesn't fix all the issues formatting the code that was submitted though, so additional cases needs to be identified, #527 is another issue encountered formatting https://github.com/knocte/geewallet codebase.