### PR TITLE
Add TryReadConfiguration for .editorconfig

### DIFF
--- a/src/Fantomas.Tests/FormatConfigEditorConfigurationFileTests.fs
+++ b/src/Fantomas.Tests/FormatConfigEditorConfigurationFileTests.fs
@@ -148,13 +148,26 @@ fsharp_max_function_binding_width=40
     config.MaxFunctionBindingWidth == 40
 
 [<Test>]
-let ``non existing file should return default config`` () =
+let ``non existing file should return defaults for readConfiguration`` () =
     use configFixture = new ConfigurationFile(defaultConfig)
 
     let config =
         CodeFormatter.ReadConfiguration "bogus.fs"
 
     config == defaultConfig
+
+    // In the future we could ensure that the Default config isn't 
+    // being generated every time because it's a property getter     
+    // Assert.That(Object.ReferenceEquals(config, defaultConfig))
+
+[<Test>]
+let ``non existing file should return None for tryReadConfiguration`` () =
+    use configFixture = new ConfigurationFile(defaultConfig)
+
+    let config =
+        CodeFormatter.TryReadConfiguration "bogus.fs"
+
+    config == None
 
 [<Test>]
 let ``indent_style tab edge case`` () =

--- a/src/Fantomas/CodeFormatter.fs
+++ b/src/Fantomas/CodeFormatter.fs
@@ -35,3 +35,5 @@ type CodeFormatter =
     static member GetVersion() = Version.fantomasVersion.Value
 
     static member ReadConfiguration(fsharpFile) = CodeFormatterImpl.readConfiguration fsharpFile
+
+    static member TryReadConfiguration(fsharpFile) = CodeFormatterImpl.tryReadConfiguration fsharpFile

--- a/src/Fantomas/CodeFormatter.fsi
+++ b/src/Fantomas/CodeFormatter.fsi
@@ -35,4 +35,10 @@ type CodeFormatter =
     static member GetVersion : unit -> string
 
     /// Accepts a fsharp file and parses the matching .editorconfig to a FormatConfig
+    /// and returns the default configuration if no settings could be found
     static member ReadConfiguration : string -> FormatConfig
+
+    /// Accepts a fsharp file and parses the matching .editorconfig to a FormatConfig
+    /// and returns None if no matching settings could be found
+    /// for this file, otherwise returns the parsed FormatConfig
+    static member TryReadConfiguration : string -> FormatConfig option

--- a/src/Fantomas/CodeFormatterImpl.fs
+++ b/src/Fantomas/CodeFormatterImpl.fs
@@ -675,6 +675,12 @@ let makePos line col = mkPos line col
 
 let private editorConfigParser = Fantomas.EditorConfig.Core.EditorConfigParser()
 
-let readConfiguration (fsharpFile:string) : FormatConfig =
+let tryReadConfiguration (fsharpFile:string) : FormatConfig option =
     let editorConfigSettings: Fantomas.EditorConfig.Core.FileConfiguration = editorConfigParser.Parse(fileName = fsharpFile)
-    EditorConfig.parseOptionsFromEditorConfig editorConfigSettings
+    if editorConfigSettings.Properties.Count = 0 then
+        None
+    else
+        Some <| EditorConfig.parseOptionsFromEditorConfig editorConfigSettings
+
+let readConfiguration (fsharpFile:string) : FormatConfig =
+    tryReadConfiguration fsharpFile |> Option.defaultValue FormatConfig.Default

--- a/src/Fantomas/EditorConfig.fs
+++ b/src/Fantomas/EditorConfig.fs
@@ -49,7 +49,7 @@ let configToEditorConfig (config: FormatConfig): string =
             sprintf "%s=%s" (toEditorConfigName k) (if b then "true " else "false")
             |> Some
         | :? System.Int32 as i ->
-            sprintf " %s=%d" (toEditorConfigName k) i
+            sprintf "%s=%d" (toEditorConfigName k) i
             |> Some
         | _ -> None)
     |> String.concat "\n"


### PR DESCRIPTION
Useful in disambiguating situations where no settings could be found. As an added performance bonus, if no settings could be found, it doesn't reconstruct the default config object from scratch.