### PR TITLE
Revisit long members in a type declaration.

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -17,7 +17,7 @@ type Heap<'T when 'T : comparison> =
     new : capacity:int -> Heap<'T>
     member Clear : unit -> unit
     member ExtractMin : unit -> 'T
-    member Insert : k:'T -> unit
+    member Insert : k: 'T -> unit
     member IsEmpty : unit -> bool
     member PeekMin : unit -> 'T
     override ToString : unit -> string
@@ -32,10 +32,10 @@ module Heap
 
 type Heap<'T when 'T: comparison> =
     class
-        new: capacity:int -> Heap<'T>
+        new: capacity: int -> Heap<'T>
         member Clear: unit -> unit
         member ExtractMin: unit -> 'T
-        member Insert: k:'T -> unit
+        member Insert: k: 'T -> unit
         member IsEmpty: unit -> bool
         member PeekMin: unit -> 'T
         override ToString: unit -> string
@@ -156,13 +156,13 @@ type A =
         equal
         """
 type A =
-    abstract B: ?p1:(float * int) -> unit
-    abstract C: ?p1:float * int -> unit
-    abstract D: ?p1:(int -> int) -> unit
-    abstract E: ?p1:float -> unit
-    abstract F: ?p1:float * ?p2:float -> unit
-    abstract G: p1:float * ?p2:float -> unit
-    abstract H: float * ?p2:float -> unit
+    abstract B: ?p1: (float * int) -> unit
+    abstract C: ?p1: float * int -> unit
+    abstract D: ?p1: (int -> int) -> unit
+    abstract E: ?p1: float -> unit
+    abstract F: ?p1: float * ?p2: float -> unit
+    abstract G: p1: float * ?p2: float -> unit
+    abstract H: float * ?p2: float -> unit
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/InterfaceTests.fs
+++ b/src/Fantomas.Tests/InterfaceTests.fs
@@ -432,3 +432,49 @@ type IFoo =
         * [<Path "baz">] baz : string ->
         Task<Foo>
 """
+
+[<Test>]
+let ``long member with mixed type declaration`` () =
+    formatSourceString
+        false
+        """
+type IFoo =
+    abstract Bar : i : int -> a : string * foo : int -> string
+"""
+        { config with
+              MaxLineLength = 60
+              SpaceBeforeColon = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+type IFoo =
+    abstract Bar :
+        i : int ->
+        a : string * foo : int ->
+        string
+"""
+
+[<Test>]
+let ``long member with mixed type declaration with a long name`` () =
+    formatSourceString
+        false
+        """
+type IFoo =
+    abstract Bar : i : int -> a : string * foo : int * someReallyLongNameThatMakesTheTupleMultiLine : string -> string
+"""
+        { config with
+              MaxLineLength = 60
+              SpaceBeforeColon = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+type IFoo =
+    abstract Bar :
+        i : int ->
+        a : string
+        * foo : int
+        * someReallyLongNameThatMakesTheTupleMultiLine : string ->
+        string
+"""

--- a/src/Fantomas.Tests/InterfaceTests.fs
+++ b/src/Fantomas.Tests/InterfaceTests.fs
@@ -135,7 +135,7 @@ let ``should keep named arguments on abstract members`` () =
     |> should
         equal
         """type IThing =
-    abstract Foo: name:string * age:int -> bool
+    abstract Foo: name: string * age: int -> bool
 """
 
 [<Test>]
@@ -272,18 +272,19 @@ type Test =
         equal
         """
 type Test =
-    abstract RunJobs: folder:string
-                      * ?jobs:string
-                      * ?ctm:string
-                      * ?createDuplicate:bool
-                      * ?hold:bool
-                      * ?ignoreCriteria:bool
-                      * ?independentFlow:bool
-                      * ?orderDate:string
-                      * ?orderIntoFolder:string
-                      * ?variables:Dictionary<string, string> []
-                      * ?waitForOrderDate:bool
-                      -> string
+    abstract RunJobs:
+        folder: string
+        * ?jobs: string
+        * ?ctm: string
+        * ?createDuplicate: bool
+        * ?hold: bool
+        * ?ignoreCriteria: bool
+        * ?independentFlow: bool
+        * ?orderDate: string
+        * ?orderIntoFolder: string
+        * ?variables: Dictionary<string, string> []
+        * ?waitForOrderDate: bool ->
+        string
 
     override this.RunJobs
         (
@@ -360,4 +361,74 @@ printfn "DIM from C#: %d" md.Z
 // You can also implement it via an object expression
 let md' = { new MyDim }
 printfn "DIM from C# but via Object Expression: %d" md'.Z
+"""
+
+[<Test>]
+let ``long member in type declaration, 1362`` () =
+    formatSourceString
+        false
+        """
+type IFoo =
+    abstract Blah : foo : string -> bar : string -> baz : string -> int
+"""
+        { config with
+              MaxLineLength = 60
+              SpaceBeforeColon = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+type IFoo =
+    abstract Blah :
+        foo : string ->
+        bar : string ->
+        baz : string ->
+        int
+"""
+
+[<Test>]
+let ``long member in type declaration, not named`` () =
+    formatSourceString
+        false
+        """
+type IFoo =
+    abstract Blah : string -> string -> string -> int -> string -> string
+"""
+        { config with
+              MaxLineLength = 60
+              SpaceBeforeColon = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+type IFoo =
+    abstract Blah :
+        string ->
+        string ->
+        string ->
+        int ->
+        string ->
+        string
+"""
+
+[<Test>]
+let ``long member with tuple in type declaration`` () =
+    formatSourceString
+        false
+        """
+type IFoo =
+    abstract Bar : [<Path "bar">] bar : string  * [<Path "baz">] baz : string ->  Task<Foo>
+"""
+        { config with
+              MaxLineLength = 60
+              SpaceBeforeColon = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+type IFoo =
+    abstract Bar :
+        [<Path "bar">] bar : string
+        * [<Path "baz">] baz : string ->
+        Task<Foo>
 """

--- a/src/Fantomas.Tests/ModuleTests.fs
+++ b/src/Fantomas.Tests/ModuleTests.fs
@@ -172,10 +172,10 @@ val turnTracingOff: unit -> unit
 val isTraced: unit -> bool
 
 module Random =
-    val exponential: mean:float -> float
-    val nextInt: max:int -> int
-    val nextInt64: max:int64 -> int64
-    val next: max:float -> float
+    val exponential: mean: float -> float
+    val nextInt: max: int -> int
+    val nextInt64: max: int64 -> int64
+    val next: max: float -> float
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -87,25 +87,25 @@ type Element =
     interface INode
 
     /// Constructs an new empty Element.
-    static member Create: name:string * ?uri:string -> Element
+    static member Create: name: string * ?uri: string -> Element
 
     /// Replaces the children.
-    static member WithChildren: children:#seq<#INode> -> self:Element -> Element
+    static member WithChildren: children: #seq<#INode> -> self: Element -> Element
 
     /// Replaces the children.
-    static member (-): self:Element * children:#seq<#INode> -> Element
+    static member (-): self: Element * children: #seq<#INode> -> Element
 
     /// Replaces the attributes.
-    static member WithAttributes: attrs:#seq<string * string> -> self:Element -> Element
+    static member WithAttributes: attrs: #seq<string * string> -> self: Element -> Element
 
     /// Replaces the attributes.
-    static member (+): self:Element * attrs:#seq<string * string> -> Element
+    static member (+): self: Element * attrs: #seq<string * string> -> Element
 
     /// Replaces the children with a single text node.
-    static member WithText: text:string -> self:Element -> Element
+    static member WithText: text: string -> self: Element -> Element
 
     /// Replaces the children with a single text node.
-    static member (--): self:Element * text:string -> Element
+    static member (--): self: Element * text: string -> Element
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -186,7 +186,7 @@ type Test =
 module Test
 
 type Test =
-    static member internal FormatAroundCursorAsync: fileName:string -> unit
+    static member internal FormatAroundCursorAsync: fileName: string -> unit
 """
 
 [<Test>]
@@ -582,11 +582,9 @@ open FSharp.Compiler.SourceCodeServices
 [<Sealed>]
 type CodeFormatter =
     /// Parse a source string using given config
-    static member ParseAsync: fileName:string
-                              * source:SourceOrigin
-                              * parsingOptions:FSharpParsingOptions
-                              * checker:FSharpChecker
-                              -> Async<(ParsedInput * string list) array>
+    static member ParseAsync:
+        fileName: string * source: SourceOrigin * parsingOptions: FSharpParsingOptions * checker: FSharpChecker ->
+        Async<(ParsedInput * string list) array>
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -1005,7 +1005,7 @@ type ILogger =
         equal
         """
 type ILogger =
-    abstract DebugFormat: format:String * [<ParamArray>] args:Object [] -> unit
+    abstract DebugFormat: format: String * [<ParamArray>] args: Object [] -> unit
 """
 
 [<Test>]
@@ -1786,7 +1786,7 @@ type DataGroup =
 [<AllowNullLiteral>]
 type SubGroupStackOptions =
     [<Emit "$0[$1]{{=$2}}">]
-    abstract Item: name:string -> bool with get, set
+    abstract Item: name: string -> bool with get, set
 
 [<AllowNullLiteral>]
 type DataGroup =
@@ -1814,7 +1814,7 @@ let foo bar = zero
 [<AllowNullLiteral>]
 type SubGroupStackOptions =
     [<Emit "$0[$1]{{=$2}}">]
-    abstract Item: name:string -> bool with get, set
+    abstract Item: name: string -> bool with get, set
 
 [<AllowNullLiteral>]
 let foo bar = zero
@@ -1860,7 +1860,7 @@ type TimelineOptionsGroupEditableType = U2<bool, TimelineGroupEditableOption>
 [<AllowNullLiteral>]
 type TimelineOptionsGroupCallbackFunction =
     [<Emit "$0($1...)">]
-    abstract Invoke: group:TimelineGroup * callback:(TimelineGroup option -> unit) -> unit
+    abstract Invoke: group: TimelineGroup * callback: (TimelineGroup option -> unit) -> unit
 
 type TimelineOptionsGroupEditableType = U2<bool, TimelineGroupEditableOption>
 """
@@ -1885,7 +1885,7 @@ let myBinding a = 7
 [<AllowNullLiteral>]
 type TimelineOptionsGroupCallbackFunction =
     [<Emit "$0($1...)">]
-    abstract Invoke: group:TimelineGroup * callback:(TimelineGroup option -> unit) -> unit
+    abstract Invoke: group: TimelineGroup * callback: (TimelineGroup option -> unit) -> unit
 
 let myBinding a = 7
 """

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3719,8 +3719,7 @@ and genMemberSig astContext node =
         genPreXmlDoc px
         +> genAttributes astContext ats
         +> atCurrentColumn (
-            indent
-            +> genMemberFlagsForMemberBinding
+            genMemberFlagsForMemberBinding
                 { astContext with
                       InterfaceRange = None }
                 mf
@@ -3732,7 +3731,6 @@ and genMemberSig astContext node =
             +> genTypeList astContext namedArgs
             +> genConstraints astContext t
             -- (genPropertyKind (not isFunctionProperty) mf.MemberKind)
-            +> unindent
         )
 
     | MSInterface t -> !- "interface " +> genType astContext false t
@@ -4005,67 +4003,60 @@ and genPrefixTypes astContext node ctx =
             ctx
 
 and genTypeList astContext node =
-    match node with
-    | [] -> sepNone
-    | (t, [ ArgInfo (ats, so, isOpt) ]) :: ts ->
-        let gt =
+    let gt (t, args: SynArgInfo list) =
+        match t, args with
+        | TTuple ts', _ ->
+            // The '/' separator shouldn't appear here
+            let hasBracket = not node.IsEmpty
+
+            let gt sepBefore =
+                if args.Length = ts'.Length then
+                    col
+                        sepBefore
+                        (Seq.zip args (Seq.map snd ts'))
+                        (fun ((ArgInfo (ats, so, isOpt)), t) ->
+                            genOnelinerAttributes astContext ats
+                            +> opt
+                                sepColon
+                                so
+                                (if isOpt then
+                                     (sprintf "?%s" >> (!-))
+                                 else
+                                     (!-))
+                            +> genType astContext hasBracket t)
+                else
+                    col sepBefore ts' (snd >> genType astContext hasBracket)
+
+            let shortExpr = gt sepStar
+            let longExpr = gt (sepNln +> sepStarFixed)
+            expressionFitsOnRestOfLine shortExpr longExpr
+
+        | _, [ ArgInfo (ats, so, isOpt) ] ->
             match t with
-            | TTuple _ -> not ts.IsEmpty
+            | TTuple _ -> not node.IsEmpty
             | TFun _ -> true // Fun is grouped by brackets inside 'genType astContext true t'
             | _ -> false
             |> fun hasBracket ->
-                opt
-                    sepColonFixed
+                genOnelinerAttributes astContext ats
+                +> opt
+                    sepColon
                     so
                     (if isOpt then
                          (sprintf "?%s" >> (!-))
                      else
                          (!-))
                 +> genType astContext hasBracket t
+        | _ -> genType astContext false t
 
-        genOnelinerAttributes astContext ats
-        +> gt
-        +> ifElse ts.IsEmpty sepNone (autoNlnIfExpressionExceedsPageWidth (sepArrow +> genTypeList astContext ts))
+    let shortExpr = col sepArrow node gt
 
-    | (TTuple ts', argInfo) :: ts ->
-        // The '/' separator shouldn't appear here
-        let hasBracket = not ts.IsEmpty
+    let longExpr =
+        indent
+        +> sepNln
+        +> col (sepArrow +> sepNln) node gt
+        +> unindent
 
-        let gt sepBefore =
-            col
-                sepBefore
-                (Seq.zip argInfo (Seq.map snd ts'))
-                (fun ((ArgInfo (ats, so, isOpt)), t) ->
-                    genOnelinerAttributes astContext ats
-                    +> opt
-                        sepColonFixed
-                        so
-                        (if isOpt then
-                             (sprintf "?%s" >> (!-))
-                         else
-                             (!-))
-                    +> genType astContext hasBracket t)
-
-        let shortExpr =
-            gt sepStar
-            +> ifElse ts.IsEmpty sepNone (sepArrow +> genTypeList astContext ts)
-
-        let longExpr =
-            gt (sepNln +> sepStarFixed)
-            +> ifElse
-                ts.IsEmpty
-                sepNone
-                (sepNln
-                 +> sepArrowFixed
-                 +> genTypeList astContext ts)
-
-        atCurrentColumn (expressionFitsOnRestOfLine shortExpr longExpr)
-
-    | (t, _) :: ts ->
-        let gt = genType astContext false t
-
-        gt
-        +> ifElse ts.IsEmpty sepNone (autoNlnIfExpressionExceedsPageWidth (sepArrow +> genTypeList astContext ts))
+    expressionFitsOnRestOfLine shortExpr longExpr
 
 and genTypar astContext (Typar (s, isHead) as node) =
     ifElse isHead (ifElse astContext.IsFirstTypeParam (!- " ^") (!- "^")) (!- "'")

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4006,7 +4006,6 @@ and genTypeList astContext node =
     let gt (t, args: SynArgInfo list) =
         match t, args with
         | TTuple ts', _ ->
-            // The '/' separator shouldn't appear here
             let hasBracket = not node.IsEmpty
 
             let gt sepBefore =


### PR DESCRIPTION
Fixes #1362.
@Smaug123 having the arrows at the start or at the end is not really a big deal for Fantomas.