### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**PLEASE USE THE ONLINE TOOL TO REPORT BUGS!!**
+
+Go to https://jindraivanek.gitlab.io/fantomas-ui/#?fantomas=preview and reproduce your problem there.
+Use the `create issue` link at the bottom, this will generate a report with everything we need to investigate your problem.
+
+![Fantomas online](https://i.imgur.com/ZbRsbqa.png)
+
+Try and reproduce your problem against the `preview` version of the tool, this is linked to the master branch of the project.
+
+In case you wish to report another problem, continue writing this current issue.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
I would really like that all bugs are created via the online tool.
This isn't always clear for newcomers, see #682 for example.