### PR TITLE
Remove IsInsideDotGet and IsInsideDotIndexed

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -466,7 +466,7 @@ let longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNa
 System.String.Concat(
     "a",
     "b"
-    + longNamedFunlongNamedFunlongNamedFunlongNamedFunlongNamedFun (
+    + longNamedFunlongNamedFunlongNamedFunlongNamedFunlongNamedFun(
         longNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClasslongNamedClass
     )
         .Property

--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -419,7 +419,9 @@ let start (args: IArgs) =
                 .CreateDefaultBuilder()
                 .UseWebRoot(args.ClientPath)
 #if DEBUG
-                .UseContentRoot(args.ContentRoot)
+                .UseContentRoot(
+                    args.ContentRoot
+                )
                 .UseUrls(args.Host + ":" + string args.Port)
 #endif
                 .UseSerilog()
@@ -642,7 +644,7 @@ type FunctionComponent =
                 (fun () ->
                     // React.lazy requires a default export
                     (importValueDynamic f)
-                        .``then``(fun x -> createObj [ "default" ==> x ]))
+                        .``then`` (fun x -> createObj [ "default" ==> x ]))
 
         fun props ->
             ReactElementType.create
@@ -863,7 +865,7 @@ type FunctionComponent =
                 (fun () ->
                     // React.lazy requires a default export
                     (importValueDynamic f)
-                        .``then``(fun x -> createObj [ "default" ==> x ]))
+                        .``then`` (fun x -> createObj [ "default" ==> x ]))
 
         fun props ->
             ReactElementType.create

--- a/src/Fantomas.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Tests/ControlStructureTests.fs
@@ -712,7 +712,7 @@ let ``keep new line before for loop, 1317`` () =
 
       state
 """
-        config
+        { config with MaxDotGetExpressionWidth = 60 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Tests/ControlStructureTests.fs
@@ -712,7 +712,8 @@ let ``keep new line before for loop, 1317`` () =
 
       state
 """
-        { config with MaxDotGetExpressionWidth = 60 }
+        { config with
+              MaxDotGetExpressionWidth = 60 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -456,3 +456,109 @@ let getColl4 =
             x)
         .Foo
 """
+
+[<Test>]
+let ``comment between chained call`` () =
+    formatSourceString false """
+Log
+    .Foo()
+    // Bar
+    .Poo()
+"""  config
+    |> prepend newline
+    |> should equal """
+Log
+    .Foo()
+    // Bar
+    .Poo()
+"""
+
+[<Test>]
+let ``short DotGetApp with unit`` () =
+    formatSourceString false """
+Foo().Bar()
+"""  config
+    |> prepend newline
+    |> should equal """
+Foo().Bar()
+"""
+
+[<Test>]
+let ``short DotGetApp with lowercase function name and unit`` () =
+    formatSourceString false """
+Foo().bar()
+"""  config
+    |> prepend newline
+    |> should equal """
+Foo().bar ()
+"""
+
+[<Test>]
+let ``short DotGetApp with constant`` () =
+    formatSourceString false """
+Foo().Bar "meh"
+"""  config
+    |> prepend newline
+    |> should equal """
+Foo().Bar "meh"
+"""
+
+[<Test>]
+let ``short DotGetApp with property`` () =
+    formatSourceString false """
+Foo().Bar().Length
+"""  config
+    |> prepend newline
+    |> should equal """
+Foo().Bar().Length
+"""
+
+[<Test>]
+let ``short DotGetApp with multiline idents and constant`` () =
+    formatSourceString false """
+MyModule.Foo().Bar()
+"""  config
+    |> prepend newline
+    |> should equal """
+MyModule.Foo().Bar()
+"""
+
+[<Test>]
+let ``short DotGet TypedApp`` () =
+    formatSourceString false """
+typeof<System.Collections.IEnumerable>.FullName
+"""  config
+    |> prepend newline
+    |> should equal """
+typeof<System.Collections.IEnumerable>.FullName
+"""
+
+[<Test>]
+let ``short DotGet with lambda`` () =
+    formatSourceString false """
+Foo(fun x -> x).Bar()
+"""  config
+    |> prepend newline
+    |> should equal """
+Foo(fun x -> x).Bar()
+"""
+
+[<Test>]
+let ``named argument inside DotGet application`` () =
+    formatSourceString false """
+SomeFunction(name = SearchForName(
+    "foooooooooooooooooooooooooooooooooooooooooooooooooo",
+    "baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar"
+)).ChainedFunctionCall()
+"""  config
+    |> prepend newline
+    |> should equal """
+SomeFunction(
+    name =
+        SearchForName(
+            "foooooooooooooooooooooooooooooooooooooooooooooooooo",
+            "baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar"
+        )
+)
+    .ChainedFunctionCall()
+"""

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -459,14 +459,19 @@ let getColl4 =
 
 [<Test>]
 let ``comment between chained call`` () =
-    formatSourceString false """
+    formatSourceString
+        false
+        """
 Log
     .Foo()
     // Bar
     .Poo()
-"""  config
+"""
+        config
     |> prepend newline
-    |> should equal """
+    |> should
+        equal
+        """
 Log
     .Foo()
     // Bar
@@ -475,84 +480,124 @@ Log
 
 [<Test>]
 let ``short DotGetApp with unit`` () =
-    formatSourceString false """
+    formatSourceString
+        false
+        """
 Foo().Bar()
-"""  config
+"""
+        config
     |> prepend newline
-    |> should equal """
+    |> should
+        equal
+        """
 Foo().Bar()
 """
 
 [<Test>]
 let ``short DotGetApp with lowercase function name and unit`` () =
-    formatSourceString false """
+    formatSourceString
+        false
+        """
 Foo().bar()
-"""  config
+"""
+        config
     |> prepend newline
-    |> should equal """
+    |> should
+        equal
+        """
 Foo().bar ()
 """
 
 [<Test>]
 let ``short DotGetApp with constant`` () =
-    formatSourceString false """
+    formatSourceString
+        false
+        """
 Foo().Bar "meh"
-"""  config
+"""
+        config
     |> prepend newline
-    |> should equal """
+    |> should
+        equal
+        """
 Foo().Bar "meh"
 """
 
 [<Test>]
 let ``short DotGetApp with property`` () =
-    formatSourceString false """
+    formatSourceString
+        false
+        """
 Foo().Bar().Length
-"""  config
+"""
+        config
     |> prepend newline
-    |> should equal """
+    |> should
+        equal
+        """
 Foo().Bar().Length
 """
 
 [<Test>]
 let ``short DotGetApp with multiline idents and constant`` () =
-    formatSourceString false """
+    formatSourceString
+        false
+        """
 MyModule.Foo().Bar()
-"""  config
+"""
+        config
     |> prepend newline
-    |> should equal """
+    |> should
+        equal
+        """
 MyModule.Foo().Bar()
 """
 
 [<Test>]
 let ``short DotGet TypedApp`` () =
-    formatSourceString false """
+    formatSourceString
+        false
+        """
 typeof<System.Collections.IEnumerable>.FullName
-"""  config
+"""
+        config
     |> prepend newline
-    |> should equal """
+    |> should
+        equal
+        """
 typeof<System.Collections.IEnumerable>.FullName
 """
 
 [<Test>]
 let ``short DotGet with lambda`` () =
-    formatSourceString false """
+    formatSourceString
+        false
+        """
 Foo(fun x -> x).Bar()
-"""  config
+"""
+        config
     |> prepend newline
-    |> should equal """
+    |> should
+        equal
+        """
 Foo(fun x -> x).Bar()
 """
 
 [<Test>]
 let ``named argument inside DotGet application`` () =
-    formatSourceString false """
+    formatSourceString
+        false
+        """
 SomeFunction(name = SearchForName(
     "foooooooooooooooooooooooooooooooooooooooooooooooooo",
     "baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar"
 )).ChainedFunctionCall()
-"""  config
+"""
+        config
     |> prepend newline
-    |> should equal """
+    |> should
+        equal
+        """
 SomeFunction(
     name =
         SearchForName(

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -20,9 +20,11 @@ Microsoft
     .FSharp
     .Reflection
     .FSharpType
-    .GetUnionCases(typeof<option<option<unit>>>
-        .GetGenericTypeDefinition()
-        .MakeGenericType(t))
+    .GetUnionCases(
+        typeof<option<option<unit>>>
+            .GetGenericTypeDefinition()
+            .MakeGenericType(t)
+    )
     .Assembly
 """
 
@@ -42,11 +44,13 @@ System.Diagnostics.FileVersionInfo.GetVersionInfo(
 System
     .Diagnostics
     .FileVersionInfo
-    .GetVersionInfo(System
-        .Reflection
-        .Assembly
-        .GetExecutingAssembly()
-        .Location)
+    .GetVersionInfo(
+        System
+            .Reflection
+            .Assembly
+            .GetExecutingAssembly()
+            .Location
+    )
     .FileVersion
 """
 
@@ -72,11 +76,13 @@ root.SetAttribute(
     + System
         .Diagnostics
         .FileVersionInfo
-        .GetVersionInfo(System
-            .Reflection
-            .Assembly
-            .GetExecutingAssembly()
-            .Location)
+        .GetVersionInfo(
+            System
+                .Reflection
+                .Assembly
+                .GetExecutingAssembly()
+                .Location
+        )
         .FileVersion
 )
 """
@@ -95,7 +101,14 @@ Equinox.EventStore.Resolver<'event, 'state, _>(gateway, codec, fold, initial, ca
         """
 Equinox
     .EventStore
-    .Resolver<'event, 'state, _>(gateway, codec, fold, initial, cacheStrategy, accessStrategy)
+    .Resolver<'event, 'state, _>(
+        gateway,
+        codec,
+        fold,
+        initial,
+        cacheStrategy,
+        accessStrategy
+    )
     .Resolve
 """
 
@@ -146,7 +159,12 @@ module Services =
             | Storage.MemoryStore store ->
                 Equinox
                     .MemoryStore
-                    .Resolver(store, FsCodec.Box.Codec.Create(), fold, initial)
+                    .Resolver(
+                        store,
+                        FsCodec.Box.Codec.Create(),
+                        fold,
+                        initial
+                    )
                     .Resolve
             | Storage.EventStore (gateway, cache) ->
                 let accessStrategy =
@@ -157,7 +175,14 @@ module Services =
 
                 Equinox
                     .EventStore
-                    .Resolver<'event, 'state, _>(gateway, codec, fold, initial, cacheStrategy, accessStrategy)
+                    .Resolver<'event, 'state, _>(
+                        gateway,
+                        codec,
+                        fold,
+                        initial,
+                        cacheStrategy,
+                        accessStrategy
+                    )
                     .Resolve
 """
 
@@ -304,7 +329,12 @@ Equinox.MemoryStore.Resolver(store, FsCodec.Box.Codec.Create(), fold, initial)
         """
 Equinox
     .MemoryStore
-    .Resolver(store, FsCodec.Box.Codec.Create(), fold, initial)
+    .Resolver(
+        store,
+        FsCodec.Box.Codec.Create(),
+        fold,
+        initial
+    )
     .Resolve
 """
 
@@ -328,7 +358,14 @@ let ``long ident with dots inside type app inside dotget`` () =
         """
 Equinox
     .EventStore
-    .Resolver<'event, 'state, _>(gateway, codec, fold, initial, cacheStrategy, accessStrategy)
+    .Resolver<'event, 'state, _>(
+        gateway,
+        codec,
+        fold,
+        initial,
+        cacheStrategy,
+        accessStrategy
+    )
     .Resolve
 """
 

--- a/src/Fantomas.Tests/DotIndexedGetTests.fs
+++ b/src/Fantomas.Tests/DotIndexedGetTests.fs
@@ -1,0 +1,72 @@
+module Fantomas.Tests.DotIndexedGetTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Tests.TestHelper
+
+[<Test>]
+let ``multiline function application inside DotIndexedGet`` () =
+    formatSourceString
+        false
+        """
+foo.Bar(
+            ziggy,
+            jiggy,
+            "looooooooooooooooooooooooooooooooonStringValue"
+        ).[5]
+"""
+        { config with MaxLineLength = 70 }
+    |> prepend newline
+    |> should
+        equal
+        """
+foo.Bar(
+    ziggy,
+    jiggy,
+    "looooooooooooooooooooooooooooooooonStringValue"
+).[5]
+"""
+
+[<Test>]
+let ``multiline function application after indexer`` () =
+    formatSourceString
+        false
+        """
+myList.[7].SomeFunctionCallOnSeven("looooooooooooooooooooooooooooooooonnggggStringArgument", otherArg1, otherArg2, otherArg3, otherArgument4)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+myList.[7]
+    .SomeFunctionCallOnSeven(
+        "looooooooooooooooooooooooooooooooonnggggStringArgument",
+        otherArg1,
+        otherArg2,
+        otherArg3,
+        otherArgument4
+    )
+"""
+
+[<Test>]
+let ``multiline lowercased function application after indexer`` () =
+    formatSourceString
+        false
+        """
+myList.[7].lowerSomeFunctionCallOnSeven("looooooooooooooooooooooooooooooooonnggggStringArgument", otherArg1, otherArg2, otherArg3, otherArgument4)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+myList.[7]
+    .lowerSomeFunctionCallOnSeven(
+        "looooooooooooooooooooooooooooooooonnggggStringArgument",
+        otherArg1,
+        otherArg2,
+        otherArg3,
+        otherArgument4
+    )
+"""

--- a/src/Fantomas.Tests/DotIndexedSetTests.fs
+++ b/src/Fantomas.Tests/DotIndexedSetTests.fs
@@ -1,0 +1,49 @@
+module Fantomas.Tests.DotIndexedSetTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Tests.TestHelper
+
+[<Test>]
+let ``multiline expression should indent`` () =
+    formatSourceString
+        false
+        """
+foo.Bar().[5] <- someReallyLongFunctionCall("loooooooooooooooongggStringArg",otherArg, otherReallyLongArgument)
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+foo.Bar().[5] <-
+    someReallyLongFunctionCall (
+        "loooooooooooooooongggStringArg",
+        otherArg,
+        otherReallyLongArgument
+    )
+"""
+
+[<Test>]
+let ``multiline expression application call in set expression`` () =
+    formatSourceString
+        false
+        """
+foo.Bar("loooooooooooooooongggStringArg",otherArg, otherReallyLongArgument).[5] <- someReallyLongFunctionCall("loooooooooooooooongggStringArg",otherArg, otherReallyLongArgument)
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+foo.Bar(
+    "loooooooooooooooongggStringArg",
+    otherArg,
+    otherReallyLongArgument
+).[5] <-
+    someReallyLongFunctionCall (
+        "loooooooooooooooongggStringArg",
+        otherArg,
+        otherReallyLongArgument
+    )
+"""

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -82,6 +82,8 @@
     <Compile Include="MultiLineLambdaClosingNewlineTests.fs" />
     <Compile Include="OpenTypeTests.fs" />
     <Compile Include="CodeFormatterTests.fs" />
+    <Compile Include="DotIndexedGetTests.fs" />
+    <Compile Include="DotIndexedSetTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Extras\Fantomas.Extras.fsproj" />

--- a/src/Fantomas.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Tests/FunctionDefinitionTests.fs
@@ -293,12 +293,15 @@ let ``should indent fun blocks`` () =
 let ``should not add spaces into a series of function application`` () =
     formatSourceString
         false
-        """let f x = "d"
+        """
+let f x = "d"
 f(1).Contains("3")"""
         config
+    |> prepend newline
     |> should
         equal
-        """let f x = "d"
+        """
+let f x = "d"
 f(1).Contains("3")
 """
 

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -1242,8 +1242,9 @@ let x =
            info.ProvidedType.PUntaint(
                (fun st ->
                    (st :> IProvidedCustomAttributeProvider)
-                       .GetHasTypeProviderEditorHideMethodsAttribute(info.ProvidedType.TypeProvider.PUntaintNoFailure
-                                                                         (id))),
+                       .GetHasTypeProviderEditorHideMethodsAttribute(
+                           info.ProvidedType.TypeProvider.PUntaintNoFailure(id)
+                       )),
                m
            )
        | _ ->
@@ -1276,8 +1277,11 @@ let ``app tuple inside dotget expression`` () =
         equal
         """
 (st :> IProvidedCustomAttributeProvider)
-    .GetHasTypeProviderEditorHideMethodsAttribute(info.ProvidedType.TypeProvider.PUntaintNoFailure
-                                                      (id))
+    .GetHasTypeProviderEditorHideMethodsAttribute(
+        info.ProvidedType.TypeProvider.PUntaintNoFailure(
+            id
+        )
+    )
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/LongIdentWithDotsTests.fs
+++ b/src/Fantomas.Tests/LongIdentWithDotsTests.fs
@@ -50,10 +50,12 @@ Log.Logger <-
     LoggerConfiguration()
         // Suave.SerilogExtensions has native destructuring mechanism
         // this helps Serilog deserialize the fsharp types like unions/records
-        .Destructure.FSharpTypes()
+        .Destructure
+        .FSharpTypes()
         // use package Serilog.Sinks.Console
         // https://github.com/serilog/serilog-sinks-console
-        .WriteTo.Console()
+        .WriteTo
+        .Console()
         // add more sinks etc.
         .CreateLogger()
 """
@@ -138,8 +140,9 @@ let main _ =
                 .UseConfiguration(config)
                 .UseKestrel()
                 .UseSerilog()
-                .ConfigureAppConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder>
-                                               configureAppConfiguration)
+                .ConfigureAppConfiguration(
+                    Action<WebHostBuilderContext, IConfigurationBuilder> configureAppConfiguration
+                )
                 .ConfigureServices(Action<WebHostBuilderContext, IServiceCollection> configureServices)
                 .Configure(Action<IApplicationBuilder> configureApp)
                 .Build()

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -177,8 +177,10 @@ let ``should break on . operator and keep indentation`` () =
         equal
         """let pattern =
     (x + y)
-        .Replace(seperator + "**" + seperator,
-                 replacementSeparator + "(.|?" + replacementSeparator + ")?")
+        .Replace(
+            seperator + "**" + seperator,
+            replacementSeparator + "(.|?" + replacementSeparator + ")?"
+        )
         .Replace("**" + seperator, ".|(?<=^|" + replacementSeparator + ")")
 """
 
@@ -211,7 +213,7 @@ let ``should not add space around ? operator`` () =
     formatSourceString false """let x = y?z.d?c.[2]?d.xpto()""" config
     |> should
         equal
-        """let x = y?z.d?c.[2]?d.xpto()
+        """let x = y?z.d?c.[2]?d.xpto ()
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -426,8 +426,8 @@ let ``meaningful space should be preserved, 353`` () =
     |> should
         equal
         """
-to'
-    .WithCommon(fun o' ->
+to'.WithCommon
+    (fun o' ->
         { dotnetOptions o' with
               WorkingDirectory = Path.getFullName "RegressionTesting/issue29"
               Verbosity = Some DotNet.Verbosity.Minimal })

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -595,7 +595,7 @@ I wanted to know why you created Fable. Did you always plan to use F#? Or were y
                                  Firstname = \"Guest\"
                                  Surname = \"\"
                                  Avatar = \"guest.png\" } |] })
-            .write()
+            .write ()
 
         Logger.debug \"Database restored\"
 "

--- a/src/Fantomas.Tests/SpaceBeforeUppercaseInvocationTests.fs
+++ b/src/Fantomas.Tests/SpaceBeforeUppercaseInvocationTests.fs
@@ -47,12 +47,19 @@ let v2 = OtherFunction().Member
 """
 
 [<Test>]
-let ``spaceBeforeUppercaseInvocation should not have impact when member is called after construction invocation, 1401`` () =
-    formatSourceString false """
+let ``spaceBeforeUppercaseInvocation should not have impact when member is called after construction invocation, 1401``
+    ()
+    =
+    formatSourceString
+        false
+        """
 let x = DateTimeOffset(2017,6,1,10,3,14,TimeSpan(1,30,0)).LocalDateTime
-"""  spaceBeforeConfig
+"""
+        spaceBeforeConfig
     |> prepend newline
-    |> should equal """
+    |> should
+        equal
+        """
 let x =
     DateTimeOffset(
         2017,

--- a/src/Fantomas.Tests/SpaceBeforeUppercaseInvocationTests.fs
+++ b/src/Fantomas.Tests/SpaceBeforeUppercaseInvocationTests.fs
@@ -46,6 +46,26 @@ let ``spaceBeforeUppercaseInvocation should not have impact when member is calle
 let v2 = OtherFunction().Member
 """
 
+[<Test>]
+let ``spaceBeforeUppercaseInvocation should not have impact when member is called after construction invocation, 1401`` () =
+    formatSourceString false """
+let x = DateTimeOffset(2017,6,1,10,3,14,TimeSpan(1,30,0)).LocalDateTime
+"""  spaceBeforeConfig
+    |> prepend newline
+    |> should equal """
+let x =
+    DateTimeOffset(
+        2017,
+        6,
+        1,
+        10,
+        3,
+        14,
+        TimeSpan (1, 30, 0)
+    )
+        .LocalDateTime
+"""
+
 // Space before parentheses (a+b) in Uppercase function call
 
 [<Test>]

--- a/src/Fantomas.Tests/TypeProviderTests.fs
+++ b/src/Fantomas.Tests/TypeProviderTests.fs
@@ -72,30 +72,26 @@ let ``should handle lines with more than 512 characters`` () =
         equal
         """
 (new CsvFile<string * decimal * decimal>(
-    new Func<obj, string [], string * decimal * decimal>(
-        fun (parent: obj) (row: string []) ->
-            CommonRuntime.GetNonOptionalValue(
-                "Name",
-                CommonRuntime.ConvertString(TextConversions.AsOption(row.[0])),
-                TextConversions.AsOption(row.[0])
-            ),
-            CommonRuntime.GetNonOptionalValue(
-                "Distance",
-                CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[1])),
-                TextConversions.AsOption(row.[1])
-            ),
-            CommonRuntime.GetNonOptionalValue(
-                "Time",
-                CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[2])),
-                TextConversions.AsOption(row.[2])
-            )
-    ),
-    new Func<string * decimal * decimal, string []>(
-        fun (row: string * decimal * decimal) ->
-            [| CommonRuntime.ConvertStringBack(CommonRuntime.GetOptionalValue((let x, _, _ = row in x)))
-               CommonRuntime.ConvertDecimalBack("", CommonRuntime.GetOptionalValue((let _, x, _ = row in x)))
-               CommonRuntime.ConvertDecimalBack("", CommonRuntime.GetOptionalValue((let _, _, x = row in x))) |]
-    ),
+    new Func<obj, string [], string * decimal * decimal>(fun (parent: obj) (row: string []) ->
+        CommonRuntime.GetNonOptionalValue(
+            "Name",
+            CommonRuntime.ConvertString(TextConversions.AsOption(row.[0])),
+            TextConversions.AsOption(row.[0])
+        ),
+        CommonRuntime.GetNonOptionalValue(
+            "Distance",
+            CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[1])),
+            TextConversions.AsOption(row.[1])
+        ),
+        CommonRuntime.GetNonOptionalValue(
+            "Time",
+            CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[2])),
+            TextConversions.AsOption(row.[2])
+        )),
+    new Func<string * decimal * decimal, string []>(fun (row: string * decimal * decimal) ->
+        [| CommonRuntime.ConvertStringBack(CommonRuntime.GetOptionalValue((let x, _, _ = row in x)))
+           CommonRuntime.ConvertDecimalBack("", CommonRuntime.GetOptionalValue((let _, x, _ = row in x)))
+           CommonRuntime.ConvertDecimalBack("", CommonRuntime.GetOptionalValue((let _, _, x = row in x))) |]),
     (ProviderFileSystem.readTextAtRunTimeWithDesignTimeOptions
         @"C:\Dev\FSharp.Data-master\src\..\tests\FSharp.Data.Tests\Data"
         ""

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -638,6 +638,7 @@ let internal sepEq = !- " ="
 let internal sepEqFixed = !- "="
 let internal sepArrow = !- " -> "
 let internal sepArrowFixed = !- "-> "
+let internal sepArrowRev = !- " <- "
 let internal sepWild = !- "_"
 
 let internal sepBar = !- "| "

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -818,6 +818,7 @@ let (|AppSingleArg|_|) =
         | SynExpr.Lambda _
         | SynExpr.MatchLambda _ -> None
         | _ -> Some(e, px)
+    | App (e, [ (ConstExpr (SynConst.Unit, _) as px) ]) -> Some(e, px)
     | _ -> None
 
 let (|NewTuple|_|) =

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1020,6 +1020,21 @@ let (|DotGet|_|) =
     | SynExpr.DotGet (e, _, (LongIdentWithDots s as lid), _) -> Some(e, (s, lid.Range))
     | _ -> None
 
+/// Match function call followed by Property
+let (|DotGetAppParen|_|) e =
+    match e with
+    //| App(e, [DotGet (Paren _ as p, (s,r))]) -> Some (e, p, s, r)
+    | DotGet (App (e, [(Paren (_, Tuple _, _) as px)]), (s,r)) ->
+        Some (e,px,s,r)
+    | DotGet (App (e, [(Paren (_, singleExpr, _) as px)]), (s,r)) ->
+        match singleExpr with
+        | SynExpr.Lambda _
+        | SynExpr.MatchLambda _ -> None
+        | _ -> Some (e,px,s,r)
+    | DotGet (App (e, [(ConstExpr (SynConst.Unit, _) as px)]), (s,r)) ->
+        Some (e,px,s,r)
+    | _ -> None
+
 /// Gather series of application for line breaking
 let rec (|DotGetApp|_|) =
     function

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -822,10 +822,8 @@ let (|AppSingleArg|_|) =
 
 let (|NewTuple|_|) =
     function
-    | SynExpr.New (_, t, (Paren _ as px), _) ->
-        Some(t, px)
-    | SynExpr.New (_, t, (ConstExpr (SynConst.Unit, _) as px), _) ->
-        Some(t, px)
+    | SynExpr.New (_, t, (Paren _ as px), _) -> Some(t, px)
+    | SynExpr.New (_, t, (ConstExpr (SynConst.Unit, _) as px), _) -> Some(t, px)
     | _ -> None
 
 let (|CompApp|_|) =
@@ -1030,15 +1028,13 @@ let (|DotGet|_|) =
 let (|DotGetAppParen|_|) e =
     match e with
     //| App(e, [DotGet (Paren _ as p, (s,r))]) -> Some (e, p, s, r)
-    | DotGet (App (e, [(Paren (_, Tuple _, _) as px)]), lids) ->
-        Some (e,px,lids)
-    | DotGet (App (e, [(Paren (_, singleExpr, _) as px)]), lids) ->
+    | DotGet (App (e, [ (Paren (_, Tuple _, _) as px) ]), lids) -> Some(e, px, lids)
+    | DotGet (App (e, [ (Paren (_, singleExpr, _) as px) ]), lids) ->
         match singleExpr with
         | SynExpr.Lambda _
         | SynExpr.MatchLambda _ -> None
-        | _ -> Some (e,px,lids)
-    | DotGet (App (e, [(ConstExpr (SynConst.Unit, _) as px)]), lids) ->
-        Some (e,px,lids)
+        | _ -> Some(e, px, lids)
+    | DotGet (App (e, [ (ConstExpr (SynConst.Unit, _) as px) ]), lids) -> Some(e, px, lids)
     | _ -> None
 
 /// Gather series of application for line breaking


### PR DESCRIPTION
In this PR I removed `IsInsideDotGet` and `IsInsideDotIndexed` from the ASTContext.
These settings introduce a lot of issues as you constantly need to set and reset the properties accordingly.
To resolve the need for these properties I created some more fine-grained active patterns.
Most notable the `DotGet` family of expressions has been split up into different use cases.
They now also cover the recent [MS style guide recommendations](https://docs.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting#formatting-constructors-static-members-and-member-invocations).

Fixes #1401.