### PR TITLE
add atCurrentColumnIndent for record multiline expression

### DIFF
--- a/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
+++ b/src/Fantomas.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
@@ -1094,3 +1094,47 @@ type RequestParser<'ctx, 'a> =
             prohibited = []
         }
 """
+
+[<Test>]
+let ``formatting error with MultilineBlockBracketsOnSameColumn, 1396`` () =
+    formatSourceString
+        false
+        """
+namespace GeeTower.Tests.EndToEnd
+
+module WatcherTests =
+
+    let CanRevokeAnIllegalCommitmentTx () =
+        let lndAddress = obj()
+
+        let config = {
+            GeeTower.Backend.Configuration.GetTestingConfig (lndAddress.ToString())
+            with
+                BitcoinRpcUser = "btc"
+        }
+
+        ()
+"""
+        { config with
+              MaxLineLength = 80
+              MultilineBlockBracketsOnSameColumn = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+namespace GeeTower.Tests.EndToEnd
+
+module WatcherTests =
+
+    let CanRevokeAnIllegalCommitmentTx () =
+        let lndAddress = obj ()
+
+        let config =
+            { GeeTower.Backend.Configuration.GetTestingConfig(
+                  lndAddress.ToString()
+              ) with
+                BitcoinRpcUser = "btc"
+            }
+
+        ()
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2757,7 +2757,7 @@ and genMultilineRecordInstanceAlignBrackets
 
     | None, Some e ->
         sepOpenS
-        +> genExpr astContext e
+        +> atCurrentColumnIndent (genExpr astContext e)
         +> (!- " with"
             +> indent
             +> whenShortIndent indent


### PR DESCRIPTION
fix #1396 

adding `atCurrentColumnIndent` before the `genExpr` as suggested.