### PR TITLE
Fix Setup .NET Core in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup .NET Core
-      # Fix for https://github.com/actions/setup-dotnet/issues/29#issuecomment-548740241
-      uses: actions/setup-dotnet@bb95ce727fd49ec1a65933419cc7c91747785302
+      uses: actions/setup-dotnet@v1.4.0
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Install local tools


### PR DESCRIPTION
A lot of builds are failing to setup .NET Core, I think this will fix this.