### PR TITLE
Don't add newline to module where the first trivia is a newline

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -541,3 +541,16 @@ let ``unit parameter to inherited class`` () =
 type Child() =
     inherit Parent()
 """
+
+[<Test>]
+let ``class let binding with attribute should not add newline, 786`` () =
+    formatSourceString false """type A() =
+
+    [<Bar>]
+    let foo = ()
+"""  config
+    |> should equal """type A() =
+
+    [<Bar>]
+    let foo = ()
+"""

--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -541,16 +541,3 @@ let ``unit parameter to inherited class`` () =
 type Child() =
     inherit Parent()
 """
-
-[<Test>]
-let ``class let binding with attribute should not add newline, 786`` () =
-    formatSourceString false """type A() =
-
-    [<Bar>]
-    let foo = ()
-"""  config
-    |> should equal """type A() =
-
-    [<Bar>]
-    let foo = ()
-"""

--- a/src/Fantomas.Tests/ModuleTests.fs
+++ b/src/Fantomas.Tests/ModuleTests.fs
@@ -439,10 +439,9 @@ type UrlModel =
       Defines: string }
 """
 
-[<TestCase(true)>]
-[<TestCase(false)>]
-let ``comment is first trivia in module should not add newline, 784`` (isFsiFile) =
-    formatSourceString isFsiFile """
+[<Test>]
+let ``comment is first trivia in module should not add newline, 784`` () =
+    formatSourceString false """
 module foo
 
 // bar
@@ -451,6 +450,54 @@ module foo
     |> prepend newline
     |> should equal """
 module foo
+
+// bar
+// baz
+"""
+
+[<Test>]
+let ``comment is first trivia in module in signature file should not add newline, 784`` () =
+    formatSourceString true """
+module foo
+
+// bar
+// baz
+"""  config
+    |> prepend newline
+    |> should equal """
+module foo
+
+// bar
+// baz
+"""
+
+[<Test>]
+let ``comment is first trivia in namespace should not add newline, 784`` () =
+    formatSourceString false """
+namespace foo.quz
+
+// bar
+// baz
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace foo.quz
+
+// bar
+// baz
+"""
+
+[<Test>]
+let ``comment is first trivia in namespace in signature file should not add newline, 784`` () =
+    formatSourceString true """
+namespace foo.quz
+
+// bar
+// baz
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace foo.quz
 
 // bar
 // baz

--- a/src/Fantomas.Tests/ModuleTests.fs
+++ b/src/Fantomas.Tests/ModuleTests.fs
@@ -438,3 +438,20 @@ type UrlModel =
       KeepNewlineAfter: bool
       Defines: string }
 """
+
+[<TestCase(true)>]
+[<TestCase(false)>]
+let ``comment is first trivia in module should not add newline, 784`` (isFsiFile) =
+    formatSourceString isFsiFile """
+module foo
+
+// bar
+// baz
+"""  config
+    |> prepend newline
+    |> should equal """
+module foo
+
+// bar
+// baz
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -125,7 +125,10 @@ and genModuleOrNamespace astContext (ModuleOrNamespace(ats, px, ao, s, mds, isRe
         let firstDecl = List.tryHead mds
         match firstDecl with
         | None ->
-            sepNlnForEmptyModule node.Range +> sepNln
+            if moduleKind.IsModule then
+                sepNlnForEmptyModule node.Range +> sepNln
+            else
+                sepNlnForEmptyNamespace node.Range +> sepNln
         | Some mdl ->
             let attrRanges = getRangesFromAttributesFromModuleDeclaration mdl
             sepNlnConsideringTriviaContentBeforeWithAttributes mdl.Range attrRanges +> sepNln
@@ -166,7 +169,10 @@ and genSigModuleOrNamespace astContext (SigModuleOrNamespace(ats, px, ao, s, mds
         let firstDecl = List.tryHead mds
         match firstDecl with
         | None ->
-            sepNlnForEmptyModule range +> rep 2 sepNln
+            if moduleKind.IsModule then
+                sepNlnForEmptyModule range +> rep 2 sepNln
+            else
+                sepNlnForEmptyNamespace range +> sepNln
         | Some mdl ->
             sepNlnConsideringTriviaContentBefore mdl.Range +> sepNln
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -124,7 +124,8 @@ and genModuleOrNamespace astContext (ModuleOrNamespace(ats, px, ao, s, mds, isRe
     let sepModuleAndFirstDecl =
         let firstDecl = List.tryHead mds
         match firstDecl with
-        | None -> rep 2 sepNln
+        | None ->
+            sepNlnForEmptyModule node.Range +> sepNln
         | Some mdl ->
             let attrRanges = getRangesFromAttributesFromModuleDeclaration mdl
             sepNlnConsideringTriviaContentBeforeWithAttributes mdl.Range attrRanges +> sepNln
@@ -164,7 +165,8 @@ and genSigModuleOrNamespace astContext (SigModuleOrNamespace(ats, px, ao, s, mds
     let sepModuleAndFirstDecl =
         let firstDecl = List.tryHead mds
         match firstDecl with
-        | None -> rep 2 sepNln
+        | None ->
+            sepNlnForEmptyModule range +> rep 2 sepNln
         | Some mdl ->
             sepNlnConsideringTriviaContentBefore mdl.Range +> sepNln
 

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -891,6 +891,14 @@ let internal sepNlnForEmptyModule (moduleRange:range) ctx =
     | _ ->
         sepNln ctx
 
+let internal sepNlnForEmptyNamespace (namespaceRange:range) ctx =
+    let emptyNamespaceRange = mkRange namespaceRange.FileName (mkPos 0 0) namespaceRange.End
+    match TriviaHelpers.findInRange ctx.Trivia emptyNamespaceRange with
+    | Some node when hasPrintableContent node.ContentBefore || hasPrintableContent node.ContentAfter ->
+        ctx
+    | _ ->
+        sepNln ctx
+
 let internal sepNlnTypeAndMembers (firstMemberRange: range option) ctx =
     match firstMemberRange with
     | Some range when (ctx.Config.NewlineBetweenTypeDefinitionAndMembers) ->

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -883,6 +883,13 @@ let internal sepNlnConsideringTriviaContentBeforeWithAttributes (ownRange:range)
     |> Seq.exists (fun ({ ContentBefore = contentBefore }) -> hasPrintableContent contentBefore)
     |> fun hasContentBefore ->
         if hasContentBefore then ctx else sepNln ctx
+        
+let internal sepNlnForEmptyModule (moduleRange:range) ctx =    
+    match findTriviaMainNodeOrTokenOnStartFromRange ctx.Trivia moduleRange with
+    | Some node when hasPrintableContent node.ContentBefore || hasPrintableContent node.ContentAfter ->
+        ctx
+    | _ ->
+        sepNln ctx
 
 let internal sepNlnTypeAndMembers (firstMemberRange: range option) ctx =
     match firstMemberRange with

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -146,9 +146,9 @@ let private mapNodeToTriviaNode (node: Node) =
     )
     
 let private commentIsAfterLastTriviaNode (triviaNodes: TriviaNode list) (range: range) =
-    triviaNodes
-    |> List.filter isMainNodeButNotAnonModule
-    |> List.forall (fun tn -> tn.Range.EndLine < range.StartLine)
+    match List.filter isMainNodeButNotAnonModule triviaNodes with
+    | [{ Type = MainNode("SynModuleOrNamespaceSig.NamedModule") }] -> true
+    | mainNodes -> mainNodes |> List.forall (fun tn -> tn.Range.EndLine < range.StartLine)
 
 let private updateTriviaNode lens (triviaNodes: TriviaNode list) triviaNode =
     match triviaNode with

--- a/src/Fantomas/TriviaHelpers.fs
+++ b/src/Fantomas/TriviaHelpers.fs
@@ -8,6 +8,10 @@ module internal TriviaHelpers =
     let findByRange (trivia: TriviaNode list) (range: range) =
         trivia
         |> List.tryFind (fun t -> t.Range = range)
+    
+    let findInRange (trivia: TriviaNode list) (range:range) =
+        trivia
+        |> List.tryFind (fun t -> RangeHelpers.``range contains`` range t.Range)
 
     let findFirstContentBeforeByRange (trivia: TriviaNode list) (range: range) =
         findByRange trivia range


### PR DESCRIPTION
I've taken a stab at fixing #784, but I'd like to check if I'm heading in the right direction first. The problem is that the `sepModuleAndFirstDecl` checks for any declaration. If there is no such declaration, two newlines are added after the module declaration. As comments are no declarations, this means that the comment will also receive two newlines. The main problem is that running format one more time after that, will add another newlines (there will be three at this point), and so on.

Let me know if I'm heading in the right direction with my solution.