### PR TITLE
Collect empty define block as single trivia.

### DIFF
--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -2306,3 +2306,80 @@ module ReactHookExtensions =
 
             deferred
 """
+
+
+[<Test>]
+let ``simple hash directive consider as one trivia`` () =
+    formatSourceStringWithDefines
+        []
+        """
+let x =
+    #if DEBUG
+    printfn "DEBUG"
+    #endif
+    ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x =
+#if DEBUG
+
+#endif
+    ()
+"""
+
+[<Test>]
+let ``hash if and hash else should be one trivia`` () =
+    formatSourceStringWithDefines
+        []
+        """
+#if FOO
+                printfn "FOO"
+#else
+                ()
+#endif
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#if FOO
+
+#else
+()
+#endif
+"""
+
+[<Test>]
+let ``empty hash directive block should not make expression multiline`` () =
+    formatSourceString
+        false
+        """
+    do
+#if FOOBAR
+
+#endif
+        assembly.MainModule.Attributes <- assembly.MainModule.Attributes &&& (~~~ModuleAttributes.StrongNameSigned)
+        assemblyName.HasPublicKey <- false
+        assemblyName.PublicKey <- null
+        assemblyName.PublicKeyToken <- null
+"""
+        { config with
+              MaxInfixOperatorExpression = 75 }
+    |> prepend newline
+    |> should
+        equal
+        """
+do
+#if FOOBAR
+
+#endif
+    assembly.MainModule.Attributes <- assembly.MainModule.Attributes &&& (~~~ModuleAttributes.StrongNameSigned)
+    assemblyName.HasPublicKey <- false
+    assemblyName.PublicKey <- null
+    assemblyName.PublicKeyToken <- null
+"""

--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -2307,7 +2307,6 @@ module ReactHookExtensions =
             deferred
 """
 
-
 [<Test>]
 let ``simple hash directive consider as one trivia`` () =
     formatSourceStringWithDefines
@@ -2382,4 +2381,36 @@ do
     assemblyName.HasPublicKey <- false
     assemblyName.PublicKey <- null
     assemblyName.PublicKeyToken <- null
+"""
+
+[<Test>]
+let ``comment after compiler define`` () =
+    formatSourceString
+        false
+        """
+#if EXTENDED_EXTENSION_MEMBERS // indicates if extension members can add additional constraints to type parameters
+    let tcrefObjTy, enclosingDeclaredTypars, renaming, objTy = FreshenTyconRef m (if isExtrinsic then TyparRigidity.Flexible else rigid) tcref declaredTyconTypars
+#else
+    let tcrefObjTy, enclosingDeclaredTypars, renaming, objTy = FreshenTyconRef m rigid tcref declaredTyconTypars
+#endif
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#if EXTENDED_EXTENSION_MEMBERS // indicates if extension members can add additional constraints to type parameters
+let tcrefObjTy, enclosingDeclaredTypars, renaming, objTy =
+    FreshenTyconRef
+        m
+        (if isExtrinsic then
+             TyparRigidity.Flexible
+         else
+             rigid)
+        tcref
+        declaredTyconTypars
+#else
+let tcrefObjTy, enclosingDeclaredTypars, renaming, objTy =
+    FreshenTyconRef m rigid tcref declaredTyconTypars
+#endif
 """

--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -306,13 +306,10 @@ let x = 1
     let triviaNodes =
         TokenParser.tokenize defines.[0] hashTokens source
         |> getTriviaFromTokens
-        |> List.choose
-            (fun tv ->
-                match tv.Item with
-                | Directive (directive) -> Some directive
-                | _ -> None)
 
-    List.length triviaNodes == 3
+    match triviaNodes with
+    | [ { Item = Newline }; { Item = Directive "#if NOT_DEFINED\n#else\n\n#endif" } ] -> pass ()
+    | _ -> Assert.Fail(sprintf "Unexpected trivia %A" triviaNodes)
 
 [<Test>]
 let ``member and override`` () =

--- a/src/Fantomas/Queue.fs
+++ b/src/Fantomas/Queue.fs
@@ -122,4 +122,4 @@ module Queue =
     let inline append (q: Queue<'T>) xs = q.Append xs
 
     /// Equivalent of q |> Queue.toSeq |> Seq.skip n |> Seq.exists f
-    let inline skipExists n f p (q: Queue<'T>) = q.SkipExists n f p
+    let inline skipExists (n: int) (f: 'T -> bool) (p: 'T [] -> bool) (q: Queue<'T>) : bool = q.SkipExists n f p

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -670,6 +670,27 @@ let private (|EmbeddedILTokens|_|) (tokens: Token list) =
         | _ -> None
     | _ -> None
 
+let rec private (|HashTokens|_|) (tokens: Token list) =
+    match tokens with
+    | ({ TokenInfo = { TokenName = "HASH_IF" } } as head) :: rest ->
+        let tokensFromSameLine =
+            List.takeWhile (fun t -> t.LineNumber = head.LineNumber) rest
+
+        let nextTokens =
+            List.skip tokensFromSameLine.Length rest
+            |> List.skipWhile (fun t -> t.TokenInfo.Tag = whiteSpaceTag)
+
+        match nextTokens with
+        | HashTokens (nextHashTokens, rest) ->
+            let totalHashTokens =
+                [ yield head
+                  yield! tokensFromSameLine
+                  yield! nextHashTokens ]
+
+            Some(totalHashTokens, rest)
+        | _ -> Some(head :: tokensFromSameLine, rest)
+    | _ -> None
+
 let rec private getTriviaFromTokensThemSelves
     (mkRange: MkRange)
     (allTokens: Token list)
@@ -772,30 +793,34 @@ let rec private getTriviaFromTokensThemSelves
 
         getTriviaFromTokensThemSelves mkRange allTokens rest info
 
-    | headToken :: rest when (headToken.TokenInfo.TokenName = "HASH_IF") ->
-        let directiveTokens =
-            rest
-            |> List.filter (fun r -> r.LineNumber = headToken.LineNumber)
-            |> fun others -> List.prependItem others headToken
-
+    | HashTokens (hashTokens, rest) ->
         let directiveContent =
-            directiveTokens
-            |> List.map (fun t -> t.Content)
-            |> String.concat String.empty
+            let sb = StringBuilder()
+
+            hashTokens
+            |> List.fold
+                (fun (acc: StringBuilder, lastLine) token ->
+                    let sb =
+                        let delta = token.LineNumber - lastLine
+
+                        if delta > 0 then
+                            [ 1 .. delta ]
+                            |> List.fold (fun (sb: StringBuilder) _ -> sb.Append("\n")) acc
+                        else
+                            acc
+
+                    sb.Append(token.Content), token.LineNumber)
+                (sb, hashTokens.[0].LineNumber)
+            |> fun (sb, _) -> sb.ToString()
 
         let range =
-            getRangeBetween mkRange headToken (List.last directiveTokens)
+            getRangeBetween mkRange (List.head hashTokens) (List.last hashTokens)
 
         let info =
             Trivia.Create(Directive(directiveContent)) range
             |> List.prependItem foundTrivia
 
-        let nextRest =
-            match rest with
-            | [] -> []
-            | _ -> List.skip (List.length directiveTokens - 1) rest
-
-        getTriviaFromTokensThemSelves mkRange allTokens nextRest info
+        getTriviaFromTokensThemSelves mkRange allTokens rest info
 
     | EndOfInterpolatedString (stringTokens, interpStringEnd, rest) ->
         let stringContent =
@@ -936,28 +961,20 @@ let getTriviaFromTokens (mkRange: MkRange) (tokens: Token list) =
     let fromTokens =
         getTriviaFromTokensThemSelves mkRange tokens tokens []
 
-    let blockComments =
+    let isMultilineString (s: string) = s.Contains("\n")
+
+    let ignoreRanges =
         fromTokens
         |> List.choose
             (fun tc ->
                 match tc.Item with
+                | Directive (dc) when (isMultilineString dc) -> Some tc.Range
                 | Comment (BlockComment _) -> Some tc.Range
-                | _ -> None)
-
-    let isMultilineString (s: string) =
-        s.Split([| "\n" |], StringSplitOptions.None)
-        |> (Seq.isEmpty >> not)
-
-    let multilineStrings =
-        fromTokens
-        |> List.choose
-            (fun tc ->
-                match tc.Item with
                 | StringContent (sc) when (isMultilineString sc) -> Some tc.Range
                 | _ -> None)
 
     let newLines =
-        findEmptyNewlinesInTokens mkRange tokens (blockComments @ multilineStrings)
+        findEmptyNewlinesInTokens mkRange tokens ignoreRanges
 
     fromTokens @ newLines
     |> List.sortBy (fun t -> t.Range.StartLine, t.Range.StartColumn)

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -731,7 +731,9 @@ let rec private getTriviaFromTokensThemSelves
 
         getTriviaFromTokensThemSelves mkRange allTokens nextTokens info
 
-    | headToken :: rest when (headToken.TokenInfo.TokenName = "COMMENT") ->
+    | headToken :: rest when
+        (headToken.TokenInfo.TokenName = "COMMENT"
+         && headToken.Content = "(*") ->
         let blockCommentTokens =
             rest
             |> List.takeWhileState


### PR DESCRIPTION
Combines a trivia combination of define, empty lines, define into one trivia.
![image](https://user-images.githubusercontent.com/2621499/111862554-58816580-8956-11eb-9823-b555adf705d0.png)
[Example](https://fsprojects.github.io/fantomas-tools/#/trivia?data=N4KABGBEDGD2AmBTSAuKAbRAXMAPMAvADoBORAdhBAMQCWAZmACICiAQgKoDipFVYABxK1yWepSKRWnHpF6Uq1ROXgN5-ABQBKSABpwUJPRGIAzqih6DkWqYBip2hfoBDdKcQgAvkA).

