### PR TITLE
Fantomas.Tests: fix build with VS4Mac

### DIFF
--- a/src/Fantomas.Tests/FormatConfigEditorConfigurationFileTests.fs
+++ b/src/Fantomas.Tests/FormatConfigEditorConfigurationFileTests.fs
@@ -66,7 +66,7 @@ type FSharpFile internal (?fsharpFileExtension: string, ?subFolder: string) =
 
     do File.WriteAllText(fsharpFilePath, String.empty)
 
-    member _.FSharpFile: string = fsharpFilePath
+    member __.FSharpFile: string = fsharpFilePath
 
     interface IDisposable with
         member this.Dispose(): unit =

--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -301,7 +301,7 @@ type TemporaryFileCodeSample internal (codeSnippet: string) =
 
     do File.WriteAllText(filename, codeSnippet)
 
-    member _.Filename: string = filename
+    member __.Filename: string = filename
 
     interface IDisposable with
         member this.Dispose(): unit = File.Delete(filename)


### PR DESCRIPTION
Not sure why, but when trying to build this project with VS4Mac v8.6.7.2
(which uses the following underneath: mono 6.10.0.104 & fsharpc 10.2.3 with
F# 4.5 support) the following error was being reported:

```
Error FS0010: Unexpected symbol '.' in member definition. Expected 'with', '=' or other token. (FS0010) (Fantomas.Tests)
```