### PR TITLE
Perf: short-circuit (+>) in ShortExpression mode

### DIFF
--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -304,7 +304,11 @@ let internal atCurrentColumnIndent (f : _ -> Context) (ctx : Context) =
 
 /// Function composition operator
 let internal (+>) (ctx : Context -> Context) (f : _ -> Context) x =
-    f (ctx x)
+    let y = ctx x
+    match y.WriterModel.Mode with
+    | ShortExpression infos when infos |> Seq.exists (fun x -> x.ConfirmedMultiline) -> y
+    | _ -> f y
+    //f (ctx x)
 
 /// Break-line and append specified string
 let internal (++) (ctx : Context -> Context) (str : string) x =

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -308,7 +308,6 @@ let internal (+>) (ctx : Context -> Context) (f : _ -> Context) x =
     match y.WriterModel.Mode with
     | ShortExpression infos when infos |> Seq.exists (fun x -> x.ConfirmedMultiline) -> y
     | _ -> f y
-    //f (ctx x)
 
 /// Break-line and append specified string
 let internal (++) (ctx : Context -> Context) (str : string) x =


### PR DESCRIPTION
before

```
| Method |    Mean |   Error |  StdDev | Rank |       Gen 0 |       Gen 1 |      Gen 2 | Allocated |
|------- |--------:|--------:|--------:|-----:|------------:|------------:|-----------:|----------:|
| Format | 13.35 s | 5.253 s | 0.288 s |    1 | 517000.0000 | 159000.0000 | 14000.0000 |   2.76 GB |
```

after

```
| Method |    Mean |   Error |  StdDev | Rank |       Gen 0 |       Gen 1 |      Gen 2 | Allocated |
|------- |--------:|--------:|--------:|-----:|------------:|------------:|-----------:|----------:|
| Format | 11.02 s | 0.843 s | 0.046 s |    1 | 451000.0000 | 159000.0000 | 13000.0000 |   2.48 GB |
```