### PR TITLE
Support long member definitions with a single parameter

### DIFF
--- a/src/Fantomas.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Tests/FunctionDefinitionTests.fs
@@ -280,7 +280,8 @@ open Accessibility
 [<DllImport("oleacc.dll")>]
 extern int AccessibleChildren(IAccessible paccContainer, int iChildStart, int cChildren, [<Out; MarshalAs(UnmanagedType.LPArray,
                                                                                                           SizeParamIndex =
-                                                                                                              4s)>] System.Object [] rgvarChildren, int* pcObtained)
+                                                                                                              4s)>] System.Object []
+    rgvarChildren, int* pcObtained)
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1206,7 +1206,7 @@ type SomeType =
 """
 
 [<Test>]
-let ``member with one long parameter and return type`` () =
+let ``member with one long parameter and return type, 850`` () =
     formatSourceString false """type SomeType =
     static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 : string =
     printfn "a"
@@ -1215,13 +1215,16 @@ let ``member with one long parameter and return type`` () =
     |> prepend newline
     |> should equal """
 type SomeType =
-    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string =
+    static member SomeMember
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1
+        : string
+        =
         printfn "a"
         "b"
 """
 
 [<Test>]
-let ``member with one long parameter and no return type`` () =
+let ``member with one long parameter and no return type, 850`` () =
     formatSourceString false """type SomeType =
     static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 =
     printfn "a"
@@ -1230,7 +1233,41 @@ let ``member with one long parameter and no return type`` () =
     |> prepend newline
     |> should equal """
 type SomeType =
-    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 =
+    static member SomeMember
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1
+        =
         printfn "a"
         "b"
+"""
+
+[<Test>]
+let ``multiple members with one long parameter`` () =
+    formatSourceString false """type SomeType =
+    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 =
+    printfn "a"
+    "b"
+
+    static member Serialize (loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: SomeType) = Encode.string v.Meh
+    static member Deserialize (loooooooooooooooooooooooooooooooooooooooooooooooooooooonnnnnnnnnnnnnnnnnnnnngggggggggggJsonVaaaaalueeeeeeeeeeeeeeee) : SomeType = Decode.SomeType loooooooooooooooooooooooooooooooooooooooooooooooooooooonnnnnnnnnnnnnnnnnnnnngggggggggggJsonVaaaaalueeeeeeeeeeeeeeee
+"""  config
+    |> prepend newline
+    |> should equal """
+type SomeType =
+    static member SomeMember
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1
+        =
+        printfn "a"
+        "b"
+
+    static member Serialize(
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: SomeType)
+        =
+        Encode.string v.Meh
+
+    static member Deserialize(
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooonnnnnnnnnnnnnnnnnnnnngggggggggggJsonVaaaaalueeeeeeeeeeeeeeee)
+        : SomeType
+        =
+        Decode.SomeType
+            loooooooooooooooooooooooooooooooooooooooooooooooooooooonnnnnnnnnnnnnnnnnnnnngggggggggggJsonVaaaaalueeeeeeeeeeeeeeee
 """

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -575,6 +575,12 @@ let private expressionExceedsPageWidth beforeShort afterShort beforeLong afterLo
 /// add an indent and newline if the expression is longer
 let internal autoIndentAndNlnIfExpressionExceedsPageWidth expr (ctx:Context) =
     expressionExceedsPageWidth
+        sepNone sepNone // before and after for short expressions
+        (indent +> sepNln) unindent // before and after for long expressions
+        expr ctx
+
+let internal sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth expr (ctx:Context) =
+    expressionExceedsPageWidth
         sepSpace sepNone // before and after for short expressions
         (indent +> sepNln) unindent // before and after for long expressions
         expr ctx


### PR DESCRIPTION
Adds support to format long member definitions with a single parameter.

The test in FunctionDefinition had to be changed, the result is still valid AST, however, I admit this doesn't really look all the good. I already created https://github.com/fsprojects/fantomas/issues/735 a while ago to tackle this properly.
Seems like the lesser evil for now.