### PR TITLE
codeprinter: Fix SpaceBeforeArgument

### DIFF
--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -43,9 +43,9 @@ type ASTContext =
 
 let rec addSpaceBeforeParensInFunCall functionOrMethod arg = 
     match functionOrMethod, arg with
-    | SynExpr.LongIdent(_, LongIdentWithDots s, _, _), _ ->
-        let parts = s.Split '.'
-        not <| Char.IsUpper parts.[parts.Length - 1].[0]
+    | SynExpr.LongIdent(_, _, _, _), ConstExpr(Const "()", _) ->
+        true
+    | SynExpr.Ident(_), ConstExpr(Const "()", _)
     | SynExpr.Ident(_), SynExpr.Ident(_) ->
         true
     | SynExpr.Ident(Ident s), _ ->
@@ -57,9 +57,7 @@ let rec addSpaceBeforeParensInFunCall functionOrMethod arg =
 let addSpaceBeforeParensInFunDef functionOrMethod args =
     match functionOrMethod, args with
     | "new", _ -> false
-    | (s:string), _ -> 
-        let parts = s.Split '.'
-        not <| Char.IsUpper parts.[parts.Length - 1].[0]
+    | (_:string), _ -> true
     | _ -> true
 
 let rec genParsedInput astContext = function

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -43,8 +43,6 @@ type ASTContext =
 
 let rec addSpaceBeforeParensInFunCall functionOrMethod arg = 
     match functionOrMethod, arg with
-    | _, ConstExpr(Const "()", _) ->
-        false
     | SynExpr.LongIdent(_, LongIdentWithDots s, _, _), _ ->
         let parts = s.Split '.'
         not <| Char.IsUpper parts.[parts.Length - 1].[0]
@@ -58,7 +56,6 @@ let rec addSpaceBeforeParensInFunCall functionOrMethod arg =
 
 let addSpaceBeforeParensInFunDef functionOrMethod args =
     match functionOrMethod, args with
-    | _, PatParen (PatConst(Const "()", _)) -> false
     | "new", _ -> false
     | (s:string), _ -> 
         let parts = s.Split '.'


### PR DESCRIPTION
`addSpaceBeforeParentsInFunCall` would always return false for
expressions that included an ident and parens. This fix makes it so
it returns true whenever the second expression (`arg`) is parens.

Fixes #549.