### PR TITLE
Keep both keywords in abstract member definitions.

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -132,7 +132,7 @@ type Shape2D(x0: float, y0: float) =
         x <- x + dx
         y <- y + dy
 
-    abstract Rotate: float -> unit
+    abstract member Rotate: float -> unit
     default this.Rotate(angle) = rotAngle <- rotAngle + angle
 """
 
@@ -761,3 +761,24 @@ indent_size=2
   9
 \"\"\"
 "
+
+[<Test>]
+let ``keep abstract member keywords, 1106`` () =
+    formatSourceString
+        false
+        """
+module Example
+
+type Foo =
+    abstract member bar : int
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Example
+
+type Foo =
+    abstract member bar: int
+"""

--- a/src/Fantomas.Tests/InterfaceTests.fs
+++ b/src/Fantomas.Tests/InterfaceTests.fs
@@ -26,7 +26,7 @@ type Interface3 =
         equal
         """
 type IPrintable =
-    abstract Print: unit -> unit
+    abstract member Print: unit -> unit
 
 type SomeClass1(x: int, y: float) =
     interface IPrintable with
@@ -35,7 +35,7 @@ type SomeClass1(x: int, y: float) =
 type Interface3 =
     inherit Interface1
     inherit Interface2
-    abstract Method3: int -> int
+    abstract member Method3: int -> int
 """
 
 [<Test>]
@@ -202,10 +202,10 @@ type MyLogInteface() =
         equal
         """
 type LogInterface =
-    abstract Print: string -> unit
-    abstract GetLogFile: string -> string
-    abstract Info: unit -> unit
-    abstract Version: unit -> unit
+    abstract member Print: string -> unit
+    abstract member GetLogFile: string -> string
+    abstract member Info: unit -> unit
+    abstract member Version: unit -> unit
 
 type MyLogInteface() =
     interface LogInterface with

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -237,7 +237,7 @@ let ``abstract and override keywords`` () =
         """
 type MyClassBase1() =
     let mutable z = 0
-    abstract Function1: int -> int
+    abstract member Function1: int -> int
 
     default u.Function1(a: int) =
         z <- z + a
@@ -1021,8 +1021,8 @@ type A =
         equal
         """
 type A =
-    abstract M: int -> (int -> unit)
-    abstract M: float -> int
+    abstract member M: int -> (int -> unit)
+    abstract member M: float -> int
 """
 
 [<Test>]
@@ -1039,8 +1039,8 @@ type A =
         equal
         """
 type A =
-    abstract M: (int -> int) -> unit
-    abstract M: float -> int
+    abstract member M: (int -> int) -> unit
+    abstract member M: float -> int
 """
 
 [<Test>]

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4389,10 +4389,27 @@ and genMemberDefn astContext node =
             | [] -> sepColon
             | _ -> sepColonWithSpacesFixed
 
+        let genAbstractMemberKeyword (ctx: Context) =
+            Map.tryFindOrEmptyList MEMBER ctx.TriviaTokenNodes
+            |> List.choose
+                (fun tn ->
+                    if tn.Range.StartLine = node.Range.StartLine then
+                        match tn.ContentItself with
+                        | Some (Keyword (kw)) -> Some kw.Content
+                        | _ -> None
+                    else
+                        None)
+            |> List.tryHead
+            |> fun keywordOpt ->
+                match keywordOpt with
+                | Some kw -> sprintf "%s %s" kw s
+                | None -> sprintf "abstract %s" s
+            |> fun s -> !- s ctx
+
         genPreXmlDoc px
         +> genAttributes astContext ats
         +> opt sepSpace ao genAccess
-        -- sprintf "abstract %s" s
+        +> genAbstractMemberKeyword
         +> genTypeParamPostfix astContext tds tcs
         +> sepColonX
         +> genTypeList astContext namedArgs

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -390,6 +390,7 @@ let private addTriviaToTriviaNode triviaBetweenAttributeAndParentBinding
         |> updateTriviaNode
             (fun tn ->
                 match tn.Type, tn.ContentItself with
+                | TriviaNodeType.Token (MEMBER, _), Some (Keyword ({ Content = existingKeywordContent } as token))
                 | MainNode (SynMemberSig_Member), Some (Keyword ({ Content = existingKeywordContent } as token)) when existingKeywordContent = "abstract"
                                                                                                                       && keyword = "member" ->
                     // Combine the two tokens to appear as one


### PR DESCRIPTION
Fixes #1106