### PR TITLE
Don't double unindent when record has access modifier.

### DIFF
--- a/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
+++ b/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
@@ -1015,3 +1015,82 @@ module Foo =
         printfn "Last Name: %s" ln
         printfn "Age: %i" age
 """
+
+[<Test>]
+let ``access modifier on short type record inside module`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    type Stores =
+        private {
+            ModeratelyLongName : int
+        }
+
+    type private Bang = abstract Baz : int
+"""
+        { config with
+              MaxLineLength = 40
+              SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    type Stores =
+        private
+            {
+                ModeratelyLongName : int
+            }
+
+    type private Bang =
+        abstract Baz : int
+"""
+
+[<Test>]
+let ``record with an access modifier and a static member`` () =
+    formatSourceString
+        false
+        """
+type RequestParser<'ctx, 'a> =
+    internal
+        { consumedFields: Set<ConsumedFieldName>
+          parse: 'ctx -> Request -> Async<Result<'a, Error list>>
+          prohibited: ProhibitedRequestGetter list }
+
+        static member internal Create
+            (
+                consumedFields, parse: 'ctx -> Request -> Async<Result<'a, Error list>>
+            ) : RequestParser<'ctx, 'a> =
+            { consumedFields = consumedFields
+              parse = parse
+              prohibited = [] }
+
+"""
+        { config with
+              AlternativeLongMemberDefinitions = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+type RequestParser<'ctx, 'a> =
+    internal
+        {
+            consumedFields : Set<ConsumedFieldName>
+            parse : 'ctx -> Request -> Async<Result<'a, Error list>>
+            prohibited : ProhibitedRequestGetter list
+        }
+
+    static member internal Create
+        (
+            consumedFields,
+            parse : 'ctx -> Request -> Async<Result<'a, Error list>>
+        )
+        : RequestParser<'ctx, 'a>
+        =
+        {
+            consumedFields = consumedFields
+            parse = parse
+            prohibited = []
+        }
+"""

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -1387,55 +1387,6 @@ type RequestParser<'ctx, 'a> =
 """
 
 [<Test>]
-let ``record with an access modifier and a static member, MultilineBlockBracketsOnSameColumn`` () =
-    formatSourceString
-        false
-        """
-type RequestParser<'ctx, 'a> =
-    internal
-        { consumedFields: Set<ConsumedFieldName>
-          parse: 'ctx -> Request -> Async<Result<'a, Error list>>
-          prohibited: ProhibitedRequestGetter list }
-
-        static member internal Create
-            (
-                consumedFields, parse: 'ctx -> Request -> Async<Result<'a, Error list>>
-            ) : RequestParser<'ctx, 'a> =
-            { consumedFields = consumedFields
-              parse = parse
-              prohibited = [] }
-
-"""
-        { config with
-              MultilineBlockBracketsOnSameColumn = true
-              AlternativeLongMemberDefinitions = true }
-    |> prepend newline
-    |> should
-        equal
-        """
-type RequestParser<'ctx, 'a> =
-    internal
-        {
-            consumedFields: Set<ConsumedFieldName>
-            parse: 'ctx -> Request -> Async<Result<'a, Error list>>
-            prohibited: ProhibitedRequestGetter list
-        }
-
-    static member internal Create
-        (
-            consumedFields,
-            parse: 'ctx -> Request -> Async<Result<'a, Error list>>
-        )
-        : RequestParser<'ctx, 'a>
-        =
-        {
-            consumedFields = consumedFields
-            parse = parse
-            prohibited = []
-        }
-"""
-
-[<Test>]
 let ``access modifier on short type record inside module, 1404`` () =
     formatSourceString
         false

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -1434,3 +1434,32 @@ type RequestParser<'ctx, 'a> =
             prohibited = []
         }
 """
+
+[<Test>]
+let ``access modifier on short type record inside module, 1404`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    type Stores =
+        private {
+            ModeratelyLongName : int
+        }
+
+    type private Bang = abstract Baz : int
+"""
+        { config with
+              MaxLineLength = 40
+              SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    type Stores =
+        private
+            { ModeratelyLongName: int }
+
+    type private Bang =
+        abstract Baz: int
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3465,7 +3465,6 @@ and genMultilineSimpleRecordTypeDefnAlignBrackets tdr ms ao' fs astContext =
         { astContext with
               InterfaceRange = None }
         ms
-    +> onlyIf (Option.isSome ao') unindent
 
 and sepNlnBetweenSigTypeAndMembers (ms: SynMemberSig list) =
     match List.tryHead ms with

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3443,7 +3443,6 @@ and genMultilineSimpleRecordTypeDefn tdr ms ao' fs astContext =
         { astContext with
               InterfaceRange = None }
         ms
-    +> optSingle (fun _ -> unindent) ao'
 
 and genMultilineSimpleRecordTypeDefnAlignBrackets tdr ms ao' fs astContext =
     // the typeName is already printed


### PR DESCRIPTION
Fixes #1404.