### PR TITLE
Rephrased code comment

### DIFF
--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1066,7 +1066,7 @@ and genExpr astContext synExpr =
             +> indent +> sepNln +> genExpr astContext e2 +> unindent)    
 
     | SequentialSimple es | Sequentials es ->
-        // This is one situations where the newlines/trivium need to printed before atCurrentColumn due to compiler restriction (last tested 4.7)
+        // This is one situation where the trivia needs to printed before atCurrentColumn due to compiler restriction (last tested FCS 32)
         // If the trivia would be printed in a AtCurrentColumn block that code would be started too far off,
         // and thus, engender compile errors.
         // See :


### PR DESCRIPTION
The word trivium is not used anywhere in the code base so it sounds a bit weird.
It makes more sense to me to use FCS version instead of F# release version.