### PR TITLE
Support GR very long member definitions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
-### 4.0.0-alpha-012 - 06/2020
+### 4.0.0-alpha-013 - 07/2020
 * WIP for [#705](https://github.com/fsprojects/fantomas/issues/705)
-* FCS 36
+* FCS 36.0.3
 * Replaced json configuration with .editorconfig
 
 ### 3.3.0 - 02/2020

--- a/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
+++ b/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <Version>4.0.0-alpha-012</Version>
+    <Version>4.0.0-alpha-013</Version>
     <NoWarn>FS0988</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
+++ b/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <ToolCommandName>fantomas</ToolCommandName>
     <PackAsTool>True</PackAsTool>
-    <Version>4.0.0-alpha-012</Version>
+    <Version>4.0.0-alpha-013</Version>
     <AssemblyName>fantomas-tool</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
   <PropertyGroup>
-    <Version>4.0.0-alpha-012</Version>
+    <Version>4.0.0-alpha-013</Version>
     <NoWarn>FS0988</NoWarn>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1572,3 +1572,52 @@ type MyClass() =
                                             =
         someFunction aVeryLongType aSecondVeryLongType aThirdVeryLongType
 """
+
+[<Test>]
+let ``alternative long class constructor`` () =
+    formatSourceString false """
+type C(aVeryLongType: AVeryLongTypeThatYouNeedToUse,
+       aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
+       aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) =
+    class
+    end
+"""  { config with
+                AlternativeLongMemberDefinitions = true
+                SpaceBeforeColon = true }
+    |> prepend newline
+    |> should equal """
+type C
+    (
+        aVeryLongType : AVeryLongTypeThatYouNeedToUse,
+        aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,
+        aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse
+    )
+    =
+    class
+    end
+"""
+
+[<Test>]
+let ``alternative long class constructor with access modifier`` () =
+    formatSourceString false """
+type C internal (aVeryLongType: AVeryLongTypeThatYouNeedToUse,
+       aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
+       aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) =
+    class
+    end
+"""  { config with
+                AlternativeLongMemberDefinitions = true
+                SpaceBeforeColon = true }
+    |> prepend newline
+    |> should equal """
+type C
+    internal
+    (
+        aVeryLongType : AVeryLongTypeThatYouNeedToUse,
+        aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,
+        aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse
+    )
+    =
+    class
+    end
+"""

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1217,7 +1217,8 @@ let ``member with one long parameter and no return type, 850`` () =
     |> prepend newline
     |> should equal """
 type SomeType =
-    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 =
+    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1
+                             =
         printfn "a"
         "b"
 """
@@ -1235,11 +1236,13 @@ let ``multiple members with one long parameter`` () =
     |> prepend newline
     |> should equal """
 type SomeType =
-    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 =
+    static member SomeMember loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1
+                             =
         printfn "a"
         "b"
 
-    static member Serialize(loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: SomeType) =
+    static member Serialize(loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: SomeType)
+                           =
         Encode.string v.Meh
 
     static member Deserialize(loooooooooooooooooooooooooooooooooooooooooooooooooooooonnnnnnnnnnnnnnnnnnnnngggggggggggJsonVaaaaalueeeeeeeeeeeeeeee)
@@ -1460,18 +1463,21 @@ let ``alternative long member definition`` () =
 type C () =
     member __.LongMethodWithLotsOfParameters(aVeryLongType : AVeryLongTypeThatYouNeedToUse, aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse) =
         someImplementation aVeryLongType aSecondVeryLongType aThirdVeryLongType
-"""  { config with AlternativeLongMemberDefinitions = true }
+"""  { config with
+            SpaceBeforeClassConstructor = true
+            SpaceBeforeColon = true
+            AlternativeLongMemberDefinitions = true }
     |> prepend newline
     |> should equal """
 type C () =
     member __.LongMethodWithLotsOfParameters
-       (
-           aVeryLongType : AVeryLongTypeThatYouNeedToUse,
-           aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,
-           aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse
-       )
-       =
-       someImplementation aVeryLongType aSecondVeryLongType aThirdVeryLongType
+        (
+            aVeryLongType : AVeryLongTypeThatYouNeedToUse,
+            aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,
+            aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse
+        )
+        =
+        someImplementation aVeryLongType aSecondVeryLongType aThirdVeryLongType
 """
 
 [<Test>]
@@ -1496,4 +1502,73 @@ type C () =
         : int
         =
         someImplementation aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""
+
+// See https://github.com/dotnet/docs/issues/18806#issuecomment-655281219
+
+[<Test>]
+let ``member, tuple (non-curried), with return type:`` () =
+    formatSourceString false """
+type MyClass() =
+    member _.LongMethodWithLotsOfParameters(aVeryLongType: AVeryLongTypeThatYouNeedToUse, aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse, aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) : AVeryLongReturnType =
+        someFunction aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""  config
+    |> prepend newline
+    |> should equal """
+type MyClass() =
+    member _.LongMethodWithLotsOfParameters(aVeryLongType: AVeryLongTypeThatYouNeedToUse,
+                                            aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
+                                            aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse)
+                                            : AVeryLongReturnType =
+        someFunction aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""
+
+[<Test>]
+let ``member, tuple (non-curried), with no return type:`` () =
+    formatSourceString false """
+type MyClass() =
+    member _.LongMethodWithLotsOfParameters(aVeryLongType: AVeryLongTypeThatYouNeedToUse, aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse, aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) =
+        someFunction aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""  config
+    |> prepend newline
+    |> should equal """
+type MyClass() =
+    member _.LongMethodWithLotsOfParameters(aVeryLongType: AVeryLongTypeThatYouNeedToUse,
+                                            aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse,
+                                            aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) =
+        someFunction aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""
+
+[<Test>]
+let ``member, curried (non-tuple), with return type:`` () =
+    formatSourceString false """
+type MyClass() =
+    member _.LongMethodWithLotsOfParameters(aVeryLongType: AVeryLongTypeThatYouNeedToUse) (aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse) (aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) : AVeryLongReturnType =
+        someFunction aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""  config
+    |> prepend newline
+    |> should equal """
+type MyClass() =
+    member _.LongMethodWithLotsOfParameters (aVeryLongType: AVeryLongTypeThatYouNeedToUse)
+                                            (aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse)
+                                            (aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse)
+                                            : AVeryLongReturnType =
+        someFunction aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""
+
+[<Test>]
+let ``member, curried (non-tuple), with no return type:`` () =
+    formatSourceString false """
+type MyClass() =
+    member _.LongMethodWithLotsOfParameters(aVeryLongType: AVeryLongTypeThatYouNeedToUse) (aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse) (aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse) =
+        someFunction aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""  config
+    |> prepend newline
+    |> should equal """
+type MyClass() =
+    member _.LongMethodWithLotsOfParameters (aVeryLongType: AVeryLongTypeThatYouNeedToUse)
+                                            (aSecondVeryLongType: AVeryLongTypeThatYouNeedToUse)
+                                            (aThirdVeryLongType: AVeryLongTypeThatYouNeedToUse)
+                                            =
+        someFunction aVeryLongType aSecondVeryLongType aThirdVeryLongType
 """

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1453,3 +1453,47 @@ type TimelineOptionsGroupCallbackFunction =
 
 let myBinding a = 7
 """
+
+[<Test>]
+let ``alternative long member definition`` () =
+    formatSourceString false """
+type C () =
+    member __.LongMethodWithLotsOfParameters(aVeryLongType : AVeryLongTypeThatYouNeedToUse, aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse) =
+        someImplementation aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""  { config with AlternativeLongMemberDefinitions = true }
+    |> prepend newline
+    |> should equal """
+type C () =
+    member __.LongMethodWithLotsOfParameters
+       (
+           aVeryLongType : AVeryLongTypeThatYouNeedToUse,
+           aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,
+           aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse
+       )
+       =
+       someImplementation aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""
+
+[<Test>]
+let ``alternative long member definition with return type`` () =
+    formatSourceString false """
+type C () =
+    member __.LongMethodWithLotsOfParameters(aVeryLongType : AVeryLongTypeThatYouNeedToUse, aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse) : int =
+        someImplementation aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""  { config with
+            SpaceBeforeClassConstructor = true
+            SpaceBeforeColon = true
+            AlternativeLongMemberDefinitions = true }
+    |> prepend newline
+    |> should equal """
+type C () =
+    member __.LongMethodWithLotsOfParameters
+        (
+            aVeryLongType : AVeryLongTypeThatYouNeedToUse,
+            aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,
+            aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse
+        )
+        : int
+        =
+        someImplementation aVeryLongType aSecondVeryLongType aThirdVeryLongType
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -686,7 +686,6 @@ and genMemberBinding astContext b =
             | PatLongIdent(ao, s, ps, tpso) ->
                 let aoc = opt sepSpace ao genAccess
                 let tpsoc = opt sepNone tpso (fun (ValTyparDecls(tds, _, tcs)) -> genTypeParamPostfix astContext tds tcs)
-                let s = if s = "``new``" then "new" else s
                 let hasBracket = ps |> Seq.map snd |> Seq.exists hasParenInPat
                 let hasParameters = List.isNotEmpty ps
                 let multipleParameters = List.length ps > 1

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -461,6 +461,7 @@ let internal sepNlnUnlessLastEventIsNewline (ctx: Context) =
 
 let internal sepStar = !- " * "
 let internal sepEq = !- " ="
+let internal sepEqFixed = !- "="
 let internal sepArrow = !- " -> "
 let internal sepWild = !- "_"
 

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <Version>4.0.0-alpha-012</Version>
+    <Version>4.0.0-alpha-013</Version>
     <Description>Source code formatter for F#</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas/FormatConfig.fs
+++ b/src/Fantomas/FormatConfig.fs
@@ -38,6 +38,7 @@ type FormatConfig =
       KeepIfThenInSameLine : bool
       MaxElmishWidth: Num
       SingleArgumentWebMode: bool
+      AlternativeLongMemberDefinitions: bool
       /// Pretty printing based on ASTs only
       StrictMode : bool }
 
@@ -67,4 +68,5 @@ type FormatConfig =
           MaxElmishWidth = 40
           SingleArgumentWebMode = false
           NewlineBetweenTypeDefinitionAndMembers = false
+          AlternativeLongMemberDefinitions = false
           StrictMode = false }


### PR DESCRIPTION
Fixes #913 , see [GR style guide](https://github.com/G-Research/fsharp-formatting-conventions#place-parameters-on-a-new-line-for-very-long-member-definitions)

I also added some more test to get the default MS style on point.