### PR TITLE
Keep new line before SynExpr.DotIndexedSet.

### DIFF
--- a/src/Fantomas.Tests/SynExprSetTests.fs
+++ b/src/Fantomas.Tests/SynExprSetTests.fs
@@ -199,3 +199,58 @@ let ``multi line DotNamedIndexedPropertySet`` () =
     |> string
     |> StringValues
 """
+
+[<Test>]
+let ``keep new line before SynExpr.DotIndexedSet, 1314`` () =
+    formatSourceString
+        false
+        """
+          match x with
+          | NotificationEvent.Lint (file, warnings) ->
+              let uri = Path.FilePathToUri file
+
+              diagnosticCollections.AddOrUpdate((uri, "F# Linter"), [||], (fun _ _ -> [||]))
+              |> ignore
+
+              let fs =
+                warnings
+                |> List.choose
+                     (fun w ->
+                       w.Warning.Details.SuggestedFix
+                       |> Option.bind
+                            (fun f ->
+                              let f = f.Force()
+                              let range = fcsRangeToLsp w.Warning.Details.Range
+
+                              f
+                              |> Option.map (fun f -> range, { Range = range; NewText = f.ToText })))
+
+              lintFixes.[uri] <- fs
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+match x with
+| NotificationEvent.Lint (file, warnings) ->
+    let uri = Path.FilePathToUri file
+
+    diagnosticCollections.AddOrUpdate((uri, "F# Linter"), [||], (fun _ _ -> [||]))
+    |> ignore
+
+    let fs =
+        warnings
+        |> List.choose
+            (fun w ->
+                w.Warning.Details.SuggestedFix
+                |> Option.bind
+                    (fun f ->
+                        let f = f.Force()
+                        let range = fcsRangeToLsp w.Warning.Details.Range
+
+                        f
+                        |> Option.map (fun f -> range, { Range = range; NewText = f.ToText })))
+
+    lintFixes.[uri] <- fs
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2737,6 +2737,7 @@ and genExpr astContext synExpr ctx =
             | SynExpr.Upcast _ -> genTriviaFor SynExpr_Upcast synExpr.Range
             | SynExpr.Downcast _ -> genTriviaFor SynExpr_Downcast synExpr.Range
             | SynExpr.DotIndexedGet _ -> genTriviaFor SynExpr_DotIndexedGet synExpr.Range
+            | SynExpr.DotIndexedSet _ -> genTriviaFor SynExpr_DotIndexedSet synExpr.Range
             | _ -> id)
 
     expr ctx


### PR DESCRIPTION
Fixes #1314.