### PR TITLE
Perf: Collect trivias - remove unnecessary sorts

### DIFF
--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -41,7 +41,6 @@ let filterNodes nodes =
 let private findFirstNodeOnLine (nodes: TriviaNode list) lineNumber : TriviaNode option =
     nodes
     |> List.filter (fun { Range =r  } -> r.StartLine = lineNumber)
-    |> List.sortBy (fun { Range = r } -> r.StartColumn)
     |> List.tryHead
 
 let private mainNodeIs name (t:TriviaNodeAssigner) =
@@ -68,11 +67,9 @@ let private findFirstNodeAfterLine (nodes: TriviaNodeAssigner list) lineNumber :
         | moduleAndOpens when (nodesContainsBothAnonModuleAndOpen moduleAndOpens) ->
             moduleAndOpens
             |> List.filter (fun t -> t.Type = MainNode("SynModuleDecl.Open"))
-            |> List.sortBy (fun t -> t.Range.StartLine)
             |> List.tryHead
         | _ ->
             filteredNodes
-            |> List.sortBy (fun tn -> tn.Range.StartLine, tn.Range.StartColumn)
             |> List.tryHead
 
 let private findLastNodeOnLine (nodes: TriviaNodeAssigner list) lineNumber : TriviaNodeAssigner option =


### PR DESCRIPTION
before
| Method |    Mean |   Error |  StdDev | Rank |        Gen 0 |       Gen 1 |      Gen 2 | Allocated |
|------- |--------:|--------:|--------:|-----:|-------------:|------------:|-----------:|----------:|
| Format | 35.87 s | 4.575 s | 0.251 s |    1 | 2150000.0000 | 663000.0000 | 80000.0000 |   10.7 GB |

after
| Method |    Mean |   Error |  StdDev | Rank |       Gen 0 |       Gen 1 |      Gen 2 | Allocated |
|------- |--------:|--------:|--------:|-----:|------------:|------------:|-----------:|----------:|
| Format | 16.48 s | 7.260 s | 0.398 s |    1 | 665000.0000 | 247000.0000 | 35000.0000 |   3.47 GB |

Not bad for 3 lines remove 😛