### PR TITLE
Wrap lambda in atCurrentColumn

### DIFF
--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -305,3 +305,61 @@ List.tryFind (fun { Type = t; Range = r } -> // foo
     let a = 8
     a + 9)
 """
+
+[<Test>]
+let ``lambda body should be indented far enough, 870`` () =
+    formatSourceString false """  let projectIntoMap projection =
+    fun state eventEnvelope ->
+      state
+      |> Map.tryFind eventEnvelope.Metadata.Source
+      |> Option.defaultValue projection.Init
+      |> fun projectionState -> eventEnvelope.Event |> projection.Update projectionState
+      |> fun newState -> state |> Map.add eventEnvelope.Metadata.Source newState
+
+let projectIntoMap projection =
+  fun state eventEnvelope ->
+    state
+    |> Map.tryFind eventEnvelope.Metadata.Source
+    |> Option.defaultValue projection.Init
+    |> fun projectionState ->
+         eventEnvelope.Event
+         |> projection.Update projectionState
+    |> fun newState ->
+         state
+         |> Map.add eventEnvelope.Metadata.Source newState
+"""
+        ({ config with
+               IndentSpaceNum = 2
+               SpaceBeforeUppercaseInvocation = true
+               SpaceBeforeColon = true
+               SpaceAfterComma = false
+               SpaceAroundDelimiter = false
+               MaxInfixOperatorExpression = 40
+               MaxLetBindingWidth = 60
+               MultilineBlockBracketsOnSameColumn = true })
+    |> prepend newline
+    |> should equal """
+let projectIntoMap projection =
+  fun state eventEnvelope ->
+    state
+    |> Map.tryFind eventEnvelope.Metadata.Source
+    |> Option.defaultValue projection.Init
+    |> fun projectionState ->
+         eventEnvelope.Event
+         |> projection.Update projectionState
+    |> fun newState ->
+         state
+         |> Map.add eventEnvelope.Metadata.Source newState
+
+let projectIntoMap projection =
+  fun state eventEnvelope ->
+    state
+    |> Map.tryFind eventEnvelope.Metadata.Source
+    |> Option.defaultValue projection.Init
+    |> fun projectionState ->
+         eventEnvelope.Event
+         |> projection.Update projectionState
+    |> fun newState ->
+         state
+         |> Map.add eventEnvelope.Metadata.Source newState
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1050,8 +1050,11 @@ and genExpr astContext synExpr =
 
     // When there are parentheses, most likely lambda will appear in function application
     | Lambda(e, sps) ->
-        !- "fun " +> col sepSpace sps (genSimplePats astContext) +> sepArrow
-        +> autoIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e)
+        atCurrentColumn
+            (!- "fun "
+             +> col sepSpace sps (genSimplePats astContext)
+             +> sepArrow
+             +> autoIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e))
     | MatchLambda(sp, _) -> !- "function " +> colPre sepNln sepNln sp (genClause astContext true)
     | Match(e, cs) ->
         atCurrentColumn (!- "match " +> genExpr astContext e -- " with" +> colPre sepNln sepNln cs (genClause astContext true))


### PR DESCRIPTION
Fixes #870.
@jindraivanek we already had an indent if multiline so that pushes the body of the `f` of the `fun`.