### PR TITLE
Don't add extra parenthesis for DotGet(Paren(_))

### DIFF
--- a/src/Fantomas.Tests/LongIdentWithDotsTests.fs
+++ b/src/Fantomas.Tests/LongIdentWithDotsTests.fs
@@ -199,3 +199,14 @@ module Client =
                   then JS.Alert(sprintf "Your email is %s" e.Vars.Email.Value)
                   e.Event.PreventDefault()).Bind()
 """
+
+[<Test>]
+let ``don't repeat parenthesis for DotGet Paren, 989`` () =
+    formatSourceString false """(something_really_long
+  + another_thing_thats_really_long).A
+"""  config
+    |> prepend newline
+    |> should equal """
+(something_really_long
+ + another_thing_thats_really_long).A
+"""

--- a/src/Fantomas.Tests/LongIdentWithDotsTests.fs
+++ b/src/Fantomas.Tests/LongIdentWithDotsTests.fs
@@ -210,3 +210,17 @@ let ``don't repeat parenthesis for DotGet Paren, 989`` () =
 (something_really_long
  + another_thing_thats_really_long).A
 """
+
+[<Test>]
+let ``infix expression inside DotGet, 921`` () =
+    formatSourceString false """let variable =
+                (DataAccess.getById moduleName.readData
+                         { Id = createObject.Id }
+                     |> Result.okValue).Value
+"""  config
+    |> prepend newline
+    |> should equal """
+let variable =
+    (DataAccess.getById moduleName.readData { Id = createObject.Id }
+     |> Result.okValue).Value
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1864,8 +1864,7 @@ and genExpr astContext synExpr =
     | DotNamedIndexedPropertySet(e, ident, e1, e2) ->
        genExpr astContext e -- "." -- ident +> genExpr astContext e1 -- " <- "  +> genExpr astContext e2
     | DotGet(e, (s,_)) ->
-        let exprF = genExpr { astContext with IsInsideDotGet = true }
-        addParenIfAutoNln e exprF -- (sprintf ".%s" s)
+        genExpr { astContext with IsInsideDotGet = true } e -- (sprintf ".%s" s)
     | DotSet(e1, s, e2) -> addParenIfAutoNln e1 (genExpr astContext) -- sprintf ".%s <- " s +> genExpr astContext e2
 
     | SynExpr.Set(e1,e2, _) ->


### PR DESCRIPTION
Fixes #989.
