### PR TITLE
Perf: use Queue.length instead Seq.length

### DIFF
--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -576,7 +576,7 @@ let internal leadingExpressionLong threshold leadingExpression continuationExpre
     continuationExpression (lineCountAfter > lineCountBefore || (columnAfter - columnBefore > threshold)) contextAfterLeading
 
 let internal leadingExpressionIsMultiline leadingExpression continuationExpression (ctx: Context) =
-    let eventCountBeforeExpression = Seq.length ctx.WriterEvents
+    let eventCountBeforeExpression = Queue.length ctx.WriterEvents
     let contextAfterLeading = leadingExpression ctx
     let hasWriteLineEventsAfterExpression = contextAfterLeading.WriterEvents |>Seq.skip eventCountBeforeExpression |> Seq.exists (function | WriteLine _ -> true | _ -> false)
     continuationExpression hasWriteLineEventsAfterExpression contextAfterLeading


### PR DESCRIPTION
before

| Method |    Mean |   Error |  StdDev | Rank |        Gen 0 |       Gen 1 |       Gen 2 | Allocated |
|------- |--------:|--------:|--------:|-----:|-------------:|------------:|------------:|----------:|
| Format | 41.41 s | 21.28 s | 1.166 s |    1 | 2660000.0000 | 920000.0000 | 148000.0000 |   13.1 GB |

after

| Method |    Mean |   Error |  StdDev | Rank |        Gen 0 |       Gen 1 |      Gen 2 | Allocated |
|------- |--------:|--------:|--------:|-----:|-------------:|------------:|-----------:|----------:|
| Format | 37.33 s | 2.964 s | 0.162 s |    1 | 2357000.0000 | 759000.0000 | 66000.0000 |  11.92 GB |