### PR TITLE
Fix missing backtick in Documentation.md

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -254,7 +254,7 @@ type Person() =
     end
 ```
 
-`{ defaultConfig with SpaceBeforeClassConstructor = true }
+`{ defaultConfig with SpaceBeforeClassConstructor = true }`
 
 ```fsharp
 type Person () =


### PR DESCRIPTION
This trivial PR fixes a missing backtick in Documentaion.md