### PR TITLE
Extract shared logic between json config and editorconfig.

### DIFF
--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
   <PropertyGroup>
     <Version>3.2.0-beta-002</Version>
@@ -57,7 +57,8 @@
     <Compile Include="ElmishTests.fs" />
     <Compile Include="LambdaTests.fs" />
     <Compile Include="IfThenElseTests.fs" />
-    <Compile Include="FormatConfigConfigurationFileTests.fs" />
+    <Compile Include="FormatConfigJsonConfigurationFileTests.fs" />
+    <Compile Include="FormatConfigEditorConfigurationFileTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas\Fantomas.fsproj" />

--- a/src/Fantomas.Tests/FormatConfigEditorConfigurationFileTests.fs
+++ b/src/Fantomas.Tests/FormatConfigEditorConfigurationFileTests.fs
@@ -1,0 +1,2 @@
+module Fantomas.Tests.FormatConfigEditorConfigurationFileTests
+

--- a/src/Fantomas.Tests/FormatConfigJsonConfigurationFileTests.fs
+++ b/src/Fantomas.Tests/FormatConfigJsonConfigurationFileTests.fs
@@ -169,7 +169,7 @@ let ``$schema key should not return warning`` () =
     "IndentOnTryWith": true
 }
 """
-    let options, warnings =
+    let _, warnings =
         File.ReadAllText path
         |> JsonConfig.parseOptionsFromJson
     [] == warnings

--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -9,6 +9,7 @@ open FSharp.Compiler.Ast
 open FSharp.Compiler.Range
 open NUnit.Framework
 open FsCheck
+open System.IO
 
 let config = FormatConfig.Default
 let newline = "\n"
@@ -180,3 +181,19 @@ type NUnitRunner () =
                 // TODO : Log more information about the test failure.
                 Runner.onFinishedToString name result
                 |> Assert.Fail
+
+let private getTempFolder () = Path.GetTempPath()
+
+let private mkConfigPath fileName folder =
+    match folder with
+    | Some folder ->
+        let folderPath = Path.Combine(getTempFolder(), folder)
+        Directory.CreateDirectory(folderPath) |> ignore
+        Path.Combine(folderPath, fileName)
+    | None ->
+        Path.Combine(getTempFolder(), fileName)
+
+let mkConfigFromContent fileName folder content =
+    let file = mkConfigPath fileName folder
+    File.WriteAllText(file, content)
+    file

--- a/src/Fantomas/CodeFormatter.fs
+++ b/src/Fantomas/CodeFormatter.fs
@@ -1,8 +1,5 @@
 ﻿namespace Fantomas
 
-open Fantomas
-open FormatConfig
-
 [<Sealed>]
 type CodeFormatter =
     static member ParseAsync(fileName, source, parsingOptions, checker) =
@@ -35,6 +32,6 @@ type CodeFormatter =
     static member MakeRange(fileName, startLine, startCol, endLine, endCol) = 
         CodeFormatterImpl.makeRange fileName startLine startCol endLine endCol
 
-    static member GetVersion() = Fantomas.Version.fantomasVersion.Value
+    static member GetVersion() = Version.fantomasVersion.Value
 
     static member ReadConfiguration(fileOrFolder) = CodeFormatterImpl.readConfiguration fileOrFolder

--- a/src/Fantomas/CodeFormatter.fs
+++ b/src/Fantomas/CodeFormatter.fs
@@ -37,21 +37,4 @@ type CodeFormatter =
 
     static member GetVersion() = Fantomas.Version.fantomasVersion.Value
 
-    static member ReadConfiguration(fileOrFolder) =
-        try
-            let configurationFiles =
-                ConfigFile.findConfigurationFiles fileOrFolder
-
-            if List.isEmpty configurationFiles then failwithf "No configuration files were found for %s" fileOrFolder
-
-            let (config,warnings) =
-                List.fold (fun (currentConfig, warnings) configPath ->
-                    let updatedConfig, warningsForPath = ConfigFile.applyOptionsToConfig currentConfig configPath
-                    (updatedConfig, warnings @ warningsForPath)
-                ) (FormatConfig.Default, []) configurationFiles
-
-            match warnings with
-            | [] -> FormatConfigFileParseResult.Success config
-            | w -> FormatConfigFileParseResult.PartialSuccess (config, w)
-        with
-        | exn -> FormatConfigFileParseResult.Failure exn
+    static member ReadConfiguration(fileOrFolder) = CodeFormatterImpl.readConfiguration fileOrFolder

--- a/src/Fantomas/CodeFormatterImpl.fs
+++ b/src/Fantomas/CodeFormatterImpl.fs
@@ -11,7 +11,6 @@ open FSharp.Compiler.SourceCodeServices
 
 open FSharp.Compiler.Text
 open Fantomas
-open Fantomas
 open Fantomas.FormatConfig
 open Fantomas.SourceOrigin
 open Fantomas.SourceParser

--- a/src/Fantomas/CodeFormatterImpl.fs
+++ b/src/Fantomas/CodeFormatterImpl.fs
@@ -11,6 +11,7 @@ open FSharp.Compiler.SourceCodeServices
 
 open FSharp.Compiler.Text
 open Fantomas
+open Fantomas
 open Fantomas.FormatConfig
 open Fantomas.SourceOrigin
 open Fantomas.SourceParser
@@ -685,8 +686,10 @@ let readConfiguration fileOrFolder =
                     match System.IO.Path.GetFileName(configPath) with
                     | json when (json = ConfigFile.jsonConfigFileName) ->
                         JsonConfig.parseOptionsFromJson configContent
+                    | editorconfig when (editorconfig = ConfigFile.editorConfigFileName) ->
+                        EditorConfig.parseOptionsFromEditorConfig configContent
                     | _ ->
-                        failwithf "Filename is not support."
+                        failwithf "Filename is not supported!"
                 let updatedConfig = FormatConfig.applyOptions(currentConfig, options)
                 let locationAwareWarnings =
                     List.ofArray warningFromConfigPath

--- a/src/Fantomas/ConfigFile.fs
+++ b/src/Fantomas/ConfigFile.fs
@@ -1,0 +1,62 @@
+module internal Fantomas.ConfigFile
+
+open System.IO
+open Fantomas.FormatConfig
+open Fantomas.Version
+
+let jsonConfigFileName = "fantomas-config.json"
+let editorConfigFileName = ".editor-config"
+
+let private allowedFileNames = [jsonConfigFileName; editorConfigFileName]
+
+let rec private getParentFolders acc current =
+    let parent = Directory.GetParent(current) |> Option.ofObj
+    match parent with
+    | Some p -> getParentFolders (current::acc) p.FullName
+    | None -> current::acc
+
+/// Returns all the found configuration files for the given path
+/// fileOrFolder can be a concrete json file or a directory path
+let rec findConfigurationFiles fileOrFolder : string list =
+    let findConfigInFolder folderPath =
+        allowedFileNames
+        |> List.map (fun fn -> Path.Combine(folderPath, fn))
+        |> List.filter (File.Exists)
+
+    if Path.GetExtension(fileOrFolder) = "" && Directory.Exists fileOrFolder then
+        getParentFolders [] fileOrFolder
+        |> List.collect findConfigInFolder
+    elif File.Exists(fileOrFolder) then
+        let parentFolder =
+            Directory.GetParent(Path.GetDirectoryName(fileOrFolder))
+            |> Option.ofObj
+        match parentFolder with
+        | Some pf -> findConfigurationFiles pf.FullName @ [fileOrFolder]
+        | None -> [fileOrFolder]
+    else
+        []
+
+let makeWarningLocationAware configPath warning =
+    sprintf "%s, in %s" warning configPath
+
+let private fantomasFields = Reflection.getRecordFields FormatConfig.Default |> Array.map fst
+let private (|FantomasSetting|_|) (s:string) =
+    let s = s.Trim('\"')
+    Array.tryFind ((=) s) fantomasFields
+
+let private (|Number|_|) d =
+    match System.Int32.TryParse(d) with
+    | true, d -> Some (box d)
+    | _ -> None
+let private (|Boolean|_|) b =
+    if b = "true" then Some (box true)
+    elif b = "false" then Some (box false)
+    else None
+
+let processSetting originalLine key value =
+    match (key, value) with
+    | (FantomasSetting(fs), Number(v))
+    | (FantomasSetting(fs), Boolean(v)) -> Ok (fs, v)
+    | _ ->
+        let warning = sprintf "%s is no valid setting for Fantomas v%s" originalLine (fantomasVersion.Value)
+        Error warning

--- a/src/Fantomas/EditorConfig.fs
+++ b/src/Fantomas/EditorConfig.fs
@@ -1,0 +1,7 @@
+module internal Fantomas.EditorConfig
+
+/// Similar to how to processing of the JSON file happens, this function should the options found in the editor config.
+/// The first argument in the return tuple are the options. Listed as (key,value) where key is a member name of the FormatConfig record. Value is either a boolean or an int boxed as object.
+/// The second argument in the return tuple are warnings. F.ex. invalid settings
+let parseOptionsFromEditorConfig editorConfig : (string * obj) array * string array =
+    Array.empty, Array.empty

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="FormatConfig.fs" />
     <Compile Include="ConfigFile.fs" />
     <Compile Include="JsonConfig.fs" />
+    <Compile Include="EditorConfig.fs" />
     <Compile Include="TriviaTypes.fs" />
     <Compile Include="TokenParserBoolExpr.fs" />
     <Compile Include="TriviaHelpers.fs" />

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -16,6 +16,8 @@
     <Compile Include="Dbg.fs" />
     <Compile Include="Utils.fs" />
     <Compile Include="FormatConfig.fs" />
+    <Compile Include="ConfigFile.fs" />
+    <Compile Include="JsonConfig.fs" />
     <Compile Include="TriviaTypes.fs" />
     <Compile Include="TokenParserBoolExpr.fs" />
     <Compile Include="TriviaHelpers.fs" />

--- a/src/Fantomas/FormatConfig.fs
+++ b/src/Fantomas/FormatConfig.fs
@@ -89,91 +89,18 @@ type FormatConfig =
               SpaceAroundDelimiter = spaceAroundDelimiter;
               StrictMode = strictMode }
 
-type FormatConfigFileParseResult =
-    | Success of FormatConfig
-    | PartialSuccess of config: FormatConfig * warnings: string list
-    | Failure of exn
-
-module internal ConfigFile =
-    open System.IO
-    open System.Text.RegularExpressions
-    open Fantomas.Version
-
-    let private defaultConfigurationFileName = "fantomas-config.json"
-
-    let rec private getParentFolders acc current =
-        let parent = Directory.GetParent(current) |> Option.ofObj
-        match parent with
-        | Some p -> getParentFolders (current::acc) p.FullName
-        | None -> current::acc
-
-    /// Returns all the found configuration files for the given path
-    /// fileOrFolder can be a concrete json file or a directory path
-    let rec findConfigurationFiles fileOrFolder : string list =
-        let findConfigInFolder folderPath =
-            let configFile = Path.Combine(folderPath, defaultConfigurationFileName)
-            if File.Exists(configFile) then Some configFile else None
-
-        if Path.GetExtension(fileOrFolder) = "" && Directory.Exists fileOrFolder then
-            getParentFolders [] fileOrFolder
-            |> List.choose findConfigInFolder
-        elif File.Exists(fileOrFolder) then
-            let parentFolder =
-                Directory.GetParent(Path.GetDirectoryName(fileOrFolder))
-                |> Option.ofObj
-            match parentFolder with
-            | Some pf -> findConfigurationFiles pf.FullName @ [fileOrFolder]
-            | None -> [fileOrFolder]
-        else
-            []
-
-    let private fantomasFields = Reflection.getRecordFields FormatConfig.Default |> Array.map fst
-    let private (|FantomasSetting|_|) (s:string) =
-        let s = s.Trim('\"')
-        Array.tryFind ((=) s) fantomasFields
-
-    let private (|Number|_|) d =
-        match System.Int32.TryParse(d) with
-        | true, d -> Some (box d)
-        | _ -> None
-    let private (|Boolean|_|) b =
-        if b = "true" then Some (box true)
-        elif b = "false" then Some (box false)
-        else None
-
-    let private parseOptionsFromJson json =
-        let results =
-            Regex.Replace(json, "\s|{|}", String.Empty).Split([|','|])
-            |> Array.map (fun line -> line, line.Split([|':'|]))
-            |> Array.filter (fun (_, pieces) -> Array.length pieces = 2 && pieces.[0] <> "$schema")
-            |> Array.map(fun (line, pieces) ->
-                match pieces with
-                | [|FantomasSetting(fs); Number(v)|]
-                | [|FantomasSetting(fs); Boolean(v)|] -> Ok (fs, v)
-                | _ ->
-                    let warning = sprintf "%s is no valid setting for Fantomas v%s" line (fantomasVersion.Value)
-                    Error warning
-            )
-
-        let options = Array.choose (function | Ok r -> Some r | _ -> None) results
-        let warnings = Array.choose (function | Error r -> Some r | _ -> None) results
-        options, warnings
-
-    let private formatConfigType = FormatConfig.Default.GetType()
-    let applyOptionsToConfig currentConfig path =
-        let json = System.IO.File.ReadAllText path
-        let (options,warnings) = parseOptionsFromJson json
-
+    static member applyOptions(currentConfig, options) =
         let currentValues = Reflection.getRecordFields currentConfig
         let newValues =
             Array.fold (fun acc (k,v) ->
                 Array.map (fun (fn, ev) -> if fn = k then (fn, v) else (fn,ev)) acc
             ) currentValues options
             |> Array.map snd
-        let updatedConfig = Microsoft.FSharp.Reflection.FSharpValue.MakeRecord (formatConfigType, newValues) :?> FormatConfig
-        let warningsInFile = Seq.map (fun w -> sprintf "%s, in %s" w path) warnings |> Seq.toList
-        updatedConfig, warningsInFile
+        let formatConfigType = FormatConfig.Default.GetType()
+        Microsoft.FSharp.Reflection.FSharpValue.MakeRecord (formatConfigType, newValues) :?> FormatConfig
 
-
-
+type FormatConfigFileParseResult =
+    | Success of FormatConfig
+    | PartialSuccess of config: FormatConfig * warnings: string list
+    | Failure of exn
 

--- a/src/Fantomas/JsonConfig.fs
+++ b/src/Fantomas/JsonConfig.fs
@@ -1,0 +1,20 @@
+module internal Fantomas.JsonConfig
+
+open System
+open System.Text.RegularExpressions
+
+let parseOptionsFromJson json =
+    let results =
+        Regex.Replace(json, "\s|{|}", String.Empty).Split([|','|])
+        |> Array.map (fun line -> line, line.Split([|':'|]))
+        |> Array.choose (fun (line, pieces) ->
+            if Array.length pieces = 2 && pieces.[0] <> "$schema"
+            then Some(line, pieces.[0], pieces.[1])
+            else None)
+        |> Array.map(fun (line, key,value) ->
+            ConfigFile.processSetting line key value
+        )
+
+    let options = Array.choose (function | Ok r -> Some r | _ -> None) results
+    let warnings = Array.choose (function | Error r -> Some r | _ -> None) results
+    options, warnings


### PR DESCRIPTION
I'm on board with having support for `.editorconfig` as requested in #650.
Some of the logic of constructing the configuration record can be re-used and I've extracted just that in this PR. 

Leaving room to do the actual implementation of processing the `.editorconfig` file for somebody else.
