### PR TITLE
Keep parenthesis on same line in DotGet.

### DIFF
--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -1,0 +1,16 @@
+module Fantomas.Tests.DotGetTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Tests.TestHelper
+
+[<Test>]
+let ``a TypeApp inside a DotGet should stay on the same line, 994`` () =
+    formatSourceString false """
+Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<option<option<unit>>>.GetGenericTypeDefinition().MakeGenericType(t)).Assembly
+"""  config
+    |> prepend newline
+    |> should equal """
+Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<option<option<unit>>>.GetGenericTypeDefinition()
+        .MakeGenericType(t)).Assembly
+"""

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -72,6 +72,7 @@
     <Compile Include="MaxValueBindingWidthTests.fs" />
     <Compile Include="MaxFunctionBindingWidthTests.fs" />
     <Compile Include="InterpolatedStringTests.fs" />
+    <Compile Include="DotGetTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Extras\Fantomas.Extras.fsproj" />

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1483,7 +1483,10 @@ and genExpr astContext synExpr =
                          sepNone
                     +> indent
                     +> (ifElse (not hasPar && addSpaceBefore) sepSpace sepNone)
-                    +> appNlnFun e2 (genExpr astContext e2)
+                    +> (fun ctx ->
+                          match e2 with
+                          | Paren (App (_)) when astContext.IsInsideDotGet -> genExpr astContext e2 ctx
+                          | _ -> appNlnFun e2 (genExpr astContext e2) ctx)
                     +> unindent)
             genApp ctx
 
@@ -1530,7 +1533,7 @@ and genExpr astContext synExpr =
                     +> genExpr astContext e
                     +> unindent))))
 
-        let hasThreeOrMoreLamdbas =
+        let hasThreeOrMoreLambdas =
             List.filter (function
                 | Paren (Lambda (_)) -> true
                 | _ -> false) es
@@ -1544,7 +1547,7 @@ and genExpr astContext synExpr =
             | Paren (MatchLambda (_))
             | MultilineString _
             | CompExpr _ -> true
-            | _ -> false) es && not hasThreeOrMoreLamdbas then
+            | _ -> false) es && not hasThreeOrMoreLambdas then
             shortExpression
         else
             expressionFitsOnRestOfLine shortExpression longExpression


### PR DESCRIPTION
Fixes #994.