### PR TITLE
Further indent multiline DotGet inside infix expression.

### DIFF
--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -930,3 +930,40 @@ let retrySql<'a> =
         )
         .AsAsyncPolicy<'a>()
 """
+
+[<Test>]
+let ``dotget in multiline infix expression, 1521`` () =
+    formatSourceString
+        false
+        """
+let PublishValueDefn cenv env declKind (vspec: Val) =
+    if (declKind = ModuleOrMemberBinding) &&
+       ((GetCurrAccumulatedModuleOrNamespaceType env).ModuleOrNamespaceKind = Namespace) &&
+       (Option.isNone vspec.MemberInfo) then
+           errorR(Error(FSComp.SR.tcNamespaceCannotContainValues(), vspec.Range))
+
+    if (declKind = ExtrinsicExtensionBinding) &&
+       ((GetCurrAccumulatedModuleOrNamespaceType env).ModuleOrNamespaceKind = Namespace) then
+           errorR(Error(FSComp.SR.tcNamespaceCannotContainExtensionMembers(), vspec.Range))
+
+    ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let PublishValueDefn cenv env declKind (vspec: Val) =
+    if (declKind = ModuleOrMemberBinding)
+       && ((GetCurrAccumulatedModuleOrNamespaceType env)
+              .ModuleOrNamespaceKind = Namespace)
+       && (Option.isNone vspec.MemberInfo) then
+        errorR (Error(FSComp.SR.tcNamespaceCannotContainValues (), vspec.Range))
+
+    if (declKind = ExtrinsicExtensionBinding)
+       && ((GetCurrAccumulatedModuleOrNamespaceType env)
+              .ModuleOrNamespaceKind = Namespace) then
+        errorR (Error(FSComp.SR.tcNamespaceCannotContainExtensionMembers (), vspec.Range))
+
+    ()
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2781,6 +2781,7 @@ and genExprInMultilineInfixExpr astContext e =
                 (sepNlnConsideringTriviaContentBeforeForMainNode (synExprToFsAstType e) e.Range
                  +> genExpr astContext e)
         )
+    | Paren (_, InfixApp (_, _, DotGet _, _), _, _) -> atCurrentColumnIndent (genExpr astContext e)
     | _ -> genExpr astContext e
 
 and genLidsWithDots (lids: (string * range) list) =


### PR DESCRIPTION
Fixes #1521.