### PR TITLE
TargetFramework instead of TargetFrameworks

### DIFF
--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>4.0.0-alpha-001</Version>
     <Description>Source code formatter for F#</Description>
   </PropertyGroup>


### PR DESCRIPTION
I think this slipped back in after a bad merge.