### PR TITLE
Tool recursive - exclude .fable and node_modules dirs

### DIFF
--- a/src/Fantomas.CoreGlobalTool/Program.fs
+++ b/src/Fantomas.CoreGlobalTool/Program.fs
@@ -71,14 +71,18 @@ type OutputPath =
 
 let extensions = set [| ".fs"; ".fsx"; ".fsi"; ".ml"; ".mli"; |]
 
+let isInExcludedDir (fullPath: string) =
+    set [| "obj"; ".fable"; "node_modules" |]
+    |> Set.map (fun dir -> sprintf "%c%s%c" Path.DirectorySeparatorChar dir Path.DirectorySeparatorChar)
+    |> Set.exists (fun dir -> fullPath.Contains(dir))
+
 let isFSharpFile (s: string) = Set.contains (Path.GetExtension s) extensions
 
 /// Get all appropriate files, either recursively or non-recursively
 let rec allFiles isRec path =
     let searchOption = (if isRec then SearchOption.AllDirectories else SearchOption.TopDirectoryOnly)
-    let obj = sprintf "%cobj%c" Path.DirectorySeparatorChar Path.DirectorySeparatorChar
     Directory.GetFiles(path, "*.*", searchOption)
-    |> Seq.filter (fun f -> isFSharpFile f && not (f.Contains(obj)))
+    |> Seq.filter (fun f -> isFSharpFile f && not (isInExcludedDir f))
 
 /// Format a source string using given config and write to a text writer
 let processSourceString isFsiFile s (tw : Choice<TextWriter, string>) config =


### PR DESCRIPTION
Otherwise fantomas processes unwanted files:

```
...
./.fable/Fable.Elmish.Debugger.3.0.2/debugger.fs has been written.
./.fable/Fable.Elmish.Debugger.3.0.2/Fable.Import.RemoteDev.fs has been written.
...
./node_modules/fable-splitter/tests/allFiles/File1.fs has been written.
./node_modules/fable-splitter/tests/allFiles/File2.fs has been written.
```