### PR TITLE
Only add a space at the end of a long nested DotGet chain. 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 4.4.0-beta-005 02/2021
+
+* Fix fsharp_space_before_uppercase_invocation=true breaks method calls. [#1437](https://github.com/fsprojects/fantomas/issues/1437)
+* Fix Crash regression on 4.4.0-beta-003. [#1438](https://github.com/fsprojects/fantomas/issues/1438)
+
 ### 4.4.0-beta-004 01/2021
 
 * Fix MultiLineLambdaClosingNewline concats lambda arguments. [#1427](https://github.com/fsprojects/fantomas/issues/1427)

--- a/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
+++ b/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <Version>4.4.0-beta-004</Version>
+    <Version>4.4.0-beta-005</Version>
     <NoWarn>FS0988</NoWarn>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
   </PropertyGroup>

--- a/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
+++ b/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
@@ -5,7 +5,7 @@
     <RollForward>Major</RollForward>
     <ToolCommandName>fantomas</ToolCommandName>
     <PackAsTool>True</PackAsTool>
-    <Version>4.4.0-beta-004</Version>
+    <Version>4.4.0-beta-005</Version>
     <AssemblyName>fantomas-tool</AssemblyName>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
   </PropertyGroup>

--- a/src/Fantomas.Extras/Fantomas.Extras.fsproj
+++ b/src/Fantomas.Extras/Fantomas.Extras.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.4.0-beta-004</Version>
+    <Version>4.4.0-beta-005</Version>
     <Description>Utility package for Fantomas</Description>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
   </PropertyGroup>

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -607,3 +607,111 @@ SomeFunction(
 )
     .ChainedFunctionCall()
 """
+
+[<Test>]
+let ``space before uppercase invocation should only be respected at end of chain, 1438`` () =
+    formatSourceString
+        false
+        """
+namespace AspNetSerilog
+
+[<Extension>]
+type IWebHostBuilderExtensions() =
+
+    [<Extension>]
+    static member UseSerilog(webHostBuilder : IWebHostBuilder, index : Index) =
+        webHostBuilder.UseSerilog(fun context configuration ->
+            configuration
+                .MinimumLevel.Debug()
+                .WriteTo.Logger(fun loggerConfiguration ->
+                    loggerConfiguration
+                        .Enrich.WithProperty("host", Environment.MachineName)
+                        .Enrich.WithProperty("user", Environment.UserName)
+                        .Enrich.WithProperty("application", context.HostingEnvironment.ApplicationName)
+                    |> ignore
+                )
+            |> ignore
+        )
+"""
+        { config with
+              MaxLineLength = 100
+              SpaceBeforeUppercaseInvocation = true
+              MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+namespace AspNetSerilog
+
+[<Extension>]
+type IWebHostBuilderExtensions() =
+
+    [<Extension>]
+    static member UseSerilog(webHostBuilder: IWebHostBuilder, index: Index) =
+        webHostBuilder.UseSerilog (fun context configuration ->
+            configuration
+                .MinimumLevel
+                .Debug()
+                .WriteTo
+                .Logger(fun loggerConfiguration ->
+                    loggerConfiguration
+                        .Enrich
+                        .WithProperty("host", Environment.MachineName)
+                        .Enrich.WithProperty("user", Environment.UserName)
+                        .Enrich
+                        .WithProperty(
+                            "application",
+                            context.HostingEnvironment.ApplicationName
+                        )
+                    |> ignore)
+            |> ignore
+        )
+"""
+
+[<Test>]
+let ``space before uppercase invocation only on last lid of chain, 1437`` () =
+    formatSourceString
+        false
+        """
+Log.Logger <-
+    LoggerConfiguration()
+        .Destructure.FSharpTypes()
+        .WriteTo.Console()
+        .CreateLogger()
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+Log.Logger <-
+    LoggerConfiguration()
+        .Destructure.FSharpTypes()
+        .WriteTo.Console()
+        .CreateLogger ()
+"""
+
+[<Test>]
+let ``space before uppercase invocation only on last lid of chain, tupled arg`` () =
+    formatSourceString
+        false
+        """
+Log.Logger <-
+    LoggerConfiguration(1,2)
+        .Destructure.FSharpTypes()
+        .WriteTo.Console()
+        .CreateLogger()
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+Log.Logger <-
+    LoggerConfiguration(1, 2)
+        .Destructure.FSharpTypes()
+        .WriteTo.Console()
+        .CreateLogger ()
+"""

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.4.0-beta-004</Version>
+    <Version>4.4.0-beta-005</Version>
     <NoWarn>FS0988</NoWarn>
     <TargetFramework>net5.0</TargetFramework>
     <WarningsAsErrors>FS0025</WarningsAsErrors>

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.4.0-beta-004</Version>
+    <Version>4.4.0-beta-005</Version>
     <Description>Source code formatter for F#</Description>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #1438.
Fixes #1437.