### PR TITLE
Don't indent static member too far if record has access modifier

### DIFF
--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -1344,3 +1344,84 @@ let internal sepSemi (ctx: Context) =
     | true, true -> str " ; "
     <| ctx
 """
+
+[<Test>]
+let ``record with an access modifier and a static member, 1300`` () =
+    formatSourceString
+        false
+        """
+type RequestParser<'ctx, 'a> =
+    internal
+        { consumedFields: Set<ConsumedFieldName>
+          parse: 'ctx -> Request -> Async<Result<'a, Error list>>
+          prohibited: ProhibitedRequestGetter list }
+
+        static member internal Create
+            (
+                consumedFields, parse: 'ctx -> Request -> Async<Result<'a, Error list>>
+            ) : RequestParser<'ctx, 'a> =
+            { consumedFields = consumedFields
+              parse = parse
+              prohibited = [] }
+
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type RequestParser<'ctx, 'a> =
+    internal
+        { consumedFields: Set<ConsumedFieldName>
+          parse: 'ctx -> Request -> Async<Result<'a, Error list>>
+          prohibited: ProhibitedRequestGetter list }
+
+    static member internal Create(consumedFields, parse: 'ctx -> Request -> Async<Result<'a, Error list>>)
+                                  : RequestParser<'ctx, 'a> =
+        { consumedFields = consumedFields
+          parse = parse
+          prohibited = [] }
+"""
+
+[<Test>]
+let ``record with an access modifier and a static member, MultilineBlockBracketsOnSameColumn`` () =
+    formatSourceString
+        false
+        """
+type RequestParser<'ctx, 'a> =
+    internal
+        { consumedFields: Set<ConsumedFieldName>
+          parse: 'ctx -> Request -> Async<Result<'a, Error list>>
+          prohibited: ProhibitedRequestGetter list }
+
+        static member internal Create
+            (
+                consumedFields, parse: 'ctx -> Request -> Async<Result<'a, Error list>>
+            ) : RequestParser<'ctx, 'a> =
+            { consumedFields = consumedFields
+              parse = parse
+              prohibited = [] }
+
+"""
+        { config with
+              MultilineBlockBracketsOnSameColumn = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+type RequestParser<'ctx, 'a> =
+    internal
+        {
+            consumedFields: Set<ConsumedFieldName>
+            parse: 'ctx -> Request -> Async<Result<'a, Error list>>
+            prohibited: ProhibitedRequestGetter list
+        }
+
+    static member internal Create(consumedFields, parse: 'ctx -> Request -> Async<Result<'a, Error list>>)
+                                  : RequestParser<'ctx, 'a> =
+        {
+            consumedFields = consumedFields
+            parse = parse
+            prohibited = []
+        }
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3548,6 +3548,7 @@ and genMultilineSimpleRecordTypeDefn tdr ms ao' fs astContext =
     )
     +> sepCloseS
     +> leaveNodeTokenByName tdr.Range RBRACE
+    +> optSingle (fun _ -> unindent) ao'
     +> onlyIf (List.isNotEmpty ms) sepNln
     +> sepNlnBetweenTypeAndMembers ms
     +> genMemberDefnList
@@ -3570,6 +3571,7 @@ and genMultilineSimpleRecordTypeDefnAlignBrackets tdr ms ao' fs astContext =
     +> unindent
     +> sepNln
     +> sepCloseSFixed
+    +> optSingle (fun _ -> unindent) ao'
     +> onlyIf (List.isNotEmpty ms) sepNln
     +> sepNlnBetweenTypeAndMembers ms
     +> genMemberDefnList


### PR DESCRIPTION
Fixes #1300.