### PR TITLE
Preserve newlines within multiline strings.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 3.1.1 - ???
+* Various bug fixes
+
 ### 3.1.0 - 11/2019
 * Fix invalid code generated after multiline string when other expressions exist on same line. [#545](https://github.com/fsprojects/fantomas/issues/545)
 * Fix Trivia before elif generates invalid code due to missing indentation. [#527](https://github.com/fsprojects/fantomas/issues/527)

--- a/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
+++ b/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <ToolCommandName>fantomas</ToolCommandName>
     <PackAsTool>True</PackAsTool>
-    <Version>3.1.0</Version>
+    <Version>3.1.1</Version>
     <AssemblyName>fantomas-tool</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.1.1</Version>
     <NoWarn>FS0988</NoWarn>
     <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -381,9 +381,9 @@ I wanted to know why you created Fable. Did you always plan to use F#? Or were y
                                            Title = \"What is the average wing speed of an unladen swallow?\"
                                            Description = \"\"\"
 Hello, yesterday I saw a flight of swallows and was wondering what their **average wing speed** is?
+
 If you know the answer please share it.
                              \"\"\"
-
                                            Answers =
                                                [| { Id = 0
                                                     CreatedAt = DateTime.Parse \"2017-09-14T19:57:33.103Z\"
@@ -393,7 +393,9 @@ If you know the answer please share it.
 > What do you mean, an African or European Swallow?
 >
 > Monty Python’s: The Holy Grail
+
 Ok I must admit, I use google to search the question and found a post explaining the reference :).
+
 I thought you were asking it seriously, well done.
                                     x\"\"\"          }
                                                   { Id = 1
@@ -402,8 +404,11 @@ I thought you were asking it seriously, well done.
                                                     Score = 1
                                                     Content = \"\"\"
 Maxime,
+
 I believe you found [this blog post](http://www.saratoga.com/how-should-i-know/2013/07/what-is-the-average-air-speed-velocity-of-a-laden-swallow/).
+
 And so Robin, the conclusion of the post is:
+
 > In the end, it’s concluded that the airspeed velocity of a (European) unladen swallow is about 24 miles per hour or 11 meters per second.
                                     \"\"\"           } |]
                                            CreatedAt = DateTime.Parse \"2017-09-14T17:44:28.103Z\" }
@@ -412,9 +417,9 @@ And so Robin, the conclusion of the post is:
                                            Title = \"Why did you create Fable?\"
                                            Description = \"\"\"
 Hello Alfonso,
+
 I wanted to know why you created Fable. Did you always plan to use F#? Or were you thinking in others languages?
                              \"\"\"
-
                                            Answers = [||]
                                            CreatedAt = DateTime.Parse \"2017-09-12T09:27:28.103Z\" } |]
                                   Users =

--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -169,3 +169,21 @@ let ``quotes should be escaped in strict mode`` () =
 """  ({ config with StrictMode = true })
     |> should equal """let formatter = sprintf "%i,\"%s\""
 """
+
+[<Test>]
+let ``empty lines in multi-line string should be preserved, 577`` () =
+    formatSourceString false "
+let x = \"\"\"some
+
+content
+
+with empty lines\"\"\"
+"      config
+    |> prepend newline
+    |> should equal "
+let x = \"\"\"some
+
+content
+
+with empty lines\"\"\"
+"

--- a/src/Fantomas.Tests/TriviaTests.fs
+++ b/src/Fantomas.Tests/TriviaTests.fs
@@ -468,3 +468,47 @@ let ``if keyword should be keyword itself`` () =
          Type = TriviaNodeType.Token({ TokenInfo = { TokenName = "THEN" } }) }] ->
         pass()
     | _ -> fail()
+
+[<Test>]
+let ``string constant with blank lines`` () =
+    let multilineString =
+        "some
+
+content
+
+with empty lines"
+        |> String.normalizeNewLine
+    let source =
+        sprintf "let x = \"%s\"" multilineString
+
+    let trivia =
+        toTrivia source
+        |> List.head
+
+    match trivia with
+    | [{ ContentItself = Some(StringContent(sc))
+         Type = TriviaNodeType.MainNode("SynExpr.Const") }] ->
+        sc == sprintf "\"%s\"" multilineString
+    | _ -> fail()
+
+[<Test>]
+let ``triple quote string constant with blank lines`` () =
+    let multilineString =
+        "some
+
+content
+
+with empty lines"
+        |> String.normalizeNewLine
+    let source =
+        sprintf "let x = \"\"\"%s\"\"\"" multilineString
+
+    let trivia =
+        toTrivia source
+        |> List.head
+
+    match trivia with
+    | [{ ContentItself = Some(StringContent(sc))
+         Type = TriviaNodeType.MainNode("SynExpr.Const") }] ->
+        sc == sprintf "\"\"\"%s\"\"\"" multilineString
+    | _ -> fail()

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -3,7 +3,7 @@
   <Import Project="..\netfx.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>3.1.0</Version>
+    <Version>3.1.1</Version>
     <Description>Source code formatter for F#</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -342,7 +342,11 @@ let rec private getTriviaFromTokensThemSelves (config: FormatConfig) (allTokens:
             stringTokens
             |> List.fold(fun (b: StringBuilder, currentLine) st ->
                 if currentLine <> st.LineNumber then
-                    b.Append("\n").Append(st.Content), st.LineNumber
+                    let delta = st.LineNumber - currentLine
+                    [1..delta]
+                    |> List.iter (fun _ -> b.Append("\n") |> ignore)
+
+                    b.Append(st.Content), st.LineNumber
                 else
                     b.Append(st.Content), st.LineNumber
             ) (builder, head.LineNumber)
@@ -407,7 +411,7 @@ let private createNewLine lineNumber =
     let range = FSharp.Compiler.Range.mkRange "newline" pos pos
     { Item = Newline; Range = range }
 
-let private findEmptyNewlinesInTokens (tokens: Token list) (lineCount) (blockComments: FSharp.Compiler.Range.range list) =
+let private findEmptyNewlinesInTokens (tokens: Token list) (lineCount) (ignoreRanges: FSharp.Compiler.Range.range list) =
     let lastLineWithContent =
         tokens
         |> List.tryFindBack (fun t -> t.TokenInfo.TokenName <> "WHITESPACE")
@@ -417,7 +421,8 @@ let private findEmptyNewlinesInTokens (tokens: Token list) (lineCount) (blockCom
     let completeEmptyLines =
         [1 .. lastLineWithContent]
         |> List.filter (fun line ->
-            not (List.exists (fun t -> t.LineNumber = line) tokens) && not (List.exists (fun (br:FSharp.Compiler.Range.range) -> br.StartLine < line && br.EndLine > line) blockComments)
+            not (List.exists (fun t -> t.LineNumber = line) tokens)
+                 && not (List.exists (fun (br:FSharp.Compiler.Range.range) -> br.StartLine < line && br.EndLine > line) ignoreRanges)
         )
         |> List.map (fun line -> createNewLine line)
 
@@ -432,7 +437,10 @@ let private findEmptyNewlinesInTokens (tokens: Token list) (lineCount) (blockCom
 let getTriviaFromTokens config (tokens: Token list) linesCount =
     let fromTokens = getTriviaFromTokensThemSelves config tokens tokens []
     let blockComments = fromTokens |> List.choose (fun tc -> match tc.Item with | Comment(BlockComment(_)) -> Some tc.Range | _ -> None)
-    let newLines = findEmptyNewlinesInTokens tokens linesCount blockComments
+    let isMultilineString s = String.split StringSplitOptions.None [|"\n"|] s |> (Seq.isEmpty >> not)
+    let multilineStrings = fromTokens |> List.choose (fun tc -> match tc.Item with | StringContent(sc) when (isMultilineString sc) -> Some tc.Range | _ -> None)
+
+    let newLines = findEmptyNewlinesInTokens tokens linesCount (blockComments @ multilineStrings)
 
     fromTokens @ newLines
     |> List.sortBy (fun t -> t.Range.StartLine, t.Range.StartColumn)


### PR DESCRIPTION
Don't accept empty lines in trivia when part of multiline string.
Bump version to 3.1.1.