### PR TITLE
Only add closing parenthesis on next line if lambda is multiline.

### DIFF
--- a/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -533,3 +533,30 @@ let choose chooser source =
         )
         Set.empty
 """
+
+[<Test>]
+let ``single line lambda, 1474`` () =
+    formatSourceString
+        false
+        """
+module Caching =
+    type MainCache() =
+        member __.GetLastCachedData (): CachedNetworkData =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                sessionCachedNetworkData
+            )
+"""
+        { config with
+              MaxLineLength = 80
+              MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Caching =
+    type MainCache() =
+        member __.GetLastCachedData() : CachedNetworkData =
+            lock
+                cacheFiles.CachedNetworkData
+                (fun _ -> sessionCachedNetworkData)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3183,14 +3183,14 @@ and genApp appNlnFun astContext e es ctx =
                                 else
                                     autoNlnIfExpressionExceedsPageWidth (genExpr astContext e) ctx
 
-                            sepOpenTFor lpr -- "fun "
-                            +> pats
-                            +> indent
-                            +> triviaAfterArrow arrowRange
-                            +> genExprAfterArrow bodyExpr
-                            +> unindent
-                            +> sepNln
-                            +> sepCloseTFor rpr
+                            leadingExpressionIsMultiline
+                                (sepOpenTFor lpr -- "fun "
+                                 +> pats
+                                 +> indent
+                                 +> triviaAfterArrow arrowRange
+                                 +> genExprAfterArrow bodyExpr
+                                 +> unindent)
+                                (fun isMultiline -> onlyIf isMultiline sepNln +> sepCloseTFor rpr)
 
                         match e with
                         | Paren (lpr, DesugaredLambda (cps, e), rpr, _) ->


### PR DESCRIPTION
Fixes #1474.