### PR TITLE
Preserve back ticks in enum members

### DIFF
--- a/src/Fantomas.Tests/UnionTests.fs
+++ b/src/Fantomas.Tests/UnionTests.fs
@@ -293,3 +293,14 @@ namespace meh
 
 type DU = | Record
 """
+
+[<Test>]
+let ``enum with back ticks, 626`` () =
+    formatSourceString false """type MyEnum =
+  | ``test-one`` = 0
+"""  config
+    |> prepend newline
+    |> should equal """
+type MyEnum =
+    | ``test-one`` = 0
+"""

--- a/src/Fantomas.Tests/UnionTests.fs
+++ b/src/Fantomas.Tests/UnionTests.fs
@@ -304,3 +304,47 @@ let ``enum with back ticks, 626`` () =
 type MyEnum =
     | ``test-one`` = 0
 """
+
+[<Test>]
+let ``enum with back ticks in signature file`` () =
+    formatSourceString true """namespace foo
+
+type MyEnum =
+  | ``test-one`` = 0
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace foo
+
+type MyEnum =
+    | ``test-one`` = 0
+"""
+
+[<Test>]
+let ``discriminated union with back ticks`` () =
+    formatSourceString false """type MyEnum =
+  | ``test-one`` of int
+  | ``test-two`` of string
+"""  config
+    |> prepend newline
+    |> should equal """
+type MyEnum =
+    | ``test-one`` of int
+    | ``test-two`` of string
+"""
+
+[<Test>]
+let ``discriminated union with back ticks in signature file`` () =
+    formatSourceString true """namespace foo
+type MyEnum =
+  | ``test-one`` of int
+  | ``test-two`` of string
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace foo
+
+type MyEnum =
+    | ``test-one`` of int
+    | ``test-two`` of string
+"""

--- a/src/Fantomas/AstTransformer.fs
+++ b/src/Fantomas/AstTransformer.fs
@@ -138,7 +138,7 @@ module private Ast =
              Properties = p []
              FsAstNode = ast
              Childs = [visitSynModuleOrNamespace moduleOrNamespace]}
-    
+
     and visitSynExpr(synExpr: SynExpr): Node =
         match synExpr with
         | SynExpr.Paren(expr,leftParenRange,rightParenRange,range) ->
@@ -354,7 +354,7 @@ module private Ast =
         | Sequentials xs -> // use tail-rec active pattern to avoid stack overflow
             let rec cons xs =
                 match xs with
-                | [] -> failwith "should not happen" // expr2Opt is always Some in last item 
+                | [] -> failwith "should not happen" // expr2Opt is always Some in last item
                 | ((isTrueSeq,expr1,expr2Opt,range)::rest) ->
                     {Type = "SynExpr.Sequential"
                      Range = r range
@@ -398,13 +398,14 @@ module private Ast =
              FsAstNode = synExpr
              Childs = []}
         | SynExpr.LongIdent(isOptional,longDotId,_,range) ->
+            let ids = visitLongIdentWithDots longDotId
             {Type = "SynExpr.LongIdent"
              Range = r range
              Properties =
                  p ["isOptional" ==> isOptional
                     "longDotId" ==> lid longDotId]
              FsAstNode = synExpr
-             Childs = []}
+             Childs = ids}
         | SynExpr.LongIdentSet(longDotId,expr,range) ->
             {Type = "SynExpr.LongIdentSet"
              Range = r range
@@ -413,17 +414,7 @@ module private Ast =
              Childs = [yield visitSynExpr expr]}
         | SynExpr.DotGet(expr,rangeOfDot,longDotId,range) ->
             // Idents are collected as childs here to deal with unit test ``Fluent api with comments should remain on same lines``
-            let ids =
-                match longDotId with
-                | LongIdentWithDots(ids,_) ->
-                    ids
-                    |> List.map (fun (ident) -> {
-                        Type = "Ident"
-                        Range = Some ident.idRange
-                        Properties = Map.empty
-                        FsAstNode = ident
-                        Childs = []
-                    })
+            let ids = visitLongIdentWithDots longDotId
             {Type = "SynExpr.DotGet"
              Range = r range
              Properties =
@@ -772,7 +763,7 @@ module private Ast =
                  [yield visitSynComponentInfo sci
                   yield visitSynTypeDefnSigRepr synTypeDefnSigReprs
                   yield! (memberSig |> List.map visitSynMemberSig)]}
-            
+
     and visitSynTypeDefnSigRepr(stdr: SynTypeDefnSigRepr): Node =
         match stdr with
         | SynTypeDefnSigRepr.ObjectModel(kind,members,range) ->
@@ -1367,7 +1358,7 @@ module private Ast =
                 yield "typeName" ==> lid attr.TypeName]
          FsAstNode = attr
          Childs = [visitSynExpr attr.ArgExpr]}
-        
+
     and visitSynAttributeList(attrs: SynAttributeList): Node =
         {Type = "SynAttributeList"
          Range = r attrs.Range
@@ -1411,9 +1402,9 @@ module private Ast =
         | EnumCase(attrs,ident,_,_,range) ->
             {Type = "EnumCase"
              Range = r range
-             Properties = p ["ident" ==> i ident]
+             Properties = p []
              FsAstNode = sec
-             Childs = [yield! attrs |> List.map visitSynAttributeList]}
+             Childs = [yield! attrs |> List.map visitSynAttributeList; yield visitIdent ident]}
 
     and visitSynField(sfield: SynField): Node =
         match sfield with
@@ -1601,18 +1592,10 @@ module private Ast =
                     "longIdent" ==> longIdent]
              FsAstNode = hash
              Childs = []}
-            
+
     and visitSynModuleOrNamespaceSig(modOrNs: SynModuleOrNamespaceSig): Node =
         match modOrNs with
         | SynModuleOrNamespaceSig(longIdent,isRecursive,isModule,decls,_,attrs,access,range) ->
-            let collectIdents (idents: LongIdent) =
-                idents
-                |> List.map (fun ident ->
-                    { Type = "Ident"
-                      Range = r ident.idRange
-                      Properties = Map.empty
-                      FsAstNode = ident
-                      Childs = [] })
             {Type = sprintf "SynModuleOrNamespaceSig.%A" isModule
              Range = r range
              Properties =
@@ -1622,10 +1605,10 @@ module private Ast =
                     if access.IsSome then yield "access" ==> (access.Value |> visitSynAccess)]
              FsAstNode = modOrNs
              Childs =
-                 [yield! (if isModule = SynModuleOrNamespaceKind.DeclaredNamespace then collectIdents longIdent else [])
+                 [yield! (if isModule = SynModuleOrNamespaceKind.DeclaredNamespace then visitLongIdent longIdent else [])
                   yield! attrs |> List.map visitSynAttributeList
                   yield! (decls |> List.map visitSynModuleSigDecl)]}
-            
+
     and visitSynModuleSigDecl(ast: SynModuleSigDecl) : Node =
         match ast with
         | SynModuleSigDecl.ModuleAbbrev(ident,longIdent,range) ->
@@ -1676,7 +1659,7 @@ module private Ast =
              Properties = p []
              FsAstNode = ast
              Childs = [visitSynExceptionSig synExceptionSig]}
-            
+
     and visitSynExceptionSig(exceptionDef: SynExceptionSig): Node =
         match exceptionDef with
         | SynExceptionSig(sedr,members,range) ->
@@ -1687,6 +1670,21 @@ module private Ast =
              Childs =
                  [yield visitSynExceptionDefnRepr sedr
                   yield! (members |> List.map visitSynMemberSig)]}
+
+    and visitLongIdentWithDots (lid: LongIdentWithDots): Node list =
+        match lid with
+        | LongIdentWithDots(ids,_) ->
+            List.map visitIdent ids
+
+    and visitLongIdent (li: LongIdent) : Node list =
+        List.map visitIdent li
+
+    and visitIdent (ident: Ident) : Node =
+        { Type = "Ident"
+          Range = r ident.idRange
+          Properties = Map.empty
+          FsAstNode = ident
+          Childs = [] }
 
 let astToNode (hds: ParsedHashDirective list) (mdls: SynModuleOrNamespace list): Node =
     let children =

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -321,7 +321,8 @@ let private addTriviaToTriviaNode (triviaNodes: TriviaNode list) trivia =
             let isIdent =
                 match t.Type with
                 | MainNode("SynExpr.Ident")
-                | MainNode("SynPat.Named") -> true
+                | MainNode("SynPat.Named")
+                | MainNode("Ident") -> true
                 | _ -> false
             isIdent && (t.Range.StartColumn = range.StartColumn || t.Range.StartColumn = range.StartColumn + 1) && t.Range.StartLine = range.StartLine
         )

--- a/src/Fantomas/TriviaHelpers.fs
+++ b/src/Fantomas/TriviaHelpers.fs
@@ -52,3 +52,11 @@ module TriviaHelpers =
         |> List.tryFind (fun tv -> tv.Range = range)
         |> Option.map (fun tv -> tv.ContentBefore |> List.exists (function | Comment(LineCommentOnSingleLine(_)) -> true | _ -> false))
         |> Option.defaultValue false
+
+    let internal ``has content itself is ident between ticks`` range (triviaNodes: TriviaNode list) =
+        triviaNodes
+        |> List.choose (fun tn ->
+            match tn.Range = range, tn.ContentItself with
+            | true, Some(IdentBetweenTicks(ident)) -> Some ident
+            | _ -> None)
+        |> List.tryHead


### PR DESCRIPTION
Fixes #626 , I've modified the AstTransformer to consider Ident as children instead of properties.
That way we can more fine-grained add trivia to AST nodes.

The `OptVar` change was necessary to preserve the comment after `.IsNone` in https://github.com/fsprojects/fantomas/blob/818c5a956be2fdaf6f4f756c0bd8e5277cd99f38/src/Fantomas.Tests/ControlStructureTests.fs#L246.