### PR TITLE
fantomas local tool install command is more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The [fsharp-support](https://github.com/JetBrains/fsharp-support) uses fantomas 
 #### Using the latest version inside Rider
 
 For technical reasons Rider cannot always use the latest version of Fantomas found on NuGet.
-As a workaround you could install [fantomas-tool](https://www.nuget.org/packages/fantomas-tool) with `dotnet tool install fantomas-tool` and configure it as an [External tool](https://www.jetbrains.com/help/rider/Settings_Tools_External_Tools.html).
+As a workaround you could install [fantomas-tool](https://www.nuget.org/packages/fantomas-tool) locally with `dotnet tool install fantomas-tool` and configure it as an [External tool](https://www.jetbrains.com/help/rider/Settings_Tools_External_Tools.html).
 
 ![Rider external tool window](./docs/rider-external-tool.png)
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ The [fsharp-support](https://github.com/JetBrains/fsharp-support) uses fantomas 
 #### Using the latest version inside Rider
 
 For technical reasons Rider cannot always use the latest version of Fantomas found on NuGet.
-As a workaround you could install [fantomas-tool](https://www.nuget.org/packages/fantomas-tool) and configure it as an [External tool](https://www.jetbrains.com/help/rider/Settings_Tools_External_Tools.html).
-
-> dotnet tool install fantomas-tool
+As a workaround you could install [fantomas-tool](https://www.nuget.org/packages/fantomas-tool) with `dotnet tool install fantomas-tool` and configure it as an [External tool](https://www.jetbrains.com/help/rider/Settings_Tools_External_Tools.html).
 
 ![Rider external tool window](./docs/rider-external-tool.png)
 


### PR DESCRIPTION
I moved the command line for installing fantomas as a local tool into the paragraph. That should make it a bit more obvious and should prevent people from clicking the link to nuget and using the command line shown there, which is a global install.

No hard feelings, if you think, it was better before ;-)