### PR TITLE
Keep parenthesis on the same for App inside multiline DotGet thing

### DIFF
--- a/src/Fantomas.Tests/LongIdentWithDotsTests.fs
+++ b/src/Fantomas.Tests/LongIdentWithDotsTests.fs
@@ -109,8 +109,8 @@ let main _ =
                 ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory()).Build()
 
             WebHostBuilder().UseConfiguration(config).UseKestrel().UseSerilog()
-                .ConfigureAppConfiguration
-                    (Action<WebHostBuilderContext, IConfigurationBuilder> configureAppConfiguration)
+                .ConfigureAppConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder>
+                                               configureAppConfiguration)
                 .ConfigureServices(Action<WebHostBuilderContext, IServiceCollection> configureServices)
                 .Configure(Action<IApplicationBuilder> configureApp).Build().Run()
             |> ignore

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -109,9 +109,8 @@ let ``should break on . operator and keep indentation``() =
     """ { config with MaxLineLength = 80; MaxInfixOperatorExpression = 60 }
     |> should equal """let pattern =
     (x + y)
-        .Replace
-            (seperator + "**" + seperator,
-             replacementSeparator + "(.|?" + replacementSeparator + ")?")
+        .Replace(seperator + "**" + seperator,
+                 replacementSeparator + "(.|?" + replacementSeparator + ")?")
         .Replace("**" + seperator, ".|(?<=^|" + replacementSeparator + ")")
 """
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1415,6 +1415,8 @@ and genExpr astContext synExpr =
                     let genMultilineExpr =
                         match e with
                         | Paren(Lambda(_)) -> atCurrentColumnIndent(genExpr astContext e)
+                        | Paren(App(_)) ->
+                            atCurrentColumn(genExpr astContext e)
                         | _ ->
                             ifElse hasParenthesis
                                     (indent +> sepNln +> genExpr astContext e +> unindent)

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1415,7 +1415,8 @@ and genExpr astContext synExpr =
                     let genMultilineExpr =
                         match e with
                         | Paren(Lambda(_)) -> atCurrentColumnIndent(genExpr astContext e)
-                        | Paren(App(_)) ->
+                        | Paren(App(_))
+                        | Paren(Tuple(_)) ->
                             atCurrentColumn(genExpr astContext e)
                         | _ ->
                             ifElse hasParenthesis


### PR DESCRIPTION
Fixes #862.