### PR TITLE
Use ranges for parenthesis found in SynExpr.Paren to print trivia

### DIFF
--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -496,8 +496,8 @@ let (|Quote|_|) = function
     | _ -> None
 
 let (|Paren|_|) = function 
-    | SynExpr.Paren(e, _, _, _) ->
-        Some e
+    | SynExpr.Paren(e, lpr, rpr, _) ->
+        Some (lpr, e, rpr)
     | _ -> None
 
 type ExprKind = 


### PR DESCRIPTION
Fixes #1084