### PR TITLE
fix function application being formatted toward invalid syntax

### DIFF
--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -20,3 +20,57 @@ let a =
     |> List.exists (fun p ->
         p.a && p.b |> List.exists (fun o -> o.a = "lorem ipsum dolor sit amet"))
 """
+
+// compile error due to expression starting before the beginning of the function expression
+[<Test>]
+let ``require to ident at least +1 after function name #545``() =
+    formatSourceString false @"
+let a s =
+    if s <> """" then
+        printfn """"""fooo
+%s
+%s
+%s
+%s""""""                (llloooooooooooooooooooooooooo s)
+                            s
+                               s
+                                     s"
+        config
+    |> prepend newline
+    |> should equal @"
+let a s =
+    if s <> """" then
+        printfn """"""fooo
+%s
+%s
+%s
+%s""""""    (llloooooooooooooooooooooooooo s) s s s
+"
+
+// compile error due to expression starting before the beginning of the function expression
+[<Test>]
+let ``require to ident at least +1 after function name #545 (long expression and short line settings)``() =
+    formatSourceString false @"
+let a s =
+    if s <> """" then
+        printfn """"""fooo
+%s
+%s
+%s
+%s""""""                (llloooooooooooooooooooooooooo s)
+                            s
+                               (llloooooooooooooooooooooooooo s)
+                                     (llloooooooooooooooooooooooooo s)"
+        { config  with PageWidth = 50 } 
+    |> prepend newline
+    |> should equal @"
+let a s =
+    if s <> """" then
+        printfn """"""fooo
+%s
+%s
+%s
+%s""""""    (llloooooooooooooooooooooooooo s) s
+            (llloooooooooooooooooooooooooo s)
+            (llloooooooooooooooooooooooooo s)
+"

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1032,16 +1032,12 @@ and genExpr astContext synExpr =
 
     // Always spacing in multiple arguments
     | App(e, es) ->
-        // https://github.com/fsprojects/fantomas/issues/545
         // we need to make sure each expression in the function application has offset at least greater than
         // identation of the function expression itself
         // we replace sepSpace in such case
-        let mutable savedColumn = 0
-        let retainColumn ctx =
-            savedColumn <- ctx.Writer.Column
-            ctx
-        let indentIfNeeded ctx =
-            let savedColumn = savedColumn
+        // remarks: https://github.com/fsprojects/fantomas/issues/545
+        let indentIfNeeded (ctx: Context) =
+            let savedColumn = ctx.Writer.AtColumn
             if savedColumn > ctx.Writer.Column then
                 // missingSpaces needs to be at least one more than the column
                 // of function expression being applied upon, otherwise (as known up to F# 4.7)
@@ -1051,7 +1047,7 @@ and genExpr astContext synExpr =
             else
                 sepSpace ctx
                 
-        atCurrentColumn (retainColumn +> genExpr astContext e +>
+        atCurrentColumn (genExpr astContext e +>
             colPre sepSpace sepSpace es (fun e ->
                 indent +> appNlnFun e (indentIfNeeded +> genExpr astContext e) +> unindent))
 


### PR DESCRIPTION
The indentation needs to be checked against the function expression start column in which case, prepend the "to be printed" expression with enough leading space.

fixes #545

Please let me know if the changes in implementation needs to be handled in a better way.
