### PR TITLE
Take SynExpr.TypeApp into account with long DotGet chains.

### DIFF
--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -679,13 +679,13 @@ type IWebHostBuilderExtensions() =
                 .MinimumLevel
                 .Debug()
                 .WriteTo
-                .Logger(fun loggerConfiguration ->
+                .Logger (fun loggerConfiguration ->
                     loggerConfiguration
                         .Enrich
                         .WithProperty("host", Environment.MachineName)
                         .Enrich.WithProperty("user", Environment.UserName)
                         .Enrich
-                        .WithProperty(
+                        .WithProperty (
                             "application",
                             context.HostingEnvironment.ApplicationName
                         )
@@ -774,7 +774,7 @@ let blah =
         """
 let blah =
     Mock()
-        .Returns(fun _ ->
+        .Returns (fun _ ->
             {
                 dasdasdsadsadsadsa = ""
                 Sdadsadasdasdas = "sdsadsadasdsa"
@@ -813,7 +813,7 @@ let blah =
         """
 let blah =
     Mock("foo")
-        .Returns(fun _ ->
+        .Returns (fun _ ->
             {
                 dasdasdsadsadsadsa = ""
                 Sdadsadasdasdas = "sdsadsadasdsa"
@@ -864,4 +864,29 @@ let x =
     LoggerConfiguration<Foo>()
         .Enrich.WithProperty<Bar>("user", Environment.UserName)
         .Enrich.WithProperty ("application", context.HostingEnvironment.ApplicationName)
+"""
+
+[<Test>]
+let ``typeApp followed by chained lambda, 1448`` () =
+    formatSourceString
+        false
+        """
+let blah =
+    Mock<Foo>()
+        .Returns (fun _ ->
+            { dasdasdsadsadsadsa = ""
+              Sdadsadasdasdas = "sdsadsadasdsa" })
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeMember = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let blah =
+    Mock<Foo>()
+        .Returns (fun _ ->
+            { dasdasdsadsadsadsa = ""
+              Sdadsadasdasdas = "sdsadsadasdsa" })
 """

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -819,3 +819,49 @@ let blah =
                 Sdadsadasdasdas = "sdsadsadasdsa"
             })
 """
+
+[<Test>]
+let ``typedApp should not have space with chained DotGet, 1447`` () =
+    formatSourceString
+        false
+        """
+let x =
+                        LoggerConfiguration<Foo>("host", Environment.MachineName)
+                            .Enrich.WithProperty<Bar>("user", Environment.UserName)
+                            .Enrich.WithProperty ("application", context.HostingEnvironment.ApplicationName)
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeMember = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let x =
+    LoggerConfiguration<Foo>("host", Environment.MachineName)
+        .Enrich.WithProperty<Bar>("user", Environment.UserName)
+        .Enrich.WithProperty ("application", context.HostingEnvironment.ApplicationName)
+"""
+
+[<Test>]
+let ``typedApp should not have space with chained DotGet, unit arg`` () =
+    formatSourceString
+        false
+        """
+let x =
+                        LoggerConfiguration<Foo>()
+                            .Enrich.WithProperty<Bar>("user", Environment.UserName)
+                            .Enrich.WithProperty ("application", context.HostingEnvironment.ApplicationName)
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeMember = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let x =
+    LoggerConfiguration<Foo>()
+        .Enrich.WithProperty<Bar>("user", Environment.UserName)
+        .Enrich.WithProperty ("application", context.HostingEnvironment.ApplicationName)
+"""

--- a/src/Fantomas.Tests/DotIndexedGetTests.fs
+++ b/src/Fantomas.Tests/DotIndexedGetTests.fs
@@ -62,7 +62,7 @@ myList.[7].lowerSomeFunctionCallOnSeven("looooooooooooooooooooooooooooooooonnggg
         equal
         """
 myList.[7]
-    .lowerSomeFunctionCallOnSeven(
+    .lowerSomeFunctionCallOnSeven (
         "looooooooooooooooooooooooooooooooonnggggStringArgument",
         otherArg1,
         otherArg2,

--- a/src/Fantomas.Tests/SynExprSetTests.fs
+++ b/src/Fantomas.Tests/SynExprSetTests.fs
@@ -254,3 +254,27 @@ match x with
 
     lintFixes.[uri] <- fs
 """
+
+[<Test>]
+let ``space before uppercase invocation with TypeApp`` () =
+    formatSourceString
+        false
+        """
+Log.Logger <-
+    LoggerConfiguration<Foo>()
+        .Destructure.FSharpTypes()
+        .WriteTo.Console()
+        .CreateLogger()
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+Log.Logger <-
+    LoggerConfiguration<Foo>()
+        .Destructure.FSharpTypes()
+        .WriteTo.Console()
+        .CreateLogger ()
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1845,19 +1845,19 @@ and genExpr astContext synExpr ctx =
             let lastEsIndex = es.Length - 1
 
             let genApp (idx: int) ((lids, e, ts): (string * range) list * SynExpr * SynType list) : Context -> Context =
+                let addSpace ctx =
+                    let config =
+                        let s = fst lids.[0]
+
+                        if Char.IsUpper(s.[0]) then
+                            ctx.Config.SpaceBeforeUppercaseInvocation
+                        else
+                            ctx.Config.SpaceBeforeLowercaseInvocation
+
+                    (lastEsIndex = idx)
+                    && (not (hasParenthesis e) || config)
+
                 let short =
-                    let addSpace ctx =
-                        let config =
-                            let s = fst lids.[0]
-
-                            if Char.IsUpper(s.[0]) then
-                                ctx.Config.SpaceBeforeUppercaseInvocation
-                            else
-                                ctx.Config.SpaceBeforeLowercaseInvocation
-
-                        (lastEsIndex = idx)
-                        && (not (hasParenthesis e) || config)
-
                     genLidsWithDots lids
                     +> genGenericTypeParameters astContext ts
                     +> ifElseCtx (addSpace) sepSpace sepNone
@@ -1866,6 +1866,7 @@ and genExpr astContext synExpr ctx =
                 let long =
                     genLidsWithDotsAndNewlines lids
                     +> genGenericTypeParameters astContext ts
+                    +> ifElseCtx (addSpace) sepSpace sepNone
                     +> genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext e
 
                 expressionFitsOnRestOfLine short long

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1819,21 +1819,24 @@ and genExpr astContext synExpr ctx =
         | DotGetApp (e, es) ->
             let genLongFunctionName =
                 match e with
-                | App (LongIdentPieces (lids), [ e2 ]) when (List.moreThanOne lids) ->
-                    genFunctionNameWithMultilineLids (genExpr astContext e2) lids
-                | App (TypeApp (LongIdentPieces (lids), ts), [ e2 ]) when (List.moreThanOne lids) ->
+                | AppOrTypeApp (LongIdentPieces (lids), ts, [ e2 ]) when (List.moreThanOne lids) ->
                     genFunctionNameWithMultilineLids
-                        (genGenericTypeParameters astContext ts
+                        (optSingle (genGenericTypeParameters astContext) ts
                          +> genExpr astContext e2)
                         lids
-                | App (SimpleExpr e, [ ConstExpr (SynConst.Unit, r) ]) ->
-                    genExpr astContext e +> genConst SynConst.Unit r
-                | App (SimpleExpr e, [ Paren _ as px ]) ->
+                | AppOrTypeApp (SimpleExpr e, ts, [ ConstExpr (SynConst.Unit, r) ]) ->
+                    genExpr astContext e
+                    +> optSingle (genGenericTypeParameters astContext) ts
+                    +> genConst SynConst.Unit r
+                | AppOrTypeApp (SimpleExpr e, ts, [ Paren _ as px ]) ->
                     let short =
-                        genExpr astContext e +> genExpr astContext px
+                        genExpr astContext e
+                        +> optSingle (genGenericTypeParameters astContext) ts
+                        +> genExpr astContext px
 
                     let long =
                         genExpr astContext e
+                        +> optSingle (genGenericTypeParameters astContext) ts
                         +> genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext px
 
                     expressionFitsOnRestOfLine short long

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -821,6 +821,12 @@ let (|AppSingleArg|_|) =
     | App (e, [ (ConstExpr (SynConst.Unit, _) as px) ]) -> Some(e, px)
     | _ -> None
 
+let (|AppOrTypeApp|_|) e =
+    match e with
+    | App (TypeApp (e, ts), es) -> Some(e, Some ts, es)
+    | App (e, es) -> Some(e, None, es)
+    | _ -> None
+
 let (|NewTuple|_|) =
     function
     | SynExpr.New (_, t, (Paren _ as px), _) -> Some(t, px)


### PR DESCRIPTION
Fixes #1447 
Fixes #1448