### PR TITLE
Consider Trivia Content before multiline members - fixes #569

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -385,7 +385,42 @@ type Exception with
 """
 
 [<Test>]
-let ``No extra new lines between type members, 569``() =
+let ``no extra new lines between interface members, 569``() =
+    let original = """namespace Quartz.Fsharp
+
+module Logging =
+    open Quartz.Logging
+    open System
+
+    //todo: it seems that quartz doesn't use mapped and nested context,
+    //however, check if this is the best implementation for this interface
+    type private QuartzLoggerWrapper(f) =
+        interface ILogProvider with
+
+            member this.OpenMappedContext(_, _) =
+                { new IDisposable with
+                    member this.Dispose() = () }
+
+            member this.OpenNestedContext _ =
+                { new IDisposable with
+                    member this.Dispose() = () }
+
+            member this.GetLogger _name = new Logger(f)
+
+    let SetQuartzLoggingFunction f =
+        let loggerFunction level (func: Func<string>) exc parameters =
+            let wrappedFunction = Helpers.nullValuesToOptions (fun (x: Func<string>) -> (fun () -> x.Invoke())) func
+            let wrappedException = Helpers.nullValuesToOptions id exc
+            f level wrappedFunction wrappedException (parameters |> List.ofArray)
+        LogProvider.SetCurrentLogProvider(QuartzLoggerWrapper(loggerFunction))
+
+    let SetQuartzLogger l = LogProvider.SetCurrentLogProvider(l)
+"""
+
+    formatSourceString false original config |> should equal original
+
+[<Test>]
+let ``no extra new lines between type members, 569``() =
     let original = """type A() =
 
     member this.MemberA =

--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -383,3 +383,18 @@ type Exception with
 type Exception with
     member inline __.FirstLine = __.Message.Split([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries).[0]
 """
+
+[<Test>]
+let ``No extra new lines between type members, 569``() =
+    let original = """type A() =
+
+    member this.MemberA =
+        if true then 0 else 1
+
+    member this.MemberB =
+        if true then 2 else 3
+
+    member this.MemberC = 0
+"""
+
+    formatSourceString false original config |> should equal original

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1939,7 +1939,7 @@ and genMemberDefnList astContext node =
                 let attributes = getRangesFromAttributesFromSynMemberDefinition x
                 sepNln +> sepNlnConsideringTriviaContentBeforeWithAttributes x.Range attributes
 
-        let y =
+        let genYs =
             match ys with
             | [ ] -> sepNone
             | _ -> sepNln +> genMemberDefnList astContext ys
@@ -1948,7 +1948,7 @@ and genMemberDefnList astContext node =
         +> colEx sepMember xs (function
                 | Pair(x1, x2) -> genPropertyWithGetSet astContext (x1, x2)
                 | Single x -> genMemberDefn astContext x) 
-        +> y
+        +> genYs
 
     | OneLinerMemberDefnL(xs, ys) ->
         let sepNlnFirstExpr =

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1950,8 +1950,17 @@ and genMemberDefnList astContext node =
                 sepNlnConsideringTriviaContentBeforeWithAttributes xsh.Range attributes
             | _ -> sepNln
         
+        let sepMember (m:Composite<SynMemberDefn, SynBinding>) =
+            match m with
+            | Pair(x1,_) ->
+                let attributes = getRangesFromAttributesFromSynBinding x1
+                sepNln +> sepNlnConsideringTriviaContentBeforeWithAttributes x1.RangeOfBindingSansRhs attributes
+            | Single x ->
+                let attributes = getRangesFromAttributesFromSynMemberDefinition x
+                sepNln +> sepNlnConsideringTriviaContentBeforeWithAttributes x.Range attributes
+
         sepNln +> sepNlnFirstExpr 
-        +> col (rep 2 sepNln) xs (function
+        +> colEx sepMember xs (function
                 | Pair(x1, x2) -> genPropertyWithGetSet astContext (x1, x2)
                 | Single x -> genMemberDefn astContext x) 
         +> sepNln +> genMemberDefnList astContext ys

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1919,26 +1919,6 @@ and genMemberDefnList astContext node =
             | [] -> col sepNln xs (genMemberDefn astContext) ctx
             | _ -> (col sepNln xs (genMemberDefn astContext) +> rep 2 sepNln +> genMemberDefnList astContext ys) ctx
 
-    | MultilineMemberDefnL(xs, []) ->
-        let sepMember (m:Composite<SynMemberDefn, SynBinding>) =
-            match m with
-            | Pair(x1,_) ->
-                let attributes = getRangesFromAttributesFromSynBinding x1
-                sepNln +> sepNlnConsideringTriviaContentBeforeWithAttributes x1.RangeOfBindingSansRhs attributes
-            | Single x ->
-                let attributes = getRangesFromAttributesFromSynMemberDefinition x
-                sepNln +> sepNlnConsideringTriviaContentBeforeWithAttributes x.Range attributes
-
-        let firstTwoNln =
-            match List.tryHead xs with
-            | Some xsh -> sepMember xsh
-            | None -> rep 2 sepNln
-        
-        firstTwoNln
-        +> colEx sepMember xs (function
-                | Pair(x1, x2) -> genPropertyWithGetSet astContext (x1, x2)
-                | Single x -> genMemberDefn astContext x)
-
     | MultilineMemberDefnL(xs, ys) ->
         let sepNlnFirstExpr =
             match List.tryHead xs with
@@ -1959,11 +1939,16 @@ and genMemberDefnList astContext node =
                 let attributes = getRangesFromAttributesFromSynMemberDefinition x
                 sepNln +> sepNlnConsideringTriviaContentBeforeWithAttributes x.Range attributes
 
+        let y =
+            match ys with
+            | [ ] -> sepNone
+            | _ -> sepNln +> genMemberDefnList astContext ys
+
         sepNln +> sepNlnFirstExpr 
         +> colEx sepMember xs (function
                 | Pair(x1, x2) -> genPropertyWithGetSet astContext (x1, x2)
                 | Single x -> genMemberDefn astContext x) 
-        +> sepNln +> genMemberDefnList astContext ys
+        +> y
 
     | OneLinerMemberDefnL(xs, ys) ->
         let sepNlnFirstExpr =


### PR DESCRIPTION
The pattern matching above uses nested `sepMember` function
to consider Trivia Content. The difference between those
pattern matching cases is that latter one matches on when
there are trailing non-multiline members.
There's some code duplication between those two now, which
I'm happy to refactor - feedback welcome.