### PR TITLE
Sync Documentation.md with FormatConfig.fs

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -74,8 +74,6 @@ fsharp_indent_on_try_with=false
 fsharp_space_around_delimiter=true
 fsharp_max_if_then_else_short_width=40
 fsharp_max_infix_operator_expression=50
-fsharp_max_newline_infix_operator_expression_number_of_items=1
-fsharp_multiline_infix_multiline_formatter=character_width
 fsharp_max_record_width=40
 fsharp_max_record_number_of_items=1
 fsharp_record_multiline_formatter=character_width
@@ -92,8 +90,8 @@ fsharp_max_elmish_width=40
 fsharp_single_argument_web_mode=false
 fsharp_align_function_signature_to_indentation=false
 fsharp_alternative_long_member_definitions=false
-fsharp_disable_elmish_syntax=false
 fsharp_multi_line_lambda_closing_newline=false
+fsharp_disable_elmish_syntax=false
 fsharp_strict_mode=false
 ```
 
@@ -953,31 +951,6 @@ type C
     end
 ```
 
-### fsharp_disable_elmish_syntax
-
-Disable the default [Elmish formatting style](./Formatting-Elmish-code.md). When `fsharp_disable_elmish_syntax` is enabled `fsharp_max_elmish_width` and `fsharp_single_argument_web_mode` will have no effect anymore.
-
-`defaultConfig`
-
-```fsharp
-let encodeInput (input: Input) =
-    Encode.object [ "sourceCode", Encode.string input.SourceCode
-                    "defines",
-                    (Array.map Encode.string input.Defines
-                     |> Encode.array)
-                    "isFsi", Encode.bool input.IsFsi ]
-```
-
-`{ defaultConfig with DisableElmishSyntax = true }`
-
-```fsharp
-let encodeUrlModel code model: JsonValue =
-    Encode.object
-        [ "defines", Encode.string model.Defines
-          "isFsi", Encode.bool model.IsFsi
-          "code", Encode.string code ]
-```
-
 ### fsharp_multi_line_lambda_closing_newline
 
 Places the closing parenthesis of a multiline lambda argument on the next line.
@@ -1020,6 +993,30 @@ let printListWithOffset a list1 =
     )
 ```
 
+### fsharp_disable_elmish_syntax
+
+Disable the default [Elmish formatting style](./Formatting-Elmish-code.md). When `fsharp_disable_elmish_syntax` is enabled `fsharp_max_elmish_width` and `fsharp_single_argument_web_mode` will have no effect anymore.
+
+`defaultConfig`
+
+```fsharp
+let encodeInput (input: Input) =
+    Encode.object [ "sourceCode", Encode.string input.SourceCode
+                    "defines",
+                    (Array.map Encode.string input.Defines
+                     |> Encode.array)
+                    "isFsi", Encode.bool input.IsFsi ]
+```
+
+`{ defaultConfig with DisableElmishSyntax = true }`
+
+```fsharp
+let encodeUrlModel code model: JsonValue =
+    Encode.object
+        [ "defines", Encode.string model.Defines
+          "isFsi", Encode.bool model.IsFsi
+          "code", Encode.string code ]
+```
 
 ### fsharp_strict_mode
 


### PR DESCRIPTION
* Remove two `.editorconfig` entries that seem to be unused.
* Minor ordering change to align with FormatConfig.fs.