### PR TITLE
Don't close string when there is a triple backslash before the double quote

### DIFF
--- a/src/Fantomas.Tests/SynConstTests.fs
+++ b/src/Fantomas.Tests/SynConstTests.fs
@@ -179,3 +179,35 @@ let ``preserve underscore in int64, 1120`` () =
     formatSourceString false "let x = 60_000L" config
     |> should equal "let x = 60_000L
 "
+
+[<Test>]
+let ``spaces before hash define inside string, 1290`` () =
+    formatSourceString false "
+[<Test>]
+let ``defines inside string, escaped quote`` () =
+    let source = \"
+let a = \\\"\\\\\\\"
+#if FOO
+  #if BAR
+  #endif
+#endif
+\\\"
+\"
+
+    getDefines source == []
+"    config
+    |> prepend newline
+    |> should equal "
+[<Test>]
+let ``defines inside string, escaped quote`` () =
+    let source = \"
+let a = \\\"\\\\\\\"
+#if FOO
+  #if BAR
+  #endif
+#endif
+\\\"
+\"
+
+    getDefines source == []
+"

--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -13,7 +13,8 @@ let private isNewline item =
     | _ -> false
 
 let getDefines v =
-    let _, hashTokens = getDefines v
+    let normalizedString = String.normalizeNewLine v
+    let _, hashTokens = getDefines normalizedString
     getDefinesWords hashTokens
 
 let tokenize v = tokenize [] [] v
@@ -546,3 +547,22 @@ let file =
 #endif
 "
     getDefines source == [ "WATCH" ]
+
+[<Test>]
+let ``escaped backslash inside escaped string, 1290`` () =
+    let source = "
+[<Test>]
+let ``defines inside string, escaped quote`` () =
+    let source = \"
+let a = \\\"\\\\\\\"
+#if FOO
+  #if BAR
+  #endif
+#endif
+\\\"
+\"
+
+    getDefines source == []
+"
+
+    getDefines source == []

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -265,8 +265,11 @@ let rec private getTokenizedHashes (sourceCode: string): Token list =
                     { acc with
                           NewlineIndexes = idx :: acc.NewlineIndexes }
                 | InsideString, (DoubleQuoteChar, _, _) ->
-                    match minusOne, minusTwo with
-                    | BackSlashChar, NoBackSlashChar -> acc
+                    let minusThree = sourceCode.[idx - 3]
+
+                    match minusOne, minusTwo, minusThree with
+                    | BackSlashChar, NoBackSlashChar, _
+                    | BackSlashChar, BackSlashChar, BackSlashChar -> acc
                     | _ -> { acc with State = Normal }
                 | InsideString, (DoubleQuoteChar, _, _) -> { acc with State = Normal }
                 | InsideTripleQuoteString _, (NewlineChar, _, _) ->


### PR DESCRIPTION
Fixes #1290.