### PR TITLE
Use equals from FCS to compare ranges.

### DIFF
--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -12,12 +12,18 @@ let private isNewline item =
     | Newline -> true
     | _ -> false
 
-let getDefines v =
+let private getDefines v =
     let normalizedString = String.normalizeNewLine v
     let _, hashTokens = getDefines normalizedString
     getDefinesWords hashTokens
 
-let tokenize v = tokenize [] [] v
+let private tokenize v = tokenize [] [] v
+
+let private mkRange : MkRange =
+    CodeFormatterImpl.makeRange "TokenParserTests"
+
+let private getTriviaFromTokens = getTriviaFromTokens mkRange
+let private getTriviaNodesFromTokens = getTriviaNodesFromTokens mkRange
 
 [<Test>]
 let ``Simple compiler directive should be found`` () =

--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -20,7 +20,11 @@ let private getDefines v =
 let private tokenize v = tokenize [] [] v
 
 let private mkRange : MkRange =
-    CodeFormatterImpl.makeRange "TokenParserTests"
+    fun (sl, sc) (el, ec) ->
+        FSharp.Compiler.Range.mkRange
+            "TokenParserTests"
+            (FSharp.Compiler.Range.mkPos sl sc)
+            (FSharp.Compiler.Range.mkPos el ec)
 
 let private getTriviaFromTokens = getTriviaFromTokens mkRange
 let private getTriviaNodesFromTokens = getTriviaNodesFromTokens mkRange

--- a/src/Fantomas.Tests/TriviaTests.fs
+++ b/src/Fantomas.Tests/TriviaTests.fs
@@ -6,7 +6,12 @@ open Fantomas.Tests.TestHelper
 open Fantomas.TriviaTypes
 
 let private collectTrivia =
-    Trivia.collectTrivia (CodeFormatterImpl.makeRange "Fantomas.Tests.TriviaTests")
+    Trivia.collectTrivia
+        (fun (sl, sc) (el, ec) ->
+            FSharp.Compiler.Range.mkRange
+                "TriviaTests"
+                (FSharp.Compiler.Range.mkPos sl sc)
+                (FSharp.Compiler.Range.mkPos el ec))
 
 let private toTrivia source =
     let astWithDefines = parse false source |> Array.toList

--- a/src/Fantomas.Tests/TriviaTests.fs
+++ b/src/Fantomas.Tests/TriviaTests.fs
@@ -1,10 +1,12 @@
 module Fantomas.Tests.TriviaTests
 
 open NUnit.Framework
-open FsUnit
 open Fantomas
 open Fantomas.Tests.TestHelper
 open Fantomas.TriviaTypes
+
+let private collectTrivia =
+    Trivia.collectTrivia (CodeFormatterImpl.makeRange "Fantomas.Tests.TriviaTests")
 
 let private toTrivia source =
     let astWithDefines = parse false source |> Array.toList
@@ -15,7 +17,7 @@ let private toTrivia source =
             let tokens =
                 TokenParser.tokenize defines hashTokens source
 
-            Trivia.collectTrivia tokens ast)
+            collectTrivia tokens ast)
 
 let private toTriviaWithDefines source =
     let astWithDefines = parse false source |> Array.toList
@@ -26,7 +28,7 @@ let private toTriviaWithDefines source =
             let tokens =
                 TokenParser.tokenize defines hashTokens source
 
-            defines, Trivia.collectTrivia tokens ast)
+            defines, collectTrivia tokens ast)
     |> Map.ofList
 
 [<Test>]

--- a/src/Fantomas/CodeFormatterImpl.fs
+++ b/src/Fantomas/CodeFormatterImpl.fs
@@ -390,7 +390,7 @@ let formatWith ast defines hashTokens formatContext config =
 
     let formattedSourceCode =
         let context =
-            Context.Context.Create config defines hashTokens sourceCodeOrEmptyString (Some ast)
+            Context.Context.Create config defines formatContext.FileName hashTokens sourceCodeOrEmptyString (Some ast)
 
         context
         |> genParsedInput
@@ -546,7 +546,8 @@ let private formatRange
     (range: range)
     (lines: _ [])
     config
-    ({ Source = sourceCode } as formatContext)
+    ({ Source = sourceCode
+       FileName = fileName } as formatContext)
     =
     let startLine = range.StartLine
     let startCol = range.StartColumn
@@ -627,7 +628,7 @@ let private formatRange
     let reconstructSourceCode startCol formatteds pre post =
         Debug.WriteLine("Formatted parts: '{0}' at column {1}", sprintf "%A" formatteds, startCol)
         // Realign results on the correct column
-        Context.Context.Create config [] [] String.Empty None
+        Context.Context.Create config [] fileName [] String.Empty None
         // Mono version of indent text writer behaves differently from .NET one,
         // So we add an empty string first to regularize it
         |> if returnFormattedContentOnly then

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -201,7 +201,7 @@ type internal Context =
         let trivia =
             match maybeAst, config.StrictMode with
             | Some ast, false ->
-                let mkRange startLine startCol endLine endCol =
+                let mkRange (startLine, startCol) (endLine, endCol) =
                     mkRange fileName (mkPos startLine startCol) (mkPos endLine endCol)
 
                 Trivia.collectTrivia mkRange tokens ast

--- a/src/Fantomas/RangeHelpers.fs
+++ b/src/Fantomas/RangeHelpers.fs
@@ -24,4 +24,4 @@ module RangeHelpers =
         r1.EndLine = r2.EndLine
         && r1.EndColumn = r2.EndColumn
 
-    let rangeEq (r1: range) (r2: range) = rangeStartEq r1 r2 && rangeEndEq r1 r2
+    let rangeEq = equals

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -417,12 +417,12 @@ let getDefines sourceCode =
 let private getRangeBetween (mkRange: MkRange) startToken endToken =
     let l = startToken.TokenInfo.LeftColumn
     let r = endToken.TokenInfo.RightColumn
-    mkRange startToken.LineNumber l endToken.LineNumber (if l = r then r + 1 else r)
+    mkRange (startToken.LineNumber, l) (endToken.LineNumber, (if l = r then r + 1 else r))
 
 let private getRangeForSingleToken (mkRange: MkRange) token =
     let l = token.TokenInfo.LeftColumn
     let r = l + token.TokenInfo.FullMatchedLength
-    mkRange token.LineNumber l token.LineNumber r
+    mkRange (token.LineNumber, l) (token.LineNumber, r)
 
 let private hasOnlySpacesAndLineCommentsOnLine lineNumber tokens =
     if List.isEmpty tokens then
@@ -818,7 +818,7 @@ let rec private getTriviaFromTokensThemSelves
     | [] -> foundTrivia
 
 let private createNewLine (mkRange: MkRange) lineNumber =
-    let range = mkRange lineNumber 0 lineNumber 0
+    let range = mkRange (lineNumber, 0) (lineNumber, 0)
     { Item = Newline; Range = range }
 
 let private findEmptyNewlinesInTokens

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -526,7 +526,7 @@ let private triviaNodeIsNotEmpty (triviaNode: TriviaNodeAssigner) =
     3. Merge trivias with triviaNodes
     4. genTrivia should use ranges to identify what extra content should be added from what triviaNode
 *)
-let collectTrivia tokens (ast: ParsedInput) =
+let collectTrivia (mkRange: MkRange) tokens (ast: ParsedInput) =
     let node =
         match ast with
         | ParsedInput.ImplFile (ParsedImplFileInput.ParsedImplFileInput (_, _, _, _, hds, mns, _)) -> astToNode hds mns
@@ -553,7 +553,7 @@ let collectTrivia tokens (ast: ParsedInput) =
             (fun _ _ -> None)
 
     let triviaNodesFromTokens =
-        TokenParser.getTriviaNodesFromTokens tokens
+        TokenParser.getTriviaNodesFromTokens mkRange tokens
 
     let triviaNodes =
         triviaNodesFromAST @ triviaNodesFromTokens
@@ -562,7 +562,8 @@ let collectTrivia tokens (ast: ParsedInput) =
     let hasAnonModulesAndOpenStatements =
         nodesContainsBothAnonModuleAndOpen triviaNodes
 
-    let trivias = TokenParser.getTriviaFromTokens tokens
+    let trivias =
+        TokenParser.getTriviaFromTokens mkRange tokens
 
     match trivias with
     | [] -> []

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -351,4 +351,4 @@ type TriviaNodeAssigner(nodeType: TriviaNodeType, range: range, ?linesBetweenPar
     member val ContentItself = Option<TriviaContent>.None with get, set
     member val ContentAfter = ResizeArray<TriviaContent>() with get, set
 
-type MkRange = int -> int -> int -> int -> range
+type MkRange = int * int -> int * int -> range

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -343,10 +343,12 @@ type TriviaNode =
       ContentAfter: TriviaContent list
       Range: range }
 
-type internal TriviaNodeAssigner(nodeType: TriviaNodeType, range: range, ?linesBetweenParent: int) =
+type TriviaNodeAssigner(nodeType: TriviaNodeType, range: range, ?linesBetweenParent: int) =
     member this.Type = nodeType
     member this.Range = range
     member this.AttributeLinesBetweenParent = linesBetweenParent
     member val ContentBefore = ResizeArray<TriviaContent>() with get, set
     member val ContentItself = Option<TriviaContent>.None with get, set
     member val ContentAfter = ResizeArray<TriviaContent>() with get, set
+
+type MkRange = int -> int -> int -> int -> range


### PR DESCRIPTION
Replace RangeHelpers.rangeEq with actual equals function of FCS.
https://github.com/dotnet/fsharp/blob/501f7551636f9ab5585ad18e7908b78760274d69/src/fsharp/range.fs#L337

@jindraivanek any thoughts on the MkRange field I added in Context?