### PR TITLE
Preserve comments before and after empty arrays and lists

### DIFF
--- a/src/Fantomas.Tests/ListTests.fs
+++ b/src/Fantomas.Tests/ListTests.fs
@@ -163,6 +163,48 @@ let y = matrix.[3, *]
 """
 
 [<Test>]
+let ``comment before empty list`` () =
+    formatSourceString false """
+let x =
+    // Comment
+    []
+"""  config
+    |> prepend newline
+    |> should equal """
+let x =
+    // Comment
+    []
+"""
+
+[<Test>]
+let ``comment after empty list`` () =
+    formatSourceString false """let x = [] // Comment
+"""  config
+    |> should equal """let x = [] // Comment
+"""
+
+[<Test>]
+let ``comment before empty array`` () =
+    formatSourceString false """
+let x =
+    // Comment
+    [||]
+"""  config
+    |> prepend newline
+    |> should equal """
+let x =
+    // Comment
+    [||]
+"""
+
+[<Test>]
+let ``comment after empty array`` () =
+    formatSourceString false """let x = [||] // Comment
+"""  config
+    |> should equal """let x = [||] // Comment
+"""
+
+[<Test>]
 let ``comment after string in list`` () =
     formatSourceString false """let xxxxxxxxxxxx = ["yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy" //
                     "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz" //
@@ -1755,6 +1797,34 @@ let choices: Foo list =
 """
 
 [<Test>]
+let ``comment after opening bracket of single-item list`` () =
+    formatSourceString false """
+let x = [ // comment
+    1
+]
+"""  config
+    |> prepend newline
+    |> should equal """
+let x =
+    [ // comment
+      1 ]
+"""
+
+[<Test>]
+let ``comment after opening bracket of single-item array`` () =
+    formatSourceString false """
+let x = [| // comment
+    1
+|]
+"""  config
+    |> prepend newline
+    |> should equal """
+let x =
+    [| // comment
+       1 |]
+"""
+
+[<Test>]
 let ``preserve comment above first element of list, 990`` () =
     formatSourceString false """
 let x = [
@@ -1808,6 +1878,34 @@ let ``comment after closing array bracket`` () =
     genSubDeclExpr
     genSubDeclExpr
     genSubSynPat |] //
+"""
+
+[<Test>]
+let ``comment after multi-line closing list bracket`` () =
+    formatSourceString false """
+[ 1 // one
+  2 // two
+  3 ] // three
+"""  config
+    |> prepend newline 
+    |> should equal """
+[ 1 // one
+  2 // two
+  3 ] // three
+"""
+
+[<Test>]
+let ``comment after multi-line closing array bracket`` () =
+    formatSourceString false """
+[| 1 // one
+   2 // two
+   3 |] // three
+"""  config
+    |> prepend newline 
+    |> should equal """
+[| 1 // one
+   2 // two
+   3 |] // three
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/ListTests.fs
+++ b/src/Fantomas.Tests/ListTests.fs
@@ -1797,34 +1797,6 @@ let choices: Foo list =
 """
 
 [<Test>]
-let ``comment after opening bracket of single-item list`` () =
-    formatSourceString false """
-let x = [ // comment
-    1
-]
-"""  config
-    |> prepend newline
-    |> should equal """
-let x =
-    [ // comment
-      1 ]
-"""
-
-[<Test>]
-let ``comment after opening bracket of single-item array`` () =
-    formatSourceString false """
-let x = [| // comment
-    1
-|]
-"""  config
-    |> prepend newline
-    |> should equal """
-let x =
-    [| // comment
-       1 |]
-"""
-
-[<Test>]
 let ``preserve comment above first element of list, 990`` () =
     formatSourceString false """
 let x = [
@@ -1878,34 +1850,6 @@ let ``comment after closing array bracket`` () =
     genSubDeclExpr
     genSubDeclExpr
     genSubSynPat |] //
-"""
-
-[<Test>]
-let ``comment after multi-line closing list bracket`` () =
-    formatSourceString false """
-[ 1 // one
-  2 // two
-  3 ] // three
-"""  config
-    |> prepend newline 
-    |> should equal """
-[ 1 // one
-  2 // two
-  3 ] // three
-"""
-
-[<Test>]
-let ``comment after multi-line closing array bracket`` () =
-    formatSourceString false """
-[| 1 // one
-   2 // two
-   3 |] // three
-"""  config
-    |> prepend newline 
-    |> should equal """
-[| 1 // one
-   2 // two
-   3 |] // three
 """
 
 [<Test>]

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2704,6 +2704,7 @@ and genExpr astContext synExpr ctx =
             | SynExpr.YieldOrReturnFrom _ -> genTriviaFor SynExpr_YieldOrReturnFrom synExpr.Range
             | SynExpr.TryFinally _ -> genTriviaFor SynExpr_TryFinally synExpr.Range
             | SynExpr.LongIdentSet _ -> genTriviaFor SynExpr_LongIdentSet synExpr.Range
+            | SynExpr.ArrayOrList _ -> genTriviaFor SynExpr_ArrayOrList synExpr.Range
             | SynExpr.ArrayOrListOfSeqExpr _ -> genTriviaFor SynExpr_ArrayOrListOfSeqExpr synExpr.Range
             | SynExpr.Paren _ -> genTriviaFor SynExpr_Paren synExpr.Range
             | SynExpr.InterpolatedString _ -> genTriviaFor SynExpr_InterpolatedString synExpr.Range


### PR DESCRIPTION
This PR adds a missing `genTriviaFor SynExpr_ArrayOrList` in the expression printer so that comments before and after empty array and list literals are preserved. (The new "comment after empty list" test passed before the printer change, but the other three failed.)

Thanks @nojaf for pointing out where the problem was!

Resolves #1281.