### PR TITLE
Rename MultiLineLambdaClosingNewline to MultilineLambdaClosingNewline

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -93,7 +93,7 @@ fsharp_single_argument_web_mode=false
 fsharp_align_function_signature_to_indentation=false
 fsharp_alternative_long_member_definitions=false
 fsharp_disable_elmish_syntax=false
-fsharp_multi_line_lambda_closing_newline=false
+fsharp_multiline_lambda_closing_newline=false
 fsharp_strict_mode=false
 ```
 
@@ -978,7 +978,7 @@ let encodeUrlModel code model: JsonValue =
           "code", Encode.string code ]
 ```
 
-### fsharp_multi_line_lambda_closing_newline
+### fsharp_multiline_lambda_closing_newline
 
 Places the closing parenthesis of a multiline lambda argument on the next line.
 Default = false.

--- a/src/Fantomas.Tests/FormatConfigEditorConfigurationFileTests.fs
+++ b/src/Fantomas.Tests/FormatConfigEditorConfigurationFileTests.fs
@@ -369,10 +369,10 @@ end_of_line = %s
     config.EndOfLine == eol
 
 [<Test>]
-let fsharp_multiLine_lambda_closing_newline () =
+let fsharp_multiline_lambda_closing_newline () =
     let editorConfig = """
 [*.fs]
-fsharp_multi_line_lambda_closing_newline = true
+fsharp_multiline_lambda_closing_newline = true
 """
 
     use configFixture =
@@ -383,4 +383,4 @@ fsharp_multi_line_lambda_closing_newline = true
     let config =
         EditorConfig.readConfiguration fsharpFile.FSharpFile
 
-    Assert.IsTrue config.MultiLineLambdaClosingNewline
+    Assert.IsTrue config.MultilineLambdaClosingNewline

--- a/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -1,4 +1,4 @@
-module Fantomas.Tests.MultiLineLambdaClosingNewlineTests
+module Fantomas.Tests.MultilineLambdaClosingNewlineTests
 
 open NUnit.Framework
 open FsUnit
@@ -8,7 +8,7 @@ let defaultConfig = config
 
 let config =
     { config with
-          MultiLineLambdaClosingNewline = true }
+          MultilineLambdaClosingNewline = true }
 
 [<Test>]
 let ``function with single multiline lambda`` () =

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3011,7 +3011,7 @@ and genApp appNlnFun astContext e es ctx =
     let shouldHaveAlternativeLambdaStyle =
         let hasLambdas = List.exists isParenLambda es
 
-        ctx.Config.MultiLineLambdaClosingNewline
+        ctx.Config.MultilineLambdaClosingNewline
         && hasLambdas
 
     let longExpression =

--- a/src/Fantomas/FormatConfig.fs
+++ b/src/Fantomas/FormatConfig.fs
@@ -90,7 +90,7 @@ type FormatConfig =
       SingleArgumentWebMode: bool
       AlignFunctionSignatureToIndentation: bool
       AlternativeLongMemberDefinitions: bool
-      MultiLineLambdaClosingNewline: bool
+      MultilineLambdaClosingNewline: bool
       DisableElmishSyntax: bool
       EndOfLine: EndOfLineStyle
       /// Pretty printing based on ASTs only
@@ -129,7 +129,7 @@ type FormatConfig =
           SingleArgumentWebMode = false
           AlignFunctionSignatureToIndentation = false
           AlternativeLongMemberDefinitions = false
-          MultiLineLambdaClosingNewline = false
+          MultilineLambdaClosingNewline = false
           DisableElmishSyntax = false
           EndOfLine = EndOfLineStyle.FromEnvironment
           StrictMode = false }


### PR DESCRIPTION
For consistency with the other older setting named
'MultilineBlockBracketsOnSameColumn', it's better to rename
this new one.