### PR TITLE
Keep new line before SynExpr.For.

### DIFF
--- a/src/Fantomas.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Tests/ControlStructureTests.fs
@@ -688,3 +688,50 @@ let internal coli f' (c: seq<'T>) f (ctx: Context) =
 
     st
 """
+
+[<Test>]
+let ``keep new line before for loop, 1317`` () =
+    formatSourceString
+        false
+        """
+  /// Fold over the array passing the index and element at that index to a folding function
+  let foldi (folder: 'State -> int -> 'T -> 'State) (state: 'State) (array: 'T []) =
+    checkNonNull "array" array
+
+    if array.Length = 0 then
+      state
+    else
+      let folder =
+        OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt folder
+
+      let mutable state: 'State = state
+      let len = array.Length
+
+      for i = 0 to len - 1 do
+        state <- folder.Invoke(state, i, array.[i])
+
+      state
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+/// Fold over the array passing the index and element at that index to a folding function
+let foldi (folder: 'State -> int -> 'T -> 'State) (state: 'State) (array: 'T []) =
+    checkNonNull "array" array
+
+    if array.Length = 0 then
+        state
+    else
+        let folder =
+            OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt folder
+
+        let mutable state: 'State = state
+        let len = array.Length
+
+        for i = 0 to len - 1 do
+            state <- folder.Invoke(state, i, array.[i])
+
+        state
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2715,6 +2715,7 @@ and genExpr astContext synExpr ctx =
             | SynExpr.IfThenElse _ -> genTriviaFor SynExpr_IfThenElse synExpr.Range
             | SynExpr.Lambda _ -> genTriviaFor SynExpr_Lambda synExpr.Range
             | SynExpr.ForEach _ -> genTriviaFor SynExpr_ForEach synExpr.Range
+            | SynExpr.For _ -> genTriviaFor SynExpr_For synExpr.Range
             | SynExpr.Match _ -> genTriviaFor SynExpr_Match synExpr.Range
             | SynExpr.MatchBang _ -> genTriviaFor SynExpr_MatchBang synExpr.Range
             | SynExpr.YieldOrReturn _ -> genTriviaFor SynExpr_YieldOrReturn synExpr.Range


### PR DESCRIPTION
 Fixes #1317.