### PR TITLE
Add SynConst nodes to TriviaNodes.

### DIFF
--- a/src/Fantomas.Tests/TriviaTests.fs
+++ b/src/Fantomas.Tests/TriviaTests.fs
@@ -406,7 +406,7 @@ with empty lines"
 
     match trivia with
     | [ { ContentItself = Some (StringContent (sc))
-          Type = TriviaNodeType.MainNode (SynExpr_Const) } ] -> sc == sprintf "\"%s\"" multilineString
+          Type = TriviaNodeType.MainNode (SynConst_String) } ] -> sc == sprintf "\"%s\"" multilineString
     | _ -> fail ()
 
 [<Test>]
@@ -426,7 +426,7 @@ with empty lines"
 
     match trivia with
     | [ { ContentItself = Some (StringContent (sc))
-          Type = TriviaNodeType.MainNode (SynExpr_Const) } ] -> sc == sprintf "\"\"\"%s\"\"\"" multilineString
+          Type = TriviaNodeType.MainNode (SynConst_String) } ] -> sc == sprintf "\"\"\"%s\"\"\"" multilineString
     | _ -> fail ()
 
 [<Test>]
@@ -436,7 +436,7 @@ let ``char content`` () =
 
     match trivia with
     | [ { ContentItself = Some (CharContent ("\'\\u0000\'"))
-          Type = TriviaNodeType.MainNode (SynExpr_Const) } ] -> pass ()
+          Type = TriviaNodeType.MainNode (SynConst_Char) } ] -> pass ()
     | _ -> fail ()
 
 [<Test>]

--- a/src/Fantomas/AstTransformer.fs
+++ b/src/Fantomas/AstTransformer.fs
@@ -128,13 +128,13 @@ module private Ast =
         | SynModuleDecl.Open (target, parentRange) ->
             // we use the parent ranges here to match up with the trivia parsed
             match target with
-            | SynOpenDeclTarget.ModuleOrNamespace (longIdent, range) ->
+            | SynOpenDeclTarget.ModuleOrNamespace (longIdent, _range) ->
                 { Type = SynModuleDecl_Open
                   Range = r parentRange
                   Properties = p [ "longIdent" ==> li longIdent ]
                   FsAstNode = ast
                   Childs = [] }
-            | SynOpenDeclTarget.Type (synType, range) ->
+            | SynOpenDeclTarget.Type (synType, _range) ->
                 { Type = SynModuleDecl_OpenType
                   Range = r parentRange
                   Properties = p []
@@ -183,9 +183,9 @@ module private Ast =
         | SynExpr.Const (constant, range) ->
             { Type = SynExpr_Const
               Range = r range
-              Properties = p [ "constant" ==> visitSynConst constant ]
+              Properties = p []
               FsAstNode = synExpr
-              Childs = [] }
+              Childs = [ visitSynConst range constant ] }
         | SynExpr.Typed (expr, typeName, range) ->
             { Type = SynExpr_Typed
               Range = r range
@@ -853,13 +853,13 @@ module private Ast =
         | SynMemberDefn.Open (target, parentRange) ->
             // we use the parent ranges here to match up with the trivia parsed
             match target with
-            | SynOpenDeclTarget.ModuleOrNamespace (longIdent, range) ->
+            | SynOpenDeclTarget.ModuleOrNamespace (longIdent, _range) ->
                 { Type = SynMemberDefn_Open
                   Range = r parentRange
                   Properties = p [ "longIdent" ==> li longIdent ]
                   FsAstNode = target
                   Childs = [] }
-            | SynOpenDeclTarget.Type (synType, range) ->
+            | SynOpenDeclTarget.Type (synType, _range) ->
                 { Type = SynMemberDefn_OpenType
                   Range = r parentRange
                   Properties = p []
@@ -1122,9 +1122,9 @@ module private Ast =
         | SynPat.Const (sc, range) ->
             { Type = SynPat_Const
               Range = r range
-              Properties = p [ "const" ==> visitSynConst sc ]
+              Properties = p []
               FsAstNode = sp
-              Childs = [] }
+              Childs = [ visitSynConst range sc ] }
         | SynPat.Wild (range) ->
             { Type = SynPat_Wild
               Range = r range
@@ -1659,9 +1659,9 @@ module private Ast =
         | SynType.StaticConstant (constant, range) ->
             { Type = SynType_StaticConstant
               Range = r range
-              Properties = p [ "constant" ==> visitSynConst constant ]
+              Properties = p []
               FsAstNode = st
-              Childs = [] }
+              Childs = [ visitSynConst range constant ] }
         | SynType.StaticConstantExpr (expr, range) ->
             { Type = SynType_StaticConstantExpr
               Range = r range
@@ -1689,7 +1689,36 @@ module private Ast =
               FsAstNode = st
               Childs = [ yield visitSynType innerType ] }
 
-    and visitSynConst (sc: SynConst) = sprintf "%A" sc
+    and visitSynConst (parentRange: range) (sc: SynConst) =
+        let t =
+            match sc with
+            | SynConst.Bool _ -> SynConst_Bool
+            | SynConst.Unit _ -> SynConst_Unit
+            | SynConst.SByte _ -> SynConst_SByte
+            | SynConst.Byte _ -> SynConst_Byte
+            | SynConst.Int16 _ -> SynConst_Int16
+            | SynConst.UInt16 _ -> SynConst_UInt16
+            | SynConst.Int32 _ -> SynConst_Int32
+            | SynConst.UInt32 _ -> SynConst_UInt32
+            | SynConst.Int64 _ -> SynConst_Int64
+            | SynConst.UInt64 _ -> SynConst_UInt64
+            | SynConst.IntPtr _ -> SynConst_IntPtr
+            | SynConst.UIntPtr _ -> SynConst_UIntPtr
+            | SynConst.Single _ -> SynConst_Single
+            | SynConst.Double _ -> SynConst_Double
+            | SynConst.Char _ -> SynConst_Char
+            | SynConst.Decimal _ -> SynConst_Decimal
+            | SynConst.UserNum _ -> SynConst_UserNum
+            | SynConst.String _ -> SynConst_String
+            | SynConst.Bytes _ -> SynConst_Bytes
+            | SynConst.UInt16s _ -> SynConst_UInt16s
+            | SynConst.Measure _ -> SynConst_Measure
+
+        { Type = t
+          Range = r (sc.Range parentRange)
+          Properties = p []
+          FsAstNode = sc
+          Childs = [] }
 
     and visitSynValInfo (svi: SynValInfo) =
         match svi with
@@ -1808,13 +1837,13 @@ module private Ast =
         | SynModuleSigDecl.Open (target, parentRange) ->
             // we use the parent ranges here to match up with the trivia parsed
             match target with
-            | SynOpenDeclTarget.ModuleOrNamespace (longIdent, range) ->
+            | SynOpenDeclTarget.ModuleOrNamespace (longIdent, _range) ->
                 { Type = SynModuleSigDecl_Open
                   Range = r parentRange
                   Properties = p [ "longIdent" ==> li longIdent ]
                   FsAstNode = target
                   Childs = [] }
-            | SynOpenDeclTarget.Type (synType, range) ->
+            | SynOpenDeclTarget.Type (synType, _range) ->
                 { Type = SynModuleSigDecl_OpenType
                   Range = r parentRange
                   Properties = p []

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -192,12 +192,12 @@ let private findConstNodeOnLineAndColumn (nodes: TriviaNodeAssigner list) (const
                 && tn.Range.EndColumn = constantRange.EndColumn
             | _ -> false)
 
-let private findConstNodeAfter (nodes: TriviaNodeAssigner list) (range: range) =
+let private findSynConstStringNodeAfter (nodes: TriviaNodeAssigner list) (range: range) =
     nodes
     |> List.tryFind
         (fun tn ->
             match tn.Type, range.StartLine = tn.Range.StartLine, range.StartColumn + 1 = tn.Range.StartColumn with
-            | MainNode (SynExpr_Const), true, true -> true
+            | MainNode (SynConst_String), true, true -> true
             | _ -> false)
 
 let private mapNodeToTriviaNode (node: Node) =
@@ -419,7 +419,7 @@ let private addTriviaToTriviaNode
 
     | { Item = Keyword ({ TokenInfo = { TokenName = tn } } as kw)
         Range = range } when (tn = "QMARK") ->
-        findConstNodeAfter triviaNodes range
+        findSynConstStringNodeAfter triviaNodes range
         |> updateTriviaNode (fun tn -> tn.ContentBefore.Add(Keyword(kw))) triviaNodes
 
     | { Item = Keyword ({ Content = keyword })
@@ -504,7 +504,7 @@ let private addTriviaToTriviaNode
                     | MainNode (SynPat_Named)
                     | MainNode (SynPat_LongIdent)
                     | MainNode (Ident_)
-                    | MainNode (SynExpr_Const) -> true
+                    | MainNode (SynConst_String) -> true
                     | _ -> false
 
                 isIdent

--- a/src/Fantomas/TriviaHelpers.fs
+++ b/src/Fantomas/TriviaHelpers.fs
@@ -121,8 +121,8 @@ module internal TriviaHelpers =
                 && contentItSelfIsMultilineString ())
 
     let ``get CharContent`` range (nodes: Map<FsAstType, TriviaNode list>) =
-        getNodesForTypes [ SynExpr_Const; SynPat_Const ] nodes
-        |> List.tryFind (fun tv -> RangeHelpers.rangeEq tv.Range range)
+        Map.tryFindOrEmptyList SynConst_Char nodes
+        |> List.tryFind (fun t -> RangeHelpers.rangeEq t.Range range)
         |> Option.bind
             (fun tv ->
                 match tv.ContentItself with

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -237,6 +237,27 @@ type FsAstType =
     | SynPat_DeprecatedCharRange
     | SynPat_InstanceMember
     | SynPat_FromParseError
+    | SynConst_Bool
+    | SynConst_Unit
+    | SynConst_SByte
+    | SynConst_Byte
+    | SynConst_Int16
+    | SynConst_UInt16
+    | SynConst_Int32
+    | SynConst_UInt32
+    | SynConst_Int64
+    | SynConst_UInt64
+    | SynConst_IntPtr
+    | SynConst_UIntPtr
+    | SynConst_Single
+    | SynConst_Double
+    | SynConst_Char
+    | SynConst_Decimal
+    | SynConst_UserNum
+    | SynConst_String
+    | SynConst_Bytes
+    | SynConst_UInt16s
+    | SynConst_Measure
     | Pats_
     | NamePatPairs_
     | ComponentInfo_


### PR DESCRIPTION
Related to #1372. 
Characters in F# will always be `SynConst.Char`, we never consider using SynConst as trivia nodes so that is why we worked with the parent nodes (SynExpr.Const and SynPat.Const). However, the is not correct and we should use the appropriate nodes instead.
