### PR TITLE
Don't print if/then/else as short when ifBranch is SynExpr.IfThenElse

### DIFF
--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -1058,3 +1058,52 @@ let fn () =
 
 let nextfunc () = printf "Hi"
 """
+
+[<Test>]
+let ``nested if/then/else in short mode, 1243`` () =
+    formatSourceString false """
+            let funcs =
+                fse.MembersFunctionsAndValues
+                |> Seq.sortWith (fun n1 n2 ->
+                    let modifierScore (f : FSharpMemberOrFunctionOrValue) =
+                        if f.IsProperty then
+                            if f.IsInstanceMember then
+                                if f.IsDispatchSlot then 9 else 1
+                            else 8
+                        elif f.IsMember then
+                            if f.IsInstanceMember then
+                                if f.IsDispatchSlot then 11 else 2
+                            else 10
+                        else 3
+                    let n1Score = modifierScore n1
+                    let n2Score = modifierScore n2
+                    if n1Score = n2Score then
+                        n1.DisplayName.CompareTo n2.DisplayName
+                    else
+                        n1Score.CompareTo n2Score
+                )
+"""  config
+    |> prepend newline
+    |> should equal """
+let funcs =
+    fse.MembersFunctionsAndValues
+    |> Seq.sortWith
+        (fun n1 n2 ->
+            let modifierScore (f: FSharpMemberOrFunctionOrValue) =
+                if f.IsProperty then
+                    if f.IsInstanceMember then
+                        if f.IsDispatchSlot then 9 else 1
+                    else
+                        8
+                elif f.IsMember then
+                    if f.IsInstanceMember then
+                        if f.IsDispatchSlot then 11 else 2
+                    else
+                        10
+                else
+                    3
+
+            let n1Score = modifierScore n1
+            let n2Score = modifierScore n2
+            if n1Score = n2Score then n1.DisplayName.CompareTo n2.DisplayName else n1Score.CompareTo n2Score)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2340,6 +2340,11 @@ and genExpr astContext synExpr ctx =
                             +> genElse synExpr.Range
                             +> genExpr astContext e4))
 
+                let isIfThenElse =
+                    function
+                    | SynExpr.IfThenElse _ -> true
+                    | _ -> false
+
                 // This is a simplistic check to see if everything fits on one line
                 let isOneLiner =
                     not hasElfis
@@ -2347,6 +2352,7 @@ and genExpr astContext synExpr ctx =
                     && not isAnyExpressionIsMultiline
                     && not hasCommentAfterIfBranchExpr
                     && not anyElifBranchHasCommentAfterBranchExpr
+                    && not (isIfThenElse e2)
                     && not (futureNlnCheck genOneliner ctx)
 
                 let keepIfThenInSameLine = ctx.Config.KeepIfThenInSameLine


### PR DESCRIPTION
Fixes #1243