### PR TITLE
Bug 1223 Starting of multi-line comments should be not moved when are alone "(*"

### DIFF
--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -1119,7 +1119,7 @@ let ``starting of a multi-line comment should not be removed (with Begin of Comm
         """
 module Foo =
     let v1 = method7
-            (* Begin of Comment 
+            (* Begin of Comment
        Body of Comment
              *)
     printf "Hello World!"

--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -1111,3 +1111,88 @@ namespace Foo
 module Bar =
     let Baz () = ()
 """
+
+[<Test>]
+let ``starting of a multi-line comment should not be removed (with Begin of Comment), 1223`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let v1 = method7
+            (* Begin of Comment 
+       Body of Comment
+             *)
+    printf "Hello World!"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let v1 = method7
+    (* Begin of Comment
+       Body of Comment
+             *)
+    printf "Hello World!"
+"""
+
+[<Test>]
+let ``starting of a multi-line comment should not be removed (withOut Begin of Comment), 1223`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let v1 = method7
+            (*
+       Body of Comment
+*)
+    printf "Hello World!"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let v1 = method7
+(*
+       Body of Comment
+*)
+    printf "Hello World!"
+"""
+
+[<Test>]
+let ``starting of a multi-line comment should not be removed`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let private GetConfirmedEtherBalanceInternal (web3: Web3) (publicAddress: string): Async<HexBigInteger> =
+        async {
+             let! blockForConfirmationReference = GetBlockToCheckForConfirmedBalance web3
+(*
+             if (Config.DebugLog) then
+                 Infrastructure.LogError (SPrintF2 "Last block number and last confirmed block number: %s: %s"
+                                                  (latestBlock.Value.ToString()) (blockForConfirmationReference.BlockNumber.Value.ToString()))
+ *)
+            return blockForConfirmationReference
+        }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let private GetConfirmedEtherBalanceInternal (web3: Web3) (publicAddress: string): Async<HexBigInteger> =
+        async {
+            let! blockForConfirmationReference = GetBlockToCheckForConfirmedBalance web3
+(*
+             if (Config.DebugLog) then
+                 Infrastructure.LogError (SPrintF2 "Last block number and last confirmed block number: %s: %s"
+                                                  (latestBlock.Value.ToString()) (blockForConfirmationReference.BlockNumber.Value.ToString()))
+ *)
+            return blockForConfirmationReference
+        }
+"""

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -84,6 +84,10 @@ module WriterModel =
                 { m with
                       Lines = "" :: m.Lines
                       Column = 0 }
+            | Write s when s.Equals("(*") ->
+                { m with
+                      Lines = (s) :: (List.tail m.Lines)
+                      Column = m.Column + (String.length s) }
             | Write s ->
                 { m with
                       Lines = (List.head m.Lines + s) :: (List.tail m.Lines)


### PR DESCRIPTION
@nojaf I'm trying to solve the bug 1223. As far I can see, when multiline comment starts with the token"(*" alone in the line, this token should be moved to the first column of the line. If the comment starts with the token "(*" plus any string, this should respect the Fantomas indentation rules. I have created three test that address this issue. Any comment, please let me know.