### PR TITLE
Keep hex escapes in string literals (#1508)

### DIFF
--- a/src/Fantomas.Tests/SynConstTests.fs
+++ b/src/Fantomas.Tests/SynConstTests.fs
@@ -294,3 +294,15 @@ let f (c: char) =
     | '\u0000'
     | _ -> ()
 """
+
+[<Test>]
+let ``hex escape in string literal should be preserved, 1508`` () =
+    formatSourceString
+        false
+        """let nullString = "\x00"
+"""
+        config
+    |> should
+        equal
+        """let nullString = "\x00"
+"""

--- a/src/Fantomas.Tests/SynConstTests.fs
+++ b/src/Fantomas.Tests/SynConstTests.fs
@@ -299,10 +299,12 @@ let f (c: char) =
 let ``hex escape in string literal should be preserved, 1508`` () =
     formatSourceString
         false
-        """let nullString = "\x00"
+        """let hexEscape = "\x00"
+let controlEscapes = "\a \b \f \v"
 """
         config
     |> should
         equal
-        """let nullString = "\x00"
+        """let hexEscape = "\x00"
+let controlEscapes = "\a \b \f \v"
 """

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -507,7 +507,7 @@ let private (|InterpStringEndOrPartToken|_|) token =
         None
 
 let escapedCharacterRegex =
-    System.Text.RegularExpressions.Regex("(\\\\(n|r|u|'|\\\"|\\\\))+")
+    System.Text.RegularExpressions.Regex("(\\\\(n|r|u|x|'|\\\"|\\\\))+")
 
 let rec private (|EndOfInterpolatedString|_|) tokens =
     match tokens with

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -507,7 +507,7 @@ let private (|InterpStringEndOrPartToken|_|) token =
         None
 
 let escapedCharacterRegex =
-    System.Text.RegularExpressions.Regex("(\\\\(n|r|u|x|'|\\\"|\\\\))+")
+    System.Text.RegularExpressions.Regex("(\\\\(a|b|f|n|r|u|v|x|'|\\\"|\\\\))+")
 
 let rec private (|EndOfInterpolatedString|_|) tokens =
     match tokens with


### PR DESCRIPTION
Fixes #1508 .

And maybe `\a`, `\b`, `\f` and `\v` too? (because I don't know about these escapes so didn't touch.)