### PR TITLE
Line comment after { leads to multiline construct.

### DIFF
--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -870,3 +870,16 @@ let useAddEntry () =
         // foo
         bar ()
 """
+
+[<Test>]
+let ``line comment after { should make record multiline`` () =
+    formatSourceString false """let meh = { // this comment right
+    Name = "FOO"; Level = 78 }
+"""  config
+    |> prepend newline
+    |> should equal """
+let meh =
+    { // this comment right
+      Name = "FOO"
+      Level = 78 }
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -821,6 +821,7 @@ and genExpr astContext synExpr =
     | Record(inheritOpt, xs, eo) ->
         let shortRecordExpr =
             sepOpenS +>
+            leaveLeftBrace synExpr.Range +>
             optSingle
                 (fun (inheritType, inheritExpr) -> !- "inherit " +> genType astContext false inheritType +> genExpr astContext inheritExpr +> onlyIf (List.isNotEmpty xs) sepSemi)
                 inheritOpt +>


### PR DESCRIPTION
Partial fix for #516, although the real problem there is a nasty trivia thing.
Nevertheless, the is needed as well.