### PR TITLE
Apply alternate function application style if function contains parenthesis. 

### DIFF
--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -474,3 +474,79 @@ type Queue<'T>(data: list<'T []>, length: int) =
         else
             raise (System.Exception("Queue is empty"))
 """
+
+[<Test>]
+let ``parenthesis around composed function expression, 1341`` () =
+    formatSourceString
+        false
+        """
+(f >> g) (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, c)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(f >> g)
+    (
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+        c
+    )
+"""
+
+[<Test>]
+let ``parenthesis around simple function expression`` () =
+    formatSourceString
+        false
+        """
+(ignore) ("Tuuuuuuuuuuuuurn tooooooooooooooooooooooo stooooooooooooooooooooooooone", 42)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(ignore)
+    (
+        "Tuuuuuuuuuuuuurn tooooooooooooooooooooooo stooooooooooooooooooooooooone",
+        42
+    )
+"""
+
+[<Test>]
+let ``parenthesis around simple function expression with single parenthesis argument`` () =
+    formatSourceString
+        false
+        """
+(ignore) ("Tuuuuuuuuuuuuurn tooooooooooooooooooooooo stooooooooooooooooooooooooone")
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+(ignore)
+    ("Tuuuuuuuuuuuuurn tooooooooooooooooooooooo stooooooooooooooooooooooooone")
+"""
+
+[<Test>]
+let ``parenthesis around simple function expression with single multiline parenthesis argument`` () =
+    formatSourceString
+        false
+        "
+(ignore) (\"\"\"Tuuuuuuuuuuuuurn
+tooooooooooooooooooooooo
+stooooooooooooooooooooooooone\"\"\")
+"
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        "
+(ignore)
+    (
+        \"\"\"Tuuuuuuuuuuuuurn
+tooooooooooooooooooooooo
+stooooooooooooooooooooooooone\"\"\"
+    )
+"

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3248,6 +3248,7 @@ and genAlternativeAppWithSingleParenthesisArgument (e, lpr, a, rpr, pr) astConte
     +> sepSpaceWhenOrIndentAndNlnIfExpressionExceedsPageWidth
         (fun ctx ->
             match e with
+            | Paren _ -> true
             | UppercaseSynExpr _ -> ctx.Config.SpaceBeforeUppercaseInvocation
             | LowercaseSynExpr _ -> ctx.Config.SpaceBeforeLowercaseInvocation)
         (tokN lpr LPAREN sepOpenT

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1923,6 +1923,8 @@ and genExpr astContext synExpr ctx =
 
             fun ctx -> isShortExpression ctx.Config.MaxDotGetExpressionWidth short long ctx
 
+        | AppParenArg (Choice1Of2 (Paren _, _, _, _, _, _) as app)
+        | AppParenArg (Choice2Of2 (Paren _, _, _, _, _) as app) -> genAlternativeAppWithParenthesis app astContext
         | AppSingleArg (e, px) ->
             let sepSpace (ctx: Context) =
                 match e with

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1676,8 +1676,8 @@ let rec (|UppercaseSynExpr|LowercaseSynExpr|) (synExpr: SynExpr) =
     | SynExpr.DotGet (_, _, LongIdentWithDots (lid), _) -> upperOrLower lid
 
     | SynExpr.DotIndexedGet (expr, _, _, _)
-    | SynExpr.TypeApp (expr, _, _, _, _, _, _) -> (|UppercaseSynExpr|LowercaseSynExpr|) expr
-
+    | SynExpr.TypeApp (expr, _, _, _, _, _, _)
+    | SynExpr.Paren (expr, _, _, _) -> (|UppercaseSynExpr|LowercaseSynExpr|) expr
     | _ -> failwithf "cannot determine if synExpr %A is uppercase or lowercase" synExpr
 
 let rec (|UppercaseSynType|LowercaseSynType|) (synType: SynType) =

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1676,8 +1676,7 @@ let rec (|UppercaseSynExpr|LowercaseSynExpr|) (synExpr: SynExpr) =
     | SynExpr.DotGet (_, _, LongIdentWithDots (lid), _) -> upperOrLower lid
 
     | SynExpr.DotIndexedGet (expr, _, _, _)
-    | SynExpr.TypeApp (expr, _, _, _, _, _, _)
-    | SynExpr.Paren (expr, _, _, _) -> (|UppercaseSynExpr|LowercaseSynExpr|) expr
+    | SynExpr.TypeApp (expr, _, _, _, _, _, _) -> (|UppercaseSynExpr|LowercaseSynExpr|) expr
     | _ -> failwithf "cannot determine if synExpr %A is uppercase or lowercase" synExpr
 
 let rec (|UppercaseSynType|LowercaseSynType|) (synType: SynType) =


### PR DESCRIPTION
Fixes #1341.