### PR TITLE
Limit WITH keyword range from start of SynExpr til the start of the first Clause.

### DIFF
--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -1207,3 +1207,60 @@ type Thing =
         | Foo (ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) ->
             ""
 """
+
+[<Test>]
+let ``nested try/with with newline before with should not be printed in with of match block, 1445`` () =
+    formatSourceString
+        false
+        """
+let private formatResponse<'options> () =
+    async {
+        use stream = new StreamReader(req.Body)
+        let! json = stream.ReadToEndAsync() |> Async.AwaitTask
+        let model = Decoders.decodeRequest json
+
+        let configResult =
+            Result.map (fun r -> r, mapFantomasOptionsToRecord r.Options) model
+
+        match configResult with
+        | Ok ({ SourceCode = code; IsFsi = isFsi }, config) ->
+            let fileName = if isFsi then "tmp.fsi" else "tmp.fsx"
+
+            try
+                let! formatted = format fileName code config
+                let! validationResult = validateResult fileName formatted
+
+                return sendBadRequest content
+
+            with exn -> return sendBadRequest (sprintf "%A" exn)
+        | Error err -> return sendInternalError (err)
+    }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let private formatResponse<'options> () =
+    async {
+        use stream = new StreamReader(req.Body)
+        let! json = stream.ReadToEndAsync() |> Async.AwaitTask
+        let model = Decoders.decodeRequest json
+
+        let configResult =
+            Result.map (fun r -> r, mapFantomasOptionsToRecord r.Options) model
+
+        match configResult with
+        | Ok ({ SourceCode = code; IsFsi = isFsi }, config) ->
+            let fileName = if isFsi then "tmp.fsi" else "tmp.fsx"
+
+            try
+                let! formatted = format fileName code config
+                let! validationResult = validateResult fileName formatted
+
+                return sendBadRequest content
+
+            with exn -> return sendBadRequest (sprintf "%A" exn)
+        | Error err -> return sendInternalError (err)
+    }
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1574,14 +1574,20 @@ and genExpr astContext synExpr ctx =
             +> leaveNodeTokenByName synExpr.Range FUNCTION
             +> colPre sepNln sepNln sp (genClause astContext true)
         | Match (e, cs) ->
+            let withRange =
+                ctx.MkRange e.Range.Start (List.head cs).Range.Start
+
             atCurrentColumn (
                 !- "match "
                 +> atCurrentColumnIndent (genExpr astContext e)
-                +> enterNodeTokenByName synExpr.Range WITH
-                // indent 'with' further if trivia was printed so that is appear after the match keyword.
-                +> ifElseCtx lastWriteEventIsNewline (rep 5 !- " ") sepNone
-                -- " with"
-                +> leaveNodeTokenByName synExpr.Range WITH
+                +> tokN
+                    withRange
+                    WITH
+                    (ifElseCtx
+                        lastWriteEventIsNewline
+                        (rep 5 !- " ") // indent 'with' further if trivia was printed so that is appear after the match keyword.
+                        sepNone
+                     -- " with")
                 +> colPre sepNln sepNln cs (genClause astContext true)
             )
         | MatchBang (e, cs) ->


### PR DESCRIPTION
Fixes #1445.