### PR TITLE
Don't add new line before SynAttributeList when previous SynAttributeList had content after.

### DIFF
--- a/src/Fantomas.Tests/ModuleTests.fs
+++ b/src/Fantomas.Tests/ModuleTests.fs
@@ -512,3 +512,35 @@ namespace foo.quz
 // bar
 // baz
 """
+
+[<Test>]
+let ``don't add extra new lines between comments and attributes, 1108`` () =
+    formatSourceString false """
+namespace Foo
+
+// First
+[<someAnnotation>]
+
+// Second
+[<someAnnotation>]
+
+// Third
+[<someAnnotation>]
+
+do ()
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace Foo
+
+// First
+[<someAnnotation>]
+
+// Second
+[<someAnnotation>]
+
+// Third
+[<someAnnotation>]
+
+do ()
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -351,6 +351,8 @@ and genModuleDecl astContext (node: SynModuleDecl) =
                     let hasContentAfter =
                         TriviaHelpers.``has content after after that matches`` (fun tn ->
                             RangeHelpers.rangeEq tn.Range a.Range) (function
+                            | Newline
+                            | Comment (LineCommentOnSingleLine (_))
                             | Directive (_) -> true
                             | _ -> false) (Map.tryFindOrEmptyList SynAttributeList_ ctx.TriviaMainNodes)
 


### PR DESCRIPTION
Fixes #1108.