### PR TITLE
MultilineBlockBracketsOnSameColumn: Put inherit keyword in record into newline

### DIFF
--- a/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
+++ b/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
@@ -125,6 +125,21 @@ let a =
 """
 
 [<Test>]
+let ``type with record instance with inherit keyword`` () =
+    formatSourceString false """type ServerCannotBeResolvedException =
+    inherit CommunicationUnsuccessfulException
+
+    new(message) =
+        { inherit CommunicationUnsuccessfulException(message) }"""  config
+    |> prepend newline
+    |> should equal """
+type ServerCannotBeResolvedException =
+    inherit CommunicationUnsuccessfulException
+
+    new(message) = { inherit CommunicationUnsuccessfulException(message) }
+"""
+
+[<Test>]
 let ``anonymous record`` () =
     formatSourceString false """let meh =
     {| Level = 1

--- a/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
+++ b/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
@@ -106,7 +106,8 @@ let ``record instance with inherit keyword`` () =
     |> prepend newline
     |> should equal """
 let a =
-    { inherit ProjectPropertiesBase<_>(projectTypeGuids, factoryGuid, targetFrameworkIds, dotNetCoreSDK)
+    {
+        inherit ProjectPropertiesBase<_>(projectTypeGuids, factoryGuid, targetFrameworkIds, dotNetCoreSDK)
         buildSettings = FSharpBuildSettings()
         targetPlatformData = targetPlatformData
     }

--- a/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
+++ b/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
@@ -114,6 +114,17 @@ let a =
 """
 
 [<Test>]
+let ``record instance with inherit keyword and no fields`` () =
+    formatSourceString false """let a =
+        { inherit ProjectPropertiesBase<_>(projectTypeGuids, factoryGuid, targetFrameworkIds, dotNetCoreSDK) }
+"""  config
+    |> prepend newline
+    |> should equal """
+let a =
+    { inherit ProjectPropertiesBase<_>(projectTypeGuids, factoryGuid, targetFrameworkIds, dotNetCoreSDK) }
+"""
+
+[<Test>]
 let ``anonymous record`` () =
     formatSourceString false """let meh =
     {| Level = 1

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1649,9 +1649,9 @@ and genMultilineRecordInstanceAlignBrackets
 
     match inheritOpt, eo with
     | Some (inheritType, inheritExpr), None ->
-        sepOpenS +>
+        sepOpenS +> indent +> sepNln +>
         !- "inherit " +> genType astContext false inheritType +> genExpr astContext inheritExpr
-        +> (indent +> sepNln +> fieldsExpr +> unindent +> sepNln +> sepCloseSFixed)
+        +> (sepNln +> fieldsExpr +> unindent +> sepNln +> sepCloseSFixed)
 
     | None, Some e ->
         sepOpenS +> genExpr astContext e

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1655,12 +1655,14 @@ and genMultilineRecordInstanceAlignBrackets
     astContext
     =
     let fieldsExpr = col sepSemiNln xs (genRecordFieldName astContext)
+    let hasFields = List.length xs > 0
 
     match inheritOpt, eo with
     | Some (inheritType, inheritExpr), None ->
-        sepOpenS +> indent +> sepNln +>
-        !- "inherit " +> genType astContext false inheritType +> genExpr astContext inheritExpr
-        +> (sepNln +> fieldsExpr +> unindent +> sepNln +> sepCloseSFixed)
+        sepOpenS
+        +> ifElse hasFields (indent +> sepNln) sepNone
+        +> !- "inherit " +> genType astContext false inheritType +> genExpr astContext inheritExpr
+        +> ifElse hasFields (sepNln +> fieldsExpr +> unindent +> sepNln +> sepCloseSFixed) (sepSpace +> sepCloseSFixed)
 
     | None, Some e ->
         sepOpenS +> genExpr astContext e

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1655,7 +1655,7 @@ and genMultilineRecordInstanceAlignBrackets
     astContext
     =
     let fieldsExpr = col sepSemiNln xs (genRecordFieldName astContext)
-    let hasFields = List.length xs > 0
+    let hasFields = List.isNotEmpty xs
 
     match inheritOpt, eo with
     | Some (inheritType, inheritExpr), None ->


### PR DESCRIPTION
Fixes #852 

Puts the `inherit`-keyword into a new line and indents when `MultilineBlockBracketsOnSameColumn` is enabled. Example:

**Code**
```
let a =
    { inherit ProjectPropertiesBase<_>(projectTypeGuids, factoryGuid, targetFrameworkIds, dotNetCoreSDK)
      buildSettings = FSharpBuildSettings()
      targetPlatformData = targetPlatformData }
```
**Result**
```
let a =
    {
        inherit ProjectPropertiesBase<_>(projectTypeGuids, factoryGuid, targetFrameworkIds, dotNetCoreSDK)
        buildSettings = FSharpBuildSettings()
        targetPlatformData = targetPlatformData
    }
```

At the time of writing this it is not entirely clear if the behaviour this PR implements is intended. Thus it's a draft for now until we know more.