### PR TITLE
Don't add additional new line for SynExpr.IfThenElse inside Sequential

### DIFF
--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -916,3 +916,37 @@ let ``comment after then in if/then, 730`` () =
 if true then // comment
     ()
 """
+
+[<Test>]
+let ``don't add additional new line before nested if/then, 1035`` () =
+    formatSourceString false """
+            if ast.ParseHadErrors then
+                let errors =
+                    ast.Errors
+                    |> Array.filter (fun e -> e.Severity = FSharpErrorSeverity.Error)
+
+                if not <| Array.isEmpty errors
+                then log.LogError(sprintf "Parsing failed with errors: %A\nAnd options: %A" errors checkOptions)
+
+                return Error ast.Errors
+            else
+                match ast.ParseTree with
+                | Some tree -> return Result.Ok tree
+                | _ -> return Error Array.empty // Not sure this branch can be reached.
+"""  { config with MaxValueBindingWidth = 50; MaxFunctionBindingWidth = 50 }
+    |> prepend newline
+    |> should equal """
+if ast.ParseHadErrors then
+    let errors =
+        ast.Errors
+        |> Array.filter (fun e -> e.Severity = FSharpErrorSeverity.Error)
+
+    if not <| Array.isEmpty errors
+    then log.LogError(sprintf "Parsing failed with errors: %A\nAnd options: %A" errors checkOptions)
+
+    return Error ast.Errors
+else
+    match ast.ParseTree with
+    | Some tree -> return Result.Ok tree
+    | _ -> return Error Array.empty // Not sure this branch can be reached.
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1642,6 +1642,7 @@ and genExpr astContext synExpr =
         let sepNlnBeforeExpr =
             match e with
             | SynExpr.Sequential(_,_, (SynExpr.App _ as app),_,_) -> sepNlnConsideringTriviaContentBeforeFor SynExpr_App app.Range
+            | SynExpr.Sequential(_,_, (SynExpr.IfThenElse _ as ite),_,_) -> sepNlnConsideringTriviaContentBeforeFor SynExpr_IfThenElse ite.Range
             | SynExpr.YieldOrReturn _ -> sepNlnConsideringTriviaContentBeforeFor SynExpr_YieldOrReturn e.Range
             | SynExpr.IfThenElse _ -> sepNlnConsideringTriviaContentBeforeFor SynExpr_IfThenElse e.Range
             | SynExpr.LetOrUseBang _ -> sepNlnConsideringTriviaContentBeforeFor SynExpr_LetOrUseBang e.Range


### PR DESCRIPTION
Fixes #1035.