### PR TITLE
Don't add space between function and unit/parenthesis when argument of prefix app.

### DIFF
--- a/src/Fantomas.Tests/SpaceBeforeLowercaseInvocationTests.fs
+++ b/src/Fantomas.Tests/SpaceBeforeLowercaseInvocationTests.fs
@@ -207,3 +207,22 @@ let untypedResLong =
         somethingElseWithARatherLongVariableName
     )
 """
+
+[<Test>]
+let ``ignore setting when function call is the argument of prefix application`` () =
+    formatSourceString
+        false
+        """
+!-String.Empty.padLeft(braceSize + spaceAround)
+(!-System.String.Empty.padRight(delta)) ({ ctx with RecordBraceStart = rest })
+!- meh()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+!- String.Empty.padLeft(braceSize + spaceAround)
+(!- System.String.Empty.padRight(delta)) ({ ctx with RecordBraceStart = rest })
+!- meh()
+"""

--- a/src/Fantomas.Tests/SpaceBeforeUppercaseInvocationTests.fs
+++ b/src/Fantomas.Tests/SpaceBeforeUppercaseInvocationTests.fs
@@ -252,3 +252,22 @@ module Foo =
     let Bar () =
         (doc.DocumentNode.SelectNodes "//table").[0]
 """
+
+[<Test>]
+let ``ignore setting when function call is the argument of prefix application, 1488`` () =
+    formatSourceString
+        false
+        """
+!-String.Empty.PadLeft(braceSize + spaceAround)
+(!-System.String.Empty.PadRight(delta)) ({ ctx with RecordBraceStart = rest })
+!- Meh()
+"""
+        spaceBeforeConfig
+    |> prepend newline
+    |> should
+        equal
+        """
+!- String.Empty.PadLeft(braceSize + spaceAround)
+(!- System.String.Empty.PadRight(delta)) ({ ctx with RecordBraceStart = rest })
+!- Meh()
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1713,6 +1713,12 @@ and genExpr astContext synExpr ctx =
             ifElse astContext.IsNakedRange expr (sepOpenS +> expr +> sepCloseS)
         // Separate two prefix ops by spaces
         | PrefixApp (s1, PrefixApp (s2, e)) -> !-(sprintf "%s %s" s1 s2) +> genExpr astContext e
+        | PrefixApp (s, App (e, [ Paren _ as p ]))
+        | PrefixApp (s, App (e, [ ConstExpr (SynConst.Unit _, _) as p ])) ->
+            !-s
+            +> sepSpace
+            +> genExpr astContext e
+            +> genExpr astContext p
         | PrefixApp (s, e) ->
             let extraSpaceBeforeString =
                 match e with


### PR DESCRIPTION
Fixes #1488.