### PR TITLE
Support property setter before getter (fix #664)

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -311,11 +311,16 @@ let ``member properties with type annotation``() =
     formatSourceString false """type A() =
     member this.X with get():int = 1
     member this.Y with get():int = 1 and set (_:int):unit = ()
+    member this.Z with set (_:int):unit = () and get():int = 1
 """  config
     |> should equal """type A() =
     member this.X: int = 1
 
     member this.Y
+        with get (): int = 1
+        and set (_: int): unit = ()
+
+    member this.Z
         with get (): int = 1
         and set (_: int): unit = ()
 """

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -242,6 +242,11 @@ let (|PropertyWithGetSet|_|) = function
         | PropertyBinding(_, _, _, _, MFProperty PropertySet, PatLongIdent(_, s2, _, _), _) as b2::bs when s1 = s2 -> 
             Some((b1, b2), bs)
         | _ -> None
+    | PropertyBinding(_, _, _, _, MFProperty PropertySet, PatLongIdent(_, s2, _, _), _) as b2::bs -> 
+        match bs with
+        | PropertyBinding(_, _, _, _, MFProperty PropertyGet, PatLongIdent(_, s1, _, _), _) as b1::bs when s1 = s2 -> 
+            Some((b1, b2), bs)
+        | _ -> None
     | _ -> None 
 
 let (|PropertyWithGetSetMemberDefn|_|) = function


### PR DESCRIPTION
Fix #664.

Note that this change order to be first getter then setter (see changed test).