### PR TITLE
add missing raise for formatting functions 

### DIFF
--- a/src/Fantomas.CoreGlobalTool.Tests/CheckTests.fs
+++ b/src/Fantomas.CoreGlobalTool.Tests/CheckTests.fs
@@ -28,15 +28,9 @@ let ``formatted files should report exit code 0`` () =
     exitCode |> should equal 0
 
 [<Test>]
-let ``invalid files should report exit code 1 with check`` () =
-    use fileFixture = new TemporaryFileCodeSample(WithErrors)
-    let (exitCode, _) = checkCode fileFixture.Filename
-    exitCode |> should equal 1
-
-[<Test>]
 let ``invalid files should report exit code 1`` () =
     use fileFixture = new TemporaryFileCodeSample(WithErrors)
-    let (exitCode, _) = formatCode fileFixture.Filename
+    let (exitCode, _) = checkCode fileFixture.Filename
     exitCode |> should equal 1
 
 [<Test>]

--- a/src/Fantomas.CoreGlobalTool.Tests/CheckTests.fs
+++ b/src/Fantomas.CoreGlobalTool.Tests/CheckTests.fs
@@ -28,9 +28,15 @@ let ``formatted files should report exit code 0`` () =
     exitCode |> should equal 0
 
 [<Test>]
-let ``invalid files should report exit code 1`` () =
+let ``invalid files should report exit code 1 with check`` () =
     use fileFixture = new TemporaryFileCodeSample(WithErrors)
     let (exitCode, _) = checkCode fileFixture.Filename
+    exitCode |> should equal 1
+
+[<Test>]
+let ``invalid files should report exit code 1`` () =
+    use fileFixture = new TemporaryFileCodeSample(WithErrors)
+    let (exitCode, _) = formatCode fileFixture.Filename
     exitCode |> should equal 1
 
 [<Test>]

--- a/src/Fantomas.CoreGlobalTool.Tests/ExitCodeTests.fs
+++ b/src/Fantomas.CoreGlobalTool.Tests/ExitCodeTests.fs
@@ -1,0 +1,14 @@
+module Fantomas.CoreGlobalTool.Tests.ExitCodeTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.CoreGlobalTool.Tests.TestHelpers
+
+[<Literal>]
+let WithErrors = """let a ="""
+
+[<Test>]
+let ``invalid files should report exit code 1`` () =
+    use fileFixture = new TemporaryFileCodeSample(WithErrors)
+    let (exitCode, _) = formatCode fileFixture.Filename
+    exitCode |> should equal 1

--- a/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
+++ b/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="ByteOrderMarkTests.fs" />
     <Compile Include="ConfigTests.fs" />
     <Compile Include="IgnoreFilesTests.fs" />
+    <Compile Include="ExitCodeTests.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Fantomas.CoreGlobalTool.Tests/TestHelpers.fs
+++ b/src/Fantomas.CoreGlobalTool.Tests/TestHelpers.fs
@@ -124,3 +124,7 @@ let runFantomasTool arguments =
 let checkCode file =
     let arguments = sprintf "--check \"%s\"" file
     runFantomasTool arguments
+
+let formatCode file =
+    let arguments = sprintf "\"%s\"" file
+    runFantomasTool arguments

--- a/src/Fantomas.CoreGlobalTool/Program.fs
+++ b/src/Fantomas.CoreGlobalTool/Program.fs
@@ -307,6 +307,8 @@ let main argv =
                 File.WriteAllText(outFile, File.ReadAllText inFile)
                 printfn "Force writing original contents to %s" outFile
 
+            raise exn
+
     let stringToFile (s: string) (outFile: string) config =
         try
             let fsi = Path.GetExtension(outFile) = ".fsi"
@@ -329,6 +331,8 @@ let main argv =
                 File.WriteAllText(outFile, s)
                 printfn "Force writing original contents to %s." outFile
 
+            raise exn
+
     let stringToStdOut s config =
         try
             use buffer = new StringWriter() :> TextWriter
@@ -337,6 +341,7 @@ let main argv =
         with exn ->
             eprintfn "The following exception occurs while formatting stdin: %O" exn
             if force then stdout.Write(s)
+            raise exn
 
     let processFile inputFile outputFile =
         if inputFile <> outputFile then
@@ -376,6 +381,8 @@ let main argv =
 
             if force then
                 stdout.Write(File.ReadAllText inFile)
+
+            raise exn
 
     if Option.isSome version then
         let version = CodeFormatter.GetVersion()


### PR DESCRIPTION
fix #1340 

Running `Fantomas.CoreGlobalTool` to format a file without the `--check` argument, it does the treatment in the else listed below, calling the appropriate function given type of `inputPath` and `outputPath`.

https://github.com/fsprojects/fantomas/blob/d22dc764910040fd70412c3f3c674c6f4a5a1250/src/Fantomas.CoreGlobalTool/Program.fs#L386-L406

The problem is that when an error occurred in one of these functions, it was treated locally but not propagated, 
so the `try/with` condition that changes the error code to 1 is never achieved.

The ideal solution would be to show only the error messages in the last `try\with` and add tests for each function in the `match` expression, besides the simple test that I inserted.

What do you think @nojaf ?
