### PR TITLE
First solution to create an expression visitor #893

### DIFF
--- a/src/Fantomas/CodeFormatter.fs
+++ b/src/Fantomas/CodeFormatter.fs
@@ -35,3 +35,8 @@ type CodeFormatter =
     static member GetVersion() = Version.fantomasVersion.Value
 
     static member ReadConfiguration(fileOrFolder) = CodeFormatterImpl.readConfiguration fileOrFolder
+
+    static member SetVisitorExpression(astExpressionVisitor) =
+        CodePrinter.expressionVisitor <- astExpressionVisitor
+        
+        

--- a/src/Fantomas/CodeFormatter.fsi
+++ b/src/Fantomas/CodeFormatter.fsi
@@ -37,3 +37,7 @@ type CodeFormatter =
     /// Accepts a file or a folder and parses the found json to a FormatConfig
     /// Configuration found in parent folders will be applied first.
     static member ReadConfiguration : string -> FormatConfigFileParseResult
+
+    /// SynExpr syntax visitor, to create AST-visitor that is called
+    /// when the AST is formated back to the source code
+    static member SetVisitorExpression : (SynExpr -> SynExpr) -> unit

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -46,6 +46,8 @@ type ASTContext =
           IsFirstTypeParam = false; IsInsideDotGet = false
           IsMemberDefinition = false }
 
+let mutable expressionVisitor : SynExpr -> SynExpr = id
+
 let rec addSpaceBeforeParensInFunCall functionOrMethod arg (ctx:Context) =
     match functionOrMethod, arg with
     | SynExpr.TypeApp(e, _, _, _, _, _, _), _ ->
@@ -821,8 +823,8 @@ and genExpr astContext synExpr =
     let kw tokenName f = tokN synExpr.Range tokenName f
     let sepOpenT = tokN synExpr.Range "LPAREN" sepOpenT
     let sepCloseT = tokN synExpr.Range "RPAREN" sepCloseT
-
-    match synExpr with
+    
+    match expressionVisitor(synExpr) with
     | SingleExpr(Lazy, e) ->
         // Always add braces when dealing with lazy
         let hasParenthesis = hasParenthesis e


### PR DESCRIPTION
This is an example how simply AST-parsing could be plugged in. (Issue #893)

User uses the code like this:
```fsharp
module MyParser =         
    // No need to be recursive here because the parsing in
    // genExpr is already recursive
    let myParser (expr:FSharp.Compiler.SyntaxTree.SynExpr) =  
        match expr with
        | Fantomas.SourceParser.ArrayOrList(a,b,c)->
           printfn "I saw an array or list somewhere in your code!"
           expr
        | _ -> expr
    Fantomas.CodeFormatter.SetVisitorExpression myParser
```

Now, this would be only the first part of the real solution: The next question is how would I create a new SynExpr.

I don't know Fantomas yet very well, just saw your presentation at fsharpConf2020, so feel free to not approve this, if it's not in the spirit of this library.
