### PR TITLE
Refactor ASTTransformer

### DIFF
--- a/src/Fantomas/AstTransformer.fs
+++ b/src/Fantomas/AstTransformer.fs
@@ -7,11 +7,6 @@ open Fantomas
 
 type Id = { Ident: string; Range: Range }
 
-//type Node =
-//    { Type: FsAstType
-//      Range: Range
-//      LinesBetweenParent: int }
-
 module Helpers =
     let i (id: Ident) : Id =
         { Ident = id.idText

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -11,11 +11,11 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="RangeHelpers.fs" />
     <Compile Include="TriviaTypes.fs" />
+    <Compile Include="Dbg.fs" />
+    <Compile Include="Utils.fs" />
     <Compile Include="AstTransformer.fs" />
     <Compile Include="SourceOrigin.fs" />
     <Compile Include="Version.fs" />
-    <Compile Include="Dbg.fs" />
-    <Compile Include="Utils.fs" />
     <Compile Include="Queue.fs" />
     <Compile Include="FormatConfig.fs" />
     <Compile Include="TokenParserBoolExpr.fs" />

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -225,12 +225,36 @@ let synMemberDefnToFsAstType =
     | SynMemberDefn.NestedType _ -> SynMemberDefn_NestedType
     | SynMemberDefn.AutoProperty _ -> SynMemberDefn_AutoProperty
 
-let synExprToFsAstType =
+let synConstToFsAstType =
+    function
+    | SynConst.Bool _ -> SynConst_Bool
+    | SynConst.Unit _ -> SynConst_Unit
+    | SynConst.SByte _ -> SynConst_SByte
+    | SynConst.Byte _ -> SynConst_Byte
+    | SynConst.Int16 _ -> SynConst_Int16
+    | SynConst.UInt16 _ -> SynConst_UInt16
+    | SynConst.Int32 _ -> SynConst_Int32
+    | SynConst.UInt32 _ -> SynConst_UInt32
+    | SynConst.Int64 _ -> SynConst_Int64
+    | SynConst.UInt64 _ -> SynConst_UInt64
+    | SynConst.IntPtr _ -> SynConst_IntPtr
+    | SynConst.UIntPtr _ -> SynConst_UIntPtr
+    | SynConst.Single _ -> SynConst_Single
+    | SynConst.Double _ -> SynConst_Double
+    | SynConst.Char _ -> SynConst_Char
+    | SynConst.Decimal _ -> SynConst_Decimal
+    | SynConst.UserNum _ -> SynConst_UserNum
+    | SynConst.String _ -> SynConst_String
+    | SynConst.Bytes _ -> SynConst_Bytes
+    | SynConst.UInt16s _ -> SynConst_UInt16s
+    | SynConst.Measure _ -> SynConst_Measure
+
+let rec synExprToFsAstType =
     function
     | SynExpr.YieldOrReturn _ -> SynExpr_YieldOrReturn
     | SynExpr.IfThenElse _ -> SynExpr_IfThenElse
     | SynExpr.LetOrUseBang _ -> SynExpr_LetOrUseBang
-    | SynExpr.Const _ -> SynExpr_Const
+    | SynExpr.Const (c, _) -> synConstToFsAstType c
     | SynExpr.Lambda _ -> SynExpr_Lambda
     | SynExpr.Ident _ -> SynExpr_Ident
     | SynExpr.App _ -> SynExpr_App
@@ -245,19 +269,26 @@ let synExprToFsAstType =
     | SynExpr.New _ -> SynExpr_New
     | SynExpr.Quote _ -> SynExpr_Quote
     | SynExpr.DotIndexedSet _ -> SynExpr_DotIndexedSet
-    | SynExpr.LetOrUse _ -> SynExpr_LetOrUse
+    | SynExpr.LetOrUse (_, _, bs, e, _) ->
+        match bs with
+        | [] -> synExprToFsAstType e
+        | (SynBinding.Binding (kind = kind)) :: _ ->
+            match kind with
+            | SynBindingKind.StandaloneExpression -> StandaloneExpression_
+            | SynBindingKind.NormalBinding -> NormalBinding_
+            | SynBindingKind.DoBinding -> DoBinding_
     | SynExpr.TryWith _ -> SynExpr_TryWith
     | SynExpr.YieldOrReturnFrom _ -> SynExpr_YieldOrReturnFrom
     | SynExpr.While _ -> SynExpr_While
     | SynExpr.TryFinally _ -> SynExpr_TryFinally
     | SynExpr.Do _ -> SynExpr_Do
     | SynExpr.AddressOf _ -> SynExpr_AddressOf
-    | SynExpr.Typed _ -> SynExpr_Typed
+    | SynExpr.Typed (e, _, _) -> synExprToFsAstType e
     | SynExpr.ArrayOrList _ -> SynExpr_ArrayOrList
     | SynExpr.ObjExpr _ -> SynExpr_ObjExpr
     | SynExpr.For _ -> SynExpr_For
     | SynExpr.ForEach _ -> SynExpr_ForEach
-    | SynExpr.CompExpr _ -> SynExpr_CompExpr
+    | SynExpr.CompExpr (_, _, e, _) -> synExprToFsAstType e
     | SynExpr.MatchLambda _ -> SynExpr_MatchLambda
     | SynExpr.Assert _ -> SynExpr_Assert
     | SynExpr.TypeApp _ -> SynExpr_TypeApp
@@ -289,7 +320,7 @@ let synExprToFsAstType =
     | SynExpr.DiscardAfterMissingQualificationAfterDot _ -> SynExpr_DiscardAfterMissingQualificationAfterDot
     | SynExpr.Fixed _ -> SynExpr_Fixed
     | SynExpr.InterpolatedString _ -> SynExpr_InterpolatedString
-    | SynExpr.Sequential _ -> SynExpr_Sequential
+    | SynExpr.Sequential (_, _, e, _, _) -> synExprToFsAstType e
 
 let synModuleSigDeclToFsAstType =
     function

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -153,13 +153,26 @@ let private findNodeAfterLineAndColumn (nodes: TriviaNodeAssigner list) line col
             || (range.StartLine = line
                 && range.StartColumn > column))
 
-let private findConstNodeOnLineAndColumn (nodes: TriviaNodeAssigner list) (constantRange: Range) =
+let private findConstNumberNodeOnLineAndColumn (nodes: TriviaNodeAssigner list) (constantRange: Range) =
     nodes
     |> List.tryFind
         (fun tn ->
             match tn.Type with
-            | MainNode (SynExpr_Const)
-            | MainNode (SynPat_Const) ->
+            | MainNode (SynConst_Byte)
+            | MainNode (SynConst_SByte)
+            | MainNode (SynConst_Int16)
+            | MainNode (SynConst_Int32)
+            | MainNode (SynConst_Int64)
+            | MainNode (SynConst_UInt16)
+            | MainNode (SynConst_UInt16s)
+            | MainNode (SynConst_UInt32)
+            | MainNode (SynConst_UInt64)
+            | MainNode (SynConst_Double)
+            | MainNode (SynConst_Single)
+            | MainNode (SynConst_Decimal)
+            | MainNode (SynConst_IntPtr)
+            | MainNode (SynConst_UIntPtr)
+            | MainNode (SynConst_UserNum) ->
                 constantRange.StartLine = tn.Range.StartLine
                 && constantRange.StartColumn = tn.Range.StartColumn
             | MainNode (EnumCase_) ->
@@ -439,7 +452,7 @@ let private addTriviaToTriviaNode
 
     | { Item = Number _ as number
         Range = range } ->
-        findConstNodeOnLineAndColumn triviaNodes range
+        findConstNumberNodeOnLineAndColumn triviaNodes range
         |> updateTriviaNode (fun tn -> tn.ContentItself <- Some number) triviaNodes
 
     | { Item = CharContent _ as chNode

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -33,24 +33,6 @@ let isToken (node: TriviaNode) =
     | Token _ -> true
     | _ -> false
 
-let filterNodes nodes =
-    let filterOutNodeTypes =
-        set [ SynExpr_Sequential // some Sequential nodes are not visited in CodePrinter
-              SynModuleOrNamespace_DeclaredNamespace // LongIdent inside Namespace is being processed as children.
-              SynModuleOrNamespaceSig_DeclaredNamespace
-              SynExpr_LetOrUse
-              SynTypeDefnRepr_ObjectModel
-              SynTypeDefnRepr_Simple
-              TypeDefnSig_
-              SynTypeDefnSigRepr_ObjectModel
-              SynExpr_Typed
-              // SynType_StaticConstant
-              SynExpr_CompExpr ]
-    // SynExpr_Do ]
-
-    nodes
-    |> List.filter (fun (n: Node) -> not (Set.contains n.Type filterOutNodeTypes))
-
 let private findFirstNodeOnLine (nodes: TriviaNode list) lineNumber : TriviaNode option =
     nodes
     |> List.filter (fun { Range = r } -> r.StartLine = lineNumber)
@@ -540,10 +522,7 @@ let collectTrivia (mkRange: MkRange) tokens (ast: ParsedInput) =
         | { Range = Some r } :: _ -> r.StartLine
         | _ -> 1
 
-    let triviaNodesFromAST =
-        nodes
-        |> filterNodes // TODO: perhaps not capture in the first place?
-        |> List.choose mapNodeToTriviaNode
+    let triviaNodesFromAST = nodes |> List.choose mapNodeToTriviaNode
 
     let hasAnyAttributesWithLinesBetweenParent =
         List.exists (fun (tn: TriviaNodeAssigner) -> Option.isSome tn.AttributeLinesBetweenParent) triviaNodesFromAST

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -113,8 +113,8 @@ type FsAstType =
     | SynModuleDecl_NamespaceFragment
     | SynExpr_Paren
     | SynExpr_Quote
-    | SynExpr_Const
-    | SynExpr_Typed
+    // | SynExpr_Const use SynConst instead
+    // | SynExpr_Typed use either the nested SynExpr or SynType
     | SynExpr_Tuple
     | SynExpr_StructTuple
     | SynExpr_Record
@@ -126,7 +126,7 @@ type FsAstType =
     | SynExpr_ForEach
     | SynExpr_ArrayOrListOfSeqExpr
     | SynExpr_ArrayOrList
-    | SynExpr_CompExpr
+    // | SynExpr_CompExpr use first nested SynExpr
     | SynExpr_Lambda
     | SynExpr_MatchLambda
     | SynExpr_Match
@@ -134,11 +134,11 @@ type FsAstType =
     | SynExpr_Assert
     | SynExpr_App
     | SynExpr_TypeApp
-    | SynExpr_LetOrUse
+    // | SynExpr_LetOrUse use first nested SynExpr
     | SynExpr_TryWith
     | SynExpr_TryFinally
     | SynExpr_Lazy
-    | SynExpr_Sequential
+    // | SynExpr_Sequential use first nested SynExpr
     | SynExpr_SequentialOrImplicitYield
     | SynExpr_IfThenElse
     | SynExpr_Ident
@@ -191,8 +191,8 @@ type FsAstType =
     | ArgOptions_
     | InterfaceImpl_
     | TypeDefn_
-    | TypeDefnSig_
-    | SynTypeDefnSigRepr_ObjectModel
+    // | TypeDefnSig_ use first nested type
+    // | SynTypeDefnSigRepr_ObjectModel use first nested node
     | SynTypeDefnSigRepr_Exception
     | SynMemberDefn_Open
     | SynMemberDefn_OpenType
@@ -219,7 +219,7 @@ type FsAstType =
     | TyparDecl_
     | Typar_
     | ValSpfn_
-    | SynPat_Const
+    // | SynPat_Const, use SynConst instead
     | SynPat_Wild
     | SynPat_Named
     | SynPat_Typed
@@ -262,8 +262,8 @@ type FsAstType =
     | Pats_
     | NamePatPairs_
     | ComponentInfo_
-    | SynTypeDefnRepr_ObjectModel
-    | SynTypeDefnRepr_Simple
+    // | SynTypeDefnRepr_ObjectModel use first nested node
+    // | SynTypeDefnRepr_Simple use first nested node
     | SynTypeDefnRepr_Exception
     | SynTypeDefnKind_TyconUnspecified
     | SynTypeDefnKind_TyconClass

--- a/src/Fantomas/Utils.fs
+++ b/src/Fantomas/Utils.fs
@@ -155,3 +155,10 @@ module Map =
 module Async =
     let map f computation =
         async.Bind(computation, f >> async.Return)
+
+[<RequireQualifiedAccess>]
+module Continuation =
+    let rec sequence<'a, 'ret> (recursions: (('a -> 'ret) -> 'ret) list) (finalContinuation: 'a list -> 'ret) : 'ret =
+        match recursions with
+        | [] -> [] |> finalContinuation
+        | recurse :: recurses -> recurse (fun ret -> sequence recurses (fun rets -> ret :: rets |> finalContinuation))


### PR DESCRIPTION
Refactored ASTTransformer:
- optimized for tail recursion, heavily inspired by https://www.gresearch.co.uk/article/advanced-recursion-techniques-in-f/
- Threw out ASTNodes that we never use.
- Threw out properties and FsAstNode as they are not used.

Please review if I missed something.