### PR TITLE
Split multiple parameters across multiple lines if they exceed page width

### DIFF
--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1162,3 +1162,19 @@ type SomeType() =
 
     member SomeOtherMember() = printfn "b"
 """
+
+[<Test>]
+let ``return type and equals sign in correct line when member has multiple parameters`` () =
+    formatSourceString false """type SomeType =
+    static member SomeMember (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string) (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string) : string =
+    printfn "a"
+    "b"
+"""  config
+    |> prepend newline
+    |> should equal """
+type SomeType =
+    static member SomeMember (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string)
+                  (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string): string =
+        printfn "a"
+        "b"
+"""

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1173,8 +1173,11 @@ let ``return type and equals sign in correct line when member has multiple param
     |> prepend newline
     |> should equal """
 type SomeType =
-    static member SomeMember (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string)
-                  (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string): string =
-        printfn "a"
-        "b"
+    static member SomeMember
+                  (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string)
+                  (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string)
+    : string
+    =
+    printfn "a"
+    "b"
 """

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1164,7 +1164,7 @@ type SomeType() =
 """
 
 [<Test>]
-let ``return type and equals sign in correct line when member has multiple parameters`` () =
+let ``split multiple parameters over multiple lines`` () =
     formatSourceString false """type SomeType =
     static member SomeMember (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string) (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string) : string =
     printfn "a"
@@ -1178,6 +1178,59 @@ type SomeType =
         (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string)
         : string
         =
+        printfn "a"
+        "b"
+"""
+
+[<Test>]
+let ``split multiple parameters over multiple lines and have correct indentation afterwards`` () =
+    formatSourceString false """type SomeType =
+    static member SomeMember (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string) (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string) : string =
+    printfn "a"
+    "b"
+
+    static member SomeOtherMember () = printfn "c"
+"""  config
+    |> prepend newline
+    |> should equal """
+type SomeType =
+    static member SomeMember
+        (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string)
+        (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string)
+        : string
+        =
+        printfn "a"
+        "b"
+
+    static member SomeOtherMember() = printfn "c"
+"""
+
+[<Test>]
+let ``member with one long parameter and return type`` () =
+    formatSourceString false """type SomeType =
+    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 : string =
+    printfn "a"
+    "b"
+"""  config
+    |> prepend newline
+    |> should equal """
+type SomeType =
+    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string =
+        printfn "a"
+        "b"
+"""
+
+[<Test>]
+let ``member with one long parameter and no return type`` () =
+    formatSourceString false """type SomeType =
+    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 =
+    printfn "a"
+    "b"
+"""  config
+    |> prepend newline
+    |> should equal """
+type SomeType =
+    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 =
         printfn "a"
         "b"
 """

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1174,10 +1174,10 @@ let ``return type and equals sign in correct line when member has multiple param
     |> should equal """
 type SomeType =
     static member SomeMember
-                  (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string)
-                  (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string)
-    : string
-    =
-    printfn "a"
-    "b"
+        (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string)
+        (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string)
+        : string
+        =
+        printfn "a"
+        "b"
 """

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2675,18 +2675,17 @@ and genPat astContext pat =
         | ps ->
             let hasBracket = ps |> Seq.map fst |> Seq.exists Option.isSome
             let genName = aoc -- s +> tpsoc +> sepSpace
-            // let genParameters = colAutoNlnSkip0 (ifElse hasBracket sepSemi sepSpace) ps (genPatWithIdent astContext)
 
             let genParameters = 
                 (expressionFitsOnRestOfLine
-                (col (ifElse hasBracket sepSemi sepSpace) ps (genPatWithIdent astContext))
-                (sepNln +> col sepNln ps (genPatWithIdent astContext)))
+                (atCurrentColumn (col (ifElse hasBracket sepSemi sepSpace) ps (genPatWithIdent astContext)))
+                (indent +> sepNln +> col sepNln ps (genPatWithIdent astContext)))
 
 
-            atCurrentColumn (genName
-                +> ifElse hasBracket sepOpenT sepNone
-                +> genParameters
-                +> ifElse hasBracket sepCloseT sepNone)
+            genName
+            +> ifElse hasBracket sepOpenT sepNone
+            +> genParameters
+            +> ifElse hasBracket sepCloseT sepNone
 
     | PatParen(PatConst(Const "()", _)) -> !- "()"
     | PatParen(p) -> sepOpenT +> genPat astContext p +> sepCloseT

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -672,12 +672,18 @@ and genMemberBinding astContext b =
             genMemberFlagsForMemberBinding astContext mf b.RangeOfBindingAndRhs
             +> ifElse isInline (!- "inline ") sepNone +> opt sepSpace ao genAccess +> genPat ({ astContext with IsMemberDefinition = true }) p
 
+        let hasMultipleParameters =
+            match p with 
+            | PatLongIdent(_, _, ps, _) ->
+                ps.Length > 1
+            | _ -> false
+
         match e with
         | TypedExpr(Typed, e, t) ->
             genAttributesAndXmlDoc
             +> leadingExpressionIsMultiline prefix (fun prefixIsLong ->
                 ifElse
-                    prefixIsLong
+                    (prefixIsLong && not hasMultipleParameters)
                     (sepNln +> sepColon +> genType astContext false t +> sepNln +> !- "=" +> sepNln +> genExpr astContext e +> unindent)
                     (sepColon +> genType astContext false t +> sepEq +> autoIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e)))
         | e ->


### PR DESCRIPTION
Fixes #846 

The way I have implemented this is that we check for the amount of parameters in a typed member definition. If there is more than one parameter the return type is kept in the same line as the last parameter. 

Regarding the checking for the amount of parameters I am not sure if it is implemented in the cleanest way. For that reason this PR is created as draft. When it is clear how the changes should be implemented I can also add more test cases.

cc @nojaf 