### PR TITLE
Don't consider long hash directives to be multiline.

### DIFF
--- a/src/Fantomas.Tests/HashDirectiveTests.fs
+++ b/src/Fantomas.Tests/HashDirectiveTests.fs
@@ -116,3 +116,26 @@ let o = {| X = 2; Y = "Hello" |}
 
 printfn "%s" (JsonConvert.SerializeObject o)
 """
+
+[<Test>]
+let ``don't print trivia of other hash directive, 1464`` () =
+    formatSourceString
+        false
+        """
+#r @"C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\5.0.2\Microsoft.Extensions.Hosting.dll"
+#r @"C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\5.0.2\Microsoft.Extensions.ObjectPool.dll"
+#r @"C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\5.0.2\Microsoft.Extensions.Options.ConfigurationExtensions.dll"
+
+#r "nuget: Giraffe"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#r @"C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\5.0.2\Microsoft.Extensions.Hosting.dll"
+#r @"C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\5.0.2\Microsoft.Extensions.ObjectPool.dll"
+#r @"C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\5.0.2\Microsoft.Extensions.Options.ConfigurationExtensions.dll"
+
+#r "nuget: Giraffe"
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -247,6 +247,15 @@ and genModuleDeclList astContext e =
                 sepNlnConsideringTriviaContentBeforeForMainNode SynModuleDecl_Open r
 
             [ expr, sepNln, r ] @ collectItems ys
+        | HashDirectiveL (xs, ys) ->
+            let expr = col sepNln xs (genModuleDecl astContext)
+
+            let r = List.head xs |> fun mdl -> mdl.Range
+            // SynModuleDecl.HashDirective cannot have attributes
+            let sepNln =
+                sepNlnConsideringTriviaContentBeforeForMainNode SynModuleDecl_HashDirective r
+
+            [ expr, sepNln, r ] @ collectItems ys
         | AttributesL (xs, y :: rest) ->
             let attrs =
                 getRangesFromAttributesFromModuleDeclaration y
@@ -273,6 +282,7 @@ and genModuleDeclList astContext e =
                 sepNlnConsideringTriviaContentBeforeForMainNode SynModuleDecl_Attributes r
 
             [ expr, sepNln, r ] @ collectItems rest
+
         | m :: rest ->
             let attrs =
                 getRangesFromAttributesFromModuleDeclaration m


### PR DESCRIPTION
Fixes #1464