### PR TITLE
Split MaxLetBindingWidth into two separate settings

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -268,7 +268,8 @@ A default configuration file would look like
   "MaxInfixOperatorExpression":50,
   "MaxRecordWidth":40,
   "MaxArrayOrListWidth":40,
-  "MaxLetBindingWidth":40,
+  "MaxFunctionBindingWidth":40,
+  "MaxValueBindingWidth":40,
   "MultilineBlockBracketsOnSameColumn":false,
   "NewlineBetweenTypeDefinitionAndMembers":false,
   "StrictMode":false 

--- a/src/Fantomas.Tests/ActivePatternTests.fs
+++ b/src/Fantomas.Tests/ActivePatternTests.fs
@@ -43,7 +43,7 @@ let (|ParseRegex|_|) regex str =
    let m = Regex(regex).Match(str)
    if m.Success
    then Some (List.tail [ for x in m.Groups -> x.Value ])
-   else None""" ({ config with MaxLetBindingWidth = 30 })
+   else None""" ({ config with MaxFunctionBindingWidth = 30; MaxValueBindingWidth = 30 })
     |> prepend newline
     |> should equal """
 let (|Even|Odd|) input =

--- a/src/Fantomas.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Tests/ComputationExpressionTests.fs
@@ -90,7 +90,7 @@ let factors number =
     {2L .. number / 2L}
     |> Seq.filter (fun x -> number % x = 0L)""" ({ config with
                                                         MaxInfixOperatorExpression = 65
-                                                        MaxLetBindingWidth = 65 })
+                                                        MaxFunctionBindingWidth = 65 })
     |> prepend newline
     |> should equal """
 let factors number = { 2L .. number / 2L } |> Seq.filter (fun x -> number % x = 0L)

--- a/src/Fantomas.Tests/FormattingSelectionOnlyTests.fs
+++ b/src/Fantomas.Tests/FormattingSelectionOnlyTests.fs
@@ -69,7 +69,7 @@ let source = "
           done;
       done;;
     Multiple9x9 ();;"
-"""     ({ config with MaxLetBindingWidth = 60; MaxRecordWidth = 50 })
+"""     ({ config with MaxFunctionBindingWidth = 60; MaxValueBindingWidth = 60; MaxRecordWidth = 50 })
     |> should equal """let config = { FormatConfig.Default with IndentSpaceNum = 2 }"""
 
 [<Test>]

--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -222,7 +222,7 @@ let foo = Foo(fun () -> Foo.Create x).Value
 [<Test>]
 let ``line comment after lambda should not necessary make it multiline`` () =
     formatSourceString false """let a = fun _ -> div [] [] // React.lazy is not compatible with SSR, so just use an empty div
-"""  ({ config with MaxLetBindingWidth = 150 })
+"""  ({ config with MaxValueBindingWidth = 150 })
     |> prepend newline
     |> should equal """
 let a = fun _ -> div [] [] // React.lazy is not compatible with SSR, so just use an empty div

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -35,7 +35,7 @@ let f () =
       x + y
 """
 
-    formatSourceString false codeSnippet ({ config with MaxLetBindingWidth = 50 })
+    formatSourceString false codeSnippet ({ config with MaxFunctionBindingWidth = 50; MaxValueBindingWidth = 50 })
     |> should equal """let f () =
     let x = 1 (* the "in" keyword is available in F# *)
     let y = 2
@@ -81,7 +81,7 @@ let ``DotGet on newline should be indented far enough`` () =
 let tomorrow =
     DateTimeOffset(n.Year, n.Month, n.Day, 0, 0, 0, n.Offset)
         .AddDays(1.)
-"""  ({ config with MaxLetBindingWidth = 70 })
+"""  ({ config with MaxValueBindingWidth = 70 })
     |> prepend newline
     |> should equal """
 let tomorrow = DateTimeOffset(n.Year, n.Month, n.Day, 0, 0, 0, n.Offset).AddDays(1.)

--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -6,7 +6,7 @@ open Fantomas.Tests.TestHelper
 
 [<Test>]
 let ``triple-quoted strings``() =
-    formatSourceString false "let xmlFragment2 = \"\"\"<book author=\"Milton, John\" title=\"Paradise Lost\">\"\"\"" ({ config with MaxLetBindingWidth = 60 })
+    formatSourceString false "let xmlFragment2 = \"\"\"<book author=\"Milton, John\" title=\"Paradise Lost\">\"\"\"" ({ config with MaxValueBindingWidth = 60 })
     |> should equal "let xmlFragment2 = \"\"\"<book author=\"Milton, John\" title=\"Paradise Lost\">\"\"\"
 "
 
@@ -15,7 +15,7 @@ let ``string literals``() =
     formatSourceString false """
 let xmlFragment1 = @"<book author=""Milton, John"" title=""Paradise Lost"">"
 let str1 = "abc"
-    """ ({ config with MaxLetBindingWidth = 60 })
+    """ ({ config with MaxValueBindingWidth = 60 })
     |> prepend newline
     |> should equal """
 let xmlFragment1 = @"<book author=""Milton, John"" title=""Paradise Lost"">"

--- a/src/Fantomas.Tests/TupleTests.fs
+++ b/src/Fantomas.Tests/TupleTests.fs
@@ -12,7 +12,7 @@ let private carouselSample =
     FunctionComponent.Of<obj>(fun _ ->
         fragment [] []
     ,"CarouselSample")
-"""  ({ config with MaxLetBindingWidth = 75 })
+"""  ({ config with MaxValueBindingWidth = 75 })
     |> should equal """let private carouselSample = FunctionComponent.Of<obj>((fun _ -> fragment [] []), "CarouselSample")
 """
 

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -330,7 +330,7 @@ type SpeedingTicket() =
 
 let CalculateFine (ticket : SpeedingTicket) =
     let delta = ticket.GetMPHOver(limit = 55, speed = 70)
-    if delta < 20 then 50.0 else 100.0""" ({ config with MaxLetBindingWidth = 45 })
+    if delta < 20 then 50.0 else 100.0""" ({ config with MaxValueBindingWidth = 45 })
     |> prepend newline
     |> should equal """
 type SpeedingTicket() =
@@ -568,7 +568,7 @@ let ``should keep brackets around type signatures``() =
     formatSourceString false """
 let user_printers = ref([] : (string * (term -> unit)) list)
 let the_interface = ref([] : (string * (string * hol_type)) list)
-    """ ({ config with MaxLetBindingWidth = 50 })
+    """ ({ config with MaxValueBindingWidth = 50 })
     |> prepend newline
     |> should equal """
 let user_printers = ref ([]: (string * (term -> unit)) list)

--- a/src/Fantomas/FormatConfig.fs
+++ b/src/Fantomas/FormatConfig.fs
@@ -32,7 +32,8 @@ type FormatConfig =
       MaxInfixOperatorExpression: Num
       MaxRecordWidth: Num
       MaxArrayOrListWidth: Num
-      MaxLetBindingWidth: Num
+      MaxFunctionBindingWidth: Num
+      MaxValueBindingWidth: Num
       MultilineBlockBracketsOnSameColumn : bool
       NewlineBetweenTypeDefinitionAndMembers: bool
       KeepIfThenInSameLine : bool
@@ -58,7 +59,8 @@ type FormatConfig =
           MaxInfixOperatorExpression = 50
           MaxRecordWidth = 40
           MaxArrayOrListWidth = 40
-          MaxLetBindingWidth = 40
+          MaxFunctionBindingWidth = 40
+          MaxValueBindingWidth = 40
           MultilineBlockBracketsOnSameColumn = false
           KeepIfThenInSameLine = false
           StrictMode = false

--- a/src/Fantomas/schema.json
+++ b/src/Fantomas/schema.json
@@ -59,7 +59,10 @@
     "MaxArrayOrListWidth": {
       "type": "integer"
     },
-    "MaxLetBindingWidth": {
+    "MaxFunctionBindingWidth": {
+      "type": "integer"
+    },
+    "MaxValueBindingWidth": {
       "type": "integer"
     },
     "MultilineBlockBracketsOnSameColumn": {


### PR DESCRIPTION
Implements #848 as discussed.

The `MaxLetBindingWidth` has been split into two separate settings:

- `MaxValueBindingWidth`: Handles values like `let someValue = 1`
- `MaxFunctionBindingWidth`: Handles function definitions like `let someFunction someParam = someParam + 1`

Schema and docs are updated for the new settings. Existing test cases are also updated to work with the new settings. However, I did not add new tests since, in my opinion, the existing tests should cover these new settings. If desired new tests can also be added.