### PR TITLE
.editorconfig support

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -12,5 +12,6 @@ nuget NUnit3TestAdapter 3.15.1
 nuget NunitXml.TestLogger
 nuget Argu
 nuget BenchmarkDotNet
+nuget editorconfig
 
 github: fsprojects/fantomas:829faa6ba834f99afed9b4434b3a1680536474b2 src/Fantomas/CodePrinter.fs

--- a/paket.lock
+++ b/paket.lock
@@ -23,6 +23,7 @@ NUGET
       System.ValueTuple (>= 4.5)
     BenchmarkDotNet.Annotations (0.12.1)
     CommandLineParser (2.8)
+    editorconfig (0.12.1)
     FsCheck (2.14)
       FSharp.Core (>= 4.2.3)
     FSharp.Compiler.Service (36.0.1)

--- a/src/Fantomas.Tests/FormatConfigEditorConfigurationFileTests.fs
+++ b/src/Fantomas.Tests/FormatConfigEditorConfigurationFileTests.fs
@@ -1,2 +1,55 @@
 module Fantomas.Tests.FormatConfigEditorConfigurationFileTests
 
+open Fantomas
+open Fantomas.EditorConfig
+open Fantomas.FormatConfig
+open NUnit.Framework
+open System.IO
+open Fantomas.Tests.TestHelper
+open EditorConfig.Core
+open System
+
+[<Literal>]
+let private ConfigFileName = ".editorconfig"
+
+// TODO: Generalize/move/remove? [JB]
+/// Creates a new temporary folder and allows creating files in it. Cleans the folder up on dispose.
+type TemporaryFolder() =
+    let folderPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+    do Directory.CreateDirectory(folderPath) |> ignore
+
+    member _.GetFileName(name: string) =
+        Path.Combine(folderPath, name)
+
+    member this.AddTextFile(name: string, content: string) =
+        let fileName = this.GetFileName(name)
+        File.WriteAllText(fileName, content)
+        fileName
+
+    interface IDisposable with
+        member this.Dispose() = Directory.Delete(folderPath, true)
+
+[<Test>]
+let ``editorconfig options are parsed`` () =
+    use temp = new TemporaryFolder()
+    let sourceFile = temp.GetFileName("source.fs")
+    temp.AddTextFile(ConfigFileName, @"root=true
+        [*.fs]
+        indent_style = space
+        indent_size = 3
+        ") |> ignore
+    let opt, warns = readOptionsFromEditorConfig sourceFile
+    CollectionAssert.Contains(opt, ("IndentSpaceNum", 3))
+    [] == warns
+
+[<Test>]
+let ``unknown editorconfig options are silently ignored`` () =
+    use temp = new TemporaryFolder()
+    let sourceFile = temp.GetFileName("source.fs")
+    temp.AddTextFile(ConfigFileName, @"root=true
+        [*.fs]
+        fsharp_mysterious_setting = abrakadabra
+        ") |> ignore
+    let opt, warns = readOptionsFromEditorConfig sourceFile
+    [] == opt
+    [] == warns

--- a/src/Fantomas/CodeFormatter.fs
+++ b/src/Fantomas/CodeFormatter.fs
@@ -35,3 +35,5 @@ type CodeFormatter =
     static member GetVersion() = Version.fantomasVersion.Value
 
     static member ReadConfiguration(fileOrFolder) = CodeFormatterImpl.readConfiguration fileOrFolder
+
+    static member ReadDocumentConfiguration(fileName) = CodeFormatterImpl.readDocumentConfiguration fileName

--- a/src/Fantomas/CodeFormatter.fsi
+++ b/src/Fantomas/CodeFormatter.fsi
@@ -1,5 +1,6 @@
 ﻿namespace Fantomas
 
+open System
 open Fantomas.FormatConfig
 open Fantomas.SourceOrigin
 open FSharp.Compiler.Range
@@ -36,4 +37,8 @@ type CodeFormatter =
 
     /// Accepts a file or a folder and parses the found json to a FormatConfig
     /// Configuration found in parent folders will be applied first.
+    [<Obsolete("Use ReadDocumentConfiguration method instead.")>]
     static member ReadConfiguration : string -> FormatConfigFileParseResult
+
+    /// Given a source document file name, loads the appropriate FormatConfig from configuration files.
+    static member ReadDocumentConfiguration : string -> FormatConfigFileParseResult

--- a/src/Fantomas/CodeFormatterImpl.fs
+++ b/src/Fantomas/CodeFormatterImpl.fs
@@ -688,7 +688,7 @@ let readConfiguration fileOrFolder =
                     | json when (json = ConfigFile.jsonConfigFileName) ->
                         JsonConfig.parseOptionsFromJson configContent
                     | editorconfig when (editorconfig = ConfigFile.editorConfigFileName) ->
-                        EditorConfig.parseOptionsFromEditorConfig configContent
+                        Array.empty, Array.empty
                     | _ ->
                         failwithf "Filename is not supported!"
                 let updatedConfig = FormatConfig.ApplyOptions(currentConfig, options)
@@ -704,3 +704,13 @@ let readConfiguration fileOrFolder =
         | w -> FormatConfigFileParseResult.PartialSuccess (config, w)
     with
     | exn -> FormatConfigFileParseResult.Failure exn
+
+let readDocumentConfiguration fileName =
+    try
+        let options, warnings = EditorConfig.readOptionsFromEditorConfig fileName
+        let config = FormatConfig.ApplyOptions(FormatConfig.Default, options)
+        match List.ofArray warnings with
+        | [] -> Success config
+        | w -> PartialSuccess (config, w)
+    with
+    | exn -> Failure exn

--- a/src/Fantomas/EditorConfig.fs
+++ b/src/Fantomas/EditorConfig.fs
@@ -1,7 +1,35 @@
+/// Implements loading formatting options from .editorconfig files.
 module internal Fantomas.EditorConfig
 
-/// Similar to how to processing of the JSON file happens, this function should the options found in the editor config.
+open EditorConfig.Core
+
+let private ecParser = EditorConfigParser()
+
+let private readConfigFor fileName = ecParser.Parse [|fileName|] |> Seq.exactlyOne
+
+let private tryGetIndentSize (cfg : FileConfiguration) =
+    let style = Option.ofNullable cfg.IndentStyle
+    let size = Option.ofObj cfg.IndentSize
+    match style, size with
+    | Some IndentStyle.Space, Some indentSize when not indentSize.UseTabWidth -> Option.ofNullable indentSize.NumberOfColumns
+    | _ -> None
+
+let private tryGetIndentSpaceNum (cfg : FileConfiguration) : (string * obj) array =
+    match tryGetIndentSize cfg with
+    | Some spaces -> [|("IndentSpaceNum", spaces :> obj)|]
+    | _ -> [||]
+
+/// Reads supported options from editorconfig's <see cref="FileConfiguration">FileConfiguration</see>.
+let toFantomasOptions (cfg : FileConfiguration) : (string * obj) array =
+    [|
+        yield! (cfg |> tryGetIndentSpaceNum)
+        // TODO: Read other options [JB]
+    |]
+
+/// Reads the formatting options for the given source file from related editorconfig files.
 /// The first argument in the return tuple are the options. Listed as (key,value) where key is a member name of the FormatConfig record. Value is either a boolean or an int boxed as object.
 /// The second argument in the return tuple are warnings. F.ex. invalid settings
-let parseOptionsFromEditorConfig _editorConfig : (string * obj) array * string array =
-    Array.empty, Array.empty
+let readOptionsFromEditorConfig sourceFileName : (string * obj) array * string array =
+    let cfg = readConfigFor sourceFileName
+    let options = toFantomasOptions cfg
+    options, Array.empty

--- a/src/Fantomas/paket.references
+++ b/src/Fantomas/paket.references
@@ -1,2 +1,3 @@
 FSharp.Compiler.Service
 FSharp.Core
+EditorConfig


### PR DESCRIPTION
This is my work-in-progress on the issue #650. In the first commit, I've implemented reading indentation size from a `.editorconfig` file. There is a new method ``CodeFormatter.ReadDocumentConfiguration`` to get the formatting configuration for a source file. It is intended to replace the current ``CodeFormatter.ReadConfiguration``.

Notable TODOs are:
- [ ] Define and read other Fantomas formatting options from the file.
- [ ] Implement assembly weaving (or something equivalent), so that the dependency library is hidden.
- [ ] Get rid of the restore warnings during build. 

Also feel free to comment my programming style. I come from the C# world and F# is still a new language for me.