### PR TITLE
Ignore SynExpr.CompExpr as TriviaNode candidate.

### DIFF
--- a/src/Fantomas.Tests/ListTests.fs
+++ b/src/Fantomas.Tests/ListTests.fs
@@ -1601,3 +1601,23 @@ let value =
         if bar then yield "d" else yield! [ "e"; "f" ]
     ]
 """
+
+[<Test>]
+let ``preserve comment above first element of list, 990`` () =
+    formatSourceString false """
+let x = [
+    // comment
+    1
+    // another comment
+    2
+]
+"""  config
+    |> prepend newline
+    |> should equal """
+let x =
+    [
+      // comment
+      1
+      // another comment
+      2 ]
+"""

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -35,6 +35,7 @@ let filterNodes nodes =
             "SynTypeDefnRepr.ObjectModel"
             "TypeDefnSig"
             "SynTypeDefnSigRepr.ObjectModel"
+            "SynExpr.CompExpr"
         ]
     nodes |> List.filter (fun (n: Node) -> not (Set.contains n.Type filterOutNodeTypes))
 


### PR DESCRIPTION
 Fixes #990 