### PR TITLE
Don't indent and add newline when multiline Feliz expression has no children

### DIFF
--- a/src/Fantomas.Tests/ElmishTests.fs
+++ b/src/Fantomas.Tests/ElmishTests.fs
@@ -1290,3 +1290,37 @@ let html =
                                                           (* meh *)
                                                            ] ] ] ]
 """
+
+[<Test>]
+let ``empty single list long expression, 1510`` () =
+    formatSourceString
+        false
+        """
+[<ReactComponent>]
+let Dashboard () =
+    Html.div [
+        Html.div []
+        Html.div [
+            Html.text "hola muy buenas"
+        ]
+    ]
+"""
+        { config with
+              RecordMultilineFormatter = Fantomas.FormatConfig.MultilineFormatterType.NumberOfItems
+              MaxArrayOrListWidth = 20
+              MaxElmishWidth = 10
+              SingleArgumentWebMode = true
+              MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+[<ReactComponent>]
+let Dashboard () =
+    Html.div [
+        Html.div []
+        Html.div [
+            Html.text "hola muy buenas"
+        ]
+    ]
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1090,17 +1090,18 @@ and genExpr astContext synExpr ctx =
                             | _ -> false)
                             (Map.tryFindOrEmptyList closingTokenType ctx.TriviaTokenNodes)
 
+                    let hasChildren = List.isNotEmpty children
+
                     atCurrentColumn (
                         !-identifier
                         +> sepSpace
                         +> tokN openingTokenRange openTokenType (ifElse isArray sepOpenAFixed sepOpenLFixed)
-                        +> indent
-                        +> sepNln
+                        +> onlyIf hasChildren (indent +> sepNln)
                         +> col sepNln children (genExpr astContext)
                         +> onlyIf hasBlockCommentBeforeClosingToken (sepNln +> unindent)
                         +> enterNodeTokenByName closingTokenRange closingTokenType
                         +> onlyIfNot hasBlockCommentBeforeClosingToken unindent
-                        +> sepNlnUnlessLastEventIsNewline
+                        +> onlyIf hasChildren sepNlnUnlessLastEventIsNewline
                         +> ifElse isArray sepCloseAFixed sepCloseLFixed
                         +> leaveNodeTokenByName closingTokenRange closingTokenType
                     )


### PR DESCRIPTION
Fixes #1510.