### PR TITLE
Refactored LetBindings

### DIFF
--- a/src/Fantomas.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Tests/FunctionDefinitionTests.fs
@@ -68,10 +68,10 @@ let ``should keep identifiers with whitespace in double backticks`` () =
 """
 
 [<Test>]
-let ``should remove backticks from shouldn't identifier`` () =
+let ``should not remove backticks from shouldn't identifier`` () =
     formatSourceString false """let ``shouldn't`` () = x
     """ config
-    |> should equal """let shouldn't () = x
+    |> should equal """let ``shouldn't`` () = x
 """
 
 [<Test>]
@@ -83,7 +83,8 @@ let ``should keep identifiers with + in double backticks`` () =
 
 [<Test>]
 let ``double backticks with non-alphanum character, 776`` () =
-    formatSourceString false """let ``!foo hoo`` () = ()
+    formatSourceString false """
+let ``!foo hoo`` () = ()
 let ``@foo hoo`` () = ()
 let ``$foo hoo`` () = ()
 let ``%foo hoo`` () = ()
@@ -94,8 +95,13 @@ let ``<foo hoo`` () = ()
 let ``>foo hoo`` () = ()
 let ``=foo hoo`` () = ()
 let ``-foo hoo`` () = ()
+let ``!foo hoo`` () : unit = ()
+let ``@foo hoo`` = ()
+let ``$foo hoo`` : unit = ()
     """ config
-    |> should equal """let ``!foo hoo`` () = ()
+    |> prepend newline
+    |> should equal """
+let ``!foo hoo`` () = ()
 let ``@foo hoo`` () = ()
 let ``$foo hoo`` () = ()
 let ``%foo hoo`` () = ()
@@ -106,6 +112,9 @@ let ``<foo hoo`` () = ()
 let ``>foo hoo`` () = ()
 let ``=foo hoo`` () = ()
 let ``-foo hoo`` () = ()
+let ``!foo hoo`` (): unit = ()
+let ``@foo hoo`` = ()
+let ``$foo hoo``: unit = ()
 """
 
 [<Test>]
@@ -716,34 +725,6 @@ let inline deserialize< ^a when ^a: (static member FromJson: ^a -> Json< ^a >)> 
 """
 
 [<Test>]
-let ``meh xx`` () =
-    formatSourceString false """
-module Infrastructure =
-
-    let internal ReportMessage (message: string)
-                               (_: ErrorLevel)
-
-                               (errorLevel: ErrorLevel)
-
-                               =
-    // meh
-    ()
-"""  config
-    |> prepend newline
-    |> should equal """
-module Infrastructure =
-
-    let internal ReportMessage (message: string)
-                               (_: ErrorLevel)
-
-                               (errorLevel: ErrorLevel)
-
-                               =
-        // meh
-        ()
-"""
-
-[<Test>]
 let ``equals sign between hash directives, 1218`` () =
     formatSourceString false """
 module Infrastructure =
@@ -782,4 +763,150 @@ module Infrastructure =
 
         ()
 #endif
+"""
+
+[<Test>]
+let ``single line value without return type `` () =
+    formatSourceString false """
+let a =  7
+let private b  = ""
+let internal c  = 8
+let [<Foo>] d  = 9
+let e<'t>  = 8
+"""  config
+    |> prepend newline
+    |> should equal """
+let a = 7
+let private b = ""
+let internal c = 8
+
+[<Foo>]
+let d = 9
+
+let e<'t> = 8
+"""
+
+[<Test>]
+let ``single line value with return type `` () =
+    formatSourceString false """
+let a : int =  7
+let private b : string = ""
+let internal c : int = 8
+let [<Foo>] d : int = 9
+let e<'t> : int = 8
+"""  config
+    |> prepend newline
+    |> should equal """
+let a: int = 7
+let private b: string = ""
+let internal c: int = 8
+
+[<Foo>]
+let d: int = 9
+
+let e<'t> : int = 8
+"""
+
+[<Test>]
+let ``multiline value without return type `` () =
+    formatSourceString false """
+let a =
+    // a comment makes things multiline
+    7
+let private b =
+    // a comment makes things multiline
+    ""
+let internal c =
+    // a comment makes things multiline
+    8
+let [<Foo>] d =
+    // a comment makes things multiline
+    9
+let e<'t> =
+    // a comment makes things multiline
+    8
+"""  config
+    |> prepend newline
+    |> should equal """
+let a =
+    // a comment makes things multiline
+    7
+
+let private b =
+    // a comment makes things multiline
+    ""
+
+let internal c =
+    // a comment makes things multiline
+    8
+
+[<Foo>]
+let d =
+    // a comment makes things multiline
+    9
+
+let e<'t> =
+    // a comment makes things multiline
+    8
+"""
+
+[<Test>]
+let ``multiline value with return type `` () =
+    formatSourceString false """
+let a : int =
+    // a comment makes things multiline
+    7
+let private b : string =
+    // a comment makes things multiline
+    ""
+let internal c : int =
+    // a comment makes things multiline
+    8
+let [<Foo>] d : int =
+    // a comment makes things multiline
+    9
+let e<'t> : int =
+    // a comment makes things multiline
+    8
+"""  config
+    |> prepend newline
+    |> should equal """
+let a: int =
+    // a comment makes things multiline
+    7
+
+let private b: string =
+    // a comment makes things multiline
+    ""
+
+let internal c: int =
+    // a comment makes things multiline
+    8
+
+[<Foo>]
+let d: int =
+    // a comment makes things multiline
+    9
+
+let e<'t> : int =
+    // a comment makes things multiline
+    8
+"""
+
+[<Test>]
+let ``short function binding name without return type`` () =
+    formatSourceString false """
+let add a b = a + b
+let subtract (a: int) (b:int) = a - b
+let private multiply a b = a * b
+let internal divide a b = a / b
+let SetQuartzLogger l = LogProvider.SetCurrentLogProvider(l)
+"""  config
+    |> prepend newline
+    |> should equal """
+let add a b = a + b
+let subtract (a: int) (b: int) = a - b
+let private multiply a b = a * b
+let internal divide a b = a / b
+let SetQuartzLogger l = LogProvider.SetCurrentLogProvider(l)
 """

--- a/src/Fantomas.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Tests/FunctionDefinitionTests.fs
@@ -714,3 +714,72 @@ let inline deserialize< ^a when ( ^a or FromJsonDefaults) : (static member FromJ
 let inline deserialize< ^a when ^a: (static member FromJson: ^a -> Json< ^a >)> json =
     json |> Json.parse |> Json.deserialize< ^a>
 """
+
+[<Test>]
+let ``meh xx`` () =
+    formatSourceString false """
+module Infrastructure =
+
+    let internal ReportMessage (message: string)
+                               (_: ErrorLevel)
+
+                               (errorLevel: ErrorLevel)
+
+                               =
+    // meh
+    ()
+"""  config
+    |> prepend newline
+    |> should equal """
+module Infrastructure =
+
+    let internal ReportMessage (message: string)
+                               (_: ErrorLevel)
+
+                               (errorLevel: ErrorLevel)
+
+                               =
+        // meh
+        ()
+"""
+
+[<Test>]
+let ``equals sign between hash directives, 1218`` () =
+    formatSourceString false """
+module Infrastructure =
+
+    let internal ReportMessage
+        (message: string)
+#if DEBUG
+        (_: ErrorLevel)
+#else
+        (errorLevel: ErrorLevel)
+#endif
+        =
+#if DEBUG
+        failwith message
+#else
+        let sentryEvent = SentryEvent (SentryMessage message, Level = errorLevel)
+        ()
+#endif
+"""  config
+    |> prepend newline
+    |> should equal """
+module Infrastructure =
+
+    let internal ReportMessage (message: string)
+#if DEBUG
+                               (_: ErrorLevel)
+#else
+                               (errorLevel: ErrorLevel)
+#endif
+                               =
+#if DEBUG
+        failwith message
+#else
+        let sentryEvent =
+            SentryEvent(SentryMessage message, Level = errorLevel)
+
+        ()
+#endif
+"""

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -396,6 +396,7 @@ let ``has symbol in signature requires paren, 564`` () =
     formatSourceString false """module Bar =
   let foo (_ : #(int seq)) = 1
   let meh (_: #seq<int>) = 2
+  let evenMoreMeh (_: #seq<int>) : int = 2
 """
         ({ config with
                SpaceAfterComma = false
@@ -407,6 +408,7 @@ let ``has symbol in signature requires paren, 564`` () =
 module Bar =
     let foo(_: #(int seq)) = 1
     let meh(_: #seq<int>) = 2
+    let evenMoreMeh(_: #seq<int>): int = 2
 """
 
 [<Test>]
@@ -564,7 +566,31 @@ let Baz (firstParam: string)
 #else
         (secndParam: int)
 #endif
-    =
+        =
+    ()
+"""
+
+[<Test>]
+let ``handle hash directives before equals, no defines`` () =
+    formatSourceStringWithDefines [] """let Baz (firstParam: string)
+#if DEBUG
+            (_         : int)
+#else
+            (secndParam: int)
+#endif
+                =
+        ()
+
+    """ config
+    |> prepend newline
+    |> should equal """
+let Baz (firstParam: string)
+#if DEBUG
+
+#else
+        (secndParam: int)
+#endif
+        =
     ()
 """
 
@@ -588,7 +614,7 @@ let ``multiple empty lines between equals and expression`` () =
 #else
         (secndParam: int)
 #endif
-    =
+        =
 
 
     ()

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -568,14 +568,44 @@ and genExprSepEqPrependType astContext
 
     let sepEqual predicate =
         if predicate then
-            fun ctx ->
+            fun (ctx: Context) ->
                 let alreadyHasNewline = lastWriteEventIsNewline ctx
 
                 if alreadyHasNewline then
+                    // AST Context ??
+
+                    let lines =
+                        ctx.WriterModel.Lines
+                        |> Seq.skipWhile String.IsNullOrWhiteSpace
+                        |> Seq.head
+
+                    let repSize =
+                            let spacesFromStartOfString = Seq.takeWhile Char.IsWhiteSpace >> Seq.length
+
+                            ctx.WriterModel.Lines
+                            |> Seq.skipWhile String.IsNullOrWhiteSpace
+                            |> Seq.tryHead
+                            |> Option.map (fun lastLineWithContent ->
+                                let spacesOnLastLineWithContent =
+                                    spacesFromStartOfString lastLineWithContent
+
+                                let spacesOnLastLine =
+                                    ctx.WriterModel.Lines
+                                    |> Seq.tryHead
+                                    |> Option.map spacesFromStartOfString
+                                    |> Option.defaultValue 0
+
+                                spacesOnLastLineWithContent - spacesOnLastLine
+                            )
+                            |> Option.defaultValue ctx.Config.IndentSize
+
+                    (rep repSize (!- " ") +> !- "=") ctx
+
                     // Column could be 0 when a hash directive was just written
-                    if ctx.Column = 0
-                    then (rep ctx.Config.IndentSize (!- " ") +> !- "=") ctx
-                    else !- "=" ctx
+                    //if ctx.Column = 0 then
+
+                    //else
+                    //    !- "=" ctx
                 elif ctx.Config.AlignFunctionSignatureToIndentation then
                     (indent +> sepNln +> !- "=" +> unindent) ctx
                 else

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -72,6 +72,7 @@ let addSpaceBeforeParensInFunDef (astContext: ASTContext) (functionOrMethod: str
     | "new", _ -> false
     | _, PatParen _ ->
         if astContext.IsMemberDefinition then ctx.Config.SpaceBeforeMember else ctx.Config.SpaceBeforeParameter
+    | _, PatNamed _ -> true
     | (_: string), _ -> not isLastPartUppercase
     | _ -> true
 
@@ -555,113 +556,16 @@ and addSpaceAfterGenericConstructBeforeColon ctx =
         sepNone
     <| ctx
 
-and genExprSepEqPrependType astContext
-                            (pat: SynPat)
-                            (e: SynExpr)
-                            (valInfo: SynValInfo option)
-                            (isPrefixMultiline: bool)
-                            ctx
-                            =
-    let hasTriviaContentAfterEqual =
-        Map.tryFindOrEmptyList EQUALS ctx.TriviaTokenNodes
-        |> List.exists (fun tn -> tn.Range.StartLine = pat.Range.StartLine)
-
-    let sepEqual predicate =
-        if predicate then
-            fun (ctx: Context) ->
-                let alreadyHasNewline = lastWriteEventIsNewline ctx
-
-                if alreadyHasNewline then
-                    // AST Context ??
-
-                    let lines =
-                        ctx.WriterModel.Lines
-                        |> Seq.skipWhile String.IsNullOrWhiteSpace
-                        |> Seq.head
-
-                    let repSize =
-                            let spacesFromStartOfString = Seq.takeWhile Char.IsWhiteSpace >> Seq.length
-
-                            ctx.WriterModel.Lines
-                            |> Seq.skipWhile String.IsNullOrWhiteSpace
-                            |> Seq.tryHead
-                            |> Option.map (fun lastLineWithContent ->
-                                let spacesOnLastLineWithContent =
-                                    spacesFromStartOfString lastLineWithContent
-
-                                let spacesOnLastLine =
-                                    ctx.WriterModel.Lines
-                                    |> Seq.tryHead
-                                    |> Option.map spacesFromStartOfString
-                                    |> Option.defaultValue 0
-
-                                spacesOnLastLineWithContent - spacesOnLastLine
-                            )
-                            |> Option.defaultValue ctx.Config.IndentSize
-
-                    (rep repSize (!- " ") +> !- "=") ctx
-
-                    // Column could be 0 when a hash directive was just written
-                    //if ctx.Column = 0 then
-
-                    //else
-                    //    !- "=" ctx
-                elif ctx.Config.AlignFunctionSignatureToIndentation then
-                    (indent +> sepNln +> !- "=" +> unindent) ctx
-                else
-                    (sepEq +> sepSpace) ctx
-        else
-            (sepEq +> sepSpace)
-
-    let maxWidth =
-        if isFunctionBinding pat then ctx.Config.MaxFunctionBindingWidth else ctx.Config.MaxValueBindingWidth
-
+and genExprSepEqPrependType (astContext: ASTContext) (e: SynExpr) =
     match e with
     | TypedExpr (Typed, e, t) ->
-        let addExtraSpaceBeforeGenericType =
-            match pat with
-            | SynPat.LongIdent (_, _, Some (SynValTyparDecls _), _, _, _) -> addSpaceAfterGenericConstructBeforeColon
-            | _ -> sepNone
-
-        let genCommentBeforeColon =
-            atCurrentColumn (enterNodeFor SynBindingReturnInfo_ t.Range)
-
-        let genMetadataAttributes =
-            match valInfo with
-            | Some (SynValInfo (_, SynArgInfo (attributes, _, _))) -> genOnelinerAttributes astContext attributes
-            | None -> sepNone
-
-        (addExtraSpaceBeforeGenericType
-         +> genCommentBeforeColon
-         +> sepColon
-         +> genMetadataAttributes
-         +> genType astContext false t
-         +> sepEqual (isPrefixMultiline)
-         +> ifElse
-             (isPrefixMultiline || hasTriviaContentAfterEqual)
-                (indent
-                 +> sepNln
-                 +> genExpr astContext e
-                 +> unindent)
-                (isShortExpressionOrAddIndentAndNewline maxWidth (genExpr astContext e))) ctx
-    | e ->
-        let genE =
-            match e with
-            | MultilineString _
-            | _ when (TriviaHelpers.``has content itself that is multiline string``
-                          e.Range
-                          (Map.tryFindOrEmptyList SynExpr_Const ctx.TriviaMainNodes)) -> genExpr astContext e
-            | _ -> isShortExpressionOrAddIndentAndNewline maxWidth (genExpr astContext e)
-
-        (sepEqual isPrefixMultiline
-         +> leaveEqualsToken pat.Range
-         +> ifElse
-             (isPrefixMultiline || hasTriviaContentAfterEqual)
-                (indent
-                 +> sepNln
-                 +> genExpr astContext e
-                 +> unindent)
-                genE) ctx
+        sepColon
+        +> genType astContext false t
+        +> sepEq
+        +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e)
+    | _ ->
+        sepEq
+        +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e)
 
 and genTyparList astContext tps =
     ifElse
@@ -702,38 +606,30 @@ and genTypeParamPostfix astContext tds tcs =
 and genLetBinding astContext pref b =
     match b with
     | LetBinding (ats, px, ao, isInline, isMutable, p, e, valInfo) ->
-        let genPat =
-            match e, p with
-            | TypedExpr (Typed, _, t), PatLongIdent (ao, s, ps, tpso) when (List.isNotEmpty ps) ->
-                genPatWithReturnType ao s ps tpso (Some t) astContext
-            | _, PatLongIdent (ao, s, ps, tpso) when (List.length ps > 1) ->
-                genPatWithReturnType ao s ps tpso None astContext
-            | _, PatTuple _ ->
-                expressionFitsOnRestOfLine (genPat astContext p) (sepOpenT +> genPat astContext p +> sepCloseT)
-            | _ -> genPat astContext p
-
-        let genAttr =
-            ifElse
-                astContext.IsFirstChild
-                (genAttributes astContext ats -- pref)
-                (!-pref +> genOnelinerAttributes astContext ats)
-
-        let afterLetKeyword =
-            opt sepSpace ao genAccess
-            +> ifElse isMutable (!- "mutable ") sepNone
-            +> ifElse isInline (!- "inline ") sepNone
-
-        let rangeBetweenBindingPatternAndExpression =
-            mkRange "range between binding pattern and expression" b.RangeOfBindingSansRhs.End e.Range.Start
-
-        genPreXmlDoc px
-        +> genAttr // this already contains the `let` or `and` keyword
-        +> leadingExpressionIsMultiline
-            (afterLetKeyword
-             +> genPat
-             +> enterNodeTokenByName rangeBetweenBindingPatternAndExpression EQUALS)
-               (genExprSepEqPrependType astContext p e (Some(valInfo)))
-
+        match e, p with
+        | TypedExpr (Typed, e, t), PatLongIdent (ao, s, ps, tpso) when (List.isNotEmpty ps) ->
+            getLetBindingFunctionWithReturnType
+                astContext
+                px
+                ats
+                pref
+                ao
+                isInline
+                isMutable
+                s
+                p.Range
+                ps
+                tpso
+                t
+                valInfo
+                e
+        | e, PatLongIdent (ao, s, ps, tpso) when (List.isNotEmpty ps) ->
+            getLetBindingFunction astContext px ats pref ao isInline isMutable s p.Range ps tpso valInfo e
+        | TypedExpr (Typed, e, t), pat ->
+            genLetBindingValue astContext px ats pref ao isInline isMutable pat (Some t) valInfo e
+        | _, PatTuple _ -> genLetBindingDestructedTuple astContext px ats pref ao isInline isMutable p e
+        | _, pat -> genLetBindingValue astContext px ats pref ao isInline isMutable pat None valInfo e
+        | _ -> sepNone
     | DoBinding (ats, px, e) ->
         let prefix =
             if pref.Contains("let") then pref.Replace("let", "do") else "do "
@@ -744,9 +640,6 @@ and genLetBinding astContext pref b =
 
     | b -> failwithf "%O isn't a let binding" b
     +> leaveNodeFor (synBindingToFsAstType b) b.RangeOfBindingAndRhs
-
-and genShortGetProperty astContext (pat: SynPat) e =
-    genExprSepEqPrependType astContext pat e None false
 
 and genProperty astContext prefix ao propertyKind ps e =
     let tuplerize ps =
@@ -772,15 +665,13 @@ and genProperty astContext prefix ao propertyKind ps e =
                 +> sepCloseT
                 +> sepSpace)
         +> genPat astContext p
-        +> genExprSepEqPrependType astContext p e None false
+        +> genExprSepEqPrependType astContext e
 
     | ps ->
-        let (_, p) = tuplerize ps
-
         !-prefix +> opt sepSpace ao genAccess
         -- propertyKind
         +> col sepSpace ps (genPat astContext)
-        +> genExprSepEqPrependType astContext p e None false
+        +> genExprSepEqPrependType astContext e
 
 and genPropertyWithGetSet astContext (b1, b2) rangeOfMember =
     match b1, b2 with
@@ -847,7 +738,8 @@ and genMemberBinding astContext b =
             match ao, propertyKind, ps with
             | None, "get ", [ _, PatParen (PatConst (Const "()", _)) ] ->
                 // Provide short-hand notation `x.Member = ...` for `x.Member with get()` getters
-                prefix -- s +> genShortGetProperty astContext p e
+                prefix -- s
+                +> genExprSepEqPrependType astContext e
             | _ ->
                 let ps = List.map snd ps
 
@@ -4400,82 +4292,339 @@ and genPat astContext pat =
         | SynPat.Paren _ -> genTriviaFor SynPat_Paren pat.Range
         | _ -> id)
 
-and genPatWithReturnType ao s ps tpso (t: SynType option) (astContext: ASTContext) =
-    let aoc = opt sepSpace ao genAccess
+and getLetBindingFunction (astContext: ASTContext)
+                          (px: FSharp.Compiler.XmlDoc.PreXmlDoc)
+                          (ats: SynAttributes)
+                          (pref: string)
+                          (ao: SynAccess option)
+                          (isInline: bool)
+                          (isMutable: bool)
+                          (functionName: string)
+                          (patRange: range)
+                          (parameters: (string option * SynPat) list)
+                          (genericTypeParameters: SynValTyparDecls option)
+                          (valInfo: SynValInfo)
+                          (e: SynExpr)
+                          =
+    let genAttrIsFirstChild =
+        onlyIf astContext.IsFirstChild (genAttributes astContext ats)
 
-    let tpsoc =
-        opt sepNone tpso (fun (ValTyparDecls (tds, _, tcs)) -> genTypeParamPostfix astContext tds tcs)
-    // Override escaped new keyword
-    let s = if s = "``new``" then "new" else s
+    let genPref =
+        if astContext.IsFirstChild
+        then (!-pref)
+        else (!-pref +> genOnelinerAttributes astContext ats)
 
-    let hasBracket =
-        ps |> Seq.map fst |> Seq.exists Option.isSome
+    let afterLetKeyword =
+        opt sepSpace ao genAccess
+        +> ifElse isMutable (!- "mutable ") sepNone
+        +> ifElse isInline (!- "inline ") sepNone
 
-    let genName = aoc -- s +> tpsoc +> sepSpace
+    let genFunctionName =
+        getIndentBetweenTicksFromSynPat patRange functionName
+        +> opt sepNone genericTypeParameters (fun (ValTyparDecls (tds, _, tcs)) ->
+               genTypeParamPostfix astContext tds tcs)
 
-    let genParametersInitial =
-        colAutoNlnSkip0 (ifElse hasBracket sepSemi sepSpace) ps (genPatWithIdent astContext)
+    let genParameters sep =
+        col sep parameters (genPatWithIdent astContext)
 
-    let genReturnType, newlineBeforeReturnType =
-        match t with
-        | Some t ->
-            enterNodeFor SynBindingReturnInfo_ t.Range
-            +> genType astContext false t,
-            sepNln
-        | None ->
-            let genReturnType = sepNone
+    let genSignature =
+        let firstParameter = List.head parameters |> snd
 
-            let newline ctx =
-                if ctx.Config.AlignFunctionSignatureToIndentation then
-                    ctx
-                else
-                    match ps with
-                    | [ (_, PatTuple _) ] -> ctx
-                    | _ -> sepNln ctx
+        let rangeBetweenBindingPatternAndExpression =
+            let endOfParameters =
+                List.last parameters
+                |> snd
+                |> fun p -> p.Range.End
 
-            genReturnType, newline
+            mkRange "range between binding pattern and expression" endOfParameters e.Range.Start
 
-    let genParametersWithNewlines ctx =
-        if ctx.Config.AlignFunctionSignatureToIndentation then
-            (indent
-             +> sepNln
-             +> col sepNln ps (genPatWithIdent astContext)
-             +> newlineBeforeReturnType
-             +> unindent) ctx
-        else
-            atCurrentColumn
-                (col sepNln ps (genPatWithIdent astContext)
-                 +> newlineBeforeReturnType)
-                ctx
+        let short =
+            genPref
+            +> afterLetKeyword
+            +> genFunctionName
+            +> ifElseCtx (addSpaceBeforeParensInFunDef astContext functionName firstParameter) sepSpace sepNone
+            +> genParameters sepSpace
+            +> enterNodeTokenByName rangeBetweenBindingPatternAndExpression EQUALS
+            +> sepEq
 
-    let isLongFunctionSignature (ctx: Context) =
-        let space = 1
+        let long (ctx: Context) =
+            if ctx.Config.AlignFunctionSignatureToIndentation then
+                (genPref
+                 +> afterLetKeyword
+                 +> sepSpace
+                 +> genFunctionName
+                 +> indent
+                 +> sepNln
+                 +> genParameters sepNln
+                 +> sepNln
+                 +> enterNodeTokenByName rangeBetweenBindingPatternAndExpression EQUALS
+                 +> sepEqFixed
+                 +> unindent) ctx
+            else
+                let genEq, genNlnAfterParameters =
+                    match parameters with
+                    | [ _, PatParen (PatTuple _) ]
+                    | [ _, PatParen (PatTyped (_, SynType.AnonRecd _)) ] -> sepEq, sepNone
+                    | _ -> sepEqFixed, sepNln
 
-        let colon =
-            if ctx.Config.SpaceBeforeColon then 3 else 2
+                (genPref
+                 +> afterLetKeyword
+                 +> sepSpace
+                 +> genFunctionName
+                 +> sepSpace
+                 +> atCurrentColumn
+                     (genParameters sepNln
+                      +> genNlnAfterParameters
+                      +> enterNodeTokenByName rangeBetweenBindingPatternAndExpression EQUALS
+                      +> genEq)) ctx
 
-        let lengthByAST =
-            getSynAccessLength ao
-            + lengthWhenSome (fun _ -> space) ao
-            + s.Length
-            + space
-            + List.sumBy (snd >> getSynPatLength >> (+) space) ps
-            + lengthWhenSome (fun _ -> colon) t
-            + lengthWhenSome getSynTypeLength t
+        expressionFitsOnRestOfLine short long
 
-        (ctx.Column + lengthByAST > ctx.Config.MaxLineLength)
-        || futureNlnCheck (genName +> genParametersInitial +> genReturnType) ctx
+    genPreXmlDoc px
+    +> genAttrIsFirstChild
+    +> leadingExpressionIsMultiline genSignature (fun isMultiline ctx ->
+           if isMultiline then
+               (indent
+                +> sepNln
+                +> genExpr astContext e
+                +> unindent) ctx
+           else
+               sepSpaceIfShortExpressionOrAddIndentAndNewline
+                   ctx.Config.MaxFunctionBindingWidth
+                   (genExpr astContext e)
+                   ctx)
 
-    fun ctx ->
-        let isLong = isLongFunctionSignature ctx
+and getLetBindingFunctionWithReturnType (astContext: ASTContext)
+                                        (px: FSharp.Compiler.XmlDoc.PreXmlDoc)
+                                        (ats: SynAttributes)
+                                        (pref: string)
+                                        (ao: SynAccess option)
+                                        (isInline: bool)
+                                        (isMutable: bool)
+                                        (functionName: string)
+                                        (patRange: range)
+                                        (parameters: (string option * SynPat) list)
+                                        (genericTypeParameters: SynValTyparDecls option)
+                                        (returnType: SynType)
+                                        (valInfo: SynValInfo)
+                                        (e: SynExpr)
+                                        =
+    let genAttrIsFirstChild =
+        onlyIf astContext.IsFirstChild (genAttributes astContext ats)
 
-        let expr =
-            genName
-            +> ifElse hasBracket sepOpenT sepNone
-            +> ifElse isLong genParametersWithNewlines genParametersInitial
-            +> ifElse hasBracket sepCloseT sepNone
+    let genPref =
+        if astContext.IsFirstChild
+        then (!-pref)
+        else (!-pref +> genOnelinerAttributes astContext ats)
 
-        expr ctx
+    let afterLetKeyword =
+        ifElse isMutable (!- "mutable ") sepNone
+        +> ifElse isInline (!- "inline ") sepNone
+        +> opt sepSpace ao genAccess
+
+    let genFunctionName =
+        getIndentBetweenTicksFromSynPat patRange functionName
+        +> opt sepNone genericTypeParameters (fun (ValTyparDecls (tds, _, tcs)) ->
+               genTypeParamPostfix astContext tds tcs)
+
+    let genParameters sep =
+        col sep parameters (genPatWithIdent astContext)
+
+    let genReturnType isFixed =
+        let genMetadataAttributes =
+            match valInfo with
+            | SynValInfo (_, SynArgInfo (attributes, _, _)) -> genOnelinerAttributes astContext attributes
+
+        enterNodeFor SynBindingReturnInfo_ returnType.Range
+        +> ifElse isFixed (sepColonFixed +> sepSpace) sepColon
+        +> genMetadataAttributes
+        +> genType astContext false returnType
+
+    let genSignature =
+        let firstParameter = List.head parameters |> snd
+
+        let short =
+            genPref
+            +> afterLetKeyword
+            +> sepSpace
+            +> genFunctionName
+            +> ifElseCtx (addSpaceBeforeParensInFunDef astContext functionName firstParameter) sepSpace sepNone
+            +> genParameters sepSpace
+            +> genReturnType false
+            +> sepEq
+
+        let long (ctx: Context) =
+            if ctx.Config.AlignFunctionSignatureToIndentation then
+                (genPref
+                 +> afterLetKeyword
+                 +> sepSpace
+                 +> genFunctionName
+                 +> indent
+                 +> sepNln
+                 +> genParameters sepNln
+                 +> sepNln
+                 +> genReturnType true
+                 +> sepNln
+                 +> sepEqFixed
+                 +> unindent) ctx
+            else
+                (genPref
+                 +> afterLetKeyword
+                 +> sepSpace
+                 +> genFunctionName
+                 +> sepSpace
+                 +> atCurrentColumn
+                     (genParameters sepNln
+                      +> sepNln
+                      +> genReturnType true
+                      +> sepEq)) ctx
+
+        expressionFitsOnRestOfLine short long
+
+    genPreXmlDoc px
+    +> genAttrIsFirstChild
+    +> leadingExpressionIsMultiline genSignature (fun isMultiline ctx ->
+           if isMultiline then
+               (indent
+                +> sepNln
+                +> genExpr astContext e
+                +> unindent) ctx
+           else
+               sepSpaceIfShortExpressionOrAddIndentAndNewline
+                   ctx.Config.MaxFunctionBindingWidth
+                   (genExpr astContext e)
+                   ctx)
+
+and genLetBindingDestructedTuple (astContext: ASTContext)
+                                 (px: FSharp.Compiler.XmlDoc.PreXmlDoc)
+                                 (ats: SynAttributes)
+                                 (pref: string)
+                                 (ao: SynAccess option)
+                                 (isInline: bool)
+                                 (isMutable: bool)
+                                 (pat: SynPat)
+                                 (e: SynExpr)
+                                 =
+    let genAttrAndPref =
+        if astContext.IsFirstChild
+        then (genAttributes astContext ats -- pref)
+        else (!-pref +> genOnelinerAttributes astContext ats)
+
+    let afterLetKeyword =
+        opt sepSpace ao genAccess
+        +> ifElse isMutable (!- "mutable ") sepNone
+        +> ifElse isInline (!- "inline ") sepNone
+
+    let genDestructedTuples =
+        expressionFitsOnRestOfLine (genPat astContext pat) (sepOpenT +> genPat astContext pat +> sepCloseT)
+
+    genPreXmlDoc px
+    +> leadingExpressionIsMultiline
+        (genAttrAndPref
+         +> afterLetKeyword
+         +> sepSpace
+         +> genDestructedTuples
+         +> sepEq
+         +> sepSpace) (fun isMultiline ctx ->
+           let short = genExpr astContext e
+
+           let long =
+               indent
+               +> sepNln
+               +> genExpr astContext e
+               +> unindent
+
+           if isMultiline
+           then long ctx
+           else isShortExpression ctx.Config.MaxValueBindingWidth short long ctx)
+
+and genLetBindingValue (astContext: ASTContext)
+                       (px: FSharp.Compiler.XmlDoc.PreXmlDoc)
+                       (ats: SynAttributes)
+                       (pref: string)
+                       (ao: SynAccess option)
+                       (isInline: bool)
+                       (isMutable: bool)
+                       (valueName: SynPat)
+                       (returnType: SynType option)
+                       (valInfo: SynValInfo)
+                       (e: SynExpr)
+                       =
+    let genAttrIsFirstChild =
+        onlyIf astContext.IsFirstChild (genAttributes astContext ats)
+
+    let genPref =
+        if astContext.IsFirstChild
+        then (!-pref)
+        else (!-pref +> genOnelinerAttributes astContext ats)
+
+    let afterLetKeyword =
+        opt sepSpace ao genAccess
+        +> ifElse isMutable (!- "mutable ") sepNone
+        +> ifElse isInline (!- "inline ") sepNone
+
+    let genValueName =
+        let addExtraSpace =
+            match valueName with
+            | PatLongIdent (_, _, _, Some _) -> Option.isSome returnType
+            | _ -> false
+
+        genPat astContext valueName
+        +> onlyIf addExtraSpace sepSpace
+
+    let genReturnType =
+        match returnType with
+        | Some rt -> sepColon +> genType astContext false rt
+        | None -> sepNone
+
+    let equalsRange =
+        let endPos =
+            match returnType with
+            | Some rt -> rt.Range.End
+            | None -> valueName.Range.End
+
+        mkRange "range between binding pattern and expression" endPos e.Range.Start
+
+    let genSpaceAfterEquals (ctx: Context) =
+        ctx.TriviaTokenNodes
+        |> Map.tryFindOrEmptyList EQUALS
+        |> fun triviaNodes ->
+            match triviaNodes with
+            | [] -> sepSpace ctx
+            | nodes ->
+                if List.exists (fun tn -> List.isNotEmpty tn.ContentAfter) nodes
+                then sepNone ctx
+                else sepSpace ctx
+
+    genPreXmlDoc px
+    +> genAttrIsFirstChild
+    +> leadingExpressionIsMultiline
+        (genPref
+         +> afterLetKeyword
+         +> sepSpace
+         +> genValueName
+         +> genReturnType
+         +> sepEq
+         +> leaveNodeTokenByName equalsRange EQUALS
+         +> genSpaceAfterEquals) (fun isMultiline ctx ->
+           let short = genExpr astContext e
+
+           let long =
+               indent
+               +> sepNln
+               +> genExpr astContext e
+               +> unindent
+
+           let hasMultilineString =
+               ctx.TriviaMainNodes
+               |> Map.tryFindOrEmptyList SynExpr_Const
+               |> TriviaHelpers.hasMultilineString e.Range
+
+           if hasMultilineString
+           then short ctx
+           elif isMultiline
+           then long ctx
+           else isShortExpression ctx.Config.MaxValueBindingWidth short long ctx)
 
 and genConst (c: SynConst) (r: range) =
     match c with

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -717,6 +717,9 @@ let internal isShortExpression maxWidth (shortExpression: Context -> Context) (f
 let internal isShortExpressionOrAddIndentAndNewline maxWidth expr (ctx: Context) =
     shortExpressionWithFallback expr (indent +> sepNln +> expr +> unindent) maxWidth None ctx
 
+let internal sepSpaceIfShortExpressionOrAddIndentAndNewline maxWidth expr (ctx: Context) =
+    shortExpressionWithFallback (sepSpace +> expr) (indent +> sepNln +> expr +> unindent) maxWidth None ctx
+
 let internal expressionFitsOnRestOfLine expression fallbackExpression (ctx: Context) =
     shortExpressionWithFallback expression fallbackExpression ctx.Config.MaxLineLength (Some 0) ctx
 

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -1046,17 +1046,6 @@ let internal leaveNodeFor (mainNodeName: FsAstType) (range: range) (ctx: Context
         | None -> ctx
     | None -> ctx
 
-let internal leaveEqualsToken (range: range) (ctx: Context) =
-    (Map.tryFindOrEmptyList EQUALS ctx.TriviaTokenNodes)
-    |> List.filter (fun tn -> tn.Range.StartLine = range.StartLine)
-    |> List.tryHead
-    |> fun tn ->
-        match tn with
-        | Some ({ ContentAfter = [ TriviaContent.Comment (LineCommentAfterSourceCode (lineComment)) ] }) ->
-            sepSpace +> !-lineComment
-        | _ -> id
-    <| ctx
-
 let internal leaveLeftToken (tokenName: FsTokenType) (range: range) (ctx: Context) =
     (Map.tryFindOrEmptyList tokenName ctx.TriviaTokenNodes)
     |> List.tryFind (fun tn ->

--- a/src/Fantomas/TriviaContext.fs
+++ b/src/Fantomas/TriviaContext.fs
@@ -71,3 +71,18 @@ let ``else if / elif`` (rangeOfIfThenElse: range) (ctx: Context) =
                 "Unexpected scenario when formatting else if / elif, please open an issue via https://jindraivanek.gitlab.io/fantomas-ui"
 
     resultExpr ctx
+
+let getIndentBetweenTicksFromSynPat patRange fallback ctx =
+    TriviaHelpers.getNodesForTypes [ SynPat_LongIdent; SynPat_Named ] ctx.TriviaMainNodes
+    |> List.choose (fun t ->
+        match t.Range = patRange with
+        | true ->
+            match t.ContentItself with
+            | Some (IdentBetweenTicks (iiw)) -> Some iiw
+            | _ -> None
+        | _ -> None)
+    |> List.tryHead
+    |> fun iiw ->
+        match iiw with
+        | Some iiw -> !- iiw ctx
+        | None -> !- fallback ctx

--- a/src/Fantomas/TriviaHelpers.fs
+++ b/src/Fantomas/TriviaHelpers.fs
@@ -97,3 +97,15 @@ module internal TriviaHelpers =
         types
         |> List.map (fun t -> if Map.containsKey t dict then Map.find t dict else List.empty)
         |> List.collect id
+
+    let hasMultilineString range (triviaNodes: TriviaNode list) =
+        triviaNodes
+        |> List.exists (fun tn ->
+            let contentItSelfIsMultilineString () =
+                match tn.ContentItself with
+                | Some (StringContent sc) -> String.isMultiline sc
+                | _ -> false
+
+
+            RangeHelpers.rangeEq tn.Range range
+            && contentItSelfIsMultilineString ())


### PR DESCRIPTION
Both style guides ([MS](https://docs.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting#place-parameters-on-a-new-line-for-long-definitions), [GR](https://github.com/G-Research/fsharp-formatting-conventions#long-function-signatures)) have very strict rules to what should have when a function signature is getting longer than the `max_length`.

The current implement for this is a bit in `genExprSepEqPrependType` and `genPatWithReturnType `.
This was hard to maintain as the information had to be present in both functions and especially the MS way of doing things is rather hard.
So I've split it up into four functions. I've deliberately chosen for some repetition within those functions as it will be beneficial to solve future bugs.

Fixes #1218