### PR TITLE
Add comma at EOL for member/ctor tuples

### DIFF
--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1062,8 +1062,8 @@ let ``long type members should have parameters on separate lines, 719`` () =
     |> should equal """
 type C () =
     member __.LongMethodWithLotsOfParameters(
-        aVeryLongType: AVeryLongTypeThatYouNeedToUse
-        aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse
+        aVeryLongType: AVeryLongTypeThatYouNeedToUse,
+        aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
         aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse)
         =
         aVeryLongType aSecondVeryLongType aThirdVeryLongType
@@ -1078,8 +1078,8 @@ let ``long type member with return type should have parameters on separate lines
     |> should equal """
 type C () =
     member __.LongMethodWithLotsOfParameters(
-        aVeryLongType: AVeryLongTypeThatYouNeedToUse
-        aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse
+        aVeryLongType: AVeryLongTypeThatYouNeedToUse,
+        aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
         aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse)
         : int
         =
@@ -1094,8 +1094,8 @@ let ``long constructors should have parameters on separate lines`` () =
     |> prepend newline
     |> should equal """
 type C (
-    aVeryLongType: AVeryLongTypeThatYouNeedToUse
-    aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse
+    aVeryLongType: AVeryLongTypeThatYouNeedToUse,
+    aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
     aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse)
     =
     member this.X = 42

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2524,7 +2524,7 @@ and genMemberDefn astContext node =
         let ctorPats =
             expressionFitsOnRestOfLine
                 (col sepComma (simplePats ps) (genSimplePat astContext))
-                (indent +> sepNln +> col sepNln (simplePats ps) (genSimplePat astContext) +> unindent)
+                (indent +> sepNln +> col (sepComma +> sepNln) (simplePats ps) (genSimplePat astContext) +> unindent)
 
         // In implicit constructor, attributes should come even before access qualifiers
         ifElse ats.IsEmpty sepNone (sepSpace +> genOnelinerAttributes astContext ats)
@@ -2686,7 +2686,7 @@ and genPat astContext pat =
     | PatTuple ps ->
         expressionFitsOnRestOfLine
             (col sepComma ps (genPat astContext))
-            (indent +> sepNln +> col sepNln ps (genPat astContext))
+            (indent +> sepNln +> col (sepComma +> sepNln) ps (genPat astContext))
     | PatStructTuple ps ->
         !- "struct " +> sepOpenT +> atCurrentColumn (colAutoNlnSkip0 sepComma ps (genPat astContext)) +> sepCloseT
     | PatSeq(PatList, ps) ->


### PR DESCRIPTION
Fixes #841 

Member and constructor tuples should have a comma at the end of their corresponding lines.