### PR TITLE
Remove getByLookup function in SourceTransformer.fs

### DIFF
--- a/src/Fantomas/CodeFormatterImpl.fs
+++ b/src/Fantomas/CodeFormatterImpl.fs
@@ -14,7 +14,6 @@ open Fantomas.FormatConfig
 open Fantomas.SourceOrigin
 open Fantomas.SourceParser
 open Fantomas.CodePrinter
-open System.IO
 
 let private getSourceString (source: SourceOrigin) =
     match source with
@@ -378,9 +377,6 @@ let isValidFSharpCode (checker: FSharpChecker) (parsingOptions: FSharpParsingOpt
     }
 
 let formatWith ast defines hashTokens formatContext config =
-    let moduleName =
-        Path.GetFileNameWithoutExtension formatContext.FileName
-
     let sourceCodeOrEmptyString =
         if String.IsNullOrWhiteSpace formatContext.Source then
             String.Empty
@@ -392,10 +388,7 @@ let formatWith ast defines hashTokens formatContext config =
             Context.Context.Create config defines formatContext.FileName hashTokens sourceCodeOrEmptyString (Some ast)
 
         context
-        |> genParsedInput
-            { ASTContext.Default with
-                  TopLevelModuleName = moduleName }
-            ast
+        |> genParsedInput ASTContext.Default ast
         |> Dbg.tee (fun ctx -> printfn "%A" ctx.WriterEvents)
         |> Context.dump
 

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -160,8 +160,6 @@ type internal Context =
       BreakOn: string -> bool
       /// The original source string to query as a last resort
       Content: string
-      /// Positions of new lines in the original source string
-      Positions: int []
       TriviaMainNodes: Map<FsAstType, TriviaNode list>
       TriviaTokenNodes: Map<FsTokenType, TriviaNode list>
       RecordBraceStart: int list
@@ -175,7 +173,6 @@ type internal Context =
           BreakLines = true
           BreakOn = (fun _ -> false)
           Content = ""
-          Positions = [||]
           TriviaMainNodes = Map.empty
           TriviaTokenNodes = Map.empty
           RecordBraceStart = []
@@ -190,12 +187,6 @@ type internal Context =
         (maybeAst: ParsedInput option)
         =
         let content = String.normalizeNewLine content
-
-        let positions =
-            content.Split('\n')
-            |> Seq.map (fun s -> String.length s + 1)
-            |> Seq.scan (+) 0
-            |> Seq.toArray
 
         let tokens =
             TokenParser.tokenize defines hashTokens content
@@ -234,7 +225,6 @@ type internal Context =
         { Context.Default with
               Config = config
               Content = content
-              Positions = positions
               TriviaMainNodes = triviaByNodes
               TriviaTokenNodes = triviaByTokenNames
               FileName = fileName }
@@ -1146,7 +1136,8 @@ let internal printTriviaContent (c: TriviaContent) (ctx: Context) =
     | StringContent _
     | IdentOperatorAsWord _
     | IdentBetweenTicks _
-    | CharContent _ -> sepNone // don't print here but somewhere in CodePrinter
+    | CharContent _
+    | EmbeddedIL _ -> sepNone // don't print here but somewhere in CodePrinter
     | Directive (s)
     | Comment (LineCommentOnSingleLine s) ->
         (ifElse addNewline sepNln sepNone)

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -24,49 +24,6 @@ let MaxLength = 512
 [<Literal>]
 let private MangledGlobalName : string = "`global`"
 
-/// Get source string content based on range value
-let lookup (r: Range) (c: Context) =
-    if r.EndLine < c.Positions.Length then
-        let start =
-            c.Positions.[r.StartLine - 1] + r.StartColumn
-
-        let startLength =
-            c.Positions.[r.StartLine]
-            - c.Positions.[r.StartLine - 1]
-
-        let finish =
-            c.Positions.[r.EndLine - 1] + r.EndColumn - 1
-
-        let finishLength =
-            c.Positions.[r.EndLine]
-            - c.Positions.[r.EndLine - 1]
-
-        let content = c.Content
-        // Any line with more than 512 characters isn't reliable for querying
-        if start > finish
-           || startLength >= MaxLength
-           || finishLength >= MaxLength then
-            Debug.WriteLine("Can't lookup between start = {0} and finish = {1}", start, finish)
-            None
-        else
-            let s = content.[start..finish]
-            Debug.WriteLine("Content: {0} at start = {1}, finish = {2}", s, start, finish)
-
-            if s.Contains("\\\n") then
-                // Terrible hack to compensate the offset made by F# compiler
-                let last =
-                    content.[c.Positions.[r.EndLine - 1]..finish]
-
-                let offset =
-                    min (last.Length - last.TrimStart(' ').Length) (content.Length - finish - 1)
-
-                Debug.WriteLine("Content after patch: {0} with offset = {1}", s, offset)
-                Some content.[start..finish + offset]
-            else
-                Some s
-    else
-        None
-
 let (|Ident|) (s: Ident) =
     let ident = s.idText
 

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -31,15 +31,6 @@ let hasParenInPat =
     | PatParen _ -> true
     | _ -> false
 
-let getByLookup range f x =
-    fun ctx ->
-        if ctx.Config.StrictMode then
-            f x ctx
-        else
-            match lookup range ctx with
-            | Some x' -> str x' ctx
-            | None -> f x ctx
-
 // A few active patterns for printing purpose
 
 let rec (|DoExprAttributesL|_|) =

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -513,6 +513,15 @@ let private addTriviaToTriviaNode
                 && t.Range.StartLine = range.StartLine)
         |> updateTriviaNode (fun tn -> tn.ContentItself <- Some iNode) triviaNodes
 
+    | { Item = EmbeddedIL _ as eil
+        Range = range } ->
+        triviaNodes
+        |> List.tryFind
+            (fun t ->
+                match t.Type with
+                | MainNode (SynExpr_LibraryOnlyILAssembly) -> RangeHelpers.rangeEq t.Range range
+                | _ -> false)
+        |> updateTriviaNode (fun tn -> tn.ContentItself <- Some eil) triviaNodes
     | _ -> triviaNodes
 
 let private triviaNodeIsNotEmpty (triviaNode: TriviaNodeAssigner) =

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -85,6 +85,7 @@ type TriviaContent =
     | Newline
     | Directive of directive: string
     | CharContent of string
+    | EmbeddedIL of string
 
 type Trivia =
     { Item: TriviaContent


### PR DESCRIPTION
This PR captures the tokens for `SynExpr.LibraryOnlyILAssembly` and prints the collected trivia.
This removes the need to have positions in ASTContext.
Also removed unused field `TopLevelModuleName`.

Fixes #594