### PR TITLE
Fix 944

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-### 4.0.0-alpha-013 - 07/2020
+### 4.0.0-alpha-014 - 07/2020
 * WIP for [#705](https://github.com/fsprojects/fantomas/issues/705)
 * FCS 36.0.3
 * Replaced json configuration with .editorconfig

--- a/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
+++ b/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <Version>4.0.0-alpha-013</Version>
+    <Version>4.0.0-alpha-014</Version>
     <NoWarn>FS0988</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
+++ b/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <ToolCommandName>fantomas</ToolCommandName>
     <PackAsTool>True</PackAsTool>
-    <Version>4.0.0-alpha-013</Version>
+    <Version>4.0.0-alpha-014</Version>
     <AssemblyName>fantomas-tool</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
   <PropertyGroup>
-    <Version>4.0.0-alpha-013</Version>
+    <Version>4.0.0-alpha-014</Version>
     <NoWarn>FS0988</NoWarn>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>

--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -524,7 +524,7 @@ type internal Foo2 =
 namespace Foo
 
 type internal Foo2 =
-    member Bar<'k> : unit -> unit when 'k: comparison
+    abstract Bar<'k> : unit -> unit when 'k: comparison
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -524,7 +524,7 @@ type internal Foo2 =
 namespace Foo
 
 type internal Foo2 =
-    abstract Bar<'k> : unit -> unit when 'k: comparison
+    abstract member Bar<'k> : unit -> unit when 'k: comparison
 """
 
 [<Test>]
@@ -679,7 +679,7 @@ type Foo =
 namespace Baz
 
 type Foo =
-    abstract Bar : Type
+    abstract member Bar : Type
     abstract Bar2 : Type
     member Bar3 : Type
 """

--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -663,3 +663,23 @@ namespace B
 type Foo =
     member Item : 't -> unit when 't : comparison with set
 """
+
+[<Test>]
+let ``preserve abstract member in type, 944`` () =
+    formatSourceString true """
+namespace Baz
+
+type Foo =
+    abstract member Bar : Type
+    abstract Bar2 : Type
+    member Bar3 : Type
+"""  { config with SpaceBeforeColon = true }
+    |> prepend newline
+    |> should equal """
+namespace Baz
+
+type Foo =
+    abstract Bar : Type
+    abstract Bar2 : Type
+    member Bar3 : Type
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -860,7 +860,7 @@ and genMemberFlagsForMemberBinding astContext (mf:MemberFlags) (rangeOfBindingAn
                     tn.ContentItself
                     |> Option.bind (fun tc ->
                         match tc with
-                        | Keyword({ Content = ("override" | "default" | "member" | "abstract") as kw }) -> Some (!- (kw + " "))
+                        | Keyword({ Content = ("override" | "default" | "member" | "abstract" | "abstract member") as kw }) -> Some (!- (kw + " "))
                         | _ -> None
                     )
                 )

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <Version>4.0.0-alpha-013</Version>
+    <Version>4.0.0-alpha-014</Version>
     <Description>Source code formatter for F#</Description>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
So the problem we have with #944 is that the trivia detects two keywords and assigns them both to TriviaContentItSelf.
And so the last keyword (`member` in this case) wins.

I've added a rather targeted workaround to avoid `abstract` being replaced by `member` in `SynMemberSig.Member`.
I think this will make your code compile again, however, in the future it would be nice to preserve both keywords.
This fix might suffice short term...