### PR TITLE
Fix: print line comment after arrow in lamda between paranthesis.

### DIFF
--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
   <PropertyGroup>
     <Version>3.0.0</Version>
@@ -54,7 +54,7 @@
     <Compile Include="TupleTests.fs" />
     <Compile Include="KeepNewlineAfterTests.fs" />
     <Compile Include="ElmishTests.fs" />
-    <Compile Include="LamdaTests.fs" />
+    <Compile Include="LambdaTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas\Fantomas.fsproj" />

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -54,6 +54,7 @@
     <Compile Include="TupleTests.fs" />
     <Compile Include="KeepNewlineAfterTests.fs" />
     <Compile Include="ElmishTests.fs" />
+    <Compile Include="LamdaTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas\Fantomas.fsproj" />

--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -1,4 +1,4 @@
-module Fantomas.Tests.LamdaTests
+module Fantomas.Tests.LambdaTests
 
 open NUnit.Framework
 open FsUnit

--- a/src/Fantomas.Tests/LamdaTests.fs
+++ b/src/Fantomas.Tests/LamdaTests.fs
@@ -1,0 +1,16 @@
+module Fantomas.Tests.LamdaTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Tests.TestHelper
+
+[<Test>]
+let ``keep comment after arrow`` () =
+    formatSourceString false """_Target "FSharpTypesDotNet" (fun _ -> // obsolete
+ ())
+"""  ({ config with IndentSpaceNum = 2; PageWidth = 90 })
+    |> prepend newline
+    |> should equal """
+_Target "FSharpTypesDotNet" (fun _ -> // obsolete
+  ())
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -880,7 +880,9 @@ and genExpr astContext synExpr =
         expr
     | JoinIn(e1, e2) -> genExpr astContext e1 -- " in " +> genExpr astContext e2
     | Paren(DesugaredLambda(cps, e)) ->
-        sepOpenT -- "fun " +>  col sepSpace cps (genComplexPats astContext) +> sepArrow +> noIndentBreakNln astContext e +> sepCloseT
+        sepOpenT -- "fun " +>  col sepSpace cps (genComplexPats astContext)
+        +> triviaAfterArrow synExpr.Range
+        +> noIndentBreakNln astContext e +> sepCloseT
     | DesugaredLambda(cps, e) -> 
         !- "fun " +>  col sepSpace cps (genComplexPats astContext) +> sepArrow +> preserveBreakNln astContext e 
     | Paren(Lambda(e, sps)) ->
@@ -2045,11 +2047,7 @@ and genConstBytes (bytes: byte []) (r: range) =
 and genTrivia (range: range) f =
     enterNode range +> f +> leaveNode range
 
-and tok (range: range) (s: string) =
-    enterNodeToken range +> (!-s) +> leaveNodeToken range
 
-and tokN (range: range) (tokenName: string) f =
-    enterNodeTokenByName range tokenName +> f +> leaveNodeTokenByName range tokenName
 
 and infixOperatorFromTrivia range fallback (ctx: Context) =
     ctx.Trivia

--- a/src/Fantomas/TriviaContext.fs
+++ b/src/Fantomas/TriviaContext.fs
@@ -1,9 +1,16 @@
 module internal Fantomas.TriviaContext
 
 open FSharp.Compiler.Ast
+open FSharp.Compiler.Range
 open Fantomas
 open Fantomas.Context
 open Fantomas.TriviaTypes
+
+let tok (range: range) (s: string) =
+    enterNodeToken range +> (!-s) +> leaveNodeToken range
+
+let tokN (range: range) (tokenName: string) f =
+    enterNodeTokenByName range tokenName +> f +> leaveNodeTokenByName range tokenName
 
 let firstNewline (es: SynExpr list) (ctx: Context) =
     es
@@ -24,3 +31,12 @@ let firstNewline (es: SynExpr list) (ctx: Context) =
             printTriviaContent Newline ctx'
         | _ -> sepNone ctx
 
+let triviaAfterArrow (range: range) (ctx: Context) =
+    let hasCommentAfterArrow =
+        findTriviaTokenFromName range ctx.Trivia "RARROW"
+        |> Option.bind (fun t ->
+            t.ContentAfter
+            |> List.tryFind (function | Comment(LineCommentAfterSourceCode(_)) -> true | _ -> false)
+        )
+        |> Option.isSome
+    ((tokN range "RARROW" sepArrow) +> ifElse hasCommentAfterArrow sepNln sepNone) ctx


### PR DESCRIPTION
Fixes #534 

Currently, two tests fail but I'm a bit confused about those tests in the first place.

```fsharp
[<Test>]
let ``line comment after "if"``() =
    formatSourceString false """
if //comment
    true then 1
else 0""" config
    |> prepend newline
    |> should equal """
if true then 1 //comment
else 0
"""

[<Test>]
let ``line comment after "else"``() =
    formatSourceString false """
if true then 1
else //comment
    0""" config
    |> prepend newline
    |> should equal """
if true then 1
else 0 //comment
"""
```

Why can't the comments not be after the keyword like in the original code?