### PR TITLE
Don't add extra newline when no else expression is present. 

### DIFF
--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -989,3 +989,72 @@ let foo result total =
     then total // and another one
     else result
 """
+
+[<Test>]
+let ``if/then/elif without else, 1211`` () =
+    formatSourceString false """
+let a =
+        // check if the current # char is part of an define expression
+        // if so add to defines
+        let captureHashDefine idx =
+                if trimmed.StartsWith("#if")
+                then defines.Add(processLine "#if" trimmed lineNumber offset)
+                elif trimmed.StartsWith("#elseif")
+                then defines.Add(processLine "#elseif" trimmed lineNumber offset)
+                elif trimmed.StartsWith("#else")
+                then defines.Add(processLine "#else" trimmed lineNumber offset)
+                elif trimmed.StartsWith("#endif")
+                then defines.Add(processLine "#endif" trimmed lineNumber offset)
+
+        for idx in [ 0 .. lastIndex ] do
+            let zero = sourceCode.[idx]
+            let plusOne = sourceCode.[idx + 1]
+            let plusTwo = sourceCode.[idx + 2]
+            ()
+"""  config
+    |> prepend newline
+    |> should equal """
+let a =
+    // check if the current # char is part of an define expression
+    // if so add to defines
+    let captureHashDefine idx =
+        if trimmed.StartsWith("#if")
+        then defines.Add(processLine "#if" trimmed lineNumber offset)
+        elif trimmed.StartsWith("#elseif")
+        then defines.Add(processLine "#elseif" trimmed lineNumber offset)
+        elif trimmed.StartsWith("#else")
+        then defines.Add(processLine "#else" trimmed lineNumber offset)
+        elif trimmed.StartsWith("#endif")
+        then defines.Add(processLine "#endif" trimmed lineNumber offset)
+
+    for idx in [ 0 .. lastIndex ] do
+        let zero = sourceCode.[idx]
+        let plusOne = sourceCode.[idx + 1]
+        let plusTwo = sourceCode.[idx + 2]
+        ()
+"""
+
+[<Test>]
+let ``multiline if/then/elif without else, 1187`` () =
+    formatSourceString false """
+let fn () =
+    if true then
+        DoSomething ()
+        DoSomethingElse()
+    elif shouldWe then
+        Whatever()
+
+let  nextfunc () =
+    printf "Hi"
+"""  config
+    |> prepend newline
+    |> should equal """
+let fn () =
+    if true then
+        DoSomething()
+        DoSomethingElse()
+    elif shouldWe then
+        Whatever()
+
+let nextfunc () = printf "Hi"
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2428,8 +2428,11 @@ and genExpr astContext synExpr ctx =
                         +> genThen synExpr.Range
                         +> genExpr astContext e2
                         +> sepNln
-                        +> colPost sepNln sepNln elfis genElifTwoLiner
-                        +> opt id enOpt (fun e4 -> genElse synExpr.Range +> genExpr astContext e4)
+                        +> col sepNln elfis genElifTwoLiner
+                        +> opt id enOpt (fun e4 ->
+                               onlyIf (List.isNotEmpty elfis) sepNln
+                               +> genElse synExpr.Range
+                               +> genExpr astContext e4)
 
                     elif hasElfis
                          && not isAnyExpressionIsMultiline
@@ -2518,14 +2521,15 @@ and genExpr astContext synExpr ctx =
                         +> genExpr astContext e2
                         +> unindent
                         +> sepNln
-                        +> colPost sepNln sepNln elfis genElifMultiLine
+                        +> col sepNln elfis genElifMultiLine
                         +> opt id enOpt (fun e4 ->
                                let correctedElseRange =
                                    match List.tryLast elfis with
                                    | Some (_, te, _) -> mkRange "correctedElseRange" te.Range.End synExpr.Range.End
                                    | None -> synExpr.Range
 
-                               genElse correctedElseRange
+                               onlyIf (List.isNotEmpty elfis) sepNln
+                               +> genElse correctedElseRange
                                +> indent
                                +> sepNln
                                +> genExpr astContext e4


### PR DESCRIPTION
Fixes #1211. 
Fixes #1187.