### PR TITLE
Stricter trivia selection.

### DIFF
--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -430,16 +430,6 @@ let ``ident between tickets `` () =
     | _ -> fail ()
 
 [<Test>]
-let ``simple char content`` () =
-    let source = "let someChar = \'s\'"
-
-    let triviaNodes = tokenize source |> getTriviaFromTokens
-
-    match triviaNodes with
-    | [ { Item = CharContent ("\'s\'") } ] -> pass ()
-    | _ -> fail ()
-
-[<Test>]
 let ``escaped char content`` () =
     let source = "let nulchar = \'\\u0000\'"
 

--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -162,7 +162,7 @@ let ``Single line block comment should be found in tokens`` () =
     | _ -> failwith "expected block comment"
 
 [<Test>]
-let ``Multi line block comment should be found in tokens`` () =
+let ``multi line block comment should be found in tokens`` () =
     let source = """let bar =
 (* multi
    line
@@ -179,7 +179,7 @@ let ``Multi line block comment should be found in tokens`` () =
 
     match triviaNodes with
     | [ { Item = Comment (BlockComment (blockComment, _, _))
-          Range = range }; { Item = Number ("7") } ] ->
+          Range = range } ] ->
         blockComment == expectedComment
         range.StartLine == 2
         range.EndLine == 4
@@ -241,7 +241,7 @@ let ``Comment after left brace of record`` () =
 
     match triviaNodes with
     | [ { Item = Comment (LineCommentAfterSourceCode (comment))
-          Range = range }; { Item = Number ("7") } ] ->
+          Range = range } ] ->
         comment == "// foo"
         range.StartLine == 2
     | _ -> failwith "expected line comment after left brace"
@@ -267,7 +267,7 @@ type T() =
     let triviaNodes = tokenize source |> getTriviaFromTokens
 
     match triviaNodes with
-    | [ { Item = Newline; Range = rAbove }; { Item = Number ("123") } ] -> rAbove.StartLine == 1
+    | [ { Item = Newline; Range = rAbove } ] -> rAbove.StartLine == 1
     | _ -> fail ()
 
 [<Test>]

--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -403,7 +403,6 @@ let ``with quotes`` () =
 
     List.length triviaNodes == 1
 
-
 [<Test>]
 let ``infix operator in full words inside an ident`` () =
     let source = """let op_LessThan(a, b) = a < b"""
@@ -496,7 +495,6 @@ let a = \"\\\"
 "
 
     getDefines source == []
-
 
 [<Test>]
 let ``defines inside triple quote string`` () =

--- a/src/Fantomas.Tests/TriviaTests.fs
+++ b/src/Fantomas.Tests/TriviaTests.fs
@@ -49,8 +49,7 @@ let a = 'c'
     let triviaNodes = toTrivia source |> List.head
 
     match triviaNodes with
-    | [ { ContentBefore = [ Comment (LineCommentOnSingleLine (lineComment)) ] };
-        { ContentItself = Some (CharContent ("\'c\'")) } ] -> lineComment == "// foo"
+    | [ { ContentBefore = [ Comment (LineCommentOnSingleLine (lineComment)) ] } ] -> lineComment == "// foo"
     | _ -> failwith "Expected line comment"
 
 [<Test>]

--- a/src/Fantomas.Tests/TriviaTests.fs
+++ b/src/Fantomas.Tests/TriviaTests.fs
@@ -37,8 +37,7 @@ let a = 9
     let triviaNodes = toTrivia source |> List.head
 
     match triviaNodes with
-    | [ { ContentBefore = [ Comment (LineCommentOnSingleLine (lineComment)) ] }; { ContentItself = Some (Number ("9")) } ] ->
-        lineComment == "// meh"
+    | [ { ContentBefore = [ Comment (LineCommentOnSingleLine (lineComment)) ] } ] -> lineComment == "// meh"
     | _ -> failwith "Expected line comment"
 
 [<Test>]
@@ -61,9 +60,7 @@ let ``line comment on same line, is after last AST item`` () =
 
     match triviaNodes with
     | [ { Type = MainNode (SynModuleOrNamespace_AnonModule)
-          ContentAfter = [ Comment (LineCommentAfterSourceCode (lineComment)) ] };
-        { Type = MainNode (SynExpr_Const)
-          ContentItself = Some (Number ("7")) } ] -> lineComment == "// should be 8"
+          ContentAfter = [ Comment (LineCommentAfterSourceCode (lineComment)) ] } ] -> lineComment == "// should be 8"
     | _ -> fail ()
 
 [<Test>]
@@ -74,8 +71,7 @@ let b = 9"""
     let triviaNodes = toTrivia source |> List.head
 
     match triviaNodes with
-    | [ { ContentItself = Some (Number ("7")) }; { ContentBefore = [ Newline ] };
-        { ContentItself = Some (Number ("9")) } ] -> pass ()
+    | [ { ContentBefore = [ Newline ] } ] -> pass ()
     | _ -> fail ()
 
 [<Test>]
@@ -93,7 +89,7 @@ let a = 7
 // bar"""
 
     match triviaNodes with
-    | [ { ContentBefore = [ Comment (LineCommentOnSingleLine (comments)) ] }; { ContentItself = Some (Number ("7")) } ] ->
+    | [ { ContentBefore = [ Comment (LineCommentOnSingleLine (comments)) ] } ] ->
         String.normalizeNewLine comments
         == expectedComment
     | _ -> fail ()
@@ -109,8 +105,7 @@ let ``comments inside record`` () =
 
     match triviaNodes with
     | [ { Type = TriviaNodeType.Token (LBRACE, _)
-          ContentAfter = [ Comment (LineCommentAfterSourceCode ("// foo")) ] }; { ContentItself = Some (Number ("7")) } ] ->
-        pass ()
+          ContentAfter = [ Comment (LineCommentAfterSourceCode ("// foo")) ] } ] -> pass ()
     | _ -> fail ()
 
 [<Test>]
@@ -124,8 +119,7 @@ let ``comment after all source code`` () =
 
     match triviaNodes with
     | [ { Type = MainNode (mn)
-          ContentAfter = [ Comment (LineCommentOnSingleLine (lineComment)) ] };
-        { ContentItself = Some (Number ("123")) } ] ->
+          ContentAfter = [ Comment (LineCommentOnSingleLine (lineComment)) ] } ] ->
         mn == SynModuleDecl_Types
 
         lineComment
@@ -141,8 +135,7 @@ let ``block comment added to trivia`` () =
     let triviaNodes = toTrivia source |> List.head
 
     match triviaNodes with
-    | [ { ContentBefore = [ Comment (BlockComment (comment, _, _)) ]
-          ContentItself = Some (Number ("9")) } ] -> comment == "(* meh *)"
+    | [ { ContentBefore = [ Comment (BlockComment (comment, _, _)) ] } ] -> comment == "(* meh *)"
     | _ -> failwith "Expected block comment"
 
 [<Test>]
@@ -200,8 +193,7 @@ let a =  9
     let triviaNodes = toTrivia source |> List.head
 
     match triviaNodes with
-    | [ { ContentBefore = [ Comment (BlockComment (comment, _, true)) ] }; { ContentItself = Some (Number ("9")) } ] ->
-        comment == "(* // meh *)"
+    | [ { ContentBefore = [ Comment (BlockComment (comment, _, true)) ] } ] -> comment == "(* // meh *)"
     | _ -> failwith "Expected block comment"
 
 
@@ -486,4 +478,15 @@ type LongIdentWithDots =
     match trivia with
     | [ { ContentBefore = [ Comment (LineCommentOnSingleLine (comment)) ] } ] ->
         String.normalizeNewLine comment == expectedComment
+    | _ -> fail ()
+
+[<Test>]
+let ``number expression`` () =
+    let source = sprintf "let x = 2.0m"
+
+    let trivia = toTrivia source |> List.head
+
+    match trivia with
+    | [ { ContentItself = Some (Number (n))
+          Type = TriviaNodeType.MainNode (SynExpr_Const) } ] -> n == "2.0m"
     | _ -> fail ()

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -487,9 +487,13 @@ let private isOperatorOrKeyword ({ TokenInfo = { CharClass = cc } }) =
     cc = FSharpTokenCharKind.Keyword
     || cc = FSharpTokenCharKind.Operator
 
-let private isNumber ({ TokenInfo = tn }) =
+let onlyNumberRegex =
+    System.Text.RegularExpressions.Regex(@"^\d+$")
+
+let private isNumber ({ TokenInfo = tn; Content = content }) =
     tn.ColorClass = FSharpTokenColorKind.Number
     && List.contains tn.TokenName numberTrivia
+    && not (onlyNumberRegex.IsMatch(content))
 
 let private identIsDecompiledOperator (token: Token) =
     let decompiledName =

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -487,13 +487,23 @@ let private isOperatorOrKeyword ({ TokenInfo = { CharClass = cc } }) =
     cc = FSharpTokenCharKind.Keyword
     || cc = FSharpTokenCharKind.Operator
 
-let onlyNumberRegex =
+let private onlyNumberRegex =
     System.Text.RegularExpressions.Regex(@"^\d+$")
 
 let private isNumber ({ TokenInfo = tn; Content = content }) =
     tn.ColorClass = FSharpTokenColorKind.Number
     && List.contains tn.TokenName numberTrivia
     && not (onlyNumberRegex.IsMatch(content))
+
+let private digitOrLetterCharRegex =
+    System.Text.RegularExpressions.Regex(@"^'(\d|[a-zA-Z])'$")
+
+let (|CharToken|_|) token =
+    if token.TokenInfo.TokenName = "CHAR"
+       && not (digitOrLetterCharRegex.IsMatch(token.Content)) then
+        Some token
+    else
+        None
 
 let private identIsDecompiledOperator (token: Token) =
     let decompiledName =
@@ -737,7 +747,7 @@ let rec private getTriviaFromTokensThemSelves (allTokens: Token list) (tokens: T
 
         getTriviaFromTokensThemSelves allTokens rest info
 
-    | head :: rest when (head.TokenInfo.TokenName = "CHAR") ->
+    | CharToken (head) :: rest ->
         let range =
             getRangeBetween head.TokenInfo.TokenName head head
 


### PR DESCRIPTION
Improves #1272, this PR adds some more restrictions on when a constant value should be considered trivia.
In short, Fantomas cannot always trust the values of string, numbers and characters that are found in the Untyped AST.
That is why these are picked up via the F# tokens.
However, all strings, numbers and characters were detected all the time.
In this PR, we are only detecting them as trivia if they are indeed special cases.