### PR TITLE
Add extra space after multiline string

### DIFF
--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -1389,13 +1389,13 @@ SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
     |> should equal "
 [<Test>]
 let ``should keep compiler directives`` () =
-    (formatSourceString false \"\"\"
+    formatSourceString false \"\"\"
 #if INTERACTIVE
 #load \"../FSharpx.TypeProviders/SetupTesting.fsx\"
 SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
 #load \"__setup__.fsx\"
 #endif
-\"\"\"   config)
+\"\"\"  config
     |> should equal \"\"\"#if INTERACTIVE
 #load \"../FSharpx.TypeProviders/SetupTesting.fsx\"
 SetupTesting.generateSetupScript __SOURCE_DIRECTORY__

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -380,12 +380,12 @@ module Types =
     |> should equal "
 [<Test>]
 let ``attribute on module after namespace`` () =
-    (formatSourceString false \"\"\"namespace SomeNamespace
+    formatSourceString false \"\"\"namespace SomeNamespace
 
 [<AutoOpen>]
 module Types =
     let a = 5
-\"\"\"   config)
+\"\"\"  config
     |> prepend newline
     |> should equal \"\"\"
 namespace SomeNamespace
@@ -406,3 +406,41 @@ let hasUnEvenAmount regex line =
     (Regex.Matches(line, regex).Count
      - Regex.Matches(line, "\\\\" + regex).Count) % 2 = 1
 """
+
+[<Test>]
+let ``parameter after multiline string, 783`` () =
+    formatSourceString false "
+let ``match bang`` () =
+    formatSourceString false \"\"\"
+async {
+    match! myAsyncFunction() with
+    | Some x -> printfn \"%A\" x
+    | None -> printfn \"Function returned None!\"
+}\"\"\"   config
+    |> prepend newline
+    |> should equal \"\"\"
+async {
+    match! myAsyncFunction () with
+    | Some x -> printfn \"%A\" x
+    | None -> printfn \"Function returned None!\"
+}
+\"\"\"
+"      config
+    |> prepend newline
+    |> should equal "
+let ``match bang`` () =
+    formatSourceString false \"\"\"
+async {
+    match! myAsyncFunction() with
+    | Some x -> printfn \"%A\" x
+    | None -> printfn \"Function returned None!\"
+}\"\"\" config
+    |> prepend newline
+    |> should equal \"\"\"
+async {
+    match! myAsyncFunction () with
+    | Some x -> printfn \"%A\" x
+    | None -> printfn \"Function returned None!\"
+}
+\"\"\"
+"

--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -55,8 +55,8 @@ let f a b =
     |> prepend newline
     |> should equal """
 let f a b =
-    (a "
-")
+    a "
+"
     |> b
 """
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1006,10 +1006,7 @@ and genExpr astContext synExpr =
             | (s,_,_)::_ when ((NoSpaceInfixOps.Contains s)) -> sepNone
             | _ -> f
 
-        let expr =
-            match e with
-            | AppWithMultilineArgument _ -> sepOpenT +> genExpr astContext e +> sepCloseT
-            | _ -> genExpr astContext e
+        let expr = genExpr astContext e
 
         atCurrentColumn
             (fun ctx ->
@@ -1139,7 +1136,7 @@ and genExpr astContext synExpr =
         // remarks: https://github.com/fsprojects/fantomas/issues/545
         let indentIfNeeded (ctx: Context) =
             let savedColumn = ctx.WriterModel.AtColumn
-            if savedColumn > ctx.Column then
+            if savedColumn >= ctx.Column then
                 // missingSpaces needs to be at least one more than the column
                 // of function expression being applied upon, otherwise (as known up to F# 4.7)
                 // this would lead to a compile error for the function application


### PR DESCRIPTION
Fixes #783, it will only add one extra space in our current problem.
Since this is such an edge case I would go for this fix.
We can revisit this another time to perhaps consider newline + tab.
