### PR TITLE
Split all parameters of a function application over multiple lines if they exceed page width

### DIFF
--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -76,3 +76,131 @@ let a s =
             (llloooooooooooooooooooooooooo s)
             (llloooooooooooooooooooooooooo s)
 "
+
+
+[<Test>]
+let ``should split parameters over multiple lines when they exceed page width``() =
+    formatSourceString false """module Caching =
+    type MainCache() =
+        member __.RetrieveLastCompoundBalance (address: PublicAddress)
+                                              (currency: Currency): NotFresh<decimal> =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then
+                        ReportProblem compoundBalance None currency address sessionCachedNetworkData
+                    ()
+            )
+            ()""" { config with PageWidth = 60 }
+    |> prepend newline
+    |> should equal """
+module Caching =
+    type MainCache() =
+        member __.RetrieveLastCompoundBalance (address: PublicAddress)
+                                              (currency: Currency): NotFresh<decimal> =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then
+                        ReportProblem
+                            compoundBalance
+                            None
+                            currency
+                            address
+                            sessionCachedNetworkData
+                    ())
+            ()
+"""
+
+[<Test>]
+let ``should split single parameter over multiple lines when it exceeds page width``() =
+    formatSourceString false """module Caching =
+    type MainCache() =
+        member __.RetrieveLastCompoundBalance (address: PublicAddress)
+                                              (currency: Currency): NotFresh<decimal> =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then
+                        ReportProblem looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+                    ()
+            )
+            ()""" { config with PageWidth = 60 }
+    |> prepend newline
+    |> should equal """
+module Caching =
+    type MainCache() =
+        member __.RetrieveLastCompoundBalance (address: PublicAddress)
+                                              (currency: Currency): NotFresh<decimal> =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then
+                        ReportProblem
+                            looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+                    ())
+            ()
+"""
+
+[<Test>]
+let ``should not split parameters over multiple lines when they do not exceed page width``() =
+    formatSourceString false """module Caching =
+    type MainCache() =
+        member __.RetrieveLastCompoundBalance (address: PublicAddress)
+                                              (currency: Currency): NotFresh<decimal> =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then
+                        ReportProblem compoundBalance None currency address sessionCachedNetworkData
+                    ()
+            )
+            ()""" { config with PageWidth = 120 }
+    |> prepend newline
+    |> should equal """
+module Caching =
+    type MainCache() =
+        member __.RetrieveLastCompoundBalance (address: PublicAddress) (currency: Currency): NotFresh<decimal> =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m
+                    then ReportProblem compoundBalance None currency address sessionCachedNetworkData
+                    ())
+            ()
+"""
+
+[<Test>]
+let ``should not split single parameter over multiple lines when it does not exceed page width``() =
+    formatSourceString false """module Caching =
+    type MainCache() =
+        member __.RetrieveLastCompoundBalance (address: PublicAddress)
+                                              (currency: Currency): NotFresh<decimal> =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then
+                        ReportProblem compoundBalance
+                    ()
+            )
+            ()""" { config with PageWidth = 120 }
+    |> prepend newline
+    |> should equal """
+module Caching =
+    type MainCache() =
+        member __.RetrieveLastCompoundBalance (address: PublicAddress) (currency: Currency): NotFresh<decimal> =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then ReportProblem compoundBalance
+                    ())
+            ()
+"""

--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -476,7 +476,9 @@ type FunctionComponent =
                 (importValueDynamic f).``then``(fun x -> createObj [ "default" ==> x ]))
 
         fun props ->
-            ReactElementType.create ReactBindings.React.Suspense (createObj [ "fallback" ==> fallback ])
+            ReactElementType.create
+                ReactBindings.React.Suspense
+                (createObj [ "fallback" ==> fallback ])
                 [ ReactElementType.create elemType props [] ]
 #else
 
@@ -678,7 +680,9 @@ type FunctionComponent =
                 (importValueDynamic f).``then``(fun x -> createObj [ "default" ==> x ]))
 
         fun props ->
-            ReactElementType.create ReactBindings.React.Suspense (createObj [ "fallback" ==> fallback ])
+            ReactElementType.create
+                ReactBindings.React.Suspense
+                (createObj [ "fallback" ==> fallback ])
                 [ ReactElementType.create elemType props [] ]
 #else
         fun _ -> div [] [] // React.lazy is not compatible with SSR, so just use an empty div

--- a/src/Fantomas.Tests/ElmishTests.fs
+++ b/src/Fantomas.Tests/ElmishTests.fs
@@ -433,7 +433,8 @@ table [ ClassName "table table-striped table-hover mb-0" ] [
         tokenDetailRow "ColorClass" (str colorClass)
         tokenDetailRow "CharClass" (str charClass)
         tokenDetailRow "Tag" (ofInt tag)
-        tokenDetailRow "FullMatchedLength"
+        tokenDetailRow
+            "FullMatchedLength"
             (span [ ClassName "has-text-weight-semibold" ] [
                 ofInt fullMatchedLength
              ])

--- a/src/Fantomas.Tests/KeepIfThenInSameLineTests.fs
+++ b/src/Fantomas.Tests/KeepIfThenInSameLineTests.fs
@@ -18,14 +18,13 @@ let ``if only, 825`` () =
                 "some very very long error message"
         if valueToSend <= 0m then
             invalidArg "valueToSend" "Amount has to be above zero"
-"""  config
+"""  { config with PageWidth = 100 }
     |> prepend newline
     |> should equal """
 type TransferAmount(valueToSend: decimal, balanceAtTheMomentOfSending: decimal) =
     do
         if balanceAtTheMomentOfSending < valueToSend then
-            invalidArg "balanceAtTheMomentOfSending"
-                "some very very long error message"
+            invalidArg "balanceAtTheMomentOfSending" "some very very long error message"
         if valueToSend <= 0m then
             invalidArg "valueToSend" "Amount has to be above zero"
 """
@@ -47,7 +46,8 @@ type TransferAmount(valueToSend: decimal, balanceAtTheMomentOfSending: decimal) 
     do
         // comment
         if balanceAtTheMomentOfSending < valueToSend then // comment
-            invalidArg "balanceAtTheMomentOfSending"  // comment
+            invalidArg
+                "balanceAtTheMomentOfSending"  // comment
                 "some very very long error message" // comment
         if valueToSend <= 0m then // comment
             invalidArg "valueToSend" "Amount has to be above zero" // comment

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -571,7 +571,8 @@ let expect =
                 Opts.oneOf
                     (Optional,
                      [ Opt.flag [ "third"; "f" ]
-                       Opt.valueWith "new value"
+                       Opt.valueWith
+                           "new value"
                            [ "fourth"
                              "ssssssssssssssssssssssssssssssssssssssssssssssssssss" ] ]) ]
           args = []

--- a/src/Fantomas.Tests/TypeProviderTests.fs
+++ b/src/Fantomas.Tests/TypeProviderTests.fs
@@ -60,7 +60,8 @@ let ``should handle lines with more than 512 characters``() =
                                             CommonRuntime.ConvertDecimalBack
                                                 ("", CommonRuntime.GetOptionalValue((let _, _, x = row in x))) |]),
                                          (ProviderFileSystem.readTextAtRunTimeWithDesignTimeOptions
-                                             @"C:\Dev\FSharp.Data-master\src\..\tests\FSharp.Data.Tests\Data" ""
+                                             @"C:\Dev\FSharp.Data-master\src\..\tests\FSharp.Data.Tests\Data"
+                                              ""
                                               "SmallTest.csv"),
                                          "",
                                          '"',

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1346,13 +1346,43 @@ and genExpr astContext synExpr =
             else
                 sepSpace ctx
 
-        atCurrentColumn
-            (genExpr astContext e
-             +> colPre sepSpace sepSpace es (fun e ->
-                    onlyIf (isCompExpr e) (sepSpace +> sepOpenSFixed +> sepSpace)
+        let shortExpression =
+            atCurrentColumn
+                (genExpr astContext e
+                 +> colPre sepSpace sepSpace es (fun e ->
+                        onlyIf (isCompExpr e) (sepSpace +> sepOpenSFixed +> sepSpace)
+                        +> indent
+                        +> appNlnFun e (indentIfNeeded +> genExpr astContext e)
+                        +> unindent))
+
+        let longExpression =
+            (atCurrentColumn
+                (genExpr astContext e
+                +> colPre sepSpace sepSpace es (fun e ->
+                ifElse (isCompExpr e)
+                    (sepSpace
+                    +> sepOpenSFixed
+                    +> sepSpace
                     +> indent
                     +> appNlnFun e (indentIfNeeded +> genExpr astContext e)
-                    +> unindent))
+                    +> unindent)
+                    (indent
+                    +> indentIfNeeded
+                    +> sepNln
+                    +> genExpr astContext e
+                    +> unindent))))
+
+        if List.exists (function
+            | Lambda _
+            | MatchLambda _
+            | Paren (Lambda (_))
+            | Paren (MatchLambda (_))
+            | MultilineString _
+            | CompExpr _ -> true
+            | _ -> false) es then
+            shortExpression
+        else
+            expressionFitsOnRestOfLine shortExpression longExpression
 
     | TypeApp(e, ts) -> genExpr astContext e -- "<" +> col sepComma ts (genType astContext false) -- ">"
     | LetOrUses(bs, e) ->


### PR DESCRIPTION
Fixes #907 by putting every parameter of a function application on a newline if the function application exceeds `PageWidth`.

cc @knocte 