### PR TITLE
Improve assigning trivia after attributes

### DIFF
--- a/src/Fantomas.CoreGlobalTool.Tests/TestHelpers.fs
+++ b/src/Fantomas.CoreGlobalTool.Tests/TestHelpers.fs
@@ -4,7 +4,6 @@ open System
 open System.Diagnostics
 open System.IO
 open System.Text
-open Fantomas
 
 type TemporaryFileCodeSample internal (codeSnippet: string, ?hasByteOrderMark: bool, ?fileName: string) =
     let hasByteOrderMark = defaultArg hasByteOrderMark false

--- a/src/Fantomas.Tests/AttributeTests.fs
+++ b/src/Fantomas.Tests/AttributeTests.fs
@@ -428,3 +428,23 @@ type Text = string
 #endif
 type Text = string
 """
+
+[<Test>]
+let ``attribute, line comment, attribute, new line, record definition field`` () =
+    formatSourceString false """
+type Commenter =
+    { [<JsonProperty("display_name")>]
+      // foo
+      [<Bar>]
+      
+      DisplayName: string }
+"""  config
+    |> prepend newline
+    |> should equal """
+type Commenter =
+    { [<JsonProperty("display_name")>]
+      // foo
+      [<Bar>]
+
+      DisplayName: string }
+"""

--- a/src/Fantomas.Tests/AttributeTests.fs
+++ b/src/Fantomas.Tests/AttributeTests.fs
@@ -346,3 +346,85 @@ let ``should preserve multiple return type attributes`` () =
     formatSourceString false """let f x : [<return: AttributeOne;AttributeTwo;AttributeThree("foo")>] int = x""" config
     |> should equal """let f x: [<return:AttributeOne; AttributeTwo; AttributeThree("foo")>] int = x
 """
+
+[<Test>]
+let ``attribute, new line, let binding`` () =
+    formatSourceString false """
+    [<Foo>]
+
+let bar = 7
+"""  config
+    |> prepend newline
+    |> should equal """
+[<Foo>]
+
+let bar = 7
+"""
+
+[<Test>]
+let ``attribute, new line, type declaration`` () =
+    formatSourceString false """
+[<Foo>]
+
+type Bar = Bar of string
+"""  config
+    |> prepend newline
+    |> should equal """
+[<Foo>]
+
+type Bar = Bar of string
+"""
+
+[<Test>]
+let ``attribute, new line, attribute, newline, let binding`` () =
+    formatSourceString false """
+[<Foo>]
+
+[<Meh>]
+
+let bar = 7
+"""  config
+    |> prepend newline
+    |> should equal """
+[<Foo>]
+
+[<Meh>]
+
+let bar = 7
+"""
+
+[<Test>]
+let ``attribute, new line, attribute, line comment, type declaration`` () =
+    formatSourceString false """
+[<Foo>]
+
+[<Meh>]
+// foo
+type Text = string
+"""  config
+    |> prepend newline
+    |> should equal """
+[<Foo>]
+
+[<Meh>]
+// foo
+type Text = string
+"""
+
+[<Test>]
+let ``attribute, hash directive, attribute, hash directive, type declaration`` () =
+    formatSourceString false """
+[<Foo>]
+#if FOO
+[<Meh>]
+#endif
+type Text = string
+"""  config
+    |> prepend newline
+    |> should equal """
+[<Foo>]
+#if FOO
+[<Meh>]
+#endif
+type Text = string
+"""

--- a/src/Fantomas.Tests/CheckTests.fs
+++ b/src/Fantomas.Tests/CheckTests.fs
@@ -2,7 +2,6 @@ module Fantomas.Tests.CheckTests
 
 open NUnit.Framework
 open FsUnit
-open Fantomas.FormatConfig
 open Fantomas.FakeHelpers
 open Fantomas.Tests.TestHelper
 

--- a/src/Fantomas.Tests/QueueTests.fs
+++ b/src/Fantomas.Tests/QueueTests.fs
@@ -6,7 +6,7 @@ open FsUnit
 open FsCheck
 
 module Queue =
-    let ofLists xss = (Queue.empty, xss) ||> List.fold (fun q xs -> Queue.append q xs) 
+    let ofLists xss = (Queue.empty, xss) ||> List.fold Queue.append 
 
 [<Test>]
 let ``Queue.append``() =

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1413,3 +1413,43 @@ type OuterType =
     abstract Apply<'r> : InnerType<'r>
         -> 'r when 'r : comparison
 """
+
+[<Test>]
+let ``attribute on type and abstract member followed by type, 949`` () =
+    formatSourceString false """
+[<AllowNullLiteral>]
+type TimelineOptionsGroupCallbackFunction =
+    [<Emit "$0($1...)">]
+    abstract Invoke: group:TimelineGroup * callback:(TimelineGroup option -> unit) -> unit
+
+type TimelineOptionsGroupEditableType = U2<bool, TimelineGroupEditableOption>
+"""  config
+    |> prepend newline
+    |> should equal """
+[<AllowNullLiteral>]
+type TimelineOptionsGroupCallbackFunction =
+    [<Emit "$0($1...)">]
+    abstract Invoke: group:TimelineGroup * callback:(TimelineGroup option -> unit) -> unit
+
+type TimelineOptionsGroupEditableType = U2<bool, TimelineGroupEditableOption>
+"""
+
+[<Test>]
+let ``attribute on type and abstract member followed by let binding`` () =
+    formatSourceString false """
+[<AllowNullLiteral>]
+type TimelineOptionsGroupCallbackFunction =
+    [<Emit "$0($1...)">]
+    abstract Invoke: group:TimelineGroup * callback:(TimelineGroup option -> unit) -> unit
+
+let myBinding a = 7
+"""  config
+    |> prepend newline
+    |> should equal """
+[<AllowNullLiteral>]
+type TimelineOptionsGroupCallbackFunction =
+    [<Emit "$0($1...)">]
+    abstract Invoke: group:TimelineGroup * callback:(TimelineGroup option -> unit) -> unit
+
+let myBinding a = 7
+"""

--- a/src/Fantomas/AstTransformer.fs
+++ b/src/Fantomas/AstTransformer.fs
@@ -1423,6 +1423,9 @@ module private Ast =
     and visitSynField(sfield: SynField): Node =
         match sfield with
         | Field(attrs,isStatic,ident,typ,_,_,access,range) ->
+            let parentRange =
+                Option.map (fun (i:Ident) -> i.idRange) ident |> Option.defaultValue range
+            
             {Type = "Field"
              Range = r range
              Properties =
@@ -1431,7 +1434,7 @@ module private Ast =
                     if access.IsSome then yield "access" ==> (access.Value |> visitSynAccess)]
              FsAstNode = sfield
              Childs =
-                 [yield! (visitSynAttributeLists range attrs)
+                 [yield! (visitSynAttributeLists parentRange attrs)
                   yield visitSynType typ]}
 
     and visitSynType(st: SynType) =

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -427,7 +427,7 @@ and genAttributes astContext (ats: SynAttributes) =
             let dontAddNewline =
                 TriviaHelpers.``has content after that ends with``
                     (fun t -> t.Range = a.Range)
-                    (function | Directive(_) | Newline -> true | _ -> false)
+                    (function | Directive(_) | Newline | Comment(LineCommentOnSingleLine(_)) -> true | _ -> false)
                     ctx.Trivia
             let chain =
                 acc +>

--- a/src/Fantomas/Queue.fs
+++ b/src/Fantomas/Queue.fs
@@ -61,7 +61,7 @@ type Queue<'T> (data : list<'T[]>, length : int) =
         let rec exists xs =
             match xs with
             | (arr: _[]) :: tl ->
-                while r = false && i < arr.Length do
+                while not r && i < arr.Length do
                     if f arr.[i] then r <- true
                     i <- i + 1
                 i <- 0

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -385,8 +385,8 @@ let collectTrivia tokens lineCount (ast: ParsedInput) =
         |> filterNodes
         |> List.choose mapNodeToTriviaNode
 
-    let hasAnyAttributes = List.exists (fun (tn:TriviaNodeAssigner) -> match tn.Type with | MainNode("SynAttributeList") -> true | _ -> false) triviaNodesFromAST
-    let triviaBetweenAttributeAndParentBinding = if hasAnyAttributes then triviaBetweenAttributeAndParentBinding else (fun _ _ -> None)
+    let hasAnyAttributesWithLinesBetweenParent = List.exists (fun (tn:TriviaNodeAssigner) -> Option.isSome tn.AttributeLinesBetweenParent) triviaNodesFromAST
+    let triviaBetweenAttributeAndParentBinding = if hasAnyAttributesWithLinesBetweenParent then triviaBetweenAttributeAndParentBinding else (fun _ _ -> None)
     let triviaNodesFromTokens = TokenParser.getTriviaNodesFromTokens tokens
     let triviaNodes = triviaNodesFromAST @ triviaNodesFromTokens |> List.sortBy (fun n -> n.Range.Start.Line, n.Range.Start.Column)
     let hasAnonModulesAndOpenStatements = nodesContainsBothAnonModuleAndOpen triviaNodes

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -147,8 +147,16 @@ let private findConstNodeAfter (nodes: TriviaNodeAssigner list) (range: range) =
 let private mapNodeToTriviaNode (node: Node) =
     node.Range
     |> Option.map (fun range ->
-        let attributeParent = Map.tryFind "parent" node.Properties
-        TriviaNodeAssigner(MainNode(node.Type), range, attributeParent))
+        let attributeParent =
+            Map.tryFind "linesBetweenParent" node.Properties
+            |> Option.bind (fun v ->
+                match v with
+                | :? int as i when (i > 0) -> Some i
+                | _ -> None)
+
+        match attributeParent with
+        | Some i -> TriviaNodeAssigner(MainNode(node.Type), range, i)
+        | None -> TriviaNodeAssigner(MainNode(node.Type), range))
 
 let private commentIsAfterLastTriviaNode (triviaNodes: TriviaNodeAssigner list) (range: range) =
     match List.filter isMainNodeButNotAnonModule triviaNodes with
@@ -201,39 +209,12 @@ let private findParsedHashOnLineAndEndswith (triviaNodes: TriviaNodeAssigner lis
 // The reason for this is that the range of the attribute is not part of the range of the parent binding.
 // This can lead to weird results when used in CodePrinter.
 let private triviaBetweenAttributeAndParentBinding (triviaNodes: TriviaNodeAssigner list) line =
-    let filteredNodes =
-        triviaNodes
-        |> List.filter (fun t ->
-            match t.Type with
-            | MainNode("SynAttributeList")
-            | MainNode("SynModuleDecl.Let")
-            | MainNode("SynModuleDecl.Types")
-            | MainNode("SynModuleSigDecl.NestedModule")
-            | MainNode("ValSpfn")
-            | MainNode("SynMemberDefn.Member")
-            | MainNode("SynMemberDefn.LetBindings")
-            | MainNode("Field") -> true
-            | _ -> false
-        )
-        |> List.pairwise
-
-    filteredNodes |> List.tryFind (function
-        | f, a when (f.Type = MainNode("Field")
-                     && a.Type = MainNode("SynAttributeList")
-                     && f.Range.StartLine = a.Range.StartLine
-                     && a.Range.StartLine + 1 = f.Range.EndLine) -> true
-        | a, p when (a.Type = MainNode("SynAttributeList") && a.Range.StartLine < line && a.Range.StartLine = a.Range.EndLine) ->
-            match p.Type with
-              | MainNode("SynModuleDecl.Let") when (p.Range.StartLine > line) -> true
-              | MainNode("SynAttributeList") when (p.Range.StartLine > line) ->
-                  // This is an edge case scenario where the trivia needs to fit between two attributes of the same parent node.
-                  match p.AttributeParent, a.AttributeParent with
-                  | Some pp, Some ap -> pp = ap
-                  | _ -> false
-              | MainNode("SynModuleDecl.Types") when (p.Range.StartLine > line) -> true
-              | _ -> false
+    triviaNodes
+    |> List.tryFind (fun tn ->
+        match tn.AttributeLinesBetweenParent with
+        | Some linesBetween when (linesBetween + tn.Range.EndLine >= line && line > tn.Range.EndLine) ->
+            true
         | _ -> false)
-    |> Option.bind (fun (a,_) -> if a.Type = MainNode("SynAttributeList") then Some a else None)
 
 let private findASTNodeOfTypeThatContains (nodes: TriviaNodeAssigner list) typeName range =
     nodes
@@ -257,8 +238,12 @@ let private addTriviaToTriviaNode
         |> updateTriviaNode (fun tn -> tn.ContentAfter.Add(comment)) triviaNodes
 
     | { Item = Comment(LineCommentOnSingleLine(_) as comment); Range = range } ->
-        findFirstNodeAfterLine triviaNodes range.StartLine hasAnonModulesAndOpenStatements
-        |> updateTriviaNode (fun tn -> tn.ContentBefore.Add (Comment(comment))) triviaNodes
+        match triviaBetweenAttributeAndParentBinding triviaNodes range.StartLine with
+        | Some _ as node ->
+            updateTriviaNode (fun tn -> tn.ContentAfter.Add(Comment(comment))) triviaNodes node
+        | None ->
+            findFirstNodeAfterLine triviaNodes range.StartLine hasAnonModulesAndOpenStatements
+            |> updateTriviaNode (fun tn -> tn.ContentBefore.Add (Comment(comment))) triviaNodes
 
     | { Item = Comment(BlockComment(comment, _,_)); Range = range } ->
         let nodeAfter = findNodeAfterLineAndColumn triviaNodes range.StartLine range.StartColumn

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -69,11 +69,7 @@ let private findFirstNodeAfterLine
     |> List.tryFind (fun tn ->
         if tn.Range.StartLine > lineNumber
            && isNotMemberKeyword tn then
-            if hasAnonModulesAndOpenStatements
-               && mainNodeIs "SynModuleOrNamespace.AnonModule" tn then
-                false
-            else
-                true
+            not (hasAnonModulesAndOpenStatements && mainNodeIs "SynModuleOrNamespace.AnonModule" tn)
         else
             false)
 

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -57,10 +57,10 @@ type TriviaNode =
     ContentAfter: TriviaContent list
     Range: range }
 
-type internal TriviaNodeAssigner(nodeType: TriviaNodeType, range: range, ?attributeParent: obj) =
+type internal TriviaNodeAssigner(nodeType: TriviaNodeType, range: range, ?linesBetweenParent: int) =
     member this.Type = nodeType
     member this.Range = range
-    member this.AttributeParent = attributeParent
+    member this.AttributeLinesBetweenParent = linesBetweenParent
     member val ContentBefore = ResizeArray<TriviaContent>() with get,set
     member val ContentItself = Option<TriviaContent>.None with get,set
     member val ContentAfter = ResizeArray<TriviaContent>() with get,set


### PR DESCRIPTION
 Fixes #949 

The main idea is that we count how many lines there are between a SynAttributeList and the parent node (or the next SynAttributeList). If there are gaps, it means trivia will need to be assigned as content after.