### PR TITLE
Wrap multiline string in parenthesis before infix operator

### DIFF
--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -355,3 +355,43 @@ let ``operator before verbatim string add extra space, 736`` () =
     |> should equal """
 Target M.Tools (fun _ -> !! @"Tools\Tools.sln" |> rebuild)
 """
+
+[<Test>]
+let ``function call before pipe operator, 754`` () =
+    formatSourceString false "
+[<Test>]
+let ``attribute on module after namespace`` () =
+    formatSourceString false \"\"\"namespace SomeNamespace
+
+[<AutoOpen>]
+module Types =
+    let a = 5
+\"\"\"  config
+    |> prepend newline
+    |> should equal \"\"\"
+namespace SomeNamespace
+
+[<AutoOpen>]
+module Types =
+    let a = 5
+\"\"\"
+"    config
+    |> prepend newline
+    |> should equal "
+[<Test>]
+let ``attribute on module after namespace`` () =
+    (formatSourceString false \"\"\"namespace SomeNamespace
+
+[<AutoOpen>]
+module Types =
+    let a = 5
+\"\"\"   config)
+    |> prepend newline
+    |> should equal \"\"\"
+namespace SomeNamespace
+
+[<AutoOpen>]
+module Types =
+    let a = 5
+\"\"\"
+"

--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -55,8 +55,8 @@ let f a b =
     |> prepend newline
     |> should equal """
 let f a b =
-    a "
-"
+    (a "
+")
     |> b
 """
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -997,12 +997,17 @@ and genExpr astContext synExpr =
             | (s,_,_)::_ when ((NoSpaceInfixOps.Contains s)) -> sepNone
             | _ -> f
 
+        let expr =
+            match e with
+            | AppWithMultilineArgument _ -> sepOpenT +> genExpr astContext e +> sepCloseT
+            | _ -> genExpr astContext e
+
         atCurrentColumn
             (fun ctx ->
                  isShortExpression
                     ctx.Config.MaxInfixOperatorExpression
-                    (genExpr astContext e +> sepAfterExpr sepSpace +> genInfixAppsShort astContext es)
-                    (genExpr astContext e +> sepAfterExpr sepNln +> genInfixApps astContext es)
+                    (expr +> sepAfterExpr sepSpace +> genInfixAppsShort astContext es)
+                    (expr +> sepAfterExpr sepNln +> genInfixApps astContext es)
                     ctx)
 
     | TernaryApp(e1,e2,e3) ->

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -725,6 +725,16 @@ let (|InfixApps|_|) e =
     | (_, []) -> None
     | (e, es) -> Some(e, List.rev es)
 
+let (|AppWithMultilineArgument|_|) e =
+    let isMultilineString p =
+        match p with
+        | MultilineString _ -> true
+        | _ -> false
+
+    match e with
+    | App (_, arguments) when (List.exists isMultilineString arguments) -> Some e
+    | _ -> None
+
 /// Gather all arguments in lambda
 let rec (|Lambda|_|) = function
     | SynExpr.Lambda(_, _, pats, Lambda(e, patss), _) ->


### PR DESCRIPTION
Not sure this is the best solution to fix #754.
Suggestion to wrap all SynExpr.App in parenthesis broke twenty tests and I think we will add it way more than needed.
So that is why I limited the scope to SynExpr.App with multiline parameters.