### PR TITLE
Add space before interpolated string in prefix application.

### DIFF
--- a/src/Fantomas.Tests/InterpolatedStringTests.fs
+++ b/src/Fantomas.Tests/InterpolatedStringTests.fs
@@ -163,3 +163,18 @@ $\"\"\"one: {1}<
 $\"\"\"one: {1}<
 >two: {2}\"\"\"
 "
+
+[<Test>]
+let ``prefix application, 1414`` () =
+    formatSourceString
+        false
+        """
+!- $".{s}"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+!- $".{s}"
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1716,7 +1716,8 @@ and genExpr astContext synExpr ctx =
         | PrefixApp (s, e) ->
             let extraSpaceBeforeString =
                 match e with
-                | String _ -> sepSpace
+                | String _
+                | SynExpr.InterpolatedString _ -> sepSpace
                 | _ -> sepNone
 
             !-s


### PR DESCRIPTION
Fixes #1414.