### PR TITLE
Add parenthesis for multiline SynPat.Tuple expression in SynBinding

### DIFF
--- a/src/Fantomas.Tests/TupleTests.fs
+++ b/src/Fantomas.Tests/TupleTests.fs
@@ -29,3 +29,58 @@ let ``multiline item in tuple - paren on its line`` () =
   then answerWhenTheConditionIsTrue
   else answerWhenTheConditionIsFalse))
 """
+
+[<Test>]
+let ``multiline SynPat.Tuple should have parenthesis, 824`` () =
+    formatSourceString false """
+namespace GWallet.Backend.Tests
+
+module Foo =
+
+    let someOtherFunc () =
+        let var1withAVeryLongLongLongLongLongLongName, var2withAVeryLongLongLongLongLongLongName =
+            someFunc 1, someFunc 2
+
+        ()
+"""  { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should equal """
+namespace GWallet.Backend.Tests
+
+module Foo =
+
+    let someOtherFunc () =
+        let (var1withAVeryLongLongLongLongLongLongName,
+             var2withAVeryLongLongLongLongLongLongName) =
+            someFunc 1, someFunc 2
+
+        ()
+"""
+
+[<Test>]
+let ``multiline SynPat.Tuple with existing parenthesis should not add additional parenthesis`` () =
+    formatSourceString false """
+namespace GWallet.Backend.Tests
+
+module Foo =
+
+    let someOtherFunc () =
+        let (var1withAVeryLongLongLongLongLongLongName,
+             var2withAVeryLongLongLongLongLongLongName) =
+            someFunc 1, someFunc 2
+
+        ()
+"""  { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should equal """
+namespace GWallet.Backend.Tests
+
+module Foo =
+
+    let someOtherFunc () =
+        let (var1withAVeryLongLongLongLongLongLongName,
+             var2withAVeryLongLongLongLongLongLongName) =
+            someFunc 1, someFunc 2
+
+        ()
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -681,6 +681,8 @@ and genLetBinding astContext pref b =
                 genPatWithReturnType ao s ps tpso (Some t) astContext
             | _, PatLongIdent (ao, s, ps, tpso) when (List.length ps > 1) ->
                 genPatWithReturnType ao s ps tpso None astContext
+            | _, PatTuple _ ->
+                expressionFitsOnRestOfLine (genPat astContext p) (sepOpenT +> genPat astContext p +> sepCloseT)
             | _ -> genPat astContext p
 
         let genAttr =


### PR DESCRIPTION
Fixes #824.