### PR TITLE
Introduce setting to add newline between record type and members.

### DIFF
--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -67,6 +67,7 @@
     <Compile Include="SpaceBeforeMemberTests.fs" />
     <Compile Include="MultilineBlockBracketsOnSameColumnRecordTests.fs" />
     <Compile Include="MultilineBlockBracketsOnSameColumnArrayOrListTests.fs" />
+    <Compile Include="NewlineBetweenTypeDefinitionAndMembersTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas\Fantomas.fsproj" />

--- a/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
+++ b/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
@@ -7,7 +7,8 @@ open Fantomas.Tests.TestHelper
 let config = ({ config with
                     MultilineBlockBracketsOnSameColumn = true
                     SpaceBeforeColon = true
-                    SpaceBeforeSemicolon = true })
+                    SpaceBeforeSemicolon = true
+                    NewlineBetweenTypeDefinitionAndMembers = true })
 
 [<Test>]
 let ``single member record stays on one line`` () =
@@ -379,6 +380,7 @@ type Range =
         From : float
         To : float
     }
+
     member this.Length = this.To - this.From
 """
 
@@ -396,6 +398,7 @@ type MyRecord =
     {
         SomeField : int
     }
+
     interface IMyInterface
 """
 
@@ -457,4 +460,31 @@ type MyRecord =
         Street : string
         Number : int
     }
+"""
+
+[<Test>]
+let ``record declaration with members in signature file`` () =
+    formatSourceString true """namespace X
+type MyRecord =
+    { Level: int
+      Progress: string
+      Bar: string
+      Street: string
+      Number: int }
+    member Score : unit -> int
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace X
+
+type MyRecord =
+    {
+        Level : int
+        Progress : string
+        Bar : string
+        Street : string
+        Number : int
+    }
+
+    member Score : unit -> int
 """

--- a/src/Fantomas.Tests/NewlineBetweenTypeDefinitionAndMembersTests.fs
+++ b/src/Fantomas.Tests/NewlineBetweenTypeDefinitionAndMembersTests.fs
@@ -1,0 +1,202 @@
+module Fantomas.Tests.NewlineBetweenTypeDefinitionAndMembersTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Tests.TestHelper
+
+let config = { config with NewlineBetweenTypeDefinitionAndMembers = true }
+
+[<Test>]
+let ``newline between record type and members`` () =
+    formatSourceString false """type Range =
+    { From : float
+      To : float
+      Name: string }
+    member this.Length = this.To - this.From
+"""  config
+    |> prepend newline
+    |> should equal """
+type Range =
+    { From: float
+      To: float
+      Name: string }
+
+    member this.Length = this.To - this.From
+"""
+
+[<Test>]
+let ``existing newline between record type and members should not be duplicate`` () =
+    formatSourceString false """type Range =
+    { From : float
+      To : float
+      Name: string }
+
+    member this.Length = this.To - this.From
+"""  config
+    |> prepend newline
+    |> should equal """
+type Range =
+    { From: float
+      To: float
+      Name: string }
+
+    member this.Length = this.To - this.From
+"""
+
+[<Test>]
+let ``no extra newline after record type with no members`` () =
+    formatSourceString false """type Range =
+    { From : float
+      To : float
+      Name: string }
+"""  config
+    |> prepend newline
+    |> should equal """
+type Range =
+    { From: float
+      To: float
+      Name: string }
+"""
+
+[<Test>]
+let ``union type with members`` () =
+    formatSourceString false """type Color =
+    | Red
+    | Green
+    | Blue
+    member this.ToInt = ()
+"""  config
+    |> prepend newline
+    |> should equal """
+type Color =
+    | Red
+    | Green
+    | Blue
+
+    member this.ToInt = ()
+"""
+
+[<Test>]
+let ``enum type with members`` () =
+    formatSourceString false """type Color =
+    | Red = 0
+    | Green = 1
+    | Blue = 2
+    member this.ToInt = ()
+"""  config
+    |> prepend newline
+    |> should equal """
+type Color =
+    | Red = 0
+    | Green = 1
+    | Blue = 2
+
+    member this.ToInt = ()
+"""
+
+[<Test>]
+let ``type abbreviation with members`` () =
+    formatSourceString false """
+type A = string
+with
+    member this.X = ()
+"""  config
+    |> prepend newline
+    |> should equal """
+type A = string
+    with
+
+        member this.X = ()
+"""
+
+[<Test>]
+let ``type augmentation with members`` () =
+    formatSourceString false """
+type HttpContext with
+    member this.QueryString () = "?"
+"""  config
+    |> prepend newline
+    |> should equal """
+type HttpContext with
+
+    member this.QueryString() = "?"
+"""
+
+[<Test>]
+let ``newline between record type signature and members`` () =
+    formatSourceString true """namespace Signature
+
+type Range =
+    { From : float
+      To : float
+      Name: string }
+    member Length : unit -> int
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace Signature
+
+type Range =
+    { From: float
+      To: float
+      Name: string }
+
+    member Length: unit -> int
+"""
+
+[<Test>]
+let ``union signature type with members`` () =
+    formatSourceString true """namespace Signature
+type Color =
+    | Red
+    | Green
+    | Blue
+    member ToInt: unit -> int
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace Signature
+
+type Color =
+    | Red
+    | Green
+    | Blue
+
+    member ToInt: unit -> int
+"""
+
+[<Test>]
+let ``enum signature type with members`` () =
+    formatSourceString true """namespace Signature
+type Color =
+    | Red = 0
+    | Green = 1
+    | Blue = 2
+    member ToInt : unit -> int
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace Signature
+
+type Color =
+    | Red = 0
+    | Green = 1
+    | Blue = 2
+
+    member ToInt: unit -> int
+"""
+
+[<Test>]
+let ``simple type in signature file with members`` () =
+    formatSourceString true """namespace Signature
+type HttpContext with
+    member QueryString : unit -> string
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace Signature
+
+type HttpContext with
+
+    member QueryString: unit -> string
+"""

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -883,6 +883,13 @@ let internal sepNlnConsideringTriviaContentBeforeWithAttributes (ownRange:range)
     |> Seq.exists (fun ({ ContentBefore = contentBefore }) -> hasPrintableContent contentBefore)
     |> fun hasContentBefore ->
         if hasContentBefore then ctx else sepNln ctx
+
+let internal sepNlnTypeAndMembers (firstMemberRange: range option) ctx =
+    match firstMemberRange with
+    | Some range when (ctx.Config.NewlineBetweenTypeDefinitionAndMembers) ->
+        sepNlnConsideringTriviaContentBefore range ctx
+    | _ ->
+        ctx
     
 let internal beforeElseKeyword (fullIfRange: range) (elseRange: range) (ctx: Context) =
     ctx.Trivia

--- a/src/Fantomas/FormatConfig.fs
+++ b/src/Fantomas/FormatConfig.fs
@@ -32,6 +32,7 @@ type FormatConfig =
       MaxArrayOrListWidth: Num
       MaxLetBindingWidth: Num
       MultilineBlockBracketsOnSameColumn : bool
+      NewlineBetweenTypeDefinitionAndMembers: bool
       /// Prettyprinting based on ASTs only
       StrictMode : bool }
 
@@ -56,7 +57,8 @@ type FormatConfig =
           MaxArrayOrListWidth = 40
           MaxLetBindingWidth = 40
           MultilineBlockBracketsOnSameColumn = false
-          StrictMode = false }
+          StrictMode = false
+          NewlineBetweenTypeDefinitionAndMembers = false }
 
     static member applyOptions(currentConfig, options) =
         let currentValues = Reflection.getRecordFields currentConfig


### PR DESCRIPTION
Fixes #752.
I think this is fairly complete, I might have missed some scenarios.
Let me know if some other cases need to be supported as well.