### PR TITLE
Add support for Feliz style

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-### 4.0.0-alpha-010 - 06/2020
+### 4.0.0-alpha-011 - 06/2020
 * WIP for [#705](https://github.com/fsprojects/fantomas/issues/705)
 * FCS 36
 

--- a/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
+++ b/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <Version>4.0.0-alpha-010</Version>
+    <Version>4.0.0-alpha-011</Version>
     <NoWarn>FS0988</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
+++ b/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <ToolCommandName>fantomas</ToolCommandName>
     <PackAsTool>True</PackAsTool>
-    <Version>4.0.0-alpha-010</Version>
+    <Version>4.0.0-alpha-011</Version>
     <AssemblyName>fantomas-tool</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas.Tests/ElmishTests.fs
+++ b/src/Fantomas.Tests/ElmishTests.fs
@@ -569,3 +569,145 @@ let view dispatch model =
         ]
     ]
 """
+
+[<Test>]
+let ``short feliz element`` () =
+    formatSourceString false """let a =
+    Html.h1 [ prop.text "some title" ]
+"""  config
+    |> prepend newline
+    |> should equal """
+let a = Html.h1 [ prop.text "some title" ]
+"""
+
+[<Test>]
+let ``multiline feliz element`` () =
+    formatSourceString false """let a =
+        Html.button [
+            prop.style [ style.marginLeft 5 ]
+            prop.onClick (fun _ -> setCount(count - 1))
+            prop.text "Decrement"
+        ]
+"""  { config with SingleArgumentWebMode = true }
+    |> prepend newline
+    |> should equal """
+let a =
+    Html.button [
+        prop.style [ style.marginLeft 5 ]
+        prop.onClick (fun _ -> setCount (count - 1))
+        prop.text "Decrement"
+    ]
+"""
+
+[<Test>]
+let ``nested feliz elements`` () =
+    formatSourceString false """let a =
+    Html.div [
+        Html.h1 [ prop.text "short" ]
+        Html.button [
+            prop.style [ style.marginRight 5 ]
+            prop.onClick (fun _ -> setCount(count + 1))
+            prop.text "Increment"
+        ]
+    ]
+"""  { config with SingleArgumentWebMode = true }
+    |> prepend newline
+    |> should equal """
+let a =
+    Html.div [
+        Html.h1 [ prop.text "short" ]
+        Html.button [
+            prop.style [ style.marginRight 5 ]
+            prop.onClick (fun _ -> setCount (count + 1))
+            prop.text "Increment"
+        ]
+    ]
+"""
+
+[<Test>]
+let ``feliz counter sample`` () =
+    formatSourceString false """module App
+
+open Feliz
+
+let counter = React.functionComponent(fun () ->
+    let (count, setCount) = React.useState(0)
+    Html.div [
+        Html.button [
+            prop.style [ style.marginRight 5 ]
+            prop.onClick (fun _ -> setCount(count + 1))
+            prop.text "Increment"
+        ]
+
+        Html.button [
+            prop.style [ style.marginLeft 5 ]
+            prop.onClick (fun _ -> setCount(count - 1))
+            prop.text "Decrement"
+        ]
+
+        Html.h1 count
+    ])
+
+open Browser.Dom
+
+ReactDOM.render(counter, document.getElementById "root")
+"""  { config with SingleArgumentWebMode = true }
+    |> prepend newline
+    |> should equal """
+module App
+
+open Feliz
+
+let counter =
+    React.functionComponent (fun () ->
+        let (count, setCount) = React.useState (0)
+        Html.div [
+            Html.button [
+                prop.style [ style.marginRight 5 ]
+                prop.onClick (fun _ -> setCount (count + 1))
+                prop.text "Increment"
+            ]
+
+            Html.button [
+                prop.style [ style.marginLeft 5 ]
+                prop.onClick (fun _ -> setCount (count - 1))
+                prop.text "Decrement"
+            ]
+
+            Html.h1 count
+        ])
+
+open Browser.Dom
+
+ReactDOM.render (counter, document.getElementById "root")
+"""
+
+[<Test>]
+let ``feliz syntax`` () =
+    formatSourceString false """
+Html.h1 42
+
+Html.div "Hello there!"
+
+Html.div [ Html.h1 "So lightweight" ]
+
+Html.ul [
+  Html.li "One"
+  Html.li [ Html.strong "Two" ]
+  Html.li [ Html.em "Three" ]
+]
+"""  { config with SingleArgumentWebMode = true }
+    |> prepend newline
+    |> should equal """
+Html.h1 42
+
+Html.div "Hello there!"
+
+Html.div [ Html.h1 "So lightweight" ]
+
+Html.ul [
+    Html.li "One"
+    Html.li [ Html.strong "Two" ]
+    Html.li [ Html.em "Three" ]
+]
+"""

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
   <PropertyGroup>
-    <Version>4.0.0-alpha-010</Version>
+    <Version>4.0.0-alpha-011</Version>
     <NoWarn>FS0988</NoWarn>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -3,7 +3,7 @@
   <Import Project="..\netfx.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.0.0-alpha-010</Version>
+    <Version>4.0.0-alpha-011</Version>
     <Description>Source code formatter for F#</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas/FormatConfig.fs
+++ b/src/Fantomas/FormatConfig.fs
@@ -38,6 +38,7 @@ type FormatConfig =
       NewlineBetweenTypeDefinitionAndMembers: bool
       KeepIfThenInSameLine : bool
       MaxElmishWidth: Num
+      SingleArgumentWebMode: bool
       /// Prettyprinting based on ASTs only
       StrictMode : bool }
 
@@ -65,6 +66,7 @@ type FormatConfig =
           MultilineBlockBracketsOnSameColumn = false
           KeepIfThenInSameLine = false
           MaxElmishWidth = 40
+          SingleArgumentWebMode = false
           NewlineBetweenTypeDefinitionAndMembers = false
           StrictMode = false }
 

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1427,10 +1427,9 @@ let isFunctionBinding (p: SynPat) =
 
 let (|ElmishReactWithoutChildren|_|) e =
     match e with
-    | App(OptVar(ident,_,_), [ArrayOrList(_) as attributes]) ->
-        Some(ident, attributes)
-    | App(OptVar(ident,_,_), [ArrayOrListOfSeqExpr(_, CompExpr(_, Sequentials _)) as attributes]) ->
-        Some(ident, attributes)
+    | App(OptVar(ident,_,_), [ArrayOrList(isArray, children, _)])
+    | App(OptVar(ident,_,_), [ArrayOrListOfSeqExpr(isArray, CompExpr(_, Sequentials children))]) ->
+        Some(ident, isArray, children)
     | _ ->
         None
 

--- a/src/Fantomas/schema.json
+++ b/src/Fantomas/schema.json
@@ -74,6 +74,9 @@
     "MaxElmishWidth": {
       "type": "integer"
     },
+    "SingleArgumentWebMode": {
+      "type": "boolean"
+    },
     "StrictMode": {
       "type": "boolean"
     }


### PR DESCRIPTION
Fixes #927.

@jindraivanek I'm not entirely happy yet with the names of the settings yet.
I'd like to rename `MaxElmishWidth` and `SingleArgumentWebMode` to something more generic.
The naming these things after the current popular frameworks seem like a bad idea.
Call me old fashion but I'd prefer a more timeless ring to the setting names.
Feel free to chime in here @auduchinok.