### PR TITLE
Don't consider attribute above field a proper candidate for trivia

### DIFF
--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1307,3 +1307,24 @@ type VersionMismatchDuringDeserializationException(message : string,
                                                    innerException : System.Exception) =
     inherit System.Exception(message, innerException)
 """
+
+[<Test>]
+let ``type record declaration with attributes, 910`` () =
+    formatSourceString false """type Commenter =
+    { [<JsonProperty("display_name")>]
+      DisplayName: string }
+
+type Message =
+    { [<JsonProperty("body")>]
+      Body: string }
+"""  config
+    |> prepend newline
+    |> should equal """
+type Commenter =
+    { [<JsonProperty("display_name")>]
+      DisplayName: string }
+
+type Message =
+    { [<JsonProperty("body")>]
+      Body: string }
+"""


### PR DESCRIPTION
Fixes #910

The problem here is the new line between the types.
It was being assigned to the attributes in the first type as content after.

The reason for this is that the range of the field does contain the attribute (unlike let binding f.ex).