### PR TITLE
Fix 776, add IdentBetweenTicks trivia for SynPat.LongIdent node, dont use backticks when not needed

### DIFF
--- a/src/Fantomas.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Tests/FunctionDefinitionTests.fs
@@ -82,6 +82,33 @@ let ``should keep identifiers with + in double backticks``() =
 """
 
 [<Test>]
+let ``double backticks with non-alphanum character, 776``() =
+    formatSourceString false """let ``!foo hoo`` () = ()
+let ``@foo hoo`` () = ()
+let ``$foo hoo`` () = ()
+let ``%foo hoo`` () = ()
+let ``^foo hoo`` () = ()
+let ``&foo hoo`` () = ()
+let ``*foo hoo`` () = ()
+let ``<foo hoo`` () = ()
+let ``>foo hoo`` () = ()
+let ``=foo hoo`` () = ()
+let ``-foo hoo`` () = ()
+    """ config
+    |> should equal """let ``!foo hoo`` () = ()
+let ``@foo hoo`` () = ()
+let ``$foo hoo`` () = ()
+let ``%foo hoo`` () = ()
+let ``^foo hoo`` () = ()
+let ``&foo hoo`` () = ()
+let ``*foo hoo`` () = ()
+let ``<foo hoo`` () = ()
+let ``>foo hoo`` () = ()
+let ``=foo hoo`` () = ()
+let ``-foo hoo`` () = ()
+"""
+
+[<Test>]
 let ``let bindings with return types``() =
     formatSourceString false """
        let divide x y =

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2753,13 +2753,16 @@ and genTrivia (range: range) f =
     enterNode range +> f +> leaveNode range
 
 and infixOperatorFromTrivia range fallback (ctx: Context) =
+    // by specs, section 3.4 https://fsharp.org/specs/language-spec/4.1/FSharpSpec-4.1-latest.pdf#page=24&zoom=auto,-137,312
+    let validIdentRegex = """^(_|\p{L}|\p{Nl})([_'0-9]|\p{L}|\p{Nl}\p{Pc}|\p{Mn}|\p{Mc}|\p{Cf})*$"""
+    let isValidIdent x = Regex.Match(x, validIdentRegex).Success
     ctx.Trivia
     |> List.choose(fun t ->
         match t.Range = range with
         | true ->
             match t.ContentItself with
             | Some(IdentOperatorAsWord(iiw)) -> Some iiw
-            | Some(IdentBetweenTicks(iiw)) -> Some iiw // Used when value between ``...``
+            | Some(IdentBetweenTicks(iiw)) when not(isValidIdent fallback) -> Some iiw // Used when value between ``...``
             | _ -> None
         | _ -> None)
     |> List.tryHead

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -343,6 +343,7 @@ let private addTriviaToTriviaNode (startOfSourceCode:int) (triviaNodes: TriviaNo
                 match t.Type with
                 | MainNode("SynExpr.Ident")
                 | MainNode("SynPat.Named")
+                | MainNode("SynPat.LongIdent")
                 | MainNode("Ident") -> true
                 | _ -> false
             isIdent && (t.Range.StartColumn = range.StartColumn || t.Range.StartColumn = range.StartColumn + 1) && t.Range.StartLine = range.StartLine


### PR DESCRIPTION
Fix #776