### PR TITLE
Only keep collecting line comments if they are not separate by a new line

### DIFF
--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -861,3 +861,45 @@ type LongIdentWithDots =
 /// LongIdent can be empty list - it is used to denote that name of some AST element is absent (i.e. empty type name in inherit)
 type LongIdentWithDots = LongIdentWithDots of id: LongIdent * dotms: range list
 """
+
+[<Test>]
+let ``newline between comments should lead to individual comments, 920`` () =
+    formatSourceString false """
+[<AllowNullLiteral>]
+type IExports =
+    abstract DataSet: DataSetStatic
+    abstract DataView: DataViewStatic
+    abstract Graph2d: Graph2dStatic
+    abstract Timeline: TimelineStatic
+    // abstract Timeline: TimelineStaticStatic
+    abstract Network: NetworkStatic
+
+// type [<AllowNullLiteral>] MomentConstructor1 =
+//     [<Emit "$0($1...)">] abstract Invoke: ?inp: MomentInput * ?format: MomentFormatSpecification * ?strict: bool -> Moment
+
+// type [<AllowNullLiteral>] MomentConstructor2 =
+//     [<Emit "$0($1...)">] abstract Invoke: ?inp: MomentInput * ?format: MomentFormatSpecification * ?language: string * ?strict: bool -> Moment
+
+// type MomentConstructor =
+//     U2<MomentConstructor1, MomentConstructor2>
+"""  config
+    |> prepend newline
+    |> should equal """
+[<AllowNullLiteral>]
+type IExports =
+    abstract DataSet: DataSetStatic
+    abstract DataView: DataViewStatic
+    abstract Graph2d: Graph2dStatic
+    abstract Timeline: TimelineStatic
+    // abstract Timeline: TimelineStaticStatic
+    abstract Network: NetworkStatic
+
+// type [<AllowNullLiteral>] MomentConstructor1 =
+//     [<Emit "$0($1...)">] abstract Invoke: ?inp: MomentInput * ?format: MomentFormatSpecification * ?strict: bool -> Moment
+
+// type [<AllowNullLiteral>] MomentConstructor2 =
+//     [<Emit "$0($1...)">] abstract Invoke: ?inp: MomentInput * ?format: MomentFormatSpecification * ?language: string * ?strict: bool -> Moment
+
+// type MomentConstructor =
+//     U2<MomentConstructor1, MomentConstructor2>
+"""

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -262,14 +262,11 @@ let rec private getTriviaFromTokensThemSelves (allTokens: Token list) (tokens: T
     match tokens with
     | headToken::rest when (headToken.TokenInfo.TokenName = "LINE_COMMENT") ->
         let lineCommentTokens =
-            let mutable currentLineNumber = headToken.LineNumber
+            Seq.zip rest (headToken::rest |> List.map (fun x -> x.LineNumber))
+            |> Seq.takeWhile (fun (t, currentLineNumber) -> t.TokenInfo.TokenName = "LINE_COMMENT" && t.LineNumber <= (currentLineNumber + 1))
+            |> Seq.map fst
+            |> Seq.toList
 
-            rest
-            |> List.takeWhile (fun t ->
-                let take = t.TokenInfo.TokenName = "LINE_COMMENT" && t.LineNumber <= (currentLineNumber + 1)
-                currentLineNumber <- t.LineNumber
-                take)
-            
         let comment =
             headToken
             |> List.prependItem lineCommentTokens

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -262,8 +262,13 @@ let rec private getTriviaFromTokensThemSelves (allTokens: Token list) (tokens: T
     match tokens with
     | headToken::rest when (headToken.TokenInfo.TokenName = "LINE_COMMENT") ->
         let lineCommentTokens =
+            let mutable currentLineNumber = headToken.LineNumber
+
             rest
-            |> List.takeWhile (fun t -> t.TokenInfo.TokenName = "LINE_COMMENT") // && t.LineNumber = headToken.LineNumber)
+            |> List.takeWhile (fun t ->
+                let take = t.TokenInfo.TokenName = "LINE_COMMENT" && t.LineNumber <= (currentLineNumber + 1)
+                currentLineNumber <- t.LineNumber
+                take)
             
         let comment =
             headToken


### PR DESCRIPTION
Fixes #920

I'm open to suggestions when it comes to using that `mutable`.
Had no immediate idea of how to do it without it.