### PR TITLE
Remove invalid check for named arguments.

### DIFF
--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -1738,3 +1738,40 @@ let private tryGetUrlWithExactMatch
   else
     None
 """
+
+[<Test>]
+let ``infix equals expression in if condition expression, 1241`` () =
+    formatSourceString
+        false
+        """
+namespace SomeNamespace
+
+module SomeModule =
+
+    let SomeFunc () =
+        let someLocalFunc someVeryLooooooooooooooooooooooooooooooooooooooooooooooooongParam =
+            async {
+                if (someVeryLooooooooooooooooooooooooooooooooooooooooooooooooongParam = 1) then
+                    return failwith "xxx"
+            }
+        ()
+
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+namespace SomeNamespace
+
+module SomeModule =
+
+    let SomeFunc () =
+        let someLocalFunc someVeryLooooooooooooooooooooooooooooooooooooooooooooooooongParam =
+            async {
+                if (someVeryLooooooooooooooooooooooooooooooooooooooooooooooooongParam = 1) then
+                    return failwith "xxx"
+            }
+
+        ()
+"""

--- a/src/Fantomas.Tests/SynExprNewTests.fs
+++ b/src/Fantomas.Tests/SynExprNewTests.fs
@@ -34,7 +34,7 @@ let ``single multi line named argument instance`` () =
         false
         """
 let myInstance =
-        new EvilBadRequest(Content = new StringContent("File was too way too large",
+        new EvilBadRequest(Content = new StringContent("File was too way too large, as in waaaaaaaaaaaaaaaaaaaay tooooooooo long",
                                                       System.Text.Encoding.UTF16,
                                                       "application/text"))
 """
@@ -45,7 +45,12 @@ let myInstance =
         """
 let myInstance =
     new EvilBadRequest(
-        Content = new StringContent("File was too way too large", System.Text.Encoding.UTF16, "application/text")
+        Content =
+            new StringContent(
+                "File was too way too large, as in waaaaaaaaaaaaaaaaaaaay tooooooooo long",
+                System.Text.Encoding.UTF16,
+                "application/text"
+            )
     )
 """
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1640,10 +1640,6 @@ and genExpr astContext synExpr ctx =
                     +> indentIfNeeded sepNone
                 )
                 +> sepCloseTFor rpr
-            | InfixApp (equal, operatorExpr, e1, e2) when (equal = "=") ->
-                sepOpenTFor lpr
-                +> genNamedArgumentExpr astContext operatorExpr e1 e2
-                +> sepCloseTFor rpr
             | LetOrUses _ ->
                 sepOpenTFor lpr
                 +> atCurrentColumn (genExpr astContext e)

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1267,6 +1267,15 @@ and genExpr astContext synExpr ctx =
                 +> col sepComma args (genExpr astContext)
                 +> sepCloseTFor rpr
 
+            let genExprLong astContext e =
+                let expr e =
+                    match e with
+                    | InfixApp (equal, operatorExpr, e1, e2) when (equal = "=") ->
+                        genNamedArgumentExpr astContext operatorExpr e1 e2
+                    | _ -> genExpr astContext e
+
+                expr e
+
             let long =
                 !- "new "
                 +> genType astContext false t
@@ -1274,7 +1283,7 @@ and genExpr astContext synExpr ctx =
                 +> sepOpenTFor lpr
                 +> indent
                 +> sepNln
-                +> col (sepComma +> sepNln) args (genExpr astContext)
+                +> col (sepCommaFixed +> sepNln) args (genExprLong astContext)
                 +> unindent
                 +> sepNln
                 +> sepCloseTFor rpr


### PR DESCRIPTION
 Fixes #1241.

In #1158 I introduced a check to capture an infix application inside the parenthesis.
This was assuming that the parenthesises were part of [SynExpr.New](https://fsharp.github.io/FSharp.Compiler.Service/reference/fsharp-compiler-syntaxtree-synexpr.html).
This check was a bit naive as that expression can occur in other places as well.
(Part of the IfThenElse in this case).

Then in #1256, I introduce some active patterns `NewTuple` and `AppTuple` that are the only valid use cases for the `genNamedArgumentExpr` function.
This PR fixes this.
