### PR TITLE
End String Content after String token

### DIFF
--- a/src/Fantomas.Tests/SynConstTests.fs
+++ b/src/Fantomas.Tests/SynConstTests.fs
@@ -128,3 +128,20 @@ module Runner =
         class
         end
 """
+
+[<Test>]
+let ``string content ends at string token, 646`` () =
+    formatSourceString false """"Yarn" ==> "Format"
+
+"Yarn" ==> "CheckCodeFormat"
+
+Target.runOrDefault "CheckCodeFormat"
+"""  config
+    |> prepend newline
+    |> should equal """
+"Yarn" ==> "Format"
+
+"Yarn" ==> "CheckCodeFormat"
+
+Target.runOrDefault "CheckCodeFormat"
+"""

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -333,8 +333,11 @@ let rec private getTriviaFromTokensThemSelves (allTokens: Token list) (tokens: T
     | head::rest when (head.TokenInfo.TokenName = "STRING_TEXT") ->
         let stringTokens =
             rest
-            |> List.takeWhile (fun ({TokenInfo = {TokenName = tn}}) -> tn = "STRING_TEXT" || tn = "STRING")
-            |> fun others -> List.prependItem others head
+            |> List.takeWhile (fun ({TokenInfo = {TokenName = tn}}) -> tn = "STRING_TEXT")
+            |> fun others ->
+                let length = List.length others
+                let closingQuote = rest.[length]
+                [ yield head; yield! others; yield closingQuote ]
 
         let stringContent =
             let builder = StringBuilder()


### PR DESCRIPTION
Fixes #646

Strings end with the `String` token:
![image](https://user-images.githubusercontent.com/2621499/79669788-6b2b7180-81be-11ea-8494-1d336db7d67c.png)

When you have two string after each other it led to incorrect behaviour.
Fixed now.