### PR TITLE
Use atCurrentColumn when parenthesis hold a LetOrUse expression

### DIFF
--- a/src/Fantomas.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Tests/ComputationExpressionTests.fs
@@ -1942,3 +1942,27 @@ type ProjectController(checker: FSharpChecker) =
       return true
     }
 """
+
+[<Test>]
+let ``multiline do bang with parenthesis`` () =
+    formatSourceString false """
+let setup =
+  meh {
+    do!
+      (let thing = Thing()
+       thing.DoSomething()
+       let value = 1
+       value)
+  }
+"""  config
+    |> prepend newline
+    |> should equal """
+let setup =
+    meh {
+        do!
+            (let thing = Thing()
+             thing.DoSomething()
+             let value = 1
+             value)
+    }
+"""

--- a/src/Fantomas.Tests/LazyTests.fs
+++ b/src/Fantomas.Tests/LazyTests.fs
@@ -40,3 +40,22 @@ let ``short lazy with parens and infix should keep parens`` () =
     |> should equal """
 let result = lazy (x + 10)
 """
+
+[<Test>]
+let ``multiline lazy with parenthesis and letOrUse expression, 1271`` () =
+    formatSourceString false """
+let setup =
+  lazy
+   (let thing = Thing()
+    thing.DoSomething()
+    let value = 1
+    value)""" config
+    |> prepend newline
+    |> should equal """
+let setup =
+    lazy
+        (let thing = Thing()
+         thing.DoSomething()
+         let value = 1
+         value)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1686,6 +1686,10 @@ and genExpr astContext synExpr ctx =
                 sepOpenTFor lpr
                 +> genNamedArgumentExpr astContext operatorExpr e1 e2
                 +> sepCloseTFor rpr
+            | LetOrUses _ ->
+                sepOpenTFor lpr
+                +> atCurrentColumn (genExpr astContext e)
+                +> sepCloseTFor rpr
             | _ ->
                 // Parentheses nullify effects of no space inside DotGet
                 // Unless there is another application with parenthesis


### PR DESCRIPTION
Fixes #1271.