### PR TITLE
Alternative function application inside match expression.

### DIFF
--- a/src/Fantomas.Tests/ElmishTests.fs
+++ b/src/Fantomas.Tests/ElmishTests.fs
@@ -1004,8 +1004,10 @@ let private useLocationDetail (auth0 : Auth0Hook) (roles : RolesHook) id =
 
     React.useEffect (
         (fun () ->
-            if roles.IsEditorOrAdmin
-               && not (String.IsNullOrWhiteSpace(location.Creator)) then
+            if
+                roles.IsEditorOrAdmin
+                && not (String.IsNullOrWhiteSpace(location.Creator))
+            then
                 auth0.getAccessTokenSilently ()
                 |> Promise.bind
                     (fun authToken ->

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -84,6 +84,7 @@
     <Compile Include="CodeFormatterTests.fs" />
     <Compile Include="DotIndexedGetTests.fs" />
     <Compile Include="DotIndexedSetTests.fs" />
+    <Compile Include="MultilineFunctionApplicationsInConditionExpressionsTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Extras\Fantomas.Extras.fsproj" />

--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -1530,10 +1530,13 @@ let code =
         equal
         "
 let code =
-  if (System.Text.RegularExpressions.Regex.IsMatch(
+  if
+    System.Text.RegularExpressions.Regex.IsMatch
+      (
         d.Name,
         \"\"\"^[a-zA-Z][a-zA-Z0-9']+$\"\"\"
-      )) then
+      )
+  then
     d.Name
   elif d.NamespaceToOpen.IsSome then
     d.Name
@@ -1840,9 +1843,13 @@ let x =
         """
 // Original input:
 let x =
-    if (not (
-            f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        )) then
+    if
+        not
+            (
+                f
+                    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            )
+    then
         1
     else
         2

--- a/src/Fantomas.Tests/MultilineFunctionApplicationsInConditionExpressionsTests.fs
+++ b/src/Fantomas.Tests/MultilineFunctionApplicationsInConditionExpressionsTests.fs
@@ -306,3 +306,37 @@ module Web3ServerSeedList =
                     raise UnexpectedRpcResponseError
         | _ -> ()
 """
+
+[<Test>]
+let ``inside infix expression of elif expression`` () =
+    formatSourceString
+        false
+        """
+let c =
+    if blah then
+        true
+    elif bar |> Seq.exists ((|KeyValue|) >> snd >> (=) (Some i)) then false else true
+"""
+        { config with
+              MaxLineLength = 40
+              SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let c =
+    if blah then
+        true
+    elif
+        bar
+        |> Seq.exists
+            (
+                (|KeyValue|)
+                >> snd
+                >> (=) (Some i)
+            )
+    then
+        false
+    else
+        true
+"""

--- a/src/Fantomas.Tests/MultilineFunctionApplicationsInConditionExpressionsTests.fs
+++ b/src/Fantomas.Tests/MultilineFunctionApplicationsInConditionExpressionsTests.fs
@@ -1,0 +1,32 @@
+﻿module Fantomas.Tests.MultilineFunctionApplicationsInConditionExpressionsTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Tests.TestHelper
+
+[<Test>]
+let ``inside match expression, 1403`` () =
+    formatSourceString
+        false
+        """
+let foo () =
+    match b.TryGetValue (longlonglonglonglong, b) with
+    | true, i -> Some i
+    | false, _ -> failwith ""
+"""
+        { config with MaxLineLength = 40 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let foo () =
+    match
+        b.TryGetValue
+            (
+                longlonglonglonglong,
+                b
+            )
+        with
+    | true, i -> Some i
+    | false, _ -> failwith ""
+"""

--- a/src/Fantomas.Tests/MultilineFunctionApplicationsInConditionExpressionsTests.fs
+++ b/src/Fantomas.Tests/MultilineFunctionApplicationsInConditionExpressionsTests.fs
@@ -216,44 +216,6 @@ let foo () =
 """
 
 [<Test>]
-let ``temp`` () =
-    formatSourceString
-        false
-        """
-            if rpcResponseEx.RpcError <> null then
-                if (not (rpcResponseEx.RpcError.Message.Contains "pruning=archive"))
-                       && (not (rpcResponseEx.RpcError.Message.Contains "header not found"))
-                       && (not (rpcResponseEx.RpcError.Message.Contains "missing trie node")) then
-                        raise UnexpectedRpcResponseError
-
-"""
-        { config with MaxLineLength = 50 }
-    |> prepend newline
-    |> should
-        equal
-        """
-if rpcResponseEx.RpcError <> null then
-    if
-        (not
-            (
-                rpcResponseEx.RpcError.Message.Contains
-                    "pruning=archive"
-            ))
-        && (not
-            (
-                rpcResponseEx.RpcError.Message.Contains
-                    "header not found"
-            ))
-        && (not
-            (
-                rpcResponseEx.RpcError.Message.Contains
-                    "missing trie node"
-            ))
-    then
-        raise UnexpectedRpcResponseError
-"""
-
-[<Test>]
 let ``multiple infix operator application inside if expression, 1390`` () =
     formatSourceString
         false

--- a/src/Fantomas.Tests/MultilineFunctionApplicationsInConditionExpressionsTests.fs
+++ b/src/Fantomas.Tests/MultilineFunctionApplicationsInConditionExpressionsTests.fs
@@ -30,3 +30,279 @@ let foo () =
     | true, i -> Some i
     | false, _ -> failwith ""
 """
+
+
+[<Test>]
+let ``inside match expression, single argument in parenthesis`` () =
+    formatSourceString
+        false
+        """
+let foo () =
+    match b.TryGetValue (longlonglonglonglong) with
+    | true, i -> Some i
+    | false, _ -> failwith ""
+"""
+        { config with MaxLineLength = 40 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let foo () =
+    match
+        b.TryGetValue
+            (longlonglonglonglong)
+        with
+    | true, i -> Some i
+    | false, _ -> failwith ""
+"""
+
+[<Test>]
+let ``inside when clause of try/with, 1406`` () =
+    formatSourceString
+        false
+        """
+module ElectrumClient =
+
+    let private Init (fqdn: string) (port: uint32): Async<StratumClient> =
+        let PROTOCOL_VERSION_SUPPORTED = Version "1.4"
+
+        async {
+            let! versionSupportedByServer =
+                try
+                    stratumClient.ServerVersion
+                        CLIENT_NAME_SENT_TO_STRATUM_SERVER_WHEN_HELLO
+                        PROTOCOL_VERSION_SUPPORTED
+                with :? ElectrumServerReturningErrorException as except when
+                    except.Message.EndsWith (PROTOCOL_VERSION_SUPPORTED.ToString ()) ->
+
+                    failwith "xxx"
+
+            return stratumClient
+        }
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+module ElectrumClient =
+
+    let private Init (fqdn: string) (port: uint32) : Async<StratumClient> =
+        let PROTOCOL_VERSION_SUPPORTED = Version "1.4"
+
+        async {
+            let! versionSupportedByServer =
+                try
+                    stratumClient.ServerVersion
+                        CLIENT_NAME_SENT_TO_STRATUM_SERVER_WHEN_HELLO
+                        PROTOCOL_VERSION_SUPPORTED
+                with :? ElectrumServerReturningErrorException as except when
+                    except.Message.EndsWith
+                        (PROTOCOL_VERSION_SUPPORTED.ToString()) ->
+
+                    failwith "xxx"
+
+            return stratumClient
+        }
+"""
+
+[<Test>]
+let ``inside infix expression of if expression, 1402`` () =
+    formatSourceString
+        false
+        """
+let c =
+    if bar |> Seq.exists ((|KeyValue|) >> snd >> (=) (Some i)) then false else true
+"""
+        { config with
+              MaxLineLength = 40
+              SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let c =
+    if
+        bar
+        |> Seq.exists
+            (
+                (|KeyValue|)
+                >> snd
+                >> (=) (Some i)
+            )
+    then
+        false
+    else
+        true
+"""
+
+[<Test>]
+let ``single parenthesis arg inside if expression`` () =
+    formatSourceString
+        false
+        """
+if MyGrandFunctionThatTakesASingleArgument ( myEvenGranderArgumentNameThatGoesOnForEverAndEver ) then
+    ()
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+if
+    MyGrandFunctionThatTakesASingleArgument
+        (myEvenGranderArgumentNameThatGoesOnForEverAndEver)
+then
+    ()
+"""
+
+[<Test>]
+let ``inside match bang expression, single argument in parenthesis`` () =
+    formatSourceString
+        false
+        """
+let foo () =
+    async {
+        match! b.TryGetValue (longlonglonglonglong) with
+        | true, i -> Some i
+        | false, _ -> failwith ""
+    }
+"""
+        { config with MaxLineLength = 40 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let foo () =
+    async {
+        match!
+            b.TryGetValue
+                (longlonglonglonglong)
+            with
+        | true, i -> Some i
+        | false, _ -> failwith ""
+    }
+"""
+
+[<Test>]
+let ``inside match bang expression, tupled argument in parenthesis`` () =
+    formatSourceString
+        false
+        """
+let foo () =
+    async {
+        match! b.TryGetValue (longlonglonglonglong, b) with
+        | true, i -> Some i
+        | false, _ -> failwith ""
+    }
+"""
+        { config with MaxLineLength = 40 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let foo () =
+    async {
+        match!
+            b.TryGetValue
+                (
+                    longlonglonglonglong,
+                    b
+                )
+            with
+        | true, i -> Some i
+        | false, _ -> failwith ""
+    }
+"""
+
+[<Test>]
+let ``temp`` () =
+    formatSourceString
+        false
+        """
+            if rpcResponseEx.RpcError <> null then
+                if (not (rpcResponseEx.RpcError.Message.Contains "pruning=archive"))
+                       && (not (rpcResponseEx.RpcError.Message.Contains "header not found"))
+                       && (not (rpcResponseEx.RpcError.Message.Contains "missing trie node")) then
+                        raise UnexpectedRpcResponseError
+
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+if rpcResponseEx.RpcError <> null then
+    if
+        (not
+            (
+                rpcResponseEx.RpcError.Message.Contains
+                    "pruning=archive"
+            ))
+        && (not
+            (
+                rpcResponseEx.RpcError.Message.Contains
+                    "header not found"
+            ))
+        && (not
+            (
+                rpcResponseEx.RpcError.Message.Contains
+                    "missing trie node"
+            ))
+    then
+        raise UnexpectedRpcResponseError
+"""
+
+[<Test>]
+let ``multiple infix operator application inside if expression, 1390`` () =
+    formatSourceString
+        false
+        """
+module Web3ServerSeedList =
+    let MaybeRethrow (ex: Exception): unit =
+        let rpcResponseExOpt =
+            FSharpUtil.FindException<RpcResponseException>
+                ex
+
+        match rpcResponseExOpt with
+        | Some rpcResponseEx ->
+            if rpcResponseEx.RpcError <> null then
+                if (not (rpcResponseEx.RpcError.Message.Contains "pruning=archive"))
+                       && (not (rpcResponseEx.RpcError.Message.Contains "header not found"))
+                       && (not (rpcResponseEx.RpcError.Message.Contains "missing trie node")) then
+                        raise UnexpectedRpcResponseError
+        | _ -> ()
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Web3ServerSeedList =
+    let MaybeRethrow (ex: Exception) : unit =
+        let rpcResponseExOpt =
+            FSharpUtil.FindException<RpcResponseException> ex
+
+        match rpcResponseExOpt with
+        | Some rpcResponseEx ->
+            if rpcResponseEx.RpcError <> null then
+                if
+                    (not
+                        (
+                            rpcResponseEx.RpcError.Message.Contains
+                                "pruning=archive"
+                        ))
+                    && (not
+                        (
+                            rpcResponseEx.RpcError.Message.Contains
+                                "header not found"
+                        ))
+                    && (not
+                        (
+                            rpcResponseEx.RpcError.Message.Contains
+                                "missing trie node"
+                        ))
+                then
+                    raise UnexpectedRpcResponseError
+        | _ -> ()
+"""

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -1142,10 +1142,13 @@ match x (Map.tryFind somelongidentifier a + Option.defaultValue longidentifier) 
     |> should
         equal
         """
-match x (
-          Map.tryFind somelongidentifier a
-          + Option.defaultValue longidentifier
-      ) with
+match
+    x
+        (
+            Map.tryFind somelongidentifier a
+            + Option.defaultValue longidentifier
+        )
+    with
 | _ -> ()
 """
 

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -699,7 +699,7 @@ let MethInfoIsUnseen g m ty minfo =
 #else
                   (fun _provAttribs -> None)
 #endif
-              with
+               with
         | Some res -> res
         | None -> false
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1032,8 +1032,8 @@ and genExpr astContext synExpr ctx =
 
     let sepOpenTFor r = tokN r LPAREN sepOpenT
 
-    let sepCloseTFor r =
-        tokN (Option.defaultValue synExpr.Range r) RPAREN sepCloseT
+    let sepCloseTFor rpr pr =
+        tokN (Option.defaultValue pr rpr) RPAREN sepCloseT
 
     let expr =
         match synExpr with
@@ -1511,7 +1511,7 @@ and genExpr astContext synExpr ctx =
         | JoinIn (e1, e2) ->
             genExpr astContext e1 -- " in "
             +> genExpr astContext e2
-        | Paren (lpr, DesugaredLambda (cps, e), rpr) ->
+        | Paren (lpr, DesugaredLambda (cps, e), rpr, pr) ->
             fun (ctx: Context) ->
                 let arrowRange =
                     List.last cps
@@ -1529,9 +1529,9 @@ and genExpr astContext synExpr ctx =
                     +> triviaAfterArrow arrowRange
                     +> (fun ctx ->
                         if hasLineCommentAfterArrow then
-                            (genExpr astContext e +> sepCloseTFor rpr) ctx
+                            (genExpr astContext e +> sepCloseTFor rpr pr) ctx
                         else
-                            (autoNlnIfExpressionExceedsPageWidth (genExpr astContext e +> sepCloseTFor rpr)) ctx)
+                            (autoNlnIfExpressionExceedsPageWidth (genExpr astContext e +> sepCloseTFor rpr pr)) ctx)
                     +> unindent
 
                 expr ctx
@@ -1541,7 +1541,7 @@ and genExpr astContext synExpr ctx =
             +> col sepSpace cps (fst >> genComplexPats astContext)
             +> sepArrow
             +> autoIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e)
-        | Paren (lpr, Lambda (e, sps), rpr) ->
+        | Paren (lpr, Lambda (e, sps), rpr, pr) ->
             fun (ctx: Context) ->
                 let hasLineCommentAfterArrow =
                     findTriviaTokenFromName RARROW synExpr.Range ctx
@@ -1554,9 +1554,9 @@ and genExpr astContext synExpr ctx =
                     +> triviaAfterArrow synExpr.Range
                     +> (fun ctx ->
                         if hasLineCommentAfterArrow then
-                            (genExpr astContext e +> sepCloseTFor rpr) ctx
+                            (genExpr astContext e +> sepCloseTFor rpr pr) ctx
                         else
-                            autoNlnIfExpressionExceedsPageWidth (genExpr astContext e +> sepCloseTFor rpr) ctx)
+                            autoNlnIfExpressionExceedsPageWidth (genExpr astContext e +> sepCloseTFor rpr pr) ctx)
                     +> unindent
 
                 expr ctx
@@ -1584,26 +1584,10 @@ and genExpr astContext synExpr ctx =
                      +> tokN withRange WITH (!- " with"))
                     (fun ctx ->
                         match e with
-                        | App (e, [ Paren (lpr, Tuple (ts, tr), rpr) ]) ->
-                            let genTupleTrivia =
-                                match tr with
-                                | Some tr -> genTriviaFor SynExpr_Tuple tr
-                                | None -> id
-
+                        | AppParenArg app ->
                             (indent
                              +> sepNln
-                             +> genExpr astContext e
-                             +> indent
-                             +> sepNln
-                             +> sepOpenT
-                             +> indent
-                             +> sepNln
-                             +> (col (sepComma +> sepNln) ts (genExpr astContext)
-                                 |> genTupleTrivia)
-                             +> unindent
-                             +> sepNln
-                             +> sepCloseT
-                             +> unindent
+                             +> genAlternativeAppWithParenthesis app astContext
                              +> sepNln
                              +> tokN withRange WITH (!- "with")
                              +> unindent)
@@ -1619,8 +1603,32 @@ and genExpr astContext synExpr ctx =
                 +> colPre sepNln sepNln cs (genClause astContext true)
             )
         | MatchBang (e, cs) ->
+            let withRange =
+                ctx.MkRange e.Range.Start (List.head cs).Range.Start
+
+            let genMatchExpr =
+                !- "match! "
+                +> expressionFitsOnRestOfLine
+                    (genExpr astContext e
+                     +> tokN withRange WITH (!- " with"))
+                    (fun ctx ->
+                        match e with
+                        | AppParenArg app ->
+                            (indent
+                             +> sepNln
+                             +> genAlternativeAppWithParenthesis app astContext
+                             +> sepNln
+                             +> tokN withRange WITH (!- "with")
+                             +> unindent)
+                                ctx
+                        | _ ->
+                            atCurrentColumnIndent
+                                (genExpr astContext e
+                                 +> tokN withRange WITH (!- " with"))
+                                ctx)
+
             atCurrentColumn (
-                !- "match! " +> genExpr astContext e -- " with"
+                genMatchExpr
                 +> colPre sepNln sepNln cs (genClause astContext true)
             )
         | TraitCall (tps, msg, e) ->
@@ -1632,23 +1640,23 @@ and genExpr astContext synExpr ctx =
             +> sepSpace
             +> genExpr astContext e
 
-        | Paren (_, ILEmbedded r, _) ->
+        | Paren (_, ILEmbedded r, _, _) ->
             // Just write out original code inside (# ... #)
             fun ctx -> !- (defaultArg (lookup r ctx) "") ctx
-        | Paren (lpr, e, rpr) ->
+        | Paren (lpr, e, rpr, pr) ->
             match e with
             | MultilineString _ ->
                 sepOpenTFor lpr
                 +> atCurrentColumn (genExpr astContext e +> indentIfNeeded sepNone)
-                +> sepCloseTFor rpr
+                +> sepCloseTFor rpr pr
             | LetOrUses _ ->
                 sepOpenTFor lpr
                 +> atCurrentColumn (genExpr astContext e)
-                +> sepCloseTFor rpr
+                +> sepCloseTFor rpr pr
             | _ ->
                 sepOpenTFor lpr
                 +> genExpr astContext e
-                +> sepCloseTFor rpr
+                +> sepCloseTFor rpr pr
         | CompApp (s, e) ->
             !-s
             +> sepSpace
@@ -1816,7 +1824,7 @@ and genExpr astContext synExpr ctx =
                     ctx
 
         // Foo(fun x -> x).Bar()
-        | DotGetApp (App (e, [ Paren (_, Lambda _, _) as px ]), es) ->
+        | DotGetApp (App (e, [ Paren (_, Lambda _, _, _) as px ]), es) ->
             let genLongFunctionName f =
                 match e with
                 | LongIdentPieces (lids) when (List.moreThanOne lids) -> genFunctionNameWithMultilineLids f lids
@@ -2174,12 +2182,6 @@ and genExpr astContext synExpr ctx =
                 let hasCommentAfterIfBranchThenKeyword =
                     commentAfterKeyword THEN (RangeHelpers.``range contains`` synExpr.Range) ctx
 
-                let isConditionMultiline =
-                    hasCommentAfterIfKeyword
-                    || hasCommentAfterBoolExpr
-                    || hasCommentAfterIfBranchThenKeyword
-                    || futureNlnCheck (!- "if " +> genExpr astContext e1) ctx
-
                 let genIf ifElseRange = tokN ifElseRange IF (!- "if ")
                 let genThen ifElseRange = tokN ifElseRange THEN (!- "then ")
                 let genElse ifElseRange = tokN ifElseRange ELSE (!- "else ")
@@ -2254,10 +2256,8 @@ and genExpr astContext synExpr ctx =
                     genIf synExpr.Range
                     +> genExpr astContext e1
                     +> sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
-                    +> dumpAndContinue
                     +> genThen synExpr.Range
                     +> genExpr astContext e2
-                    // +> col sepNone elfis (fun elf -> sepSpace +> genElifOneliner elf)
                     +> genShortElse enOpt synExpr.Range
 
                 let isIfThenElse =
@@ -2266,24 +2266,66 @@ and genExpr astContext synExpr ctx =
                     | _ -> false
 
                 let longIfThenElse =
+                    let genIfExpr =
+                        let short = genExpr astContext e1
+
+                        let long =
+                            match e1 with
+                            | SynExpr.TryWith _
+                            | SynExpr.TryFinally _ -> sepOpenT +> genExpr astContext e1 +> sepCloseT
+                            | App (SynExpr.DotGet _, [ (Paren _) ]) -> atCurrentColumn (genExpr astContext e1)
+                            | Paren (lpr, (AppSingleArg _ as ate), rpr, pr) ->
+                                sepOpenTFor lpr
+                                +> atCurrentColumnIndent (genExpr astContext ate)
+                                +> sepCloseTFor rpr pr
+                            | AppParenArg app ->
+                                indent
+                                +> sepNln
+                                +> genAlternativeAppWithParenthesis app astContext
+                                +> unindent
+                                +> sepNln
+                            | InfixApp (s, e, e1, AppParenArg app) ->
+                                indent
+                                +> sepNln
+                                +> genExpr astContext e1
+                                +> sepNln
+                                +> genInfixOperator s e
+                                +> sepSpace
+                                +> genAlternativeAppWithParenthesis app astContext
+                                +> unindent
+                                +> sepNln
+                            // very specific fix for 1380
+                            | SameInfixApps (Paren (lpr, AppParenArg e, rpr, pr), es) ->
+                                indent
+                                +> sepNln
+                                +> sepOpenTFor lpr
+                                +> genAlternativeAppWithParenthesis e astContext
+                                +> sepCloseTFor rpr pr
+                                +> sepNln
+                                +> col
+                                    sepNln
+                                    es
+                                    (fun (opText, opExpr, e) ->
+                                        genInfixOperator opText opExpr
+                                        +> sepSpace
+                                        +> (match e with
+                                            | Paren (lpr, AppParenArg app, rpr, pr) ->
+                                                sepOpenTFor lpr
+                                                +> genAlternativeAppWithParenthesis app astContext
+                                                +> sepCloseTFor rpr pr
+                                            | _ -> genExpr astContext e))
+                                +> unindent
+                                +> sepNln
+                            | _ -> genExpr astContext e1
+
+                        expressionFitsOnRestOfLine short long
+
                     genIf synExpr.Range
                     // f.ex. if // meh
                     //           x
                     // bool expr x should be indented
                     +> ifElse hasCommentAfterIfKeyword (indent +> sepNln) sepNone
-                    +> (match e1 with
-                        | SynExpr.TryWith _
-                        | SynExpr.TryFinally _ -> sepOpenT +> genExpr astContext e1 +> sepCloseT
-                        | App (SynExpr.DotGet _, [ (Paren _) ]) -> atCurrentColumn (genExpr astContext e1)
-                        | AppSingleArg _ when (isConditionMultiline) ->
-                            sepOpenT
-                            +> atCurrentColumnIndent (genExpr astContext e1)
-                            +> sepCloseT
-                        | Paren (_, (AppSingleArg _ as ate), _) when (isConditionMultiline) ->
-                            sepOpenT
-                            +> atCurrentColumnIndent (genExpr astContext ate)
-                            +> sepCloseT
-                        | _ -> genExpr astContext e1)
+                    +> genIfExpr
                     +> sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
                     //+> ifElse hasCommentAfterBoolExpr sepNln sepSpace
                     +> genThen synExpr.Range
@@ -2667,14 +2709,14 @@ and genFunctionNameWithMultilineLids f lids =
     | _ -> sepNone
 
 and genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext argExpr =
-    let argsInsideParenthesis lpr rpr f =
+    let argsInsideParenthesis lpr rpr pr f =
         sepOpenTFor lpr
         +> indent
         +> sepNln
         +> f
         +> unindent
         +> sepNln
-        +> sepCloseTFor rpr
+        +> sepCloseTFor rpr pr
 
     let genExpr astContext e =
         match e with
@@ -2683,14 +2725,14 @@ and genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext
         | _ -> genExpr astContext e
 
     match argExpr with
-    | Paren (_, Lambda _, _) -> genExpr astContext argExpr
-    | Paren (lpr, Tuple (args, tupleRange), rpr) ->
+    | Paren (_, Lambda _, _, _) -> genExpr astContext argExpr
+    | Paren (lpr, Tuple (args, tupleRange), rpr, pr) ->
         (col (sepCommaFixed +> sepNln) args (genExpr astContext))
         |> optSingle (genTriviaFor SynExpr_Tuple) tupleRange
-        |> argsInsideParenthesis lpr rpr
-    | Paren (lpr, singleExpr, rpr) ->
+        |> argsInsideParenthesis lpr rpr pr
+    | Paren (lpr, singleExpr, rpr, pr) ->
         genExpr astContext singleExpr
-        |> argsInsideParenthesis lpr rpr
+        |> argsInsideParenthesis lpr rpr pr
     | _ -> genExpr astContext argExpr
 
 and genGenericTypeParameters astContext ts =
@@ -3051,7 +3093,7 @@ and genApp appNlnFun astContext e es ctx =
 
     let isParenLambda =
         (function
-        | Paren (_, Lambda _, _) -> true
+        | Paren (_, Lambda _, _, _) -> true
         | _ -> false)
 
     let shouldHaveAlternativeLambdaStyle =
@@ -3096,14 +3138,14 @@ and genApp appNlnFun astContext e es ctx =
                             +> sepCloseTFor rpr
 
                         match e with
-                        | Paren (lpr, DesugaredLambda (cps, e), rpr) ->
+                        | Paren (lpr, DesugaredLambda (cps, e), rpr, _) ->
                             let arrowRange =
                                 List.last cps
                                 |> snd
                                 |> fun lastPatRange -> ctx.MkRange lastPatRange.End e.Range.Start
 
                             genLambda (col sepSpace cps (fst >> genComplexPats astContext)) e lpr rpr arrowRange
-                        | Paren (lpr, Lambda (e, sps), rpr) ->
+                        | Paren (lpr, Lambda (e, sps), rpr, _) ->
                             let arrowRange =
                                 List.last sps
                                 |> fun sp -> ctx.MkRange sp.Range.End e.Range.Start
@@ -3137,14 +3179,14 @@ and genApp appNlnFun astContext e es ctx =
                             +> sepCloseTFor rpr
 
                         match e with
-                        | Paren (lpr, DesugaredLambda (cps, e), rpr) ->
+                        | Paren (lpr, DesugaredLambda (cps, e), rpr, _) ->
                             let arrowRange =
                                 List.last cps
                                 |> snd
                                 |> fun lastPatRange -> ctx.MkRange lastPatRange.End e.Range.Start
 
                             genLambda (col sepSpace cps (fst >> genComplexPats astContext)) e lpr rpr arrowRange
-                        | Paren (lpr, Lambda (e, sps), rpr) ->
+                        | Paren (lpr, Lambda (e, sps), rpr, _) ->
                             let arrowRange =
                                 List.last sps
                                 |> fun sp -> ctx.MkRange sp.Range.End e.Range.Start
@@ -3180,31 +3222,46 @@ and genApp appNlnFun astContext e es ctx =
     else
         expressionFitsOnRestOfLine shortExpression longExpression ctx
 
-and genExprWhenInCondition astContext e =
-    match e with
-    | App (e, [ Paren (lpr, Tuple (ts, tr), rpr) ]) ->
-        let genTupleTrivia =
-            match tr with
-            | Some tr -> genTriviaFor SynExpr_Tuple tr
-            | None -> id
+and genAlternativeAppWithTupledArgument (e, lpr, ts, tr, rpr, pr) astContext =
+    let genTupleTrivia =
+        match tr with
+        | Some tr -> genTriviaFor SynExpr_Tuple tr
+        | None -> id
 
-        indent
-        +> sepNln
-        +> genExpr astContext e
-        +> indent
-        +> sepNln
-        +> sepOpenT
-        +> indent
-        +> sepNln
-        +> (col (sepComma +> sepNln) ts (genExpr astContext)
-            |> genTupleTrivia)
-        +> unindent
-        +> sepNln
-        +> sepCloseT
-        +> unindent
-        +> sepNln
-        +> unindent
-    | _ -> atCurrentColumnIndent (genExpr astContext e +> sepSpace)
+    genExpr astContext e
+    +> indent
+    +> sepNln
+    +> tokN lpr LPAREN sepOpenT
+    +> indent
+    +> sepNln
+    +> (col (sepComma +> sepNln) ts (genExpr astContext)
+        |> genTupleTrivia)
+    +> unindent
+    +> sepNln
+    +> tokN (Option.defaultValue pr rpr) RPAREN sepCloseT
+    +> unindent
+
+and genAlternativeAppWithSingleParenthesisArgument (e, lpr, a, rpr, pr) astContext =
+    genExpr astContext e
+    +> sepSpaceWhenOrIndentAndNlnIfExpressionExceedsPageWidth
+        (fun ctx ->
+            match e with
+            | UppercaseSynExpr _ -> ctx.Config.SpaceBeforeUppercaseInvocation
+            | LowercaseSynExpr _ -> ctx.Config.SpaceBeforeLowercaseInvocation)
+        (tokN lpr LPAREN sepOpenT
+         +> expressionFitsOnRestOfLine
+             (genExpr astContext a)
+             (indent
+              +> sepNln
+              +> genExpr astContext a
+              +> unindent
+              +> sepNln)
+         +> tokN (Option.defaultValue pr rpr) RPAREN sepCloseT)
+
+and genAlternativeAppWithParenthesis app astContext =
+    match app with
+    | Choice1Of2 t -> genAlternativeAppWithTupledArgument t astContext
+    | Choice2Of2 s -> genAlternativeAppWithSingleParenthesisArgument s astContext
 
 and sepNlnBetweenTypeAndMembers (ms: SynMemberDefn list) =
     match List.tryHead ms with
@@ -4208,7 +4265,23 @@ and genClause astContext hasBar (Clause (p, e, eo) as ce) =
             (!- " when")
             sepNone
             eo
-            (fun e -> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e))
+            (fun e ->
+                let short = sepSpace +> genExpr astContext e
+
+                let long =
+                    match e with
+                    | AppParenArg app ->
+                        indent
+                        +> sepNln
+                        +> genAlternativeAppWithParenthesis app astContext
+                        +> unindent
+                    | e ->
+                        indent
+                        +> sepNln
+                        +> (genExpr astContext e)
+                        +> unindent
+
+                expressionFitsOnRestOfLine short long)
         +> sepArrow
         +> fun ctx -> leaveNodeTokenByName (arrowRange ctx) RARROW ctx
 

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -954,6 +954,15 @@ let internal sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth expr (ctx: Conte
         expr
         ctx
 
+let internal sepSpaceWhenOrIndentAndNlnIfExpressionExceedsPageWidth (addSpace: Context -> bool) expr (ctx: Context) =
+    expressionExceedsPageWidth
+        (ifElseCtx addSpace sepSpace sepNone)
+        sepNone // before and after for short expressions
+        (indent +> sepNln)
+        unindent // before and after for long expressions
+        expr
+        ctx
+
 let internal sepSpaceOrNlnIfExpressionExceedsPageWidth expr (ctx: Context) =
     expressionExceedsPageWidth
         sepSpace

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -599,7 +599,7 @@ let (|Quote|_|) =
 
 let (|Paren|_|) =
     function
-    | SynExpr.Paren (e, lpr, rpr, _) -> Some(lpr, e, rpr)
+    | SynExpr.Paren (e, lpr, rpr, r) -> Some(lpr, e, rpr, r)
     | _ -> None
 
 type ExprKind =
@@ -812,8 +812,8 @@ let (|App|_|) e =
 // captures application with single arg
 let (|AppSingleArg|_|) =
     function
-    | App (SynExpr.DotGet _, [ (Paren (_, Tuple _, _)) ]) -> None
-    | App (e, [ (Paren (_, singleExpr, _) as px) ]) ->
+    | App (SynExpr.DotGet _, [ (Paren (_, Tuple _, _, _)) ]) -> None
+    | App (e, [ (Paren (_, singleExpr, _, _) as px) ]) ->
         match singleExpr with
         | SynExpr.Lambda _
         | SynExpr.MatchLambda _ -> None
@@ -1035,8 +1035,8 @@ let (|DotGet|_|) =
 let (|DotGetAppParen|_|) e =
     match e with
     //| App(e, [DotGet (Paren _ as p, (s,r))]) -> Some (e, p, s, r)
-    | DotGet (App (e, [ (Paren (_, Tuple _, _) as px) ]), lids) -> Some(e, px, lids)
-    | DotGet (App (e, [ (Paren (_, singleExpr, _) as px) ]), lids) ->
+    | DotGet (App (e, [ (Paren (_, Tuple _, _, _) as px) ]), lids) -> Some(e, px, lids)
+    | DotGet (App (e, [ (Paren (_, singleExpr, _, _) as px) ]), lids) ->
         match singleExpr with
         | SynExpr.Lambda _
         | SynExpr.MatchLambda _ -> None
@@ -1743,3 +1743,19 @@ let isSynExprLambda =
     function
     | SynExpr.Lambda _ -> true
     | _ -> false
+
+let (|AppParenTupleArg|_|) e =
+    match e with
+    | AppSingleArg (a, Paren (lpr, Tuple (ts, tr), rpr, pr)) -> Some(a, lpr, ts, tr, rpr, pr)
+    | _ -> None
+
+let (|AppParenSingleArg|_|) e =
+    match e with
+    | AppSingleArg (a, Paren (lpr, p, rpr, pr)) -> Some(a, lpr, p, rpr, pr)
+    | _ -> None
+
+let (|AppParenArg|_|) e =
+    match e with
+    | AppParenTupleArg t -> Choice1Of2 t |> Some
+    | AppParenSingleArg s -> Choice2Of2 s |> Some
+    | _ -> None


### PR DESCRIPTION
As the style for multiline function applications can lead to F# compiler warnings when applied inside `if`, `match` or `when` expressions, I've applied a different style to cope with this.

The formatted result is now valid F# code, though it might compromise the esthetics of the code in some cases.
Correct results outweigh the stylistic aspect, this is an acceptable premise.

Fixes #1403
Fixes #1406
Fixes #1402
Fixes #1390