### PR TITLE
Check for Trivia content before the equals sign in let bindings

### DIFF
--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -497,3 +497,27 @@ module Bar =
         for foo in bar().meh<SomeType> () do
             printf "baz"
 """
+
+[<Test>]
+let ``handle hash directives before equals, 728`` () = 
+    formatSourceString false """let Baz (firstParam: string)
+#if DEBUG
+            (_         : int)
+#else
+            (secndParam: int)
+#endif
+                =
+        ()
+
+    """ config
+    |> should equal """let Baz
+    (firstParam: string)
+#if DEBUG
+    (_: int)
+#else
+    (secndParam: int)
+#endif
+
+    =
+    ()
+"""

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -517,7 +517,33 @@ let ``handle hash directives before equals, 728`` () =
 #else
     (secndParam: int)
 #endif
-
     =
+    ()
+"""
+
+[<Test>]
+let ``multiple empty lines between equals and expression`` () =
+    formatSourceString false """let Baz (firstParam: string)
+#if DEBUG
+            (_         : int)
+#else
+            (secndParam: int)
+#endif
+                =
+
+
+        ()
+
+    """ config
+    |> should equal """let Baz
+    (firstParam: string)
+#if DEBUG
+    (_: int)
+#else
+    (secndParam: int)
+#endif
+    =
+
+
     ()
 """

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -485,7 +485,8 @@ and genExprSepEqPrependType astContext (pat:SynPat) (e: SynExpr) (isPrefixMultil
                 genExpr astContext e
             | _ -> isShortExpressionOrAddIndentAndNewline ctx.Config.MaxLetBindingWidth (genExpr astContext e)
 
-        (sepEqual isPrefixMultiline
+        (enterEqualsToken e.Range
+        +> sepEqual isPrefixMultiline
         +> leaveEqualsToken pat.Range
         +> ifElse (isPrefixMultiline || hasTriviaContentAfterEqual)
                (indent +> sepNln +> genExpr astContext e +> unindent)

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -771,6 +771,21 @@ let internal enterNode (range: range) (ctx: Context) = enterNodeWith findTriviaM
 let internal enterNodeToken (range: range) (ctx: Context) = enterNodeWith findTriviaTokenFromRange range ctx
 let internal enterNodeTokenByName (range: range) (tokenName:string) (ctx: Context) = enterNodeWith (findTriviaTokenFromName range) tokenName ctx
 
+let internal enterEqualsToken (range: range) (ctx: Context) =
+    ctx.Trivia
+    |> List.filter(fun tn ->
+        match tn.Type with
+        | Token(tok) ->
+            tok.TokenInfo.TokenName = "EQUALS" && tn.Range.StartLine = range.StartLine - 1
+        | _ -> false
+    )
+    |> List.tryHead
+    |> fun tn ->
+        match tn with
+        | Some tok -> enterNode tok.Range
+        | _ -> id
+    <| ctx
+
 let internal leaveNodeWith f x (ctx: Context) =
     match f ctx.Trivia x with
     | Some triviaNode ->


### PR DESCRIPTION
Fixes #728 

Hash directives in a let binding before the equals sign were not handled and caused the crash in the linked issue when merging the formatted code for both ASTs back together. 

The changes I made check for the presence of Trivia content before the equals sign in a let binding. In case there is Trivia content it gets printed before the equals sign.