### PR TITLE
Fix SpaceBeforeArgument edge cases

### DIFF
--- a/src/Fantomas.Tests/ActivePatternTests.fs
+++ b/src/Fantomas.Tests/ActivePatternTests.fs
@@ -36,7 +36,7 @@ let (|Even|Odd|) input = if input % 2 = 0 then Even else Odd
 
 let (|Integer|_|) (str: string) =
    let mutable intvalue = 0
-   if System.Int32.TryParse(str, &intvalue) then Some(intvalue)
+   if System.Int32.TryParse (str, &intvalue) then Some(intvalue)
    else None
 
 let (|ParseRegex|_|) regex str =
@@ -52,7 +52,7 @@ let (|Even|Odd|) input =
 
 let (|Integer|_|) (str: string) =
     let mutable intvalue = 0
-    if System.Int32.TryParse(str, &intvalue) then Some(intvalue)
+    if System.Int32.TryParse (str, &intvalue) then Some(intvalue)
     else None
 
 let (|ParseRegex|_|) regex str =

--- a/src/Fantomas.Tests/AttributeTests.fs
+++ b/src/Fantomas.Tests/AttributeTests.fs
@@ -16,7 +16,7 @@ type Funcs =
     |> should equal """[<Extension>]
 type Funcs =
     [<Extension>]
-    static member ToFunc(f: Action<_, _, _>) = Func<_, _, _, _>(fun a b c -> f.Invoke(a, b, c))
+    static member ToFunc (f: Action<_, _, _>) = Func<_, _, _, _>(fun a b c -> f.Invoke (a, b, c))
 """
 
 [<Test>]
@@ -112,9 +112,9 @@ and [<Test>] b () = 10""" config
     |> prepend newline
     |> should equal """
 [<Test>]
-let rec a() = 10
+let rec a () = 10
 
-and [<Test>] b() = 10
+and [<Test>] b () = 10
 """
 
 [<Test>]
@@ -190,10 +190,10 @@ let printInStyle (style: string) (msg): unit = jsNative
 let printModel model: unit = jsNative
 
 [<Emit("console.trace()")>]
-let printStackTrace(): unit = jsNative
+let printStackTrace (): unit = jsNative
 #endif
 
-let e2e value = Props.Data("e2e", value)
+let e2e value = Props.Data ("e2e", value)
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -91,7 +91,7 @@ type Shape2D(x0 : float, y0 : float) =
        y <- y + dy
 
     abstract member Rotate: float -> unit
-    default this.Rotate(angle) = rotAngle <- rotAngle + angle
+    default this.Rotate (angle) = rotAngle <- rotAngle + angle
     """ config
     |> prepend newline
     |> should equal """
@@ -117,7 +117,7 @@ type Shape2D(x0: float, y0: float) =
         y <- y + dy
 
     abstract Rotate: float -> unit
-    default this.Rotate(angle) = rotAngle <- rotAngle + angle
+    default this.Rotate (angle) = rotAngle <- rotAngle + angle
 """
 
 [<Test>]
@@ -186,8 +186,8 @@ let ``classes and implicit constructors``() =
     |> should equal """
 type MyClass2(dataIn) as self =
     let data = dataIn
-    do self.PrintMessage()
-    member this.PrintMessage() = printf "Creating MyClass2 with Data %d" data
+    do self.PrintMessage ()
+    member this.PrintMessage () = printf "Creating MyClass2 with Data %d" data
 """
 
 [<Test>]
@@ -202,8 +202,8 @@ let ``classes and private implicit constructors``() =
     |> should equal """
 type MyClass2 private (dataIn) as self =
     let data = dataIn
-    do self.PrintMessage()
-    member this.PrintMessage() = printf "Creating MyClass2 with Data %d" data
+    do self.PrintMessage ()
+    member this.PrintMessage () = printf "Creating MyClass2 with Data %d" data
 """
 
 [<Test>]
@@ -221,7 +221,7 @@ and File(filename: string, containingFolder: Folder) =
     |> should equal """
 type Folder(pathIn: string) =
     let path = pathIn
-    let filenameArray: string array = System.IO.Directory.GetFiles(path)
+    let filenameArray: string array = System.IO.Directory.GetFiles (path)
     member this.FileArray = Array.map (fun elem -> new File(elem, this)) filenameArray
 
 and File(filename: string, containingFolder: Folder) =
@@ -278,7 +278,7 @@ let ``should keep parens in class inheritance in the right place``() =
     class
         inherit DGMLClass()
 
-        let functions = System.Collections.Generic.Dictionary<string, IState>()
+        let functions = System.Collections.Generic.Dictionary<string, IState> ()
     end
 """
 
@@ -362,7 +362,7 @@ System.String.Concat("a", "b" +
     member __.Property = "hello"
 
 let longNamedFunlongNamedFunlongNamedFunlongNamedFunlongNamedFun (x: T) = x
-let longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClass = T()
+let longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClass = T ()
 
 System.String.Concat
     ("a",
@@ -381,5 +381,5 @@ type Exception with
     |> should equal """open System
 
 type Exception with
-    member inline __.FirstLine = __.Message.Split([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries).[0]
+    member inline __.FirstLine = __.Message.Split ([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries).[0]
 """

--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -38,12 +38,12 @@ let print_30_permut() =
     """ config
     |> prepend newline
     |> should equal """
-let print_30_permut() =
+let print_30_permut () =
 
     /// declare and initialize
     let permutation: int array =
         Array.init n (fun i ->
-            Console.Write(i + 1)
+            Console.Write (i + 1)
             i)
     permutation
 """
@@ -59,12 +59,12 @@ let print_30_permut() =
     """ config
     |> prepend newline
     |> should equal """
-let print_30_permut() =
+let print_30_permut () =
 
     /// declare and initialize
     let permutation: int array =
         Array.init n (fun (i, j) ->
-            Console.Write(i + 1)
+            Console.Write (i + 1)
             i)
     permutation
 """
@@ -120,7 +120,7 @@ let f() =
 """  config
     |> prepend newline
     |> should equal """
-let f() =
+let f () =
     // COMMENT
     x + x
 """
@@ -134,7 +134,7 @@ let f() =
 """   config
     |> prepend newline
     |> should equal """
-let f() =
+let f () =
     let x = 1 // COMMENT
     x + x
 """ 
@@ -156,7 +156,7 @@ let f() =
     |> should equal """
 /// XML COMMENT
 // Other comment
-let f() =
+let f () =
     // COMMENT A
     let y = 1
     (* COMMENT B *)
@@ -182,7 +182,7 @@ let f() =
     |> should equal """
 /// XML COMMENT A
 // Other comment
-let f() =
+let f () =
     // COMMENT A
     let y = 1
     /// XML COMMENT B
@@ -377,7 +377,7 @@ let hello() = "hello world"
 """  config
     |> prepend newline
     |> should equal """
-let hello() = "hello world"
+let hello () = "hello world"
 
 (* This is a comment. *)
 """
@@ -641,7 +641,7 @@ type substring =
     /// <param name="strA">The first string to compare.</param>
     /// <param name="strB">The second string to compare.</param>
     /// <returns>An integer that indicates the lexical relationship between the two comparands.</returns>
-    static member CompareOrdinal(strA: substring, strB: substring) =
+    static member CompareOrdinal (strA: substring, strB: substring) =
         // If both substrings are empty they are considered equal, regardless of their offset or underlying string.
         if strA.Length = 0 && strB.Length = 0 then 0
         elif

--- a/src/Fantomas.Tests/ComparisonTests.fs
+++ b/src/Fantomas.Tests/ComparisonTests.fs
@@ -17,17 +17,17 @@ let ``should keep the = on the same line in record def``() =
     """ config
     |> should equal """type UnionTypeConverter() =
     inherit JsonConverter()
-    let doRead (reader: JsonReader) = reader.Read() |> ignore
-    override x.CanConvert(typ: Type) =
+    let doRead (reader: JsonReader) = reader.Read () |> ignore
+    override x.CanConvert (typ: Type) =
         let result =
-            ((typ.GetInterface(typeof<System.Collections.IEnumerable>.FullName) = null) && FSharpType.IsUnion typ)
+            ((typ.GetInterface (typeof<System.Collections.IEnumerable>.FullName) = null) && FSharpType.IsUnion typ)
         result
 """
 
 // the current behavior results in a compile error since the = is moved to the next line and not correctly indented
 [<Test>]
 let ``should keep the = on the same line``() =
-    formatSourceString false """trimSpecialChars(controller.ServerName.ToUpper()) = trimSpecialChars(serverFilter.ToUpper())
+    formatSourceString false """trimSpecialChars(controller.ServerName.ToUpper ()) = trimSpecialChars(serverFilter.ToUpper ())
     """ config
-    |> should equal """trimSpecialChars (controller.ServerName.ToUpper()) = trimSpecialChars (serverFilter.ToUpper())
+    |> should equal """trimSpecialChars (controller.ServerName.ToUpper ()) = trimSpecialChars (serverFilter.ToUpper ())
 """

--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -89,12 +89,12 @@ let ``line, file and path identifiers``() =
     """ config
     |> prepend newline
     |> should equal """
-let printSourceLocation() =
+let printSourceLocation () =
     printfn "Line: %s" __LINE__
     printfn "Source Directory: %s" __SOURCE_DIRECTORY__
     printfn "Source File: %s" __SOURCE_FILE__
 
-printSourceLocation()
+printSourceLocation ()
 """
 
 [<Test>]
@@ -170,7 +170,7 @@ let [<Literal>] private assemblyConfig() =
     |> prepend newline
     |> should equal """
 [<Literal>]
-let private assemblyConfig() =
+let private assemblyConfig () =
 #if TRACE
     let x = ""
 #else
@@ -341,7 +341,7 @@ let start (args: IArgs) =
     // Serilog configuration
     Log.Logger <-
         LoggerConfiguration().MinimumLevel.Debug().MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-            .Enrich.FromLogContext().WriteTo.Console().WriteTo.File(Path.Combine(args.ContentRoot, "temp/log.txt"))
+            .Enrich.FromLogContext().WriteTo.Console().WriteTo.File(Path.Combine (args.ContentRoot, "temp/log.txt"))
             .CreateLogger()
 
     try
@@ -355,10 +355,10 @@ let start (args: IArgs) =
                    .ConfigureServices(configureServices args).Build().Run()
             0
         with ex ->
-            Log.Fatal(ex, "Host terminated unexpectedly")
+            Log.Fatal (ex, "Host terminated unexpectedly")
             1
     finally
-        Log.CloseAndFlush()
+        Log.CloseAndFlush ()
 """
 
 [<Test>]
@@ -450,7 +450,7 @@ type FunctionComponent =
     /// Creates a lazy React component from a function in another file
     /// ATTENTION: Requires fable-compiler 2.3, pass the external reference
     /// directly to the argument position (avoid pipes)
-    static member inline Lazy(f: 'Props -> ReactElement, fallback: ReactElement): LazyFunctionComponent<'Props> =
+    static member inline Lazy (f: 'Props -> ReactElement, fallback: ReactElement): LazyFunctionComponent<'Props> =
 #if FABLE_COMPILER
         let elemType =
             ReactBindings.React.``lazy`` (fun () ->
@@ -587,7 +587,7 @@ type FunctionComponent =
     /// Creates a lazy React component from a function in another file
     /// ATTENTION: Requires fable-compiler 2.3, pass the external reference
     /// directly to the argument position (avoid pipes)
-    static member inline Lazy(f: 'Props -> ReactElement, fallback: ReactElement): LazyFunctionComponent<'Props> =
+    static member inline Lazy (f: 'Props -> ReactElement, fallback: ReactElement): LazyFunctionComponent<'Props> =
 #if FABLE_COMPILER
 
 
@@ -654,7 +654,7 @@ type FunctionComponent =
     /// Creates a lazy React component from a function in another file
     /// ATTENTION: Requires fable-compiler 2.3, pass the external reference
     /// directly to the argument position (avoid pipes)
-    static member inline Lazy(f: 'Props -> ReactElement, fallback: ReactElement): LazyFunctionComponent<'Props> =
+    static member inline Lazy (f: 'Props -> ReactElement, fallback: ReactElement): LazyFunctionComponent<'Props> =
 #if FABLE_COMPILER
         let elemType =
             ReactBindings.React.``lazy`` (fun () ->

--- a/src/Fantomas.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Tests/ComputationExpressionTests.fs
@@ -26,7 +26,7 @@ let fetchAsync (name, url: string) =
         try
             let uri = new System.Uri(url)
             let webClient = new WebClient()
-            let! html = webClient.AsyncDownloadString(uri)
+            let! html = webClient.AsyncDownloadString (uri)
             printfn "Read %d characters for %s" html.Length name
         with
         | :? Exception -> ()
@@ -78,7 +78,7 @@ let s2 = seq { 0 .. 10 .. 100 }
 let rec inorder tree =
     seq {
         match tree with
-        | Tree(x, left, right) ->
+        | Tree (x, left, right) ->
             yield! inorder left
             yield x
             yield! inorder right
@@ -108,7 +108,7 @@ async {
     |> prepend newline
     |> should equal """
 async {
-    match! myAsyncFunction() with
+    match! myAsyncFunction () with
     | Some x -> printfn "%A" x
     | None -> printfn "Function returned None!"
 }

--- a/src/Fantomas.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Tests/ControlStructureTests.fs
@@ -54,12 +54,12 @@ let ``for loops``() =
     """ config
     |> prepend newline
     |> should equal """
-let function1() =
+let function1 () =
     for i = 1 to 10 do
         printf "%d " i
     printfn ""
 
-let function2() =
+let function2 () =
     for i = 10 downto 1 do
         printf "%d " i
     printfn ""
@@ -87,7 +87,7 @@ let lookForValue value maxValue =
     let mutable continueLooping = true
     let randomNumberGenerator = new Random()
     while continueLooping do
-        let rand = randomNumberGenerator.Next(maxValue)
+        let rand = randomNumberGenerator.Next (maxValue)
         printf "%d " rand
         if rand = value then
             printfn "\nFound a %d!" value
@@ -142,7 +142,7 @@ let function1 x y =
             else raise (OuterError("outer"))
         with
         | Failure _ -> ()
-        | InnerError(str) -> printfn "Error1 %s" str
+        | InnerError (str) -> printfn "Error1 %s" str
     finally
         printfn "Always print this."
 """
@@ -157,12 +157,12 @@ let ``range expressions``() =
     function2()""" config
     |> prepend newline
     |> should equal """
-let function2() =
+let function2 () =
     for i in 1 .. 2 .. 10 do
         printf "%d " i
     printfn ""
 
-function2()
+function2 ()
 """
 
 [<Test>]
@@ -175,8 +175,8 @@ let ``use binding``() =
     |> prepend newline
     |> should equal """
 let writetofile filename obj =
-    use file1 = File.CreateText(filename)
-    file1.WriteLine("{0}", obj.ToString())
+    use file1 = File.CreateText (filename)
+    file1.WriteLine ("{0}", obj.ToString ())
 """
 
 [<Test>]
@@ -235,8 +235,8 @@ global.Test()
     """ config
     |> prepend newline
     |> should equal """
-base.Initializer()
-global.Test()
+base.Initializer ()
+global.Test ()
 """
 
 [<Test>]
@@ -433,11 +433,11 @@ let a ex =
     |> should equal """
 let a ex =
     if null = ex then
-        fooo()
+        fooo ()
         None
     elif
         // this was None
-        ex.GetType() = typeof<obj> then
+        ex.GetType () = typeof<obj> then
         Some ex
     else
         None

--- a/src/Fantomas.Tests/DataStructureTests.fs
+++ b/src/Fantomas.Tests/DataStructureTests.fs
@@ -1389,9 +1389,9 @@ analysisKey.Headers.Item(key) <- value
 
 [<Test>]
 let ``DotNamedIndexedPropertySet`` () =
-    formatSourceString false """(foo()).Item(key) <- value
+    formatSourceString false """(foo ()).Item (key) <- value
 """  config
     |> prepend newline
     |> should equal """
-(foo()).Item(key) <- value
+(foo ()).Item(key) <- value
 """

--- a/src/Fantomas.Tests/FormattingSelectionOnlyTests.fs
+++ b/src/Fantomas.Tests/FormattingSelectionOnlyTests.fs
@@ -102,7 +102,7 @@ type T () =
   override x.Reorder () = 
         items |> List.iter ignore
 """     config
-    |> should equal """  override x.Reorder() = items |> List.iter ignore"""
+    |> should equal """  override x.Reorder () = items |> List.iter ignore"""
 
 [<Test>]
 let ``should format the and branch of recursive functions``() =

--- a/src/Fantomas.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Tests/FunctionDefinitionTests.fs
@@ -65,21 +65,21 @@ let ``should keep mutually recursive functions in nested function``() =
 let ``should keep identifiers with whitespace in double backticks``() =
     formatSourceString false """let ``should keep identifiers in double backticks``() = x
     """ config
-    |> should equal """let ``should keep identifiers in double backticks``() = x
+    |> should equal """let ``should keep identifiers in double backticks`` () = x
 """
 
 [<Test>]
 let ``should remove backticks from shouldn't identifier``() =
     formatSourceString false """let ``shouldn't``() = x
     """ config
-    |> should equal """let shouldn't() = x
+    |> should equal """let shouldn't () = x
 """
 
 [<Test>]
 let ``should keep identifiers with + in double backticks``() =
     formatSourceString false """let ``Foo+Bar``() = x
     """ config
-    |> should equal """let ``Foo+Bar``() = x
+    |> should equal """let ``Foo+Bar`` () = x
 """
 
 [<Test>]
@@ -98,15 +98,15 @@ let ``let bindings with return types``() =
     |> prepend newline
     |> should equal """
 let divide x y =
-    let stream: System.IO.FileStream = System.IO.File.Create("test.txt")
+    let stream: System.IO.FileStream = System.IO.File.Create ("test.txt")
     let writer: System.IO.StreamWriter = new System.IO.StreamWriter(stream)
     try
-        writer.WriteLine("test1")
+        writer.WriteLine ("test1")
         Some(x / y)
     finally
-        writer.Flush()
+        writer.Flush ()
         printfn "Closing stream"
-        stream.Close()
+        stream.Close ()
 """
 
 [<Test>]
@@ -271,7 +271,7 @@ type U = X of int
 let f =
     fun x ->
         match x with
-        | X(x) -> x
+        | X (x) -> x
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/InterfaceTests.fs
+++ b/src/Fantomas.Tests/InterfaceTests.fs
@@ -24,7 +24,7 @@ type IPrintable =
 
 type SomeClass1(x: int, y: float) =
     interface IPrintable with
-        member this.Print() = printfn "%d %f" x y
+        member this.Print () = printfn "%d %f" x y
 
 type Interface3 =
     inherit Interface1
@@ -38,15 +38,15 @@ let ``should not add with to interface definitions with no members``() =
     interface IDocument
         
     interface Infrastucture with
-        member this.Serialize sb = sb.AppendFormat("\"{0}\"", escape v)
+        member this.Serialize sb = sb.AppendFormat ("\"{0}\"", escape v)
         member this.ToXml() = v :> obj
     """ config
     |> should equal """type Text(text: string) =
     interface IDocument
 
     interface Infrastucture with
-        member this.Serialize sb = sb.AppendFormat("\"{0}\"", escape v)
-        member this.ToXml() = v :> obj
+        member this.Serialize sb = sb.AppendFormat ("\"{0}\"", escape v)
+        member this.ToXml () = v :> obj
 """
 
 [<Test>]
@@ -56,7 +56,7 @@ let ``object expressions``() =
     |> should equal """
 let obj1 =
     { new System.Object() with
-        member x.ToString() = "F#" }
+        member x.ToString () = "F#" }
 """
 
 [<Test>]
@@ -71,13 +71,13 @@ let ``object expressions and interfaces``() =
             member this.G() = () }""" config
     |> prepend newline
     |> should equal """
-let implementer() =
+let implementer () =
     { new ISecond with
-        member this.H() = ()
-        member this.J() = ()
+        member this.H () = ()
+        member this.J () = ()
       interface IFirst with
-          member this.F() = ()
-          member this.G() = () }
+          member this.F () = ()
+          member this.G () = () }
 """
 
 [<Test>]
@@ -91,12 +91,12 @@ let f () =
         member x.GetEnumerator() = null }""" config
     |> prepend newline
     |> should equal """
-let f() =
+let f () =
     { new obj() with
-        member x.ToString() = "INotifyEnumerableInternal"
+        member x.ToString () = "INotifyEnumerableInternal"
       interface INotifyEnumerableInternal<'T>
       interface IEnumerable<_> with
-          member x.GetEnumerator() = null }
+          member x.GetEnumerator () = null }
 """
 
 [<Test>]
@@ -130,7 +130,7 @@ open System
 
 type T() =
     interface IDisposable with
-        override x.Dispose() = ()
+        override x.Dispose () = ()
 """
 
 [<Test>]
@@ -167,8 +167,8 @@ type MyLogInteface() =
             if environment = "DEV" then "dev.log"
             else sprintf "date-%s.log" environment
 
-        member x.Info() = ()
-        override x.Version() = ()
+        member x.Info () = ()
+        override x.Version () = ()
 """
 
 

--- a/src/Fantomas.Tests/KeepNewlineAfterTests.fs
+++ b/src/Fantomas.Tests/KeepNewlineAfterTests.fs
@@ -91,7 +91,7 @@ let start (args: IArgs) =
             .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
             .Enrich.FromLogContext()
             .WriteTo.Console()
-            .WriteTo.File(Path.Combine(args.ContentRoot, "temp/log.txt"))
+            .WriteTo.File(Path.Combine (args.ContentRoot, "temp/log.txt"))
             .CreateLogger()
 
     try
@@ -105,10 +105,10 @@ let start (args: IArgs) =
                    .ConfigureServices(configureServices args).Build().Run()
             0
         with ex ->
-            Log.Fatal(ex, "Host terminated unexpectedly")
+            Log.Fatal (ex, "Host terminated unexpectedly")
             1
     finally
-        Log.CloseAndFlush()
+        Log.CloseAndFlush ()
 """
 
 

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -20,7 +20,7 @@ let f () =
 """
 
     formatSourceString false codeSnippet config
-    |> should equal """let f() =
+    |> should equal """let f () =
     let x = 1 // the "in" keyword is available in F#
     let y = 2
     x + y
@@ -36,7 +36,7 @@ let f () =
 """
 
     formatSourceString false codeSnippet config
-    |> should equal """let f() =
+    |> should equal """let f () =
     let x = 1 (* the "in" keyword is available in F# *)
     let y = 2
     x + y
@@ -52,7 +52,7 @@ let f () =
 """
 
     formatSourceString false codeSnippet config
-    |> should equal """let f() =
+    |> should equal """let f () =
     let x = 1
     if true then x
     else x
@@ -67,7 +67,7 @@ let f () =
 """
 
     formatSourceString false codeSnippet config
-    |> should equal """let f() =
+    |> should equal """let f () =
     let x = 1
     (while true do
         ()
@@ -239,7 +239,7 @@ let ``inner let binding should not add additional newline, #475`` () =
     |> prepend newline
     |> should equal "
 module Test =
-    let testFunc() =
+    let testFunc () =
         let someObject =
             someStaticObject.Create
                 (((fun o ->
@@ -288,7 +288,7 @@ let ``newline trivia before simple sequence doesn't force remaining to get offse
     q
     b
 """  config
-    |> should equal """let a() =
+    |> should equal """let a () =
     let q = 1
 
     q
@@ -304,7 +304,7 @@ let ``comment trivia before simple sequence doesn't force remaining to get offse
     q
     b
 """  config
-    |> should equal """let a() =
+    |> should equal """let a () =
     let q = 1
     // comment
     q

--- a/src/Fantomas.Tests/LongIdentWithDotsTests.fs
+++ b/src/Fantomas.Tests/LongIdentWithDotsTests.fs
@@ -103,9 +103,9 @@ module Program
 let main _ =
     try
         try
-            Config.Logger.configure()
+            Config.Logger.configure ()
 
-            let config = ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory()).Build()
+            let config = ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory ()).Build()
 
             WebHostBuilder().UseConfiguration(config).UseKestrel().UseSerilog()
                 .ConfigureAppConfiguration
@@ -115,9 +115,9 @@ let main _ =
 
             0
         with ex ->
-            Log.Fatal(ex, "Service terminated unexpectedly")
+            Log.Fatal (ex, "Service terminated unexpectedly")
 
             1
     finally
-        Log.CloseAndFlush()
+        Log.CloseAndFlush ()
 """

--- a/src/Fantomas.Tests/ModuleTests.fs
+++ b/src/Fantomas.Tests/ModuleTests.fs
@@ -230,7 +230,7 @@ type SomeType() =
 namespace global
 
 type SomeType() =
-    member this.Print() = global.System.Console.WriteLine("Hello World!")
+    member this.Print () = global.System.Console.WriteLine ("Hello World!")
 """
 
 [<Test>]
@@ -251,7 +251,7 @@ module ``member``
 let ``abstract`` = "abstract"
 
 type SomeType() =
-    member this.``new``() = System.Console.WriteLine("Hello World!")
+    member this.``new`` () = System.Console.WriteLine ("Hello World!")
 """
 
 [<Test>]
@@ -327,7 +327,7 @@ type T() =
 
 type T() =
     interface IDisposable with
-        override x.Dispose() = ()
+        override x.Dispose () = ()
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/NoTrailingSpacesTests.fs
+++ b/src/Fantomas.Tests/NoTrailingSpacesTests.fs
@@ -13,7 +13,7 @@ let ``should not confuse me with an extra space at end of line v2``() =
     |> should throw typeof<Argu.ArguParseException>"""
 
     formatSourceString false codeSnippet config
-    |> should equal """let ``should not extrude without positive distance``() =
+    |> should equal """let ``should not extrude without positive distance`` () =
     let args = [| "-i"; "input.dxf"; "-o"; "output.pdf"; "--op"; "extrude" |]
     (fun () -> parseCmdLine args |> ignore) |> should throw typeof<Argu.ArguParseException>
 """

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -66,7 +66,7 @@ let ``should keep parens around inlined ==> operator definition``() =
 let ``should keep parens around inlined operator definition``() =
     formatSourceString false """let inline (@@) path1 path2 = Path.Combine(path1, path2)
     """ config
-    |> should equal """let inline (@@) path1 path2 = Path.Combine(path1, path2)
+    |> should equal """let inline (@@) path1 path2 = Path.Combine (path1, path2)
 """
 
 [<Test>]
@@ -143,9 +143,9 @@ let ``should understand ? as an infix operator``() =
     |> fun (t : Task) -> t.Wait()
 with _ -> ()""" config
     |> should equal """try
-    item.MethodInfo.Method.Invoke(null, ipa)
+    item.MethodInfo.Method.Invoke (null, ipa)
     |> (fun x -> x?Invoke (true))
-    |> fun (t: Task) -> t.Wait()
+    |> fun (t: Task) -> t.Wait ()
 with _ -> ()
 """
 

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -152,14 +152,14 @@ let detect1 x =
     | 1 -> printfn "Found a 1!"
     | (var1: int) -> printfn "%d" var1
 
-let RegisterControl(control: Control) =
+let RegisterControl (control: Control) =
     match control with
     | :? Button as button -> button.Text <- "Registered."
     | :? CheckBox as checkbox -> checkbox.Text <- "Registered."
     | _ -> ()
 
-let ReadFromFile(reader: System.IO.StreamReader) =
-    match reader.ReadLine() with
+let ReadFromFile (reader: System.IO.StreamReader) =
+    match reader.ReadLine () with
     | null ->
         printfn "\n"
         false
@@ -270,7 +270,7 @@ let x =
     |> should equal """
 let x =
     match y with
-    | Start(-1) -> true
+    | Start (-1) -> true
     | _ -> false
 """
 
@@ -373,11 +373,11 @@ let (|OneLinerBinding|MultilineBinding|) b =
     |> should equal """
 let (|OneLinerBinding|MultilineBinding|) b =
     match b with
-    | LetBinding([], PreXmlDoc [||], _, _, _, _, OneLinerExpr _)
-    | DoBinding([], PreXmlDoc [||], OneLinerExpr _)
-    | MemberBinding([], PreXmlDoc [||], _, _, _, _, OneLinerExpr _)
-    | PropertyBinding([], PreXmlDoc [||], _, _, _, _, OneLinerExpr _)
-    | ExplicitCtor([], PreXmlDoc [||], _, _, OneLinerExpr _, _) -> OneLinerBinding b
+    | LetBinding ([], PreXmlDoc [||], _, _, _, _, OneLinerExpr _)
+    | DoBinding ([], PreXmlDoc [||], OneLinerExpr _)
+    | MemberBinding ([], PreXmlDoc [||], _, _, _, _, OneLinerExpr _)
+    | PropertyBinding ([], PreXmlDoc [||], _, _, _, _, OneLinerExpr _)
+    | ExplicitCtor ([], PreXmlDoc [||], _, _, OneLinerExpr _, _) -> OneLinerBinding b
 
     | _ -> MultilineBinding b
 """
@@ -441,11 +441,11 @@ let internal ImageLoadResilient (f: unit -> 'a) (tidy: unit -> 'a) =
     |> should equal """
 let internal ImageLoadResilient (f: unit -> 'a) (tidy: unit -> 'a) =
     try
-        f()
+        f ()
     with
     | :? BadImageFormatException
     | :? ArgumentException
-    | :? IOException -> tidy()
+    | :? IOException -> tidy ()
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/PipingTests.fs
+++ b/src/Fantomas.Tests/PipingTests.fs
@@ -54,7 +54,7 @@ let runAll() =
     |> Async.RunSynchronously |> ignore""" config
     |> prepend newline
     |> should equal """
-let runAll() =
+let runAll () =
     urlList
     |> Seq.map fetchAsync
     |> Async.Parallel

--- a/src/Fantomas.Tests/QuotationTests.fs
+++ b/src/Fantomas.Tests/QuotationTests.fs
@@ -26,5 +26,5 @@ let ``untyped quotations``() =
 [<Test>]
 let ``should preserve unit literal``() =
     shouldNotChangeAfterFormat """
-let logger = Mock<ILogger>().Setup(fun log -> <@ log.Log(error) @>).Returns(()).Create()
+let logger = Mock<ILogger>().Setup (fun log -> <@ log.Log(error) @>).Returns (()).Create ()
 """

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -147,7 +147,7 @@ let ``should not break inside of if statements in records``() =
     }
 
     """ { config with SemicolonAtEndOfLine = true }
-    |> should equal """let XpkgDefaults() =
+    |> should equal """let XpkgDefaults () =
     { ToolPath = "./tools/xpkg/xpkg.exe";
       WorkingDir = "./";
       TimeOut = TimeSpan.FromMinutes 5.;
@@ -205,9 +205,9 @@ type rate2 = Rate of float<GBP / SGD * USD>
 let ``should keep comments on records``() =
     shouldNotChangeAfterFormat """
 let newDocument = //somecomment
-    { program = Encoding.Default.GetBytes(document.Program) |> Encoding.UTF8.GetString
-      content = Encoding.Default.GetBytes(document.Content) |> Encoding.UTF8.GetString
-      created = document.Created.ToLocalTime() }
+    { program = Encoding.Default.GetBytes (document.Program) |> Encoding.UTF8.GetString
+      content = Encoding.Default.GetBytes (document.Content) |> Encoding.UTF8.GetString
+      created = document.Created.ToLocalTime () }
     |> JsonConvert.SerializeObject
 """
 
@@ -374,7 +374,7 @@ I wanted to know why you created Fable. Did you always plan to use F#? Or were y
     |> fun formatted -> formatted
     |> should equal "type Database =
 
-    static member Default() =
+    static member Default () =
         Database.Lowdb.defaults({ Version = CurrentVersion
                                   Questions =
                                       [| { Id = 0
@@ -558,7 +558,7 @@ open WebSharper.UI
 
 module Maintoc =
     let Page =
-        { MyPage.Create() with
+        { MyPage.Create () with
               body =
                   [ Doc.Verbatim \"\"\"
 This is a very long line in a multi-line string, so long in fact that it is longer than that page width to which I am trying to constrain everything, and so it goes bang.

--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -54,7 +54,7 @@ let ``should not add parens in signature``() =
     { Verb: string
       Path: string
       Handler: Map<string, string> -> HttpListenerContext -> string }
-    override x.ToString() = sprintf "%s %s" x.Verb x.Path
+    override x.ToString () = sprintf "%s %s" x.Verb x.Path
 """
 
 [<Test>]
@@ -95,7 +95,7 @@ type A () =
 
 type A() =
     interface IA with
-        member x.F(f: unit -> _) = f()
+        member x.F (f: unit -> _) = f ()
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/StructTests.fs
+++ b/src/Fantomas.Tests/StructTests.fs
@@ -27,9 +27,9 @@ type NameStruct =
         val Name: string
         new(name) = { Name = name }
 
-        member x.Upper() = x.Name.ToUpper()
+        member x.Upper () = x.Name.ToUpper ()
 
-        member x.Lower() = x.Name.ToLower()
+        member x.Lower () = x.Name.ToLower ()
     end
 
 let n = new NameStruct("Hippo")
@@ -59,9 +59,9 @@ type NameStruct =
         new(name) = { Name = name }
     end
 
-    member x.Upper() = x.Name.ToUpper()
+    member x.Upper () = x.Name.ToUpper ()
 
-    member x.Lower() = x.Name.ToLower()
+    member x.Lower () = x.Name.ToLower ()
 
 let n = new NameStruct("Hippo")
 """
@@ -80,7 +80,7 @@ match t with
 type S = S of struct (int * int)
 
 let g: struct (int * int) = struct (1, 1)
-let z = fun ((S(struct (u, v))): S) -> u + v
+let z = fun ((S (struct (u, v))): S) -> u + v
 let t = struct (1, 2)
 
 match t with

--- a/src/Fantomas.Tests/TupleTests.fs
+++ b/src/Fantomas.Tests/TupleTests.fs
@@ -13,7 +13,7 @@ let private carouselSample =
         fragment [] []
     ,"CarouselSample")
 """  config
-    |> should equal """let private carouselSample = FunctionComponent.Of<obj>((fun _ -> fragment [] []), "CarouselSample")
+    |> should equal """let private carouselSample = FunctionComponent.Of<obj> ((fun _ -> fragment [] []), "CarouselSample")
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -18,8 +18,8 @@ exception BuildException of string*list<string>
     override x.ToString() = x.Data0.ToString() + "\r\n" + (separated "\r\n" x.Data1)""" config
     |> should equal """/// An exception type to signal build errors.
 exception BuildException of string * list<string> with
-    override x.ToString() =
-        x.Data0.ToString() + "\r\n" + (separated "\r\n" x.Data1)
+    override x.ToString () =
+        x.Data0.ToString () + "\r\n" + (separated "\r\n" x.Data1)
 """
 
 [<Test>]
@@ -32,11 +32,11 @@ let ``type annotations``() =
     |> prepend newline
     |> should equal """
 let iterate1 (f: unit -> seq<int>) =
-    for e in f() do
+    for e in f () do
         printfn "%d" e
 
 let iterate2 (f: unit -> #seq<int>) =
-    for e in f() do
+    for e in f () do
         printfn "%d" e
 """
 
@@ -93,10 +93,10 @@ type Test() =
     |> prepend newline
     |> should equal """
 type Test() =
-    member this.Function1<'a>(x, y) = printfn "%A, %A" x y
+    member this.Function1<'a> (x, y) = printfn "%A, %A" x y
 
     abstract AbstractMethod<'a, 'b> : 'a * 'b -> unit
-    override this.AbstractMethod<'a, 'b>(x: 'a, y: 'b) = printfn "%A, %A" x y
+    override this.AbstractMethod<'a, 'b> (x: 'a, y: 'b) = printfn "%A, %A" x y
 """
 
 [<Test>]
@@ -109,7 +109,7 @@ type X() =
     |> prepend newline
     |> should equal """
 type X() =
-    member this.F([<ParamArray>] args: Object []) =
+    member this.F ([<ParamArray>] args: Object []) =
         for arg in args do
             printfn "%A" arg
 """
@@ -138,7 +138,7 @@ type public MyClass<'a> public (x, y) as this =
     let mutable z = x + y
 
     do
-        printfn "%s" (this.ToString())
+        printfn "%s" (this.ToString ())
         printfn "more constructor effects"
 
     internal new(a) = MyClass(a, a)
@@ -150,7 +150,7 @@ type public MyClass<'a> public (x, y) as this =
         with get () = z
         and set (a) = z <- a
 
-    member self.Method(a, b) = x + y + z + a + b
+    member self.Method (a, b) = x + y + z + a + b
 """
 
 [<Test>]
@@ -190,13 +190,13 @@ let ``abstract and override keywords``() =
 type MyClassBase1() =
     let mutable z = 0
     abstract Function1: int -> int
-    default u.Function1(a: int) =
+    default u.Function1 (a: int) =
         z <- z + a
         z
 
 type MyClassDerived1() =
     inherit MyClassBase1()
-    override u.Function1(a: int) = a + 1
+    override u.Function1 (a: int) = a + 1
 """
 
 [<Test>]
@@ -210,10 +210,10 @@ type MyClass with
     |> prepend newline
     |> should equal """
 type MyClass() =
-    member this.F() = 100
+    member this.F () = 100
 
 type MyClass with
-    member this.G() = 200
+    member this.G () = 200
 """
 
 [<Test>]
@@ -227,7 +227,7 @@ type System.Int32 with
     |> should equal """
 /// Define a new member method FromString on the type Int32.
 type System.Int32 with
-    member this.FromString(s: string) = System.Int32.Parse(s)
+    member this.FromString (s: string) = System.Int32.Parse (s)
 """
 
 [<Test>]
@@ -312,7 +312,7 @@ type MyType() =
     val mutable myInt2: int
     [<DefaultValue; Test>]
     val mutable myString: string
-    member this.SetValsAndPrint(i: int, str: string) =
+    member this.SetValsAndPrint (i: int, str: string) =
         myInt1 <- i
         this.myInt2 <- i + 1
         this.myString <- str
@@ -331,10 +331,10 @@ let CalculateFine (ticket : SpeedingTicket) =
     |> prepend newline
     |> should equal """
 type SpeedingTicket() =
-    member this.GetMPHOver(speed: int, limit: int) = speed - limit
+    member this.GetMPHOver (speed: int, limit: int) = speed - limit
 
-let CalculateFine(ticket: SpeedingTicket) =
-    let delta = ticket.GetMPHOver(limit = 55, speed = 70)
+let CalculateFine (ticket: SpeedingTicket) =
+    let delta = ticket.GetMPHOver (limit = 55, speed = 70)
     if delta < 20 then 50.0
     else 100.0
 """
@@ -543,8 +543,8 @@ let ``should keep the ? in optional parameters``() =
 
     """ config
     |> should equal """type Shell() =
-    static member private GetParams(cmd, ?args) = doStuff
-    static member Exec(cmd, ?args) = shellExec (Shell.GetParams(cmd, ?args = args))
+    static member private GetParams (cmd, ?args) = doStuff
+    static member Exec (cmd, ?args) = shellExec (Shell.GetParams (cmd, ?args = args))
 """
 
 [<Test>]
@@ -591,7 +591,7 @@ type StateMachine(makeAsync) =
 type StateMachine(makeAsync) =
     new(fileName, makeAsync, initState) as secondCtor =
         new StateMachine(makeAsync)
-        then secondCtor.Init(fileName, initState)
+        then secondCtor.Init (fileName, initState)
 """
 
 [<Test>]
@@ -610,12 +610,12 @@ type BlobHelper(Account : CloudStorageAccount) =
     |> should equal """
 type BlobHelper(Account: CloudStorageAccount) =
     new(configurationSettingName, hostedService) =
-        CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettingPublisher ->
+        CloudStorageAccount.SetConfigurationSettingPublisher (fun configName configSettingPublisher ->
             let connectionString =
-                if hostedService then RoleEnvironment.GetConfigurationSettingValue(configName)
+                if hostedService then RoleEnvironment.GetConfigurationSettingValue (configName)
                 else ConfigurationManager.ConnectionStrings.[configName].ConnectionString
-            configSettingPublisher.Invoke(connectionString) |> ignore)
-        BlobHelper(CloudStorageAccount.FromConfigurationSetting(configurationSettingName))
+            configSettingPublisher.Invoke (connectionString) |> ignore)
+        BlobHelper(CloudStorageAccount.FromConfigurationSetting (configurationSettingName))
 """
 
 [<Test>]
@@ -716,8 +716,8 @@ type A() =
     override this.Address
         with set v =
             let x =
-                match _kbytes.GetAddress(8) with
-                | Some(x) -> x
+                match _kbytes.GetAddress (8) with
+                | Some (x) -> x
                 | None -> null
             ignore x
 """
@@ -750,7 +750,7 @@ type Bar =
     member this.Item
         with get(i : string) = 
             match mo with
-            | Some(m) when m.Groups.[i].Success -> m.Groups.[i].Value
+            | Some (m) when m.Groups.[i].Success -> m.Groups.[i].Value
             | _ -> null""" config
     |> prepend newline
     |> should equal """
@@ -759,13 +759,13 @@ type Bar =
     member this.Item
         with get (i: int) =
             match mo with
-            | Some(m) when m.Groups.[i].Success -> m.Groups.[i].Value
+            | Some (m) when m.Groups.[i].Success -> m.Groups.[i].Value
             | _ -> null
 
     member this.Item
         with get (i: string) =
             match mo with
-            | Some(m) when m.Groups.[i].Success -> m.Groups.[i].Value
+            | Some (m) when m.Groups.[i].Success -> m.Groups.[i].Value
             | _ -> null
 """
 
@@ -867,7 +867,7 @@ let ``operator in words in member`` () =
     formatSourceString false """type A() =
     member this.B(op_Inequality : string) = ()""" config
     |> should equal """type A() =
-    member this.B(op_Inequality: string) = ()
+    member this.B (op_Inequality: string) = ()
 """
 
 [<Test>]
@@ -888,10 +888,10 @@ type TestExtensions =
 type TestExtensions =
 
     [<Extension>]
-    static member SomeExtension(x) = ""
+    static member SomeExtension (x) = ""
 
     [<Extension>]
-    static member SomeOtherExtension(x) = ""
+    static member SomeOtherExtension (x) = ""
 """
 
 [<Test>]
@@ -903,7 +903,7 @@ type C'() =
     |> prepend newline
     |> should equal """
 type C'() =
-    member _.M() = ()
+    member _.M () = ()
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/TypeProviderTests.fs
+++ b/src/Fantomas.Tests/TypeProviderTests.fs
@@ -41,25 +41,25 @@ let ``should handle lines with more than 512 characters``() =
     |> should equal """
 (new CsvFile<string * decimal * decimal>(new Func<obj, string [], string * decimal * decimal>(fun (parent: obj) (row: string []) ->
                                          CommonRuntime.GetNonOptionalValue
-                                             ("Name", CommonRuntime.ConvertString(TextConversions.AsOption(row.[0])),
-                                              TextConversions.AsOption(row.[0])),
+                                             ("Name", CommonRuntime.ConvertString (TextConversions.AsOption (row.[0])),
+                                              TextConversions.AsOption (row.[0])),
                                          CommonRuntime.GetNonOptionalValue
                                              ("Distance",
-                                              CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[1])),
-                                              TextConversions.AsOption(row.[1])),
+                                              CommonRuntime.ConvertDecimal ("", TextConversions.AsOption (row.[1])),
+                                              TextConversions.AsOption (row.[1])),
                                          CommonRuntime.GetNonOptionalValue
                                              ("Time",
-                                              CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[2])),
-                                              TextConversions.AsOption(row.[2]))),
+                                              CommonRuntime.ConvertDecimal ("", TextConversions.AsOption (row.[2])),
+                                              TextConversions.AsOption (row.[2]))),
                                          new Func<string * decimal * decimal, string []>(fun (row: string * decimal * decimal) ->
                                          [| CommonRuntime.ConvertStringBack
-                                             (CommonRuntime.GetOptionalValue((let x, _, _ = row in x)))
+                                             (CommonRuntime.GetOptionalValue ((let x, _, _ = row in x)))
                                             CommonRuntime.ConvertDecimalBack
                                                 ("",
-                                                 CommonRuntime.GetOptionalValue((let _, x, _ = row in x)))
+                                                 CommonRuntime.GetOptionalValue ((let _, x, _ = row in x)))
                                             CommonRuntime.ConvertDecimalBack
                                                 ("",
-                                                 CommonRuntime.GetOptionalValue((let _, _, x = row in x))) |]),
+                                                 CommonRuntime.GetOptionalValue ((let _, _, x = row in x))) |]),
                                          (ProviderFileSystem.readTextAtRunTimeWithDesignTimeOptions
                                              @"C:\Dev\FSharp.Data-master\src\..\tests\FSharp.Data.Tests\Data" ""
                                               "SmallTest.csv"), "", '"', true, false)).Cache()

--- a/src/Fantomas.Tests/UnionTests.fs
+++ b/src/Fantomas.Tests/UnionTests.fs
@@ -34,7 +34,7 @@ type uColor =
     | Green = 1u
     | Blue = 2u
 
-let col3 = Microsoft.FSharp.Core.LanguagePrimitives.EnumOfValue<uint32, uColor>(2u)
+let col3 = Microsoft.FSharp.Core.LanguagePrimitives.EnumOfValue<uint32, uColor> (2u)
 """
 
 [<Test>]
@@ -55,11 +55,11 @@ type Type =
     | TyLam of Type * Type
     | TyVar of string
     | TyCon of string * Type list
-    override this.ToString() =
+    override this.ToString () =
         match this with
-        | TyLam(t1, t2) -> sprintf "(%s -> %s)" (t1.ToString()) (t2.ToString())
+        | TyLam (t1, t2) -> sprintf "(%s -> %s)" (t1.ToString ()) (t2.ToString ())
         | TyVar a -> a
-        | TyCon(s, ts) -> s
+        | TyCon (s, ts) -> s
 """
 
 [<Test>]
@@ -141,7 +141,7 @@ type uColor =
     | Green = 1u
     | Blue = 2u
 
-let col3 = Microsoft.FSharp.Core.LanguagePrimitives.EnumOfValue<uint32, uColor>(2u)
+let col3 = Microsoft.FSharp.Core.LanguagePrimitives.EnumOfValue<uint32, uColor> (2u)
 """
 
 [<Test>]
@@ -179,7 +179,7 @@ type CustomerId =
     |> should equal """
 type CustomerId =
     | CustomerId of int
-    member this.Test() = printfn "%A" this
+    member this.Test () = printfn "%A" this
 """
 
 [<Test>]

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -43,11 +43,9 @@ type ASTContext =
 
 let rec addSpaceBeforeParensInFunCall functionOrMethod arg = 
     match functionOrMethod, arg with
-    | _, ConstExpr(Const "()", _) ->
-        false
-    | SynExpr.LongIdent(_, LongIdentWithDots s, _, _), _ ->
-        let parts = s.Split '.'
-        not <| Char.IsUpper parts.[parts.Length - 1].[0]
+    | SynExpr.LongIdent(_, _, _, _), ConstExpr(Const "()", _) ->
+        true
+    | SynExpr.Ident(_), ConstExpr(Const "()", _)
     | SynExpr.Ident(_), SynExpr.Ident(_) ->
         true
     | SynExpr.Ident(Ident s), _ ->
@@ -58,11 +56,8 @@ let rec addSpaceBeforeParensInFunCall functionOrMethod arg =
 
 let addSpaceBeforeParensInFunDef functionOrMethod args =
     match functionOrMethod, args with
-    | _, PatParen (PatConst(Const "()", _)) -> false
     | "new", _ -> false
-    | (s:string), _ -> 
-        let parts = s.Split '.'
-        not <| Char.IsUpper parts.[parts.Length - 1].[0]
+    | (_:string), _ -> true
     | _ -> true
 
 let rec genParsedInput astContext = function


### PR DESCRIPTION
Fixes #554 and #555.

105 tests need adjustment, I suppose I should do that in a separate commit? They're a lot fewer if I change the default.

I looked at a bunch of them and most seem alright, but match patterns are changed too, ie. this: https://github.com/fsprojects/fantomas/blob/cf56baefe5a971fd8726eb65e7234e91d36e346e/src/Fantomas.Tests/ComputationExpressionTests.fs#L62
becomes
```fsharp
          | Tree (x, left, right) ->
```
Is that acceptable?