### PR TITLE
Take all SynMemberDefn cases into account when printing newline

### DIFF
--- a/src/Fantomas.Tests/NewlineBetweenTypeDefinitionAndMembersTests.fs
+++ b/src/Fantomas.Tests/NewlineBetweenTypeDefinitionAndMembersTests.fs
@@ -320,3 +320,31 @@ type Color =
 
     member ToInt: unit -> int
 """
+
+[<Test>]
+let ``newline before interface, 1346`` () =
+    formatSourceString
+        false
+        """
+type andSeq<'t> =
+    | AndSeq of 't seq
+
+    interface IEnumerable<'t> with
+        member this.GetEnumerator(): Collections.IEnumerator =
+            match this with
+            | AndSeq xs -> xs.GetEnumerator() :> _
+"""
+        { config with
+              NewlineBetweenTypeDefinitionAndMembers = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+type andSeq<'t> =
+    | AndSeq of 't seq
+
+    interface IEnumerable<'t> with
+        member this.GetEnumerator(): Collections.IEnumerator =
+            match this with
+            | AndSeq xs -> xs.GetEnumerator() :> _
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3114,7 +3114,24 @@ and genApp appNlnFun astContext e es ctx =
         expressionFitsOnRestOfLine shortExpression longExpression ctx
 
 and sepNlnBetweenTypeAndMembers (ms: SynMemberDefn list) =
-    sepNlnTypeAndMembers (List.tryHead ms |> Option.map (fun e -> e.Range)) SynMemberDefn_Member
+    match List.tryHead ms with
+    | Some m ->
+        let range, mainNodeType =
+            match m with
+            | SynMemberDefn.Interface (_, _, r) -> r, SynMemberDefn_Interface
+            | SynMemberDefn.Open (_, r) -> r, SynMemberDefn_Open
+            | SynMemberDefn.Member (_, r) -> r, SynMemberDefn_Member
+            | SynMemberDefn.ImplicitCtor (_, _, _, _, _, r) -> r, SynMemberDefn_ImplicitCtor
+            | SynMemberDefn.ImplicitInherit (_, _, _, r) -> r, SynMemberDefn_ImplicitInherit
+            | SynMemberDefn.LetBindings (_, _, _, r) -> r, SynMemberDefn_LetBindings
+            | SynMemberDefn.AbstractSlot (_, _, r) -> r, SynMemberDefn_AbstractSlot
+            | SynMemberDefn.Inherit (_, _, r) -> r, SynMemberDefn_Inherit
+            | SynMemberDefn.ValField (_, r) -> r, SynMemberDefn_ValField
+            | SynMemberDefn.NestedType (_, _, r) -> r, SynMemberDefn_NestedType
+            | SynMemberDefn.AutoProperty (_, _, _, _, _, _, _, _, _, _, r) -> r, SynMemberDefn_AutoProperty
+
+        sepNlnTypeAndMembers (Some range) mainNodeType
+    | None -> sepNone
 
 and genTypeDefn astContext (TypeDef (ats, px, ao, tds, tcs, tdr, ms, s, preferPostfix) as node) =
     let typeName =


### PR DESCRIPTION
for NewlineBetweenTypeDefinitionAndMembers setting. Fixes #1346.