### PR TITLE
Don't execute genTypeByLookup when StrictMode = true. Fixes #562.

### DIFF
--- a/src/Fantomas.Tests/AttributeTests.fs
+++ b/src/Fantomas.Tests/AttributeTests.fs
@@ -261,3 +261,17 @@ Widget;
 DefaultValue(true)>]
 let foo = ()
 """
+
+[<Test>]
+let ``attribute above extern keyword, 562`` () =
+    formatSourceString false """
+module C =
+  [<DllImport("")>]
+  extern IntPtr f()
+"""  ({ config with StrictMode = true })
+    |> prepend newline
+    |> should equal """
+module C =
+    [<DllImport("")>]
+    extern IntPtr f()
+"""


### PR DESCRIPTION
The same fix will probably be relevant [here](https://github.com/fsprojects/fantomas/blob/d5654e8b91596285ada392f4dff3873662b8c9d9/src/Fantomas/CodePrinter.fs#L2121).
Any idea @jindraivanek how to write a test to verify this?