### PR TITLE
handle from-end slices for indexers

### DIFF
--- a/src/Fantomas.Tests/DataStructureTests.fs
+++ b/src/Fantomas.Tests/DataStructureTests.fs
@@ -1530,3 +1530,23 @@ let nestedList: obj list =
           // this case looks weird but seen rarely
         |] |]
 """
+
+[<Test>]
+let ``from-end slicing with lists`` () =
+    formatSourceString false """
+let a = list.[..^0]   // 1,2,3,4,5
+let b = list.[..^1]   // 1,2,3,4
+let c = list.[0..^1]  // 1,2,3,4
+let d = list.[^1..]   // 4,5
+let e = list.[^0..]   // 5
+let f = list.[^2..^1] // 3,4
+"""  ({ config with PageWidth = 80 })
+    |> prepend newline
+    |> should equal """
+let a = list.[..^0] // 1,2,3,4,5
+let b = list.[..^1] // 1,2,3,4
+let c = list.[0..^1] // 1,2,3,4
+let d = list.[^1..] // 4,5
+let e = list.[^0..] // 5
+let f = list.[^2..^1] // 3,4
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1530,18 +1530,46 @@ and genInfixApps astContext (hasNewLine:bool) synExprs (ctx:Context) =
 
 /// Use in indexed set and get only
 and genIndexers astContext node =
+    // helper to generate the remaining indexer expressions
+    // (pulled out due to duplication)
+    let inline genRest astContext (es: _ list) = ifElse es.IsEmpty sepNone (sepComma +> genIndexers astContext es)
+
+    // helper to generate a single indexer expression with support for the from-end slice marker
+    let inline genSingle astContext (isFromEnd: bool) (e: SynExpr) =
+        ifElse isFromEnd (!- "^") sepNone
+        +> genExpr astContext e
+
     match node with
-    | Indexer(Pair((IndexedVar eo1, e1FromEnd),(IndexedVar eo2, e2FromEnd))) :: es ->
-        ifElse (eo1.IsNone && eo2.IsNone) (!- "*")
-            (opt sepNone eo1 (genExpr astContext) -- ".." +> opt sepNone eo2 (genExpr astContext))
-        +> ifElse es.IsEmpty sepNone (sepComma +> genIndexers astContext es)
-    | Indexer(Single(IndexedVar eo, fromEnd)) :: es ->
-        ifElse eo.IsNone (!- "*") (opt sepNone eo (genExpr astContext))
-        +> ifElse es.IsEmpty sepNone (sepComma +> genIndexers astContext es)
-    | Indexer(Single(e, fromEnd)) :: es ->
-            genExpr astContext e +> ifElse es.IsEmpty sepNone (sepComma +> genIndexers astContext es)
+    // list.[*]
+    | Indexer(Pair((IndexedVar None, _),(IndexedVar None, _))) :: es ->
+        !- "*"
+        +> genRest astContext es
+    // list.[(fromEnd)<idx>..]
+    | Indexer(Pair((IndexedVar(Some e01), e1FromEnd),(IndexedVar None, _))) :: es ->
+        genSingle astContext e1FromEnd e01
+        -- ".."
+        +> genRest astContext es
+    // list.[..(fromEnd)<idx>]
+    | Indexer(Pair((IndexedVar None, _),(IndexedVar(Some e2), e2FromEnd))) :: es ->
+        !- ".."
+        +> genSingle astContext e2FromEnd e2
+        +> genRest astContext es
+    // list.[(fromEnd)<idx>..(fromEnd)<idx>]
+    | Indexer(Pair((IndexedVar(Some e01), e1FromEnd),(IndexedVar(Some eo2), e2FromEnd))) :: es ->
+        genSingle astContext e1FromEnd e01
+        -- ".."
+        +> genSingle astContext e2FromEnd eo2
+        +> genRest astContext es
+    // list.[*]
+    | Indexer(Single(IndexedVar None, _)) :: es ->
+        !- "*"
+        +> genRest astContext es
+    // list.[(fromEnd)<idx>]
+    | Indexer(Single(eo, fromEnd)) :: es ->
+        genSingle astContext fromEnd eo
+        +> genRest astContext es
     | _ -> sepNone
-    // |> genTrivia node, it a list
+
 
 and genTypeDefn astContext (TypeDef(ats, px, ao, tds, tcs, tdr, ms, s, preferPostfix) as node) =
     let typeName =

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -143,7 +143,7 @@ let internal dump (ctx: Context) =
 let internal dumpAndContinue (ctx: Context) =
 #if DEBUG
     let m = finalizeWriterModel ctx
-    let lines = m.Lines |> List.rev
+    let lines = m.WriterModel.Lines |> List.rev
     let code = String.concat Environment.NewLine lines
     printfn "%s" code
 #endif


### PR DESCRIPTION
This PR implements support for formatting from-end slices without losing the `^` character.

I added a test to verify, and cleaned up the matches a bit to clarify the exact kinds of slice cases each branch handled.

Fixed #691 