### PR TITLE
Only take configuration into account for space after function name in MultiLineLambdaClosingNewline

### DIFF
--- a/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -502,3 +502,34 @@ List.map
     )
     []
 """
+
+[<Test>]
+let ``multiple lambda parameters, 1427`` () =
+    formatSourceString
+        false
+        """
+let choose chooser source =
+    source
+    |> Set.fold
+        (fun set item ->
+            chooser item
+            |> Option.map (fun mappedItem -> Set.add mappedItem set)
+            |> Option.defaultValue set)
+        Set.empty
+"""
+        { config with
+              SpaceBeforeLowercaseInvocation = false }
+    |> prepend newline
+    |> should
+        equal
+        """
+let choose chooser source =
+    source
+    |> Set.fold
+        (fun set item ->
+            chooser item
+            |> Option.map(fun mappedItem -> Set.add mappedItem set)
+            |> Option.defaultValue set
+        )
+        Set.empty
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3005,7 +3005,7 @@ and genApp appNlnFun astContext e es ctx =
         if shouldHaveAlternativeLambdaStyle then
             let hasMultipleArguments = (List.length es) > 1
 
-            let sepSpace ctx =
+            let sepSpaceAfterFunctionName ctx =
                 match e with
                 | UppercaseSynExpr -> onlyIf ctx.Config.SpaceBeforeUppercaseInvocation sepSpace ctx
                 | LowercaseSynExpr -> onlyIf ctx.Config.SpaceBeforeLowercaseInvocation sepSpace ctx
@@ -3100,7 +3100,7 @@ and genApp appNlnFun astContext e es ctx =
                     singleLambdaArgument
 
             genExpr astContext e
-            +> ifElse (not hasMultipleArguments) sepSpace (indent +> sepNln)
+            +> ifElse (not hasMultipleArguments) sepSpaceAfterFunctionName (indent +> sepNln)
             +> argExpr
             +> onlyIf hasMultipleArguments unindent
         else


### PR DESCRIPTION
Fixes #1427.