### PR TITLE
Add space between function call inside DotIndexedGet

### DIFF
--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -364,3 +364,23 @@ let ``classes and private implicit constructors`` () =
         { config with
               MaxFunctionBindingWidth = 120 }
 "
+
+[<Test>]
+let ``space between function and argument in DotIndexedGet, 1261`` () =
+    formatSourceString false """
+type Queue<'T>(data: list<'T []>, length: int) =
+
+    member this.Head =
+        if length > 0
+        then (List.head data).[0]
+        else raise (System.Exception("Queue is empty"))
+"""  config
+    |> prepend newline
+    |> should equal """
+type Queue<'T>(data: list<'T []>, length: int) =
+
+    member this.Head =
+        if length > 0
+        then (List.head data).[0]
+        else raise (System.Exception("Queue is empty"))
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2506,12 +2506,14 @@ and genExpr astContext synExpr ctx =
             !-(sprintf "%s <- " s)
             +> autoIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e)
         | DotIndexedGet (e, es) ->
-            addParenIfAutoNln
-                e
-                (genExpr
+            let astCtx =
+                match e with
+                | Paren _ -> astContext
+                | _ ->
                     { astContext with
-                          IsInsideDotIndexed = true })
-            -- "."
+                          IsInsideDotIndexed = true }
+
+            addParenIfAutoNln e (genExpr astCtx) -- "."
             +> sepOpenLFixed
             +> genIndexers astContext es
             +> sepCloseLFixed


### PR DESCRIPTION
 Fixes #1261.