### PR TITLE
Preserve new lines in string portion of interpolated string

### DIFF
--- a/src/Fantomas.Tests/InterpolatedStringTests.fs
+++ b/src/Fantomas.Tests/InterpolatedStringTests.fs
@@ -146,3 +146,20 @@ $"\"{bar}\" {1} {2}"
         """
 $"\"{bar}\" {1} {2}"
 """
+
+[<Test>]
+let ``multiline string literal, issue 1451`` () =
+    formatSourceString
+        false
+        "
+$\"\"\"one: {1}<
+>two: {2}\"\"\"
+"
+        config
+    |> prepend newline
+    |> should
+        equal
+        "
+$\"\"\"one: {1}<
+>two: {2}\"\"\"
+"

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -584,13 +584,9 @@ let private extractContentPreservingNewLines (tokens: Token list) =
         function
         | [] -> result
         | [ final ] -> final.Content :: result
-        | current :: rest ->
-            let next = List.head rest
-
-            if current.LineNumber <> next.LineNumber then
-                loop (Environment.NewLine :: current.Content :: result) rest
-            else
-                loop (current.Content :: result) rest
+        | current :: ((next :: _) as rest) when (current.LineNumber <> next.LineNumber) ->
+            loop ("\n" :: current.Content :: result) rest
+        | current :: rest -> loop (current.Content :: result) rest
 
     loop [] tokens |> List.rev
 


### PR DESCRIPTION
New lines were not being preserved when combining the string tokens of an interpolated string expression. If consecutive tokens are on different lines, then we add an additional NewLine in between.

Fixes #1451