### PR TITLE
Don't add newline between empty multiline class constructor. 

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -812,3 +812,25 @@ type SomeVeryLongTypeNameWithConstructor
     class
     end
 """
+
+[<Test>]
+let ``long type generic type constraints with unit constructors, 1494`` () =
+    formatSourceString
+        false
+        """
+type ISingleExpressionValue<'p, 'o, 'v when 'p :> IProperty and 'o :> IOperator and 'p: equality and 'o: equality and 'v: equality> () =
+    abstract Property: 'p
+    abstract Operator: 'o
+    abstract Value: 'v
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type ISingleExpressionValue<'p, 'o, 'v when 'p :> IProperty and 'o :> IOperator and 'p: equality and 'o: equality and 'v: equality>
+    () =
+    abstract Property : 'p
+    abstract Operator : 'o
+    abstract Value : 'v
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4440,17 +4440,29 @@ and genMemberDefn astContext node =
                 +> col sepComma (simplePats ps) (genSimplePat astContext)
                 +> sepCloseT
 
+            let emptyPats =
+                let rec isEmpty ps =
+                    match ps with
+                    | SynSimplePats.SimplePats ([], _) -> true
+                    | SynSimplePats.SimplePats _ -> false
+                    | SynSimplePats.Typed (spts, _, _) -> isEmpty spts
+
+                isEmpty ps
+
             let longExpr ctx =
                 (indent
                  +> sepNln
                  +> optSingle (fun ao -> genAccess ao +> sepNln) ao
-                 +> sepOpenT
-                 +> indent
-                 +> sepNln
-                 +> col (sepComma +> sepNln) (simplePats ps) (genSimplePat astContext)
-                 +> unindent
-                 +> sepNln
-                 +> sepCloseT
+                 +> ifElse
+                     emptyPats
+                     (sepOpenT +> sepCloseT)
+                     (sepOpenT
+                      +> indent
+                      +> sepNln
+                      +> col (sepComma +> sepNln) (simplePats ps) (genSimplePat astContext)
+                      +> unindent
+                      +> sepNln
+                      +> sepCloseT)
                  +> onlyIf ctx.Config.AlternativeLongMemberDefinitions sepNln
                  +> unindent)
                     ctx


### PR DESCRIPTION
Fixes #1494.