### PR TITLE
Put multiline single case discriminated unions on separate line after equals.

### DIFF
--- a/src/Fantomas.Tests/UnionTests.fs
+++ b/src/Fantomas.Tests/UnionTests.fs
@@ -465,3 +465,39 @@ type SynType =
         isPostfix: bool *
         range: range // interstitial commas
 """
+
+[<Test>]
+let ``multiline single union case field`` () =
+    formatSourceString true """
+namespace X
+
+type UnresolvedAssemblyReference = UnresolvedAssemblyReference of string * AssemblyReference list
+type ResolvedExtensionReference = ResolvedExtensionReference of string * AssemblyReference list * Tainted<ITypeProvider> list
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace X
+
+type UnresolvedAssemblyReference = UnresolvedAssemblyReference of string * AssemblyReference list
+
+type ResolvedExtensionReference =
+    ResolvedExtensionReference of string * AssemblyReference list * Tainted<ITypeProvider> list
+"""
+
+[<Test>]
+let ``multiline single union case field, implementation file`` () =
+    formatSourceString false """
+namespace X
+
+type UnresolvedAssemblyReference = UnresolvedAssemblyReference of string * AssemblyReference list
+type ResolvedExtensionReference = ResolvedExtensionReference of string * AssemblyReference list * Tainted<ITypeProvider> list
+"""  config
+    |> prepend newline
+    |> should equal """
+namespace X
+
+type UnresolvedAssemblyReference = UnresolvedAssemblyReference of string * AssemblyReference list
+
+type ResolvedExtensionReference =
+    ResolvedExtensionReference of string * AssemblyReference list * Tainted<ITypeProvider> list
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -313,7 +313,11 @@ and genSigModuleDeclList astContext node =
 
     | SigMultilineModuleDeclL (xs, ys) ->
         match ys with
-        | [] -> col sepNln xs (genSigModuleDecl astContext)
+        | [] ->
+            colEx (fun (x: SynModuleSigDecl) ->
+                sepNln
+                +> sepNlnConsideringTriviaContentBeforeForMainNode (synModuleSigDeclToFsAstType x) x.Range) xs
+                (genSigModuleDecl astContext)
         | _ ->
             let sepXsYs =
                 match List.tryHead ys with
@@ -2977,17 +2981,17 @@ and genTypeDefn astContext (TypeDef (ats, px, ao, tds, tcs, tdr, ms, s, preferPo
                     || not (List.isEmpty attrs)
                     || List.isEmpty fields
 
-                indent
-                +> sepSpace
-                +> genTriviaFor
-                    SynTypeDefnSimpleRepr_Union
-                       tdr.Range
-                       (opt sepSpace ao' genAccess
-                        +> genUnionCase
-                            { astContext with
-                                  HasVerticalBar = hasVerticalBar }
-                               x)
-                <| ctx
+                let expr =
+                    genTriviaFor
+                        SynTypeDefnSimpleRepr_Union
+                        tdr.Range
+                        (opt sepSpace ao' genAccess
+                         +> genUnionCase
+                             { astContext with
+                                   HasVerticalBar = hasVerticalBar }
+                                x)
+
+                expressionFitsOnRestOfLine (sepSpace +> expr) (indent +> sepNln +> expr) ctx
             | xs ->
                 indent
                 +> sepNln
@@ -3304,16 +3308,17 @@ and genSigTypeDefn astContext (SigTypeDef (ats, px, ao, tds, tcs, tdr, ms, s, pr
                     || not (List.isEmpty attrs)
                     || List.isEmpty fs
 
-                indent
-                +> sepSpace
-                +> genTriviaFor
-                    SynTypeDefnSimpleRepr_Union
-                       tdr.Range
-                       (opt sepSpace ao' genAccess
-                        +> genUnionCase
-                            { astContext with
-                                  HasVerticalBar = hasVerticalBar }
-                               x)
+                let expr =
+                    genTriviaFor
+                        SynTypeDefnSimpleRepr_Union
+                        tdr.Range
+                        (opt sepSpace ao' genAccess
+                         +> genUnionCase
+                             { astContext with
+                                   HasVerticalBar = hasVerticalBar }
+                                x)
+
+                expressionFitsOnRestOfLine (sepSpace +> expr) (indent +> sepNln +> expr)
             | xs ->
                 indent
                 +> sepNln


### PR DESCRIPTION
This solves a regression introduced in https://github.com/fsprojects/fantomas/pull/1052.