### PR TITLE
Remove string interpolation in CodePrinter.fs.

### DIFF
--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1750,7 +1750,7 @@ and genExpr astContext synExpr ctx =
 
             genExpr astContext e
             +> genGenericTypeParameters astContext ts
-            +> !-($".{s}")
+            +> !-(sprintf ".%s" s)
             +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (col sepSpace es (genExpr astContext))
 
         // Foo().Bar


### PR DESCRIPTION
The string interpolation usage breaks the online tool.