### PR TITLE
Clarify constructors

### DIFF
--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -225,3 +225,29 @@ module Caching =
 
             ()
 """
+
+[<Test>]
+let ``single line constructor without new keyword`` () =
+    formatSourceString false """
+let smallTree = BinaryNode(BinaryValue 3, BinaryValue 4)
+"""  config
+    |> prepend newline
+    |> should equal """
+let smallTree = BinaryNode(BinaryValue 3, BinaryValue 4)
+"""
+
+[<Test>]
+let ``multiline constructor without new keyword`` () =
+    formatSourceString false """
+let tree1 =
+    BinaryNode(BinaryNode(BinaryValue 1, BinaryValue 2), BinaryNode(BinaryValue 3, BinaryValue 4))
+
+"""  { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should equal """
+let tree1 =
+    BinaryNode(
+        BinaryNode(BinaryValue 1, BinaryValue 2),
+        BinaryNode(BinaryValue 3, BinaryValue 4)
+    )
+"""

--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -251,3 +251,85 @@ let tree1 =
         BinaryNode(BinaryValue 3, BinaryValue 4)
     )
 """
+
+[<Test>]
+let ``short constructor with new keyword`` () =
+    formatSourceString false """
+let person = new Person("Jim", 33)
+"""  config
+    |> prepend newline
+    |> should equal """
+let person = new Person("Jim", 33)
+"""
+
+[<Test>]
+let ``multiline constructor with new keyword`` () =
+    formatSourceString false """
+let otherThing =
+    new Foobar(longname1, longname2, longname3, longname4, longname5, longname6, longname7)
+"""  { config with MaxLineLength = 90 }
+    |> prepend newline
+    |> should equal """
+let otherThing =
+    new Foobar(
+        longname1,
+        longname2,
+        longname3,
+        longname4,
+        longname5,
+        longname6,
+        longname7
+    )
+"""
+
+[<Test>]
+let ``short static member call`` () =
+    formatSourceString false """
+let myRegexMatch = Regex.Match(input, regex)
+"""  config
+    |> prepend newline
+    |> should equal """
+let myRegexMatch = Regex.Match(input, regex)
+"""
+
+[<Test>]
+let ``multiline static member call`` () =
+    formatSourceString false """
+let myRegexMatch =
+    Regex.Match("my longer input string with some interesting content in it","myRegexPattern")
+"""  { config with MaxLineLength = 90 }
+    |> prepend newline
+    |> should equal """
+let myRegexMatch =
+    Regex.Match(
+        "my longer input string with some interesting content in it",
+        "myRegexPattern"
+    )
+"""
+
+[<Test>]
+let ``short instance member call`` () =
+    formatSourceString false """
+let untypedRes = checker.ParseFile(file, source, opts)
+"""  config
+    |> prepend newline
+    |> should equal """
+let untypedRes = checker.ParseFile(file, source, opts)
+"""
+
+[<Test>]
+let ``multiline instance member call`` () =
+    formatSourceString false """
+let untypedRes =
+    checker.ParseFile(fileName, sourceText, parsingOptionsWithDefines, somethingElseWithARatherLongVariableName)
+"""  { config with MaxLineLength = 90 }
+    |> prepend newline
+    |> should equal """
+let untypedRes =
+    checker.ParseFile(
+        fileName,
+        sourceText,
+        parsingOptionsWithDefines,
+        somethingElseWithARatherLongVariableName
+    )
+"""

--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -374,18 +374,22 @@ let longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNa
 System.String.Concat("a", "b" +
                             longNamedFunlongNamedFunlongNamedFunlongNamedFunlongNamedFun(longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClass).Property)
 """  config
-    |> should equal """type T() =
+    |> prepend newline
+    |> should equal """
+type T() =
     member __.Property = "hello"
 
 let longNamedFunlongNamedFunlongNamedFunlongNamedFunlongNamedFun (x: T) = x
 let longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClass = T()
 
-System.String.Concat
-    ("a",
-     "b"
-     + longNamedFunlongNamedFunlongNamedFunlongNamedFunlongNamedFun
-         (longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClass)
-         .Property)
+System.String.Concat(
+    "a",
+    "b"
+    + longNamedFunlongNamedFunlongNamedFunlongNamedFunlongNamedFun (
+        longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClass
+    )
+        .Property
+)
 """
 
 [<Test>]
@@ -611,14 +615,18 @@ open Fantomas.CoreGlobalTool.Tests.TestHelpers
 [<Test>]
 let ``config file in working directory should not require relative prefix, 821`` () =
     use fileFixture =
-        new TemporaryFileCodeSample(\"let a  = // foo
-                                                            9\")
+        new TemporaryFileCodeSample(
+            \"let a  = // foo
+                                                            9\"
+        )
 
     use configFixture =
-        new ConfigurationFile(\"\"\"
+        new ConfigurationFile(
+            \"\"\"
 [*.fs]
 indent_size=2
-\"\"\"                            )
+\"\"\"
+        )
 
     let (exitCode, output) = runFantomasTool fileFixture.Filename
 

--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -712,19 +712,25 @@ type substring =
 #if INVARIANT_CULTURE_STRING_COMPARISON
             // NOTE: we don't have to null check here because System.String.Compare
             // gives reliable results on null values.
-            System.String.Compare
-                (strA.String,
-                 strA.Offset,
-                 strB.String,
-                 strB.Offset,
-                 min strA.Length strB.Length,
-                 false,
-                 CultureInfo.InvariantCulture)
+            System.String.Compare(
+                strA.String,
+                strA.Offset,
+                strB.String,
+                strB.Offset,
+                min strA.Length strB.Length,
+                false,
+                CultureInfo.InvariantCulture
+            )
 #else
             // NOTE: we don't have to null check here because System.String.CompareOrdinal
             // gives reliable results on null values.
-            System.String.CompareOrdinal
-                (strA.String, strA.Offset, strB.String, strB.Offset, min strA.Length strB.Length)
+            System.String.CompareOrdinal(
+                strA.String,
+                strA.Offset,
+                strB.String,
+                strB.Offset,
+                min strA.Length strB.Length
+            )
 #endif
 """
 

--- a/src/Fantomas.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Tests/ComputationExpressionTests.fs
@@ -1364,10 +1364,11 @@ let rec loop () =
 
         let newEvents =
           stream
-          |> Result.map
-               (asEvents
-                >> behaviour command
-                >> enveloped eventSource)
+          |> Result.map (
+            asEvents
+            >> behaviour command
+            >> enveloped eventSource
+          )
 
         let! result =
           newEvents

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -51,18 +51,19 @@ let ``split chained method call expression, 246`` () =
 """  config
     |> prepend newline
     |> should equal """
-root.SetAttribute
-    ("driverVersion",
-     "AltCover.Recorder "
-     + System
-         .Diagnostics
-         .FileVersionInfo
-         .GetVersionInfo(System
-             .Reflection
-             .Assembly
-             .GetExecutingAssembly()
-             .Location)
-         .FileVersion)
+root.SetAttribute(
+    "driverVersion",
+    "AltCover.Recorder "
+    + System
+        .Diagnostics
+        .FileVersionInfo
+        .GetVersionInfo(System
+            .Reflection
+            .Assembly
+            .GetExecutingAssembly()
+            .Location)
+        .FileVersion
+)
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/ElmishTests.fs
+++ b/src/Fantomas.Tests/ElmishTests.fs
@@ -17,12 +17,13 @@ let ``long named arguments should go on newline`` () =
     |> prepend newline
     |> should equal """
 let view (model: Model) dispatch =
-    View.ContentPage
-        (appearing = (fun () -> dispatch PageAppearing),
-         title = model.Planet.Info.Name,
-         backgroundColor = Color.Black,
-         content =
-             [ "....long line....................................................................................................." ])
+    View.ContentPage(
+        appearing = (fun () -> dispatch PageAppearing),
+        title = model.Planet.Info.Name,
+        backgroundColor = Color.Black,
+        content =
+            [ "....long line....................................................................................................." ]
+    )
 """
 
 [<Test>]
@@ -37,14 +38,14 @@ let a =
     |> prepend newline
     |> should equal """
 let a =
-    View.Entry
-        (placeholder = "User name",
-         isEnabled = (not model.IsSigningIn),
-         textChanged = (fun args -> (dispatch (UserNameChanged args.NewTextValue))))
+    View.Entry(
+        placeholder = "User name",
+        isEnabled = (not model.IsSigningIn),
+        textChanged = (fun args -> (dispatch (UserNameChanged args.NewTextValue)))
+    )
 """
 
 [<Test>]
-[<Ignore("tests works but takes way too long")>]
 let ``fabulous view`` () =
     formatSourceString false """
     let loginPage =
@@ -85,40 +86,49 @@ let ``fabulous view`` () =
     |> prepend newline
     |> should equal """
 let loginPage =
-    View.ContentPage
-        (title = "Fabulous Demo",
-         content =
-             View.ScrollView
-                 (content =
-                     View.StackLayout
-                         (padding = 30.0,
-                          children =
-                              [ View.Frame
-                                  (verticalOptions = LayoutOptions.CenterAndExpand,
-                                   content =
-                                       View.StackLayout
-                                           (children =
-                                               [ View.Entry
-                                                   (placeholder = "User name",
-                                                    isEnabled = (not model.IsSigningIn),
-                                                    textChanged =
-                                                        (fun args -> (dispatch (UserNameChanged args.NewTextValue))))
-                                                 View.Entry
-                                                     (placeholder = "Password",
-                                                      isPassword = true,
-                                                      isEnabled = (not model.IsSigningIn),
-                                                      textChanged =
-                                                          (fun args -> (dispatch (PasswordChanged args.NewTextValue))))
-                                                 View.Button
-                                                     (text = "Sign in",
-                                                      heightRequest = 30.0,
-                                                      isVisible = (not model.IsSigningIn),
-                                                      command = (fun () -> dispatch SignIn),
-                                                      canExecute = model.IsCredentialsProvided)
-                                                 View.ActivityIndicator
-                                                     (isRunning = true,
-                                                      heightRequest = 30.0,
-                                                      isVisible = model.IsSigningIn) ])) ])))
+    View.ContentPage(
+        title = "Fabulous Demo",
+        content =
+            View.ScrollView(
+                content =
+                    View.StackLayout(
+                        padding = 30.0,
+                        children =
+                            [ View.Frame(
+                                verticalOptions = LayoutOptions.CenterAndExpand,
+                                content =
+                                    View.StackLayout(
+                                        children =
+                                            [ View.Entry(
+                                                placeholder = "User name",
+                                                isEnabled = (not model.IsSigningIn),
+                                                textChanged =
+                                                    (fun args -> (dispatch (UserNameChanged args.NewTextValue)))
+                                              )
+                                              View.Entry(
+                                                  placeholder = "Password",
+                                                  isPassword = true,
+                                                  isEnabled = (not model.IsSigningIn),
+                                                  textChanged =
+                                                      (fun args -> (dispatch (PasswordChanged args.NewTextValue)))
+                                              )
+                                              View.Button(
+                                                  text = "Sign in",
+                                                  heightRequest = 30.0,
+                                                  isVisible = (not model.IsSigningIn),
+                                                  command = (fun () -> dispatch SignIn),
+                                                  canExecute = model.IsCredentialsProvided
+                                              )
+                                              View.ActivityIndicator(
+                                                  isRunning = true,
+                                                  heightRequest = 30.0,
+                                                  isVisible = model.IsSigningIn
+                                              ) ]
+                                    )
+                              ) ]
+                    )
+            )
+    )
 """
 
 [<Test>]
@@ -827,8 +837,8 @@ let private useLocationDetail (auth0 : Auth0Hook) (roles : RolesHook) id =
     let location =
         React.useMemo ((fun () -> getLocation eventCtx.Events id), [| eventCtx.Events; id |])
 
-    React.useEffect
-        ((fun () ->
+    React.useEffect (
+        (fun () ->
             if roles.IsEditorOrAdmin
                && not (String.IsNullOrWhiteSpace(location.Creator)) then
                 auth0.getAccessTokenSilently ()
@@ -850,8 +860,9 @@ let private useLocationDetail (auth0 : Auth0Hook) (roles : RolesHook) id =
                         match usersResult with
                         | Ok name -> setCreatorName (Some name)
                         | Error err -> JS.console.log err)),
-         [| box roles.Roles
-            box location.Creator |])
+        [| box roles.Roles
+           box location.Creator |]
+    )
 
     location, creatorName
 """

--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -68,8 +68,8 @@ open Fable.React.Props
 open Reactstrap
 
 let private badgeSample =
-    FunctionComponent.Of<obj>
-        ((fun _ ->
+    FunctionComponent.Of<obj>(
+        (fun _ ->
             fragment [] [
                 h3 [] [
                     str "Heading "
@@ -81,7 +81,8 @@ let private badgeSample =
                     str "oh my"
                 ]
             ]),
-         "BadgeSample")
+        "BadgeSample"
+    )
 
 exportDefault badgeSample
 """
@@ -630,10 +631,11 @@ services.AddHttpsRedirection(Action<HttpsRedirectionOptions>(fun options ->
 """  { config with MaxLineLength = 60 }
     |> prepend newline
     |> should equal """
-services.AddHttpsRedirection
-    (Action<HttpsRedirectionOptions>
+services.AddHttpsRedirection(
+    Action<HttpsRedirectionOptions>
         (fun options ->
             // meh
-            options.HttpsPort <- Nullable(7002)))
+            options.HttpsPort <- Nullable(7002))
+)
 |> ignore
 """

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -266,10 +266,11 @@ let ``inner let binding should not add additional newline, #475`` () =
 module Test =
     let testFunc () =
         let someObject =
-            someStaticObject.Create
-                (((fun o ->
+            someStaticObject.Create(
+                ((fun o ->
                     o.SomeProperty <- \"\"
-                    o.Role <- \"Has to be at least two properties\")))
+                    o.Role <- \"Has to be at least two properties\"))
+            )
 
         /// Comment can't be removed to reproduce bug
         let someOtherValue = \"\"
@@ -751,8 +752,10 @@ let private authenticateRequest (logger: ILogger) header =
     parameters.NameClaimType <- ClaimTypes.NameIdentifier // Auth0 related, see https://community.auth0.com/t/access-token-doesnt-contain-a-sub-claim/17671/2
 
     let manager =
-        ConfigurationManager<OpenIdConnectConfiguration>
-            (sprintf "https://%s/.well-known/openid-configuration" Auth0Domain, OpenIdConnectConfigurationRetriever())
+        ConfigurationManager<OpenIdConnectConfiguration>(
+            sprintf "https://%s/.well-known/openid-configuration" Auth0Domain,
+            OpenIdConnectConfigurationRetriever()
+        )
 
     let handler = JwtSecurityTokenHandler()
 
@@ -895,8 +898,10 @@ let ``preserve new line new instance of class, 1034`` () =
 let notFound () =
     let json = Encode.string "Not found" |> Encode.toString 4
 
-    new HttpResponseMessage(HttpStatusCode.NotFound,
-                            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"))
+    new HttpResponseMessage(
+        HttpStatusCode.NotFound,
+        Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+    )
 """
 
 [<Test>]
@@ -924,8 +929,10 @@ let getVersion () =
         let version = assembly.GetName().Version
         sprintf "%i.%i.%i" version.Major version.Minor version.Revision
 
-    new HttpResponseMessage(HttpStatusCode.OK,
-                            Content = new StringContent(version, System.Text.Encoding.UTF8, "application/text"))
+    new HttpResponseMessage(
+        HttpStatusCode.OK,
+        Content = new StringContent(version, System.Text.Encoding.UTF8, "application/text")
+    )
 """
 
 [<Test>]
@@ -1032,12 +1039,12 @@ let x =
     && let tcref = tcrefOfAppTy g ty in
        match tcref.TypeReprInfo with
        | TProvidedTypeExtensionPoint info ->
-           info.ProvidedType.PUntaint
-               ((fun st ->
+           info.ProvidedType.PUntaint(
+               (fun st ->
                    (st :> IProvidedCustomAttributeProvider)
-                       .GetHasTypeProviderEditorHideMethodsAttribute(info.ProvidedType.TypeProvider.PUntaintNoFailure
-                                                                         (id))),
-                m)
+                       .GetHasTypeProviderEditorHideMethodsAttribute(info.ProvidedType.TypeProvider.PUntaintNoFailure(id))),
+               m
+           )
        | _ ->
            if tcref.IsILTycon then
                tcref.ILTyconRawMetadata.CustomAttrs.AsArray
@@ -1056,12 +1063,13 @@ let x =
 
        match tcref.TypeReprInfo with
        | TProvidedTypeExtensionPoint info ->
-           info.ProvidedType.PUntaint
-               ((fun st ->
+           info.ProvidedType.PUntaint(
+               (fun st ->
                    (st :> IProvidedCustomAttributeProvider)
                        .GetHasTypeProviderEditorHideMethodsAttribute(info.ProvidedType.TypeProvider.PUntaintNoFailure
                                                                          (id))),
-                m)
+               m
+           )
        | _ ->
            if tcref.IsILTycon then
                tcref.ILTyconRawMetadata.CustomAttrs.AsArray
@@ -1071,6 +1079,24 @@ let x =
                            .FullName)
            else
                false
+"""
+
+[<Test>]
+let ``app tuple inside dotget expression`` () =
+    formatSourceString false """
+                   (st :> IProvidedCustomAttributeProvider)
+                       .GetHasTypeProviderEditorHideMethodsAttribute(
+                           info.ProvidedType.TypeProvider.PUntaintNoFailure(
+                                id
+                           )
+                        )
+
+"""  { config with MaxLineLength = 40 }
+    |> prepend newline
+    |> should equal """
+(st :> IProvidedCustomAttributeProvider)
+    .GetHasTypeProviderEditorHideMethodsAttribute(info.ProvidedType.TypeProvider.PUntaintNoFailure
+                                                      (id))
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -198,11 +198,12 @@ with
     |> prepend newline
     |> should equal """
 try
-    fst
-        (find
+    fst (
+        find
             (fun (s, (s', ty): int * int) ->
                 s' = s0 && can (type_match ty ty0) [])
-            (!the_interface))
+            (!the_interface)
+    )
 with Failure _ -> s0
 """
 

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -177,10 +177,11 @@ let rec make item depth =
     |> should equal """
 let rec make item depth =
     if depth > 0 then
-        Tree
-            ({ Left = make (2 * item - 1) (depth - 1)
-               Right = make (2 * item) (depth - 1) },
-             item)
+        Tree(
+            { Left = make (2 * item - 1) (depth - 1)
+              Right = make (2 * item) (depth - 1) },
+            item
+        )
     else
         Tree(defaultof<_>, item)
 """
@@ -192,10 +193,11 @@ let ``record inside DU constructor`` () =
     |> prepend newline
     |> should equal """
 let a =
-    Tree
-        ({ Left = make (2 * item - 1) (depth - 1)
-           Right = make (2 * item) (depth - 1) },
-         item)
+    Tree(
+        { Left = make (2 * item - 1) (depth - 1)
+          Right = make (2 * item) (depth - 1) },
+        item
+    )
 """
 
 [<Test>]
@@ -581,16 +583,18 @@ let expect =
 let expect =
     Result<Schema, SetError>.Ok
         { opts =
-              [ Opts.anyOf
-                  ([ (Optional, Opt.flagTrue [ "first"; "f" ])
-                     (Optional, Opt.value [ "second"; "s" ]) ])
-                Opts.oneOf
-                    (Optional,
-                     [ Opt.flag [ "third"; "f" ]
-                       Opt.valueWith
-                           "new value"
-                           [ "fourth"
-                             "ssssssssssssssssssssssssssssssssssssssssssssssssssss" ] ]) ]
+              [ Opts.anyOf (
+                  [ (Optional, Opt.flagTrue [ "first"; "f" ])
+                    (Optional, Opt.value [ "second"; "s" ]) ]
+                )
+                Opts.oneOf (
+                    Optional,
+                    [ Opt.flag [ "third"; "f" ]
+                      Opt.valueWith
+                          "new value"
+                          [ "fourth"
+                            "ssssssssssssssssssssssssssssssssssssssssssssssssssss" ] ]
+                ) ]
           args = []
           commands = [] }
 """

--- a/src/Fantomas.Tests/SpaceBeforeLowercaseInvocationTests.fs
+++ b/src/Fantomas.Tests/SpaceBeforeLowercaseInvocationTests.fs
@@ -43,3 +43,138 @@ let ``spaceBeforeLowercaseInvocation should not have impact when member is calle
     |> should equal """
 let v1 = myFunction().Member
 """
+
+[<Test>]
+let ``space before lower constructor without new`` () =
+    formatSourceString false """
+let tree1 =
+    binaryNode(binaryNode(binaryValue 1, binaryValue 2), binaryNode(binaryValue 3, binaryValue 4))
+"""  { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should equal """
+let tree1 =
+    binaryNode (
+        binaryNode (binaryValue 1, binaryValue 2),
+        binaryNode (binaryValue 3, binaryValue 4)
+    )
+"""
+
+[<Test>]
+let ``space before lower case constructor invocation with new keyword`` () =
+    formatSourceString false """
+let person = new person("Jim", 33)
+
+let otherThing =
+    new foobar(longname1, longname2, longname3, longname4, longname5, longname6, longname7)
+"""  { config with MaxLineLength = 90 }
+    |> prepend newline
+    |> should equal """
+let person = new person ("Jim", 33)
+
+let otherThing =
+    new foobar (
+        longname1,
+        longname2,
+        longname3,
+        longname4,
+        longname5,
+        longname6,
+        longname7
+    )
+"""
+
+[<Test>]
+let ``space before lower member call`` () =
+    formatSourceString false """
+let myRegexMatch = Regex.matches(input, regex)
+
+let myRegexMatchLong =
+    Regex.matches("my longer input string with some interesting content in it","myRegexPattern")
+
+let untypedRes = checker.parseFile(file, source, opts)
+
+let untypedResLong =
+    checker.parseFile(fileName, sourceText, parsingOptionsWithDefines, somethingElseWithARatherLongVariableName)
+"""  { config with MaxLineLength = 90 }
+    |> prepend newline
+    |> should equal """
+let myRegexMatch = Regex.matches (input, regex)
+
+let myRegexMatchLong =
+    Regex.matches (
+        "my longer input string with some interesting content in it",
+        "myRegexPattern"
+    )
+
+let untypedRes = checker.parseFile (file, source, opts)
+
+let untypedResLong =
+    checker.parseFile (
+        fileName,
+        sourceText,
+        parsingOptionsWithDefines,
+        somethingElseWithARatherLongVariableName
+    )
+"""
+
+[<Test>]
+let ``no space before lowercase member calls and constructors`` () =
+    formatSourceString false """
+let tree1 =
+    binaryNode(binaryNode(binaryValue 1, binaryValue 2), binaryNode(binaryValue 3, binaryValue 4))
+
+let person = new person("Jim", 33)
+let otherThing =
+    new foobar(longname1, longname2, longname3, longname4, longname5, longname6, longname7)
+
+let myRegexMatch = Regex.matches(input, regex)
+
+let myRegexMatchLong =
+    Regex.matches("my longer input string with some interesting content in it","myRegexPattern")
+
+let untypedRes = checker.parseFile(file, source, opts)
+
+let untypedResLong =
+    checker.parseFile(fileName, sourceText, parsingOptionsWithDefines, somethingElseWithARatherLongVariableName)
+"""
+        { noSpaceBefore with
+              MaxLineLength = 60 }
+    |> prepend newline
+    |> should equal """
+let tree1 =
+    binaryNode(
+        binaryNode(binaryValue 1, binaryValue 2),
+        binaryNode(binaryValue 3, binaryValue 4)
+    )
+
+let person = new person("Jim", 33)
+
+let otherThing =
+    new foobar(
+        longname1,
+        longname2,
+        longname3,
+        longname4,
+        longname5,
+        longname6,
+        longname7
+    )
+
+let myRegexMatch = Regex.matches(input, regex)
+
+let myRegexMatchLong =
+    Regex.matches(
+        "my longer input string with some interesting content in it",
+        "myRegexPattern"
+    )
+
+let untypedRes = checker.parseFile(file, source, opts)
+
+let untypedResLong =
+    checker.parseFile(
+        fileName,
+        sourceText,
+        parsingOptionsWithDefines,
+        somethingElseWithARatherLongVariableName
+    )
+"""

--- a/src/Fantomas.Tests/SpaceBeforeUppercaseInvocationTests.fs
+++ b/src/Fantomas.Tests/SpaceBeforeUppercaseInvocationTests.fs
@@ -91,3 +91,82 @@ module SomeModule =
         let someValue = a.Some.Thing("aaa").[0]
         someValue
 """
+
+[<Test>]
+let ``space before uppercase constructor without new`` () =
+    formatSourceString false """
+let tree1 =
+    BinaryNode(BinaryNode(BinaryValue 1, BinaryValue 2), BinaryNode(BinaryValue 3, BinaryValue 4))
+"""
+        { spaceBeforeConfig with
+              MaxLineLength = 80 }
+    |> prepend newline
+    |> should equal """
+let tree1 =
+    BinaryNode (
+        BinaryNode (BinaryValue 1, BinaryValue 2),
+        BinaryNode (BinaryValue 3, BinaryValue 4)
+    )
+"""
+
+[<Test>]
+let ``space before upper case constructor invocation with new keyword`` () =
+    formatSourceString false """
+let person = new Person("Jim", 33)
+
+let otherThing =
+    new Foobar(longname1, longname2, longname3, longname4, longname5, longname6, longname7)
+"""
+        { spaceBeforeConfig with
+              MaxLineLength = 90 }
+    |> prepend newline
+    |> should equal """
+let person = new Person ("Jim", 33)
+
+let otherThing =
+    new Foobar (
+        longname1,
+        longname2,
+        longname3,
+        longname4,
+        longname5,
+        longname6,
+        longname7
+    )
+"""
+
+[<Test>]
+let ``space before uppercase member call`` () =
+    formatSourceString false """
+let myRegexMatch = Regex.Match(input, regex)
+
+let myRegexMatchLong =
+    Regex.Match("my longer input string with some interesting content in it","myRegexPattern")
+
+let untypedRes = checker.ParseFile(file, source, opts)
+
+let untypedResLong =
+    checker.ParseFile(fileName, sourceText, parsingOptionsWithDefines, somethingElseWithARatherLongVariableName)
+"""
+        { spaceBeforeConfig with
+              MaxLineLength = 90 }
+    |> prepend newline
+    |> should equal """
+let myRegexMatch = Regex.Match (input, regex)
+
+let myRegexMatchLong =
+    Regex.Match (
+        "my longer input string with some interesting content in it",
+        "myRegexPattern"
+    )
+
+let untypedRes = checker.ParseFile (file, source, opts)
+
+let untypedResLong =
+    checker.ParseFile (
+        fileName,
+        sourceText,
+        parsingOptionsWithDefines,
+        somethingElseWithARatherLongVariableName
+    )
+"""

--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -151,16 +151,18 @@ let main argv =
 [<EntryPoint>]
 let main argv =
     use fun1 =
-        R.eval
-            (R.parse
-                (text = \"\"\"
+        R.eval (
+            R.parse (
+                text = \"\"\"
     function(i) {
         x <- rnorm(1000)
         y <- rnorm(1000)
         m <- lm(y~x)
         m$coefficients[[2]]
     }
-    \"\"\"))
+    \"\"\"
+            )
+        )
 
     0
 "

--- a/src/Fantomas.Tests/SynExprNewTests.fs
+++ b/src/Fantomas.Tests/SynExprNewTests.fs
@@ -17,11 +17,10 @@ let ``combination of named and non named arguments, 1158`` () =
     |> prepend newline
     |> should equal """
 let private sendTooLargeError () =
-    new HttpResponseMessage(HttpStatusCode.RequestEntityTooLarge,
-                            Content =
-                                new StringContent("File was too way too large",
-                                                  System.Text.Encoding.UTF16,
-                                                  "application/text"))
+    new HttpResponseMessage(
+        HttpStatusCode.RequestEntityTooLarge,
+        Content = new StringContent("File was too way too large", System.Text.Encoding.UTF16, "application/text")
+    )
 """
 
 [<Test>]
@@ -35,6 +34,7 @@ let myInstance =
     |> prepend newline
     |> should equal """
 let myInstance =
-    new EvilBadRequest(Content =
-        new StringContent("File was too way too large", System.Text.Encoding.UTF16, "application/text"))
+    new EvilBadRequest(
+        Content = new StringContent("File was too way too large", System.Text.Encoding.UTF16, "application/text")
+    )
 """

--- a/src/Fantomas.Tests/SynExprSetTests.fs
+++ b/src/Fantomas.Tests/SynExprSetTests.fs
@@ -83,10 +83,11 @@ let options =
             o.edges <- Some(jsOptions<Vis.EdgeOptions> (fun e -> e.arrows <- Some <| U2.Case1 "to"))
 
             o.interaction <-
-                Some
-                    (createObj [ "hover" ==> true
-                                 "zoomView" ==> true
-                                 "hoverConnectedEdges" ==> false ])
+                Some(
+                    createObj [ "hover" ==> true
+                                "zoomView" ==> true
+                                "hoverConnectedEdges" ==> false ]
+                )
 
             o.layout <- Some(createObj [ "randomSeed" ==> 0 ])
 

--- a/src/Fantomas.Tests/TupleTests.fs
+++ b/src/Fantomas.Tests/TupleTests.fs
@@ -6,7 +6,7 @@ open FsUnit
 open Fantomas.Tests.TestHelper
 
 [<Test>]
-let ``tuple with lamba should add parenthesis`` () =
+let ``tuple with lambda should add parenthesis`` () =
     formatSourceString false """
 let private carouselSample =
     FunctionComponent.Of<obj>(fun _ ->
@@ -24,10 +24,12 @@ let ``multiline item in tuple - paren on its line`` () =
  if longExpressionMakingTheIfElseMultiline && a then answerWhenTheConditionIsTrue
  else answerWhenTheConditionIsFalse)
 """  config
-    |> should equal """(x,
- (if longExpressionMakingTheIfElseMultiline && a
-  then answerWhenTheConditionIsTrue
-  else answerWhenTheConditionIsFalse))
+    |> prepend newline
+    |> should equal """
+(x,
+ if longExpressionMakingTheIfElseMultiline && a
+ then answerWhenTheConditionIsTrue
+ else answerWhenTheConditionIsFalse)
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -806,11 +806,14 @@ let x =
     |> prepend newline
     |> should equal """
 let x =
-    JobCollectionCreateParameters
-        (Label = "Test",
-         IntrinsicSettings =
-             JobCollectionIntrinsicSettings
-                 (Plan = JobCollectionPlan.Standard, Quota = new JobCollectionQuota(MaxJobCount = Nullable(50))))
+    JobCollectionCreateParameters(
+        Label = "Test",
+        IntrinsicSettings =
+            JobCollectionIntrinsicSettings(
+                Plan = JobCollectionPlan.Standard,
+                Quota = new JobCollectionQuota(MaxJobCount = Nullable(50))
+            )
+    )
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/TypeProviderTests.fs
+++ b/src/Fantomas.Tests/TypeProviderTests.fs
@@ -37,34 +37,40 @@ let ``should handle lines with more than 512 characters`` () =
 """  config
     |> prepend newline
     |> should equal """
-(new CsvFile<string * decimal * decimal>(new Func<obj, string [], string * decimal * decimal>(fun (parent: obj) (row: string []) ->
-                                             CommonRuntime.GetNonOptionalValue
-                                                 ("Name",
-                                                  CommonRuntime.ConvertString(TextConversions.AsOption(row.[0])),
-                                                  TextConversions.AsOption(row.[0])),
-                                             CommonRuntime.GetNonOptionalValue
-                                                 ("Distance",
-                                                  CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[1])),
-                                                  TextConversions.AsOption(row.[1])),
-                                             CommonRuntime.GetNonOptionalValue
-                                                 ("Time",
-                                                  CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[2])),
-                                                  TextConversions.AsOption(row.[2]))),
-                                         new Func<string * decimal * decimal, string []>(fun (row: string * decimal * decimal) ->
-                                             [| CommonRuntime.ConvertStringBack
-                                                 (CommonRuntime.GetOptionalValue((let x, _, _ = row in x)))
-                                                CommonRuntime.ConvertDecimalBack
-                                                    ("", CommonRuntime.GetOptionalValue((let _, x, _ = row in x)))
-                                                CommonRuntime.ConvertDecimalBack
-                                                    ("", CommonRuntime.GetOptionalValue((let _, _, x = row in x))) |]),
-                                         (ProviderFileSystem.readTextAtRunTimeWithDesignTimeOptions
-                                             @"C:\Dev\FSharp.Data-master\src\..\tests\FSharp.Data.Tests\Data"
-                                             ""
-                                             "SmallTest.csv"),
-                                         "",
-                                         '"',
-                                         true,
-                                         false))
+(new CsvFile<string * decimal * decimal>(
+    new Func<obj, string [], string * decimal * decimal>(
+        fun (parent: obj) (row: string []) ->
+            CommonRuntime.GetNonOptionalValue(
+                "Name",
+                CommonRuntime.ConvertString(TextConversions.AsOption(row.[0])),
+                TextConversions.AsOption(row.[0])
+            ),
+            CommonRuntime.GetNonOptionalValue(
+                "Distance",
+                CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[1])),
+                TextConversions.AsOption(row.[1])
+            ),
+            CommonRuntime.GetNonOptionalValue(
+                "Time",
+                CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[2])),
+                TextConversions.AsOption(row.[2])
+            )
+    ),
+    new Func<string * decimal * decimal, string []>(
+        fun (row: string * decimal * decimal) ->
+            [| CommonRuntime.ConvertStringBack(CommonRuntime.GetOptionalValue((let x, _, _ = row in x)))
+               CommonRuntime.ConvertDecimalBack("", CommonRuntime.GetOptionalValue((let _, x, _ = row in x)))
+               CommonRuntime.ConvertDecimalBack("", CommonRuntime.GetOptionalValue((let _, _, x = row in x))) |]
+    ),
+    (ProviderFileSystem.readTextAtRunTimeWithDesignTimeOptions
+        @"C:\Dev\FSharp.Data-master\src\..\tests\FSharp.Data.Tests\Data"
+        ""
+        "SmallTest.csv"),
+    "",
+    '"',
+    true,
+    false
+))
     .Cache()
 """
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1287,11 +1287,6 @@ and genExpr astContext synExpr ctx =
         | TypedExpr (TypeTest, e, t) ->
             genExpr astContext e -- " :? "
             +> genType astContext false t
-        | TypedExpr (New, e, t) ->
-            !- "new "
-            +> genType astContext false t
-            +> ifElse (hasParenthesis e) sepNone sepSpace
-            +> genExpr astContext e
         | TypedExpr (Downcast, e, t) ->
             let shortExpr =
                 genExpr astContext e -- " :?> "
@@ -1316,6 +1311,26 @@ and genExpr astContext synExpr ctx =
             genExpr astContext e
             +> sepColon
             +> genType astContext false t
+        | NewTuple (t, lpr, args, rpr) ->
+            let short =
+                !- "new "
+                +> genType astContext false t
+                +> sepOpenTFor (Some lpr)
+                +> col sepComma args (genExpr astContext)
+                +> sepCloseTFor rpr
+
+            let long =
+                !- "new "
+                +> genType astContext false t
+                +> sepOpenTFor (Some lpr)
+                +> indent
+                +> sepNln
+                +> col (sepComma +> sepNln) args (genExpr astContext)
+                +> unindent
+                +> sepNln
+                +> sepCloseTFor rpr
+
+            expressionFitsOnRestOfLine short long
         | Tuple es -> genTuple astContext es
         | StructTuple es ->
             !- "struct "

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1901,6 +1901,25 @@ and genExpr astContext synExpr ctx =
 
             expressionFitsOnRestOfLine shortExpression longExpression
 
+        | AppTuple (e, lpr, args, rpr) ->
+            let short =
+                genExpr astContext e
+                +> sepOpenTFor (Some lpr)
+                +> col sepComma args (genExpr astContext)
+                +> sepCloseTFor rpr
+
+            let long =
+                genExpr astContext e
+                +> sepOpenTFor (Some lpr)
+                +> indent
+                +> sepNln
+                +> col (sepComma +> sepNln) args (genExpr astContext)
+                +> unindent
+                +> sepNln
+                +> sepCloseTFor rpr
+
+            expressionFitsOnRestOfLine short long
+
         // Always spacing in multiple arguments
         | App (e, es) ->
             let shortExpression =

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -634,7 +634,6 @@ let (|SingleExpr|_|) =
 
 type TypedExprKind =
     | TypeTest
-    | New
     | Downcast
     | Upcast
     | Typed
@@ -642,7 +641,6 @@ type TypedExprKind =
 let (|TypedExpr|_|) =
     function
     | SynExpr.TypeTest (e, t, _) -> Some(TypeTest, e, t)
-    | SynExpr.New (_, t, e, _) -> Some(New, e, t)
     | SynExpr.Downcast (e, t, _) -> Some(Downcast, e, t)
     | SynExpr.Upcast (e, t, _) -> Some(Upcast, e, t)
     | SynExpr.Typed (e, t, _) -> Some(Typed, e, t)
@@ -798,6 +796,19 @@ let (|AppTuple|_|) =
     function
     | App (e, [ (Paren (lpr, Tuple args, rpr)) ]) -> Some(e, lpr, args, rpr)
     //| SynExpr.New(_, pat, (Paren (_, Tuple _, _) as arg), _) -> Some(NewTuple (pat, arg))
+    | _ -> None
+
+let (|NewTuple|_|) =
+    function
+    | SynExpr.New (_, t, Paren (lpr, Tuple args, rpr), _) -> Some(t, lpr, args, rpr)
+    | SynExpr.New (_, t, ConstExpr (SynConst.Unit, unitRange), _) ->
+        let lpr =
+            mkRange "lpr" unitRange.Start unitRange.Start
+
+        let rpr =
+            mkRange "rpr" unitRange.End unitRange.End
+
+        Some(t, lpr, [], Some rpr)
     | _ -> None
 
 let (|CompApp|_|) =

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -793,6 +793,13 @@ let (|App|_|) e =
     | (_, []) -> None
     | (e, es) -> Some(e, List.rev es)
 
+// captures application with single tuple arg
+let (|AppTuple|_|) =
+    function
+    | App (e, [ (Paren (lpr, Tuple args, rpr)) ]) -> Some(e, lpr, args, rpr)
+    //| SynExpr.New(_, pat, (Paren (_, Tuple _, _) as arg), _) -> Some(NewTuple (pat, arg))
+    | _ -> None
+
 let (|CompApp|_|) =
     function
     | SynExpr.App (_, _, Var "seq", (SynExpr.App _ as e), _) -> Some("seq", e)
@@ -852,16 +859,6 @@ let (|SameInfixApps|_|) e =
 let (|TernaryApp|_|) =
     function
     | SynExpr.App (_, _, SynExpr.App (_, _, SynExpr.App (_, true, Var "?<-", e1, _), e2, _), e3, _) -> Some(e1, e2, e3)
-    | _ -> None
-
-let (|AppWithMultilineArgument|_|) e =
-    let isMultilineString p =
-        match p with
-        | MultilineString _ -> true
-        | _ -> false
-
-    match e with
-    | App (_, arguments) when (List.exists isMultilineString arguments) -> Some e
     | _ -> None
 
 /// Gather all arguments in lambda


### PR DESCRIPTION
It looks like both style guides are about to land on the same conclusion in #1217.
So I wanted to add a small example of how this could work in Fantomas.
Once both style guides are merged, I can continue working on this.

A couple of things to consider;
- [x] static member calls
- [x] constructors with `new` keyword (SynExpr.New)
- [x] instance methods
- [x] fsharp_space_before_class_constructor