### PR TITLE
Add extra space before pipe if multiline line or pattern in list/array

### DIFF
--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -1410,3 +1410,122 @@ match x with
   y
 | None -> 42
 """
+
+[<Test>]
+let ``or pattern in list with when clause, 1522`` () =
+    formatSourceString
+        false
+        """
+let args =
+    match args with
+    | [SynPatErrorSkip(SynPat.Tuple (false, args, _)) | SynPatErrorSkip(SynPat.Paren(SynPatErrorSkip(SynPat.Tuple (false, args, _)), _))] when numArgTys > 1 -> args
+    | _ -> failwith "meh"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let args =
+    match args with
+    | [ SynPatErrorSkip (SynPat.Tuple (false, args, _))
+         | SynPatErrorSkip (SynPat.Paren (SynPatErrorSkip (SynPat.Tuple (false, args, _)), _)) ] when numArgTys > 1 ->
+        args
+    | _ -> failwith "meh"
+"""
+
+[<Test>]
+let ``triple or in list, short`` () =
+    formatSourceString
+        false
+        """
+let args =
+    match args with
+    | [ LongPatIndentifierOne
+         | LongPatIndentifierTwo
+         | LongPatIndentifierThree ] ->
+        args
+    | _ -> failwith "meh"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let args =
+    match args with
+    | [ LongPatIndentifierOne | LongPatIndentifierTwo | LongPatIndentifierThree ] -> args
+    | _ -> failwith "meh"
+"""
+
+[<Test>]
+let ``triple or in list, long`` () =
+    formatSourceString
+        false
+        """
+let args =
+    match args with
+    | [ LongPatIndentifierOne
+         | LongPatIndentifierTwo
+         | LongPatIndentifierThree ] ->
+        args
+    | _ -> failwith "meh"
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let args =
+    match args with
+    | [ LongPatIndentifierOne
+         | LongPatIndentifierTwo
+         | LongPatIndentifierThree ] -> args
+    | _ -> failwith "meh"
+"""
+
+[<Test>]
+let ``triple or in array, short`` () =
+    formatSourceString
+        false
+        """
+let args =
+    match args with
+    | [| LongPatIndentifierOne | LongPatIndentifierTwo | LongPatIndentifierThree |] ->
+        args
+    | _ -> failwith "meh"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let args =
+    match args with
+    | [| LongPatIndentifierOne | LongPatIndentifierTwo | LongPatIndentifierThree |] -> args
+    | _ -> failwith "meh"
+"""
+
+[<Test>]
+let ``triple or in array, long`` () =
+    formatSourceString
+        false
+        """
+let args =
+    match args with
+    | [| LongPatIndentifierOne | LongPatIndentifierTwo | LongPatIndentifierThree |] ->
+        args
+    | _ -> failwith "meh"
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let args =
+    match args with
+    | [| LongPatIndentifierOne
+          | LongPatIndentifierTwo
+          | LongPatIndentifierThree |] -> args
+    | _ -> failwith "meh"
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4739,6 +4739,32 @@ and genPat astContext pat =
         +> sepOpenT
         +> atCurrentColumn (colAutoNlnSkip0 sepComma ps (genPat astContext))
         +> sepCloseT
+    | PatSeq (patListType, [ PatOrs (patOrs) ]) ->
+        let sepOpen, sepClose =
+            match patListType with
+            | PatArray -> sepOpenA, sepCloseA
+            | PatList -> sepOpenL, sepCloseL
+
+        let short =
+            sepOpen
+            +> col (sepSpace +> sepBar) patOrs (genPat astContext)
+            +> sepClose
+
+        let long =
+            sepOpen
+            +> atCurrentColumnIndent (
+                match patOrs with
+                | [] -> sepNone
+                | hp :: pats ->
+                    genPat astContext hp +> sepNln -- " "
+                    +> atCurrentColumn (
+                        sepBar
+                        +> col (sepNln +> sepBar) pats (genPat astContext)
+                    )
+            )
+            +> sepClose
+
+        expressionFitsOnRestOfLine short long
     | PatSeq (PatList, ps) ->
         ifElse
             ps.IsEmpty

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1,7 +1,6 @@
 module internal Fantomas.SourceParser
 
 open System
-open System.Diagnostics
 open FSharp.Compiler.SourceCodeServices.PrettyNaming
 open FSharp.Compiler.SourceCodeServices.FSharpKeywords
 open FSharp.Compiler.Text
@@ -13,10 +12,6 @@ open Fantomas.Context
 type Composite<'a, 'b> =
     | Pair of 'b * 'b
     | Single of 'a
-
-#if INTERACTIVE
-type Debug = Console
-#endif
 
 [<Literal>]
 let MaxLength = 512
@@ -1100,6 +1095,12 @@ let (|PatAttrib|_|) =
 let (|PatOr|_|) =
     function
     | SynPat.Or (p1, p2, _) -> Some(p1, p2)
+    | _ -> None
+
+let rec (|PatOrs|_|) =
+    function
+    | PatOr (PatOrs (pats), p2) -> Some [ yield! pats; yield p2 ]
+    | PatOr (p1, p2) -> Some [ p1; p2 ]
     | _ -> None
 
 let (|PatAnds|_|) =


### PR DESCRIPTION
Edge case scenario but the extra space is required.
Fixes #1522.