### PR TITLE
Add indent and newline for multiline SynExpr of SynMemberDefn.AutoProperty. 

### DIFF
--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -2412,3 +2412,54 @@ type Foo =
         'a -> int -> string -> string -> bool
         when 'a: comparison
 """
+
+[<Test>]
+let ``member with val keyword with multiline expression, 1426`` () =
+    formatSourceString
+        false
+        """
+type public Foo() =
+
+    // Here it generates valid code
+    static member FooBarThing1 =
+        new TypedThingDefinition(
+            "StringA",
+            SomeLongThing.SomeProperty,
+            IsMandatory = new Nullable<bool>(true),
+            Blablablabla = moreStuff
+        )
+
+    // With "member val" it generates invalid code
+    static member val FooBarThing2 =
+        new TypedThingDefinition(
+            "StringA",
+            SomeLongThing.SomeProperty,
+            IsMandatory = new Nullable<bool>(true),
+            Blablablabla = moreStuff
+        )
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type public Foo() =
+
+    // Here it generates valid code
+    static member FooBarThing1 =
+        new TypedThingDefinition(
+            "StringA",
+            SomeLongThing.SomeProperty,
+            IsMandatory = new Nullable<bool>(true),
+            Blablablabla = moreStuff
+        )
+
+    // With "member val" it generates invalid code
+    static member val FooBarThing2 =
+        new TypedThingDefinition(
+            "StringA",
+            SomeLongThing.SomeProperty,
+            IsMandatory = new Nullable<bool>(true),
+            Blablablabla = moreStuff
+        )
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4288,9 +4288,10 @@ and genMemberDefn astContext node =
         -- s
         +> optPre sepColon sepNone typeOpt (genType astContext false)
         +> sepEq
-        +> sepSpace
-        +> genExpr astContext e
-        -- genPropertyKind (not isFunctionProperty) mk
+        +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (
+            genExpr astContext e
+            -- genPropertyKind (not isFunctionProperty) mk
+        )
 
     | MDAbstractSlot (ats, px, ao, s, t, vi, ValTyparDecls (tds, _, tcs), MFMemberFlags mk) ->
         let (FunType namedArgs) = (t, vi)


### PR DESCRIPTION
Fix #1426.