### PR TITLE
Proper handling block comment at the end of file

### DIFF
--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -388,6 +388,18 @@ let hello () = "hello world"
 """
 
 [<Test>]
+let ``should handle block comments at the end of file, 810`` () =
+    formatSourceString false """
+printfn "hello world"
+(* This is a comment. *)
+"""  config
+    |> prepend newline
+    |> should equal """
+printfn "hello world"
+(* This is a comment. *)
+"""
+
+[<Test>]
 let ``should keep comments inside unit``() =
     formatSourceString false """
 let x =

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -264,6 +264,10 @@ let private addTriviaToTriviaNode (startOfSourceCode:int) (triviaNodes: TriviaNo
             Some n |> updateTriviaNode (fun tn -> 
                 let newline = tn.Range.StartLine > range.EndLine
                 { tn with ContentBefore = tn.ContentBefore @ [Comment(BlockComment(comment,false, newline))] }) triviaNodes
+        | (Some n), _ when (commentIsAfterLastTriviaNode triviaNodes range) ->
+            findLastNode triviaNodes
+            |> updateTriviaNode (fun tn ->
+                { tn with ContentAfter = tn.ContentAfter @ [Comment(BlockComment(comment, true, false))] }) triviaNodes
         | (Some n), _ ->
             Some n |> updateTriviaNode (fun tn ->
                 { tn with ContentAfter = tn.ContentAfter @ [Comment(BlockComment(comment,true,false))] }) triviaNodes


### PR DESCRIPTION
This PR fix issue #810. 
The used strategy is similar to the one used for [LineCommentOnSingleLine](https://github.com/matteobaglini/fantomas/blob/f83a2de6b311ac89e7be56896304b1feaf6f502e/src/Fantomas/Trivia.fs#L247-L250) at EOF.