### PR TITLE
Don't duplicate new line between namespace and attribute of type in signature file

### DIFF
--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -759,3 +759,21 @@ namespace Foo
 
 type AB = A -> (B list * C -> D)
 """
+
+[<Test>]
+let ``don't add extra new line between attribute and namespace, 1097`` () =
+    formatSourceString true """
+namespace Meh
+
+[<StringEnum>]
+[<RequireQualifiedAccess>]
+type PayableFilters = | [<CompiledName "statusSelector">] Status
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace Meh
+
+[<StringEnum>]
+[<RequireQualifiedAccess>]
+type PayableFilters = | [<CompiledName "statusSelector">] Status
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -193,7 +193,10 @@ and genSigModuleOrNamespace astContext (SigModuleOrNamespace (ats, px, ao, s, md
         | Some mdl ->
             match mdl with
             | SynModuleSigDecl.Types _ ->
-                sepNlnConsideringTriviaContentBeforeForMainNode SynModuleSigDecl_Types mdl.Range
+                let attrs =
+                    getRangesFromAttributesFromSynModuleSigDeclaration mdl
+
+                sepNlnConsideringTriviaContentBeforeWithAttributesFor SynModuleSigDecl_Types mdl.Range attrs
             | SynModuleSigDecl.Val _ -> sepNlnConsideringTriviaContentBeforeForMainNode ValSpfn_ mdl.Range
             | _ -> sepNone
             +> sepNln


### PR DESCRIPTION
Fixes #1097.