### PR TITLE
Don't always split applications inside a DotGet expression.

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -376,7 +376,8 @@ System.String.Concat
     ("a",
      "b"
      + longNamedFunlongNamedFunlongNamedFunlongNamedFunlongNamedFun
-         (longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClass).Property)
+         (longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClass)
+         .Property)
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -12,5 +12,37 @@ Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<option<option<unit>>
     |> prepend newline
     |> should equal """
 Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<option<option<unit>>>.GetGenericTypeDefinition()
-        .MakeGenericType(t)).Assembly
+        .MakeGenericType(t))
+    .Assembly
+"""
+
+[<Test>]
+let ``a DotGetApp inside a DotGet should stay on the same line, 1051`` () =
+    formatSourceString false """
+System.Diagnostics.FileVersionInfo.GetVersionInfo(
+               System.Reflection.Assembly.GetExecutingAssembly().Location).FileVersion
+"""  { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should equal """
+System.Diagnostics.FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly()
+        .Location)
+    .FileVersion
+"""
+
+[<Test>]
+let ``split chained method call expression, 246`` () =
+    formatSourceString false """
+        root.SetAttribute
+          ("driverVersion",
+           "AltCover.Recorder "
+           + System.Diagnostics.FileVersionInfo.GetVersionInfo(
+               System.Reflection.Assembly.GetExecutingAssembly().Location).FileVersion)
+"""  config
+    |> prepend newline
+    |> should equal """
+root.SetAttribute
+    ("driverVersion",
+     "AltCover.Recorder "
+     + System.Diagnostics.FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location)
+         .FileVersion)
 """

--- a/src/Fantomas.Tests/LongIdentWithDotsTests.fs
+++ b/src/Fantomas.Tests/LongIdentWithDotsTests.fs
@@ -210,7 +210,8 @@ let ``don't repeat parenthesis for DotGet Paren, 989`` () =
     |> prepend newline
     |> should equal """
 (something_really_long
- + another_thing_thats_really_long).A
+ + another_thing_thats_really_long)
+    .A
 """
 
 [<Test>]
@@ -224,5 +225,6 @@ let ``infix expression inside DotGet, 921`` () =
     |> should equal """
 let variable =
     (DataAccess.getById moduleName.readData { Id = createObject.Id }
-     |> Result.okValue).Value
+     |> Result.okValue)
+        .Value
 """

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -343,10 +343,13 @@ let ``meaningful space should be preserved, 353`` () =
         { dotnetOptions o' with WorkingDirectory =
                                   Path.getFullName "RegressionTesting/issue29"
                                 Verbosity = Some DotNet.Verbosity.Minimal }).WithParameters""" config
-    |> should equal """to'.WithCommon(fun o' ->
+    |> prepend newline
+    |> should equal """
+to'.WithCommon(fun o' ->
     { dotnetOptions o' with
           WorkingDirectory = Path.getFullName "RegressionTesting/issue29"
-          Verbosity = Some DotNet.Verbosity.Minimal }).WithParameters
+          Verbosity = Some DotNet.Verbosity.Minimal })
+    .WithParameters
 """
 
 [<Test>]

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1528,6 +1528,8 @@ and genExpr astContext synExpr =
                     +> (fun ctx ->
                           match e2 with
                           | Paren (App (_)) when astContext.IsInsideDotGet -> genExpr astContext e2 ctx
+                          | Paren (DotGet (App(_), _)) when astContext.IsInsideDotGet -> genExpr astContext e2 ctx
+                          | ConstExpr(SynConst.Unit, _) when astContext.IsInsideDotGet -> genExpr astContext e2 ctx
                           | _ -> appNlnFun e2 (genExpr astContext e2) ctx)
                     +> unindent)
             genApp ctx
@@ -2005,7 +2007,9 @@ and genExpr astContext synExpr =
     | DotNamedIndexedPropertySet(e, ident, e1, e2) ->
        genExpr astContext e -- "." -- ident +> genExpr astContext e1 -- " <- "  +> genExpr astContext e2
     | DotGet(e, (s,_)) ->
-        genExpr { astContext with IsInsideDotGet = true } e -- (sprintf ".%s" s)
+        let shortExpr = genExpr { astContext with IsInsideDotGet = true } e -- (sprintf ".%s" s)
+        let longExpr = genExpr { astContext with IsInsideDotGet = true } e +> indent +> sepNln -- (sprintf ".%s" s) +> unindent
+        expressionFitsOnRestOfLine shortExpr longExpr
     | DotSet(e1, s, e2) -> addParenIfAutoNln e1 (genExpr astContext) -- sprintf ".%s <- " s +> genExpr astContext e2
 
     | SynExpr.Set(e1,e2, _) ->


### PR DESCRIPTION
Fixes #1051.
I've added a regression test for the original issue in #246 as well.
@SteveGilham could you confirm that the result in the unit test would work out in your codebase?