### PR TITLE
Preserve existing new line between type and members in signature files

### DIFF
--- a/src/Fantomas.Tests/NewlineBetweenTypeDefinitionAndMembersTests.fs
+++ b/src/Fantomas.Tests/NewlineBetweenTypeDefinitionAndMembersTests.fs
@@ -206,3 +206,59 @@ type HttpContext with
 
     member QueryString: unit -> string
 """
+
+[<Test>]
+let ``existing new line between type and members in signature file, 1094`` () =
+    formatSourceString true """
+namespace X
+
+type MyRecord =
+    {
+        Level : int
+        Progress : string
+        Bar : string
+        Street : string
+        Number : int
+    }
+
+    member Score : unit -> int
+
+type MyRecord =
+    {
+        SomeField : int
+    }
+
+    interface IMyInterface
+
+type Color =
+    | Red = 0
+    | Green = 1
+    | Blue = 2
+
+    member ToInt: unit -> int
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace X
+
+type MyRecord =
+    { Level: int
+      Progress: string
+      Bar: string
+      Street: string
+      Number: int }
+
+    member Score: unit -> int
+
+type MyRecord =
+    { SomeField: int }
+
+    interface IMyInterface
+
+type Color =
+    | Red = 0
+    | Green = 1
+    | Blue = 2
+
+    member ToInt: unit -> int
+"""

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -1173,10 +1173,10 @@ let internal sepNlnForEmptyNamespace (namespaceRange: range) ctx =
                      || hasPrintableContent node.ContentAfter -> ctx
     | _ -> sepNln ctx
 
-let internal sepNlnTypeAndMembers (firstMemberRange: range option) ctx =
+let internal sepNlnTypeAndMembers (firstMemberRange: range option) (mainNodeType: FsAstType) ctx =
     match firstMemberRange with
     | Some range when (ctx.Config.NewlineBetweenTypeDefinitionAndMembers) ->
-        sepNlnConsideringTriviaContentBeforeForMainNode SynMemberDefn_Member range ctx
+        sepNlnConsideringTriviaContentBeforeForMainNode mainNodeType range ctx
     | _ -> ctx
 
 let internal sepNlnWhenWriteBeforeNewlineNotEmpty fallback (ctx: Context) =


### PR DESCRIPTION
Fixes #1094.