### PR TITLE
Try online link updated to new URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Alternatively, you can install the [fantomas-fmt](https://marketplace.visualstud
 
 ### Online
 
-Try the Fantomas [online](https://jindraivanek.gitlab.io/fantomas-ui/#?fantomas=preview).
+Try the Fantomas [online](https://fsprojects.github.io/fantomas-tools/#/fantomas/preview).
 
 ## Early builds
 


### PR DESCRIPTION
Updated the _try online_ link to the new URL (on fsprojects.github.io).