### PR TITLE
Perf blank lines

### DIFF
--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -465,20 +465,25 @@ let private findEmptyNewlinesInTokens (tokens: Token list) (lineCount) (ignoreRa
         |> Option.map (fun t -> t.LineNumber)
         |> Option.defaultValue lineCount
 
+    let ignoredLines =
+        ignoreRanges
+        |> List.collect(fun r -> [r.StartLine..r.EndLine])
+
+    let linesWithTokens =
+        tokens
+        |> List.groupBy (fun t -> t.LineNumber)
+
     let completeEmptyLines =
         [1 .. lastLineWithContent]
-        |> List.filter (fun line ->
-            not (List.exists (fun t -> t.LineNumber = line) tokens)
-                 && not (List.exists (fun (br:FSharp.Compiler.Range.range) -> br.StartLine < line && br.EndLine > line) ignoreRanges)
-        )
+        |> List.except (ignoredLines @ List.map fst linesWithTokens)
+        |> List.filter (fun line -> not (List.exists (fun t -> t.LineNumber = line) tokens))
         |> List.map createNewLine
 
     let linesWithOnlySpaces =
-        tokens
-        |> List.groupBy (fun t -> t.LineNumber)
+        linesWithTokens
         |> List.filter (fun (ln, g) -> ln <= lastLineWithContent && (List.length g) = 1 && (List.head g).TokenInfo.TokenName = "WHITESPACE")
         |> List.map (fst >> createNewLine)
-        
+
     completeEmptyLines @ linesWithOnlySpaces
 
 let getTriviaFromTokens (tokens: Token list) linesCount =

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -43,7 +43,7 @@ let private findFirstNodeOnLine (nodes: TriviaNode list) lineNumber : TriviaNode
     |> List.filter (fun { Range =r  } -> r.StartLine = lineNumber)
     |> List.tryHead
 
-let private mainNodeIs name (t:TriviaNodeAssigner) =
+let inline private mainNodeIs name (t:TriviaNodeAssigner) =
     match t.Type with
     | MainNode(mn) -> mn = name
     | _ -> false
@@ -54,7 +54,7 @@ let private nodesContainsBothAnonModuleAndOpen (nodes: TriviaNodeAssigner list) 
 
 // the member keyword is not part of an AST node range
 // so it is not an ideal candidate node to have trivia content
-let private isNotMemberKeyword (node: TriviaNodeAssigner) =
+let inline private isNotMemberKeyword (node: TriviaNodeAssigner) =
     match node.Type with
     | Token({ TokenInfo = ti }) when (ti.TokenName = "MEMBER") -> false
     | _ -> true


### PR DESCRIPTION
Before:
```
| Method |    Mean |   Error |   StdDev | Rank |       Gen 0 |       Gen 1 |      Gen 2 | Allocated |
|------- |--------:|--------:|---------:|-----:|------------:|------------:|-----------:|----------:|
| Format | 6.588 s | 1.049 s | 0.0575 s |    1 | 606000.0000 | 160000.0000 | 12000.0000 |   2.76 GB |
```

After:
```
| Method |    Mean |   Error |   StdDev | Rank |       Gen 0 |       Gen 1 |      Gen 2 | Allocated |
|------- |--------:|--------:|---------:|-----:|------------:|------------:|-----------:|----------:|
| Format | 6.132 s | 1.095 s | 0.0600 s |    1 | 626000.0000 | 180000.0000 | 28000.0000 |   2.76 GB |
```