### PR TITLE
Put access modifier on new line when printing a long type constructor

### DIFF
--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1271,3 +1271,25 @@ type SomeType =
         Decode.SomeType
             loooooooooooooooooooooooooooooooooooooooooooooooooooooonnnnnnnnnnnnnnnnnnnnngggggggggggJsonVaaaaalueeeeeeeeeeeeeeee
 """
+
+[<Test>]
+let ``access modifier before long constructor`` () =
+    formatSourceString false """type INotifications<'a,'b,'c,'d,'e> = 
+    class
+    end
+type DeviceNotificationHandler<'Notification, 'CallbackId, 'RegisterInputData, 'RegisterOutputData, 'UnregisterOutputData> private (client: INotifications<'Notification, 'CallbackId, 'RegisterInputData, 'RegisterOutputData, 'UnregisterOutputData>, callbackId: 'CallbackId, validateUnregisterOutputData: 'UnregisterOutputData -> unit) =
+    let a = 5
+"""  config
+    |> prepend newline
+    |> should equal """
+type INotifications<'a, 'b, 'c, 'd, 'e> =
+    class
+    end
+
+type DeviceNotificationHandler<'Notification, 'CallbackId, 'RegisterInputData, 'RegisterOutputData, 'UnregisterOutputData>
+    private (client: INotifications<'Notification, 'CallbackId, 'RegisterInputData, 'RegisterOutputData, 'UnregisterOutputData>,
+             callbackId: 'CallbackId,
+             validateUnregisterOutputData: 'UnregisterOutputData -> unit)
+    =
+    let a = 5
+"""


### PR DESCRIPTION
Fixes #856