### PR TITLE
Don't add space when array or list is used inside a chained accessor

### DIFF
--- a/src/Fantomas.Tests/SpecialConstructsTests.fs
+++ b/src/Fantomas.Tests/SpecialConstructsTests.fs
@@ -12,3 +12,27 @@ let inline private retype<'T, 'U> (x : 'T) : 'U = (# "" x : 'U #)""" config
     |> should equal """
 let inline private retype<'T, 'U> (x: 'T): 'U = (# "" x : 'U #)
 """
+
+[<Test>]
+let ``don't add whitespace in chained accessors, 566`` () =
+    formatSourceString false """type F =
+  abstract G : int list -> Map<int, int>
+
+let x : F = { new F with member __.G _ = Map.empty }
+x.G[].TryFind 3
+"""  ({ config with
+          SpaceAfterComma = false
+          SpaceAfterSemicolon = false
+          SpaceAroundDelimiter = false
+          SpaceBeforeArgument = false })
+    |> prepend newline
+    |> should equal """
+type F =
+    abstract G: int list -> Map<int,int>
+
+let x: F =
+    {new F with
+        member __.G _ = Map.empty}
+
+x.G[].TryFind 3
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -977,7 +977,7 @@ and genExpr astContext synExpr =
              (colAutoNlnSkip0 sepNone es (fun ((s,r), e) ->
                 sepNlnIfTriviaBefore r +>
                 ((!- (sprintf ".%s" s) |> genTrivia r) 
-                    +> ifElse (hasParenthesis e) sepNone sepSpace +> genExpr astContext e)
+                    +> ifElse (hasParenthesis e || isArrayOrList e) sepNone sepSpace +> genExpr astContext e)
                 ))
 
     | DotGetApp(e, es) as appNode ->
@@ -1398,7 +1398,7 @@ and genExpr astContext synExpr =
         !- ident +> genExpr astContext e1  -- " <- "  +> genExpr astContext e2
     | DotNamedIndexedPropertySet(e, ident, e1, e2) ->
        genExpr astContext e -- "." -- ident +> genExpr astContext e1 -- " <- "  +> genExpr astContext e2
-    | DotGet(e, (s,_)) -> 
+    | DotGet(e, (s,_)) ->
         let exprF = genExpr { astContext with IsInsideDotGet = true }
         addParenIfAutoNln e exprF -- (sprintf ".%s" s)
     | DotSet(e1, s, e2) -> addParenIfAutoNln e1 (genExpr astContext) -- sprintf ".%s <- " s +> genExpr astContext e2

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -116,6 +116,8 @@ let hasParenthesis = function
     | Tuple _ -> true
     | _ -> false
 
+let isArrayOrList = function | ArrayOrList _ -> true | _ -> false
+
 let hasParenInPat = function
     | PatParen _ -> true
     | _ -> false


### PR DESCRIPTION
Fixes #566