### PR TITLE
Print line comment after bool expr in SynExpr.IfThenElse

### DIFF
--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -950,3 +950,19 @@ else
     | Some tree -> return Result.Ok tree
     | _ -> return Error Array.empty // Not sure this branch can be reached.
 """
+
+[<Test>]
+let ``comment after if expression, 1019`` () =
+    formatSourceString false """
+let foo result total =
+    if result = 0 // there's a comment here
+    then total // and another one
+    else result
+"""  config
+    |> prepend newline
+    |> should equal """
+let foo result total =
+    if result = 0 // there's a comment here
+    then total // and another one
+    else result
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1949,8 +1949,12 @@ and genExpr astContext synExpr =
                     // f.ex
                     // if x then 0 // meh
                     // else 1
-                    genIf synExpr.Range +> genExpr astContext e1 +> sepSpace
-                    +> genThen synExpr.Range +> genExpr astContext e2 +> sepNln
+                    genIf synExpr.Range
+                    +> genExpr astContext e1
+                    +> sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
+                    +> genThen synExpr.Range
+                    +> genExpr astContext e2
+                    +> sepNln
                     +> opt id enOpt (fun e4 -> genElse synExpr.Range +> genExpr astContext e4)
 
                 else

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -975,6 +975,12 @@ let internal sepNlnTypeAndMembers (firstMemberRange: range option) ctx =
     | _ ->
         ctx
 
+let internal sepNlnWhenWriteBeforeNewlineNotEmpty fallback (ctx:Context) =
+    if String.isNotNullOrEmpty ctx.WriterModel.WriteBeforeNewline then
+        sepNln ctx
+    else
+        fallback ctx
+
 let internal autoNlnConsideringTriviaIfExpressionExceedsPageWidth expr (key: Choice<FsAstType, FsTokenType>) range (ctx: Context) =
     expressionExceedsPageWidth
         sepNone sepNone // before and after for short expressions


### PR DESCRIPTION
Fixes #1019.