### PR TITLE
Apply opening brace in nested computation expression identifier

### DIFF
--- a/src/Fantomas.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Tests/ComputationExpressionTests.fs
@@ -258,3 +258,22 @@ let f2 =
         return r + s
     }
 """
+
+[<Test>]
+let ``computation expression with app identifier, 806`` () =
+    formatSourceString false """
+[<Tests>]
+let tests =
+  testList "tests"
+    [
+      test "test" {
+        Expect.equal true true "unexpected"
+      }
+    ]
+"""  config
+    |> prepend newline
+    |> should equal """
+[<Tests>]
+let tests =
+    testList "tests" [ test "test" { Expect.equal true true "unexpected" } ]
+"""

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -600,6 +600,8 @@ let (|CompExpr|_|) = function
         Some(isArray, expr)
     | _ -> None
 
+let isCompExpr = function | CompExpr _ -> true | _ -> false
+
 let (|ArrayOrListOfSeqExpr|_|) = function
     | SynExpr.ArrayOrListOfSeqExpr(isArray, expr, _) ->
         Some(isArray, expr)


### PR DESCRIPTION
Fixes #806

Apply same opening brace for computation expression if the identifier is a nested structure.
```fsharp
App
                             (NonAtomic,false,
                              App
                                (NonAtomic,false,Ident test,
                                 Const
                                   (String
                                      ("test",
                                       tmp.fsx (5,11--5,17) IsSynthetic=false),
                                    tmp.fsx (5,11--5,17) IsSynthetic=false),
                                 tmp.fsx (5,6--5,17) IsSynthetic=false),
```

See https://fsprojects.github.io/fantomas-tools/#/ast?data=N4KABGBEAmCmBmBLAdrAzpAXFSAacUiaAYmolmPAIYA2as%2BEkAxgPZwWQDaAPACroALmgB8AXQA6yGrEFhBQtGAC8UiArSCAMkTkTIG4frUQwXE6flCw%2Bw-rDALlsAFEAHgAdYzQQDpYAI4ArrTyAE5BsOGRNpBBqJ7eCtDGyM5gAL5OYpAgGUA