### PR TITLE
WIP fix 964

### DIFF
--- a/src/Fantomas.Tests/SpaceBeforeClassConstructorTests.fs
+++ b/src/Fantomas.Tests/SpaceBeforeClassConstructorTests.fs
@@ -102,7 +102,7 @@ type animal(length: int) =
 """
 
 [<Test>]
-let ``SpaceBeforeParenthesisParameterInUppercaseClassConstructor should add space before lowercase constructor of class`` () =
+let ``SpaceBeforeParenthesisParameterInLowercaseClassConstructor should add space before lowercase constructor of class`` () =
     formatSourceString false """
 type animal(length:int) =
     class end
@@ -112,4 +112,56 @@ type animal(length:int) =
 type animal (length: int) =
     class
     end
+"""
+
+// Space before parentheses in secondary class constructor
+
+[<Test>]
+let ``should add space before secondary constructor of class declared with new, 964`` () =
+    formatSourceString false """
+type animal (length: int) =
+    new(length) = animal (length)
+"""  spaceBeforeConfig
+    |> prepend newline
+    |> should equal """
+type animal (length: int) =
+    new (length) = animal (length)
+"""
+
+// Space before parentheses in secondary class constructor
+
+[<Test>]
+let ``should add space after inherit base class declaration, 964`` () =
+    formatSourceString false """
+type dog() =
+    inherit animal()
+"""  spaceBeforeConfig
+    |> prepend newline
+    |> should equal """
+type dog () =
+    inherit animal ()
+"""
+
+// Original issue example
+
+[<Test>]
+let ``should add space before new and inherit on constructor of class, 964`` () =
+    formatSourceString false """
+type ProtocolGlitchException =
+    inherit CommunicationUnsuccessfulException
+
+    new(message) = { inherit CommunicationUnsuccessfulException(message) }
+
+    new(message: string, innerException: Exception) =
+        { inherit CommunicationUnsuccessfulException(message, innerException) }
+"""  spaceBeforeConfig
+    |> prepend newline
+    |> should equal """
+type ProtocolGlitchException =
+    inherit CommunicationUnsuccessfulException
+
+    new (message) = { inherit CommunicationUnsuccessfulException (message) }
+
+    new (message: string, innerException: Exception) =
+        { inherit CommunicationUnsuccessfulException (message, innerException) }
 """

--- a/src/Fantomas.Tests/SpaceBeforeClassConstructorTests.fs
+++ b/src/Fantomas.Tests/SpaceBeforeClassConstructorTests.fs
@@ -140,8 +140,6 @@ type dog () =
     inherit animal ()
 """
 
-// Original issue example
-
 [<Test>]
 let ``should add space before new and inherit on constructor of class, 964`` () =
     formatSourceString false """
@@ -162,4 +160,42 @@ type ProtocolGlitchException =
 
     new (message: string, innerException: Exception) =
         { inherit CommunicationUnsuccessfulException (message, innerException) }
+"""
+
+[<Test>]
+let ``should add space before new and inherit on constructor of class with multiline record, 964`` () =
+    formatSourceString false """
+type BaseClass =
+    val string1: string
+    new(str) = { string1 = str }
+    new() = { string1 = "" }
+
+type DerivedClass =
+    inherit BaseClass
+
+    val string2: string
+
+    new(str1, str2) =
+        { inherit BaseClass(str1)
+          string2 = str2 }
+
+    new(str2) = { inherit BaseClass(); string2 = str2 }
+"""  spaceBeforeConfig
+    |> prepend newline
+    |> should equal """
+type BaseClass =
+    val string1: string
+    new (str) = { string1 = str }
+    new () = { string1 = "" }
+
+type DerivedClass =
+    inherit BaseClass
+
+    val string2: string
+
+    new (str1, str2) =
+        { inherit BaseClass (str1)
+          string2 = str2 }
+
+    new (str2) = { inherit BaseClass (); string2 = str2 }
 """

--- a/src/Fantomas.Tests/SpaceBeforeClassConstructorTests.fs
+++ b/src/Fantomas.Tests/SpaceBeforeClassConstructorTests.fs
@@ -199,3 +199,57 @@ type DerivedClass =
 
     new (str2) = { inherit BaseClass (); string2 = str2 }
 """
+
+[<Test>]
+let ``should add space before inherit on constructor that takes a constant value`` () =
+    formatSourceString false """
+type DerivedClass =
+    inherit BaseClass
+
+    val string2: string
+
+    new (str1, str2) =
+        { inherit BaseClass "meh"
+          string2 = str2 }
+"""
+        { config with
+              SpaceBeforeClassConstructor = false }
+    |> prepend newline
+    |> should equal """
+type DerivedClass =
+    inherit BaseClass
+
+    val string2: string
+
+    new(str1, str2) =
+        { inherit BaseClass "meh"
+          string2 = str2 }
+"""
+
+[<Test>]
+let ``should add space before inherit on constructor of class with multiline record, MultilineBlockBracketsOnSameColumn`` () =
+    formatSourceString false """
+type DerivedClass =
+    inherit BaseClass
+
+    val string2: string
+
+    new(str1, str2) =
+        { inherit BaseClass(str1)
+          string2 = str2 }
+"""
+        { spaceBeforeConfig with
+              MultilineBlockBracketsOnSameColumn = true }
+    |> prepend newline
+    |> should equal """
+type DerivedClass =
+    inherit BaseClass
+
+    val string2: string
+
+    new (str1, str2) =
+        {
+            inherit BaseClass (str1)
+            string2 = str2
+        }
+"""

--- a/src/Fantomas.Tests/SpaceBeforeClassConstructorTests.fs
+++ b/src/Fantomas.Tests/SpaceBeforeClassConstructorTests.fs
@@ -128,8 +128,6 @@ type animal (length: int) =
     new (length) = animal (length)
 """
 
-// Space before parentheses in secondary class constructor
-
 [<Test>]
 let ``should add space after inherit base class declaration, 964`` () =
     formatSourceString false """

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -948,7 +948,9 @@ and genMemberBinding astContext b =
             let genPat ctx =
                 match p with
                 | PatExplicitCtor pat ->
-                    (!- "new" +> onlyIf ctx.Config.SpaceBeforeClassConstructor sepSpace +> genPat astContext pat) ctx
+                    (!- "new"
+                     +> onlyIf ctx.Config.SpaceBeforeClassConstructor sepSpace
+                     +> genPat astContext pat) ctx
                 | _ -> genPat astContext p ctx
 
             genPreXmlDoc px
@@ -1399,10 +1401,9 @@ and genExpr astContext synExpr ctx =
                 +> optSingle (fun (inheritType, inheritExpr) ->
                     let addSpace ctx =
                         match inheritExpr with
-                        | Paren _ when (ctx.Config.SpaceBeforeClassConstructor) ->
-                            sepSpace ctx
+                        | Paren _ when (ctx.Config.SpaceBeforeClassConstructor) -> sepSpace ctx
                         | _ -> ctx
-                    
+
                     !- "inherit "
                     +> genType astContext false inheritType
                     +> addSpace
@@ -2767,10 +2768,9 @@ and genMultilineRecordInstance (inheritOpt: (SynType * SynExpr) option)
              +> opt (if xs.IsEmpty then sepNone else sepNln) inheritOpt (fun (typ, expr) ->
                     let addSpace ctx =
                         match expr with
-                        | Paren _ when (ctx.Config.SpaceBeforeClassConstructor) ->
-                            sepSpace ctx
+                        | Paren _ when (ctx.Config.SpaceBeforeClassConstructor) -> sepSpace ctx
                         | _ -> ctx
-                    
+
                     !- "inherit "
                     +> genType astContext false typ
                     +> addSpace
@@ -2808,10 +2808,16 @@ and genMultilineRecordInstanceAlignBrackets (inheritOpt: (SynType * SynExpr) opt
 
     match inheritOpt, eo with
     | Some (inheritType, inheritExpr), None ->
+        let addSpace ctx =
+            match inheritExpr with
+            | Paren _ when (ctx.Config.SpaceBeforeClassConstructor) -> sepSpace ctx
+            | _ -> ctx
+
         sepOpenS
         +> ifElse hasFields (indent +> sepNln) sepNone
         +> !- "inherit "
         +> genType astContext false inheritType
+        +> addSpace
         +> genExpr astContext inheritExpr
         +> ifElse
             hasFields
@@ -4180,7 +4186,7 @@ and genMemberDefn astContext node =
             | ConstExpr (SynConst.Unit, _)
             | Paren _ -> ctx.Config.SpaceBeforeClassConstructor
             | _ -> true
-        
+
         !- "inherit "
         +> genType astContext false t
         +> ifElseCtx addSpaceAfterType sepSpace sepNone

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4161,6 +4161,8 @@ and genMemberDefn astContext node =
             | SynExpr.Const _ -> true // string, numbers, ...
             | _ -> false
 
+        // Verify sepSpaceBeforeConstructor condition here with addSpaceAfterType
+        
         !- "inherit "
         +> genType astContext false t
         +> ifElse addSpaceAfterType sepSpace sepNone
@@ -4420,7 +4422,9 @@ and genPat astContext pat =
             +> genParameters
             +> ifElse hasBracket sepCloseT sepNone
 
+    // Add space before "()" 
     | PatParen (PatConst (Const "()", _)) -> !- "()"
+    // Idem, verify short and long expression
     | PatParen (p) ->
         let shortExpression =
             sepOpenT

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4429,9 +4429,7 @@ and genPat astContext pat =
             +> genParameters
             +> ifElse hasBracket sepCloseT sepNone
 
-    // Add space before "()" 
     | PatParen (PatConst (Const "()", _)) -> !- "()"
-    // Idem, verify short and long expression
     | PatParen (p) ->
         let shortExpression =
             sepOpenT

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1199,8 +1199,8 @@ let (|PatExplicitCtor|_|) =
                         _,
                         _,
                         SynArgPats.Pats ([ PatParen _ as pat ]),
-                        _,
-                        _) when (newIdent.idText = "new") -> Some pat
+                        ao,
+                        _) when (newIdent.idText = "new") -> Some(ao, pat)
     | _ -> None
 
 // Members

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1193,6 +1193,14 @@ let (|PatQuoteExpr|_|) =
     | SynPat.QuoteExpr (e, _) -> Some e
     | _ -> None
 
+let (|PatExplicitCtor|_|) =
+    function
+    | SynPat.LongIdent (LongIdentWithDots.LongIdentWithDots([newIdent], _),
+                        _,
+                        _,
+                        SynArgPats.Pats([PatParen _ as pat]), _, _) when (newIdent.idText = "new") -> Some pat
+    | _ -> None
+
 // Members
 type SynSimplePats with
     member pat.Range =

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1195,10 +1195,12 @@ let (|PatQuoteExpr|_|) =
 
 let (|PatExplicitCtor|_|) =
     function
-    | SynPat.LongIdent (LongIdentWithDots.LongIdentWithDots([newIdent], _),
+    | SynPat.LongIdent (LongIdentWithDots.LongIdentWithDots ([ newIdent ], _),
                         _,
                         _,
-                        SynArgPats.Pats([PatParen _ as pat]), _, _) when (newIdent.idText = "new") -> Some pat
+                        SynArgPats.Pats ([ PatParen _ as pat ]),
+                        _,
+                        _) when (newIdent.idText = "new") -> Some pat
     | _ -> None
 
 // Members


### PR DESCRIPTION
I created two tests to check the case separately with _new_ and _inherit_, plus a test with the original issue code.
I would like help to know what to do for each case.

For the _inherit_ test, analyzing the [tree](https://fsprojects.github.io/fantomas-tools/#/ast?data=N4KABGBEAmCmBmBLAdrAzpAXFSAacUiaAYmolmPAIYA2as%2BEkAxgPZwWQAuAngA6ww0VgHMAFAEowAXgA6yCBBQALWACdEXMFWSIAtrUmQQAXyA) I have an implicit inherit, called in ```genMemberDefn``` as ```MDImplicitInherit``` on ```CodePrinter.fs``` .  The solution would be to compare if _ctx.Config.SpaceBeforeClassConstructor_ is set and if it is the case insert a space after ```GenType``` on line 3939 and ignore the  ```addSpaceAfterType``` method.

For the _new_ test, I'm not sure, when I see the [tree](https://fsprojects.github.io/fantomas-tools/#/ast?data=N4KABGBEAmCmBmBLAdrAzpAXFSAacUiaAYmolmPAIYA2as%2BEkAxgPZwWQAuAngA6wwVZIgC2tMAAoasZAHMuAC2wouASjABeADrIIEVAHdpshYo2ahI8TSkz5StZBABfIA) I find a ```SynPat.LongIdent``` containing the new keyword and then a ```SynPat.Paren```, where I believe a space has to be inserted. 
If this is the case I would have to modify the ```PatParen``` of line 4198 to insert a space in and modify the same thing in the functions ```shortExpression``` and ```longExpression``` in the ```PatParen``` of line 4200.

Do these modifications make sense? Maybe there is another case I haven't taken into consideration.