### PR TITLE
Put long return types on the next line of SynModuleSigDecl.Val

### DIFF
--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -433,20 +433,20 @@ module Teq =
         val domain<'domain1, 'domain2, 'range> : Teq<'domain1, 'domain2> -> Teq<'domain1 -> 'range, 'domain2 -> 'range>
 
         /// Given a type equality between two function types, returns the type equality on their corresponding domains.
-        val domainOf<'domain1, 'domain2, 'range1, 'range2> : Teq<'domain1 -> 'range1, 'domain2 -> 'range2>
-             -> Teq<'domain1, 'domain2>
+        val domainOf<'domain1, 'domain2, 'range1, 'range2> :
+            Teq<'domain1 -> 'range1, 'domain2 -> 'range2> -> Teq<'domain1, 'domain2>
 
         /// Given a type equality between two types 'range1 and 'range2, returns the type equality
         /// on the function types ('domain -> 'range1) and ('domain -> 'range2), for any arbitrary 'domain.
         val range<'domain, 'range1, 'range2> : Teq<'range1, 'range2> -> Teq<'domain -> 'range1, 'domain -> 'range2>
 
         /// Given a type equality between two function types, returns the type equality on their corresponding ranges.
-        val rangeOf<'domain1, 'domain2, 'range1, 'range2> : Teq<'domain1 -> 'range1, 'domain2 -> 'range2>
-             -> Teq<'range1, 'range2>
+        val rangeOf<'domain1, 'domain2, 'range1, 'range2> :
+            Teq<'domain1 -> 'range1, 'domain2 -> 'range2> -> Teq<'range1, 'range2>
 
         /// Given a pair of type equalities, one for domains and one for ranges, returns the type equality for the corresponding function types.
-        val func<'domain1, 'range1, 'domain2, 'range2> : Teq<'domain1, 'domain2>
-             -> Teq<'range1, 'range2> -> Teq<'domain1 -> 'range1, 'domain2 -> 'range2>
+        val func<'domain1, 'range1, 'domain2, 'range2> :
+            Teq<'domain1, 'domain2> -> Teq<'range1, 'range2> -> Teq<'domain1 -> 'range1, 'domain2 -> 'range2>
 
         /// Given a type equality between two types 'fst1 and 'fst2, returns the type equality
         /// on the pair types ('fst1 * 'snd) and ('fst2 * 'snd), for any arbitrary 'snd.
@@ -458,8 +458,8 @@ module Teq =
 
         /// Given a pair of type equalities, one for the first element of a pair and one for the second element of a pair,
         /// returns the type equality for the corresponding pair types.
-        val pair<'fst1, 'snd1, 'fst2, 'snd2> : Teq<'fst1, 'fst2>
-             -> Teq<'snd1, 'snd2> -> Teq<'fst1 * 'snd1, 'fst2 * 'snd2>
+        val pair<'fst1, 'snd1, 'fst2, 'snd2> :
+            Teq<'fst1, 'fst2> -> Teq<'snd1, 'snd2> -> Teq<'fst1 * 'snd1, 'fst2 * 'snd2>
 """
 
 [<Test>]
@@ -898,4 +898,32 @@ type TestType =
     // Here is some comment about the type
     // Some more comments
     private { Meh: TimeSpan }
+"""
+
+[<Test>]
+let ``format long val return type multiline, 1181`` () =
+    formatSourceString true """
+namespace TypeEquality
+
+[<RequireQualifiedAccess>]
+module Teq =
+
+    [<RequireQualifiedAccess>]
+    module Cong =
+
+        val domainOf<'domain1, 'domain2, 'range1, 'range2> : Teq<'domain1 -> 'range1, 'domain2 -> 'range2>
+             -> Teq<'domain1, 'domain2>
+"""  { config with SpaceBeforeColon = true }
+    |> prepend newline
+    |> should equal """
+namespace TypeEquality
+
+[<RequireQualifiedAccess>]
+module Teq =
+
+    [<RequireQualifiedAccess>]
+    module Cong =
+
+        val domainOf<'domain1, 'domain2, 'range1, 'range2> :
+            Teq<'domain1 -> 'range1, 'domain2 -> 'range2> -> Teq<'domain1, 'domain2>
 """

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1103,7 +1103,10 @@ and genVal astContext (Val (ats, px, ao, s, t, vi, isInline, _) as node) =
          +> genericParams
          +> addSpaceAfterGenericConstructBeforeColon
          +> sepColon
-         +> ifElse (List.isNotEmpty namedArgs) (genTypeList astContext namedArgs) (genConstraints astContext t)
+         +> ifElse
+             (List.isNotEmpty namedArgs)
+                (autoNlnIfExpressionExceedsPageWidth (genTypeList astContext namedArgs))
+                (genConstraints astContext t)
          +> unindent)
     |> genTriviaFor ValSpfn_ range
 


### PR DESCRIPTION
Fixes #1181.

Maybe not the fix that was proposed, but this has the least impact.
Is this somewhat acceptable @Smaug123?
