### PR TITLE
DotGetApp inside multiline infix expression should indent.

### DIFF
--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -967,3 +967,37 @@ let PublishValueDefn cenv env declKind (vspec: Val) =
 
     ()
 """
+
+[<Test>]
+let ``DotGetApp inside multiline infix expression should indent, 1529`` () =
+    formatSourceString
+        false
+        """
+type Foobar =
+    member tcConfig.IsSystemAssembly (filename: string) =
+        try
+            FileSystem.SafeExists filename &&
+            ((tcConfig.GetTargetFrameworkDirectories() |> List.exists (fun clrRoot -> clrRoot = Path.GetDirectoryName filename)) ||
+             (tcConfig.FxResolver.GetSystemAssemblies().Contains (fileNameWithoutExtension filename)) ||
+             tcConfig.FxResolver.IsInReferenceAssemblyPackDirectory filename)
+        with _ ->
+            false
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Foobar =
+    member tcConfig.IsSystemAssembly(filename: string) =
+        try
+            FileSystem.SafeExists filename
+            && ((tcConfig.GetTargetFrameworkDirectories()
+                 |> List.exists (fun clrRoot -> clrRoot = Path.GetDirectoryName filename))
+                || (tcConfig
+                       .FxResolver
+                       .GetSystemAssemblies()
+                       .Contains(fileNameWithoutExtension filename))
+                || tcConfig.FxResolver.IsInReferenceAssemblyPackDirectory filename)
+        with _ -> false
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2781,7 +2781,8 @@ and genExprInMultilineInfixExpr astContext e =
                 (sepNlnConsideringTriviaContentBeforeForMainNode (synExprToFsAstType e) e.Range
                  +> genExpr astContext e)
         )
-    | Paren (_, InfixApp (_, _, DotGet _, _), _, _) -> atCurrentColumnIndent (genExpr astContext e)
+    | Paren (_, InfixApp (_, _, DotGet _, _), _, _)
+    | Paren (_, DotGetApp _, _, _) -> atCurrentColumnIndent (genExpr astContext e)
     | _ -> genExpr astContext e
 
 and genLidsWithDots (lids: (string * range) list) =


### PR DESCRIPTION
 Fixes #1529.