### PR TITLE
Don't add extra parenthesis for SynType.Fun.

### DIFF
--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -723,3 +723,35 @@ type foo = bool
 
 val bar: bool
 """
+
+[<Test>]
+let ``don't add duplicate parentheses for TypeAbbrev, 1057`` () =
+    formatSourceString false """
+type AB = A -> B list * C -> D
+type AB = A -> (B list * C -> D)
+type AB = A -> ((B list * C -> D))
+
+type AB = A -> (C -> D)
+"""  config
+    |> prepend newline
+    |> should equal """
+type AB = A -> B list * C -> D
+type AB = A -> (B list * C -> D)
+type AB = A -> ((B list * C -> D))
+
+type AB = A -> (C -> D)
+"""
+
+[<Test>]
+let ``don't add duplicate parentheses for TypeAbbrev in signature file`` () =
+    formatSourceString true """
+namespace Foo
+
+type AB = A -> (B list * C -> D)
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace Foo
+
+type AB = A -> (B list * C -> D)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2827,7 +2827,7 @@ and genType astContext outerBracket t =
         | TAnon -> sepWild
         | TVar tp -> genTypar astContext tp
         // Drop bracket around tuples before an arrow
-        | TFun(TTuple ts, t) -> sepOpenT +> loopTTupleList ts +> sepArrow +> loop t +> sepCloseT
+        | TFun(TTuple ts, t) -> loopTTupleList ts +> sepArrow +> loop t
         // Do similar for tuples after an arrow
         | TFun(t, TTuple ts) -> sepOpenT +> loop t +> sepArrow +> loopTTupleList ts +> sepCloseT
         | TFuns ts -> col sepArrow ts loop


### PR DESCRIPTION
Fixes #1057