### PR TITLE
Put comma upfront when SynExpr.IfThenElse is inside Tuple.

### DIFF
--- a/src/Fantomas.Tests/TupleTests.fs
+++ b/src/Fantomas.Tests/TupleTests.fs
@@ -238,3 +238,33 @@ let (var1withAVeryLongLongLongLongLongLongName,
      var2withAVeryLongLongLongLongLongLongName) = // foo
     someFunc 1, someFunc 2
 """
+
+[<Test>]
+let ``tuple with if/then/else, 1319`` () =
+    formatSourceString
+        false
+        """
+let y =
+    if String.IsNullOrWhiteSpace(args) then ""
+    elif args.StartsWith("(") then args
+    elif v.CurriedParameterGroups.Count > 1 && (not verboseMode) then " " + args
+    else sprintf "(%s)" args
+    , namesWithIndices
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let y =
+    if String.IsNullOrWhiteSpace(args) then
+        ""
+    elif args.StartsWith("(") then
+        args
+    elif v.CurriedParameterGroups.Count > 1
+         && (not verboseMode) then
+        " " + args
+    else
+        sprintf "(%s)" args
+    , namesWithIndices
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1151,18 +1151,19 @@ and genTuple astContext es =
         col sepComma es (genShortExpr astContext)
 
     let longExpression =
-        let containsLambdaOrMatchExpr =
+        let shouldAddCommaUpFront =
             es
             |> List.pairwise
             |> List.exists
                 (function
                 | SynExpr.Match _, _
                 | SynExpr.Lambda _, _
+                | SynExpr.IfThenElse _, _
                 | InfixApp (_, _, _, SynExpr.Lambda _), _ -> true
                 | _ -> false)
 
         let sep =
-            if containsLambdaOrMatchExpr then
+            if shouldAddCommaUpFront then
                 (sepNln +> sepComma)
             else
                 (sepComma +> sepNln)


### PR DESCRIPTION
Fixes #1319.