### PR TITLE
Ignore newlines when comparing formatted code to original code.

### DIFF
--- a/src/Fantomas.CoreGlobalTool.Tests/CheckTests.fs
+++ b/src/Fantomas.CoreGlobalTool.Tests/CheckTests.fs
@@ -52,3 +52,19 @@ let main _ = 0
 
     let (exitCode, _) = checkCode fileFixture.Filename
     exitCode |> should equal 0
+
+[<Test>]
+let ``check with different line endings`` () =
+    let codeSnippet = """let a =
+    // some comment
+    42
+"""
+
+    let snippetWithOtherLineEndings =
+        if codeSnippet.Contains("\r\n") then codeSnippet.Replace("\r\n", "\n") else codeSnippet.Replace("\n", "\r\n")
+
+    use fileFixture =
+        new TemporaryFileCodeSample(snippetWithOtherLineEndings)
+
+    let (exitCode, _) = checkCode fileFixture.Filename
+    exitCode |> should equal 0

--- a/src/Fantomas.Extras/FakeHelpers.fs
+++ b/src/Fantomas.Extras/FakeHelpers.fs
@@ -61,7 +61,11 @@ let formatContentAsync config (file: string) (originalContent: string) =
                          createParsingOptionsFromFile fileName,
                          sharedChecker.Value)
 
-                if originalContent <> formattedContent then
+                let stripNewlines (s: string) =
+                    System.Text.RegularExpressions.Regex.Replace(s, @"\n|\r", String.Empty)
+
+                if (stripNewlines originalContent)
+                   <> (stripNewlines formattedContent) then
                     let! isValid =
                         CodeFormatter.IsValidFSharpCodeAsync
                             (fileName,


### PR DESCRIPTION
Fixes #1196 