### PR TITLE
Only add parenthesis when operator length is equal or greater than indent size. 

### DIFF
--- a/src/Fantomas.Tests/DynamicOperatorTests.fs
+++ b/src/Fantomas.Tests/DynamicOperatorTests.fs
@@ -37,11 +37,35 @@ let ``keep () when dynamic operator inside boolean expr, #476`` () =
         equal
         """
 let fieldColor (fieldNameX: string) =
-    (if f.errors?(fieldNameY) && f.touched?(fieldNameZ) then
-         IsDanger
-     else
-         NoColor)
+    if f.errors?(fieldNameY) && f.touched?(fieldNameZ) then
+        IsDanger
+    else
+        NoColor
     |> Input.Color
+"""
+
+[<Test>]
+let ``keep () when dynamic operator inside boolean expr, 2 spaces indent`` () =
+    formatSourceString
+        false
+        """let fieldColor (fieldNameX: string) =
+    if f.errors?(fieldNameY) && f.touched?(fieldNameZ) then
+        IsDanger
+    else
+        NoColor
+    |> Input.Color
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let fieldColor (fieldNameX: string) =
+  (if f.errors?(fieldNameY) && f.touched?(fieldNameZ) then
+     IsDanger
+   else
+     NoColor)
+  |> Input.Color
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -1529,3 +1529,73 @@ let args =
           | LongPatIndentifierThree |] -> args
     | _ -> failwith "meh"
 """
+
+[<Test>]
+let ``match followed by pipe, 1532`` () =
+    formatSourceString
+        false
+        """
+match x with
+| Foo f -> []
+| Bar x ->
+            "\n"
+            + columnHeadersText
+            + "\n"
+            + seprator
+            + "\n"
+            + itemsText
+|> Some
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+(match x with
+ | Foo f -> []
+ | Bar x ->
+   "\n"
+   + columnHeadersText
+   + "\n"
+   + seprator
+   + "\n"
+   + itemsText)
+|> Some
+"""
+
+[<Test>]
+let ``match followed by pipe, 4 spaces indent`` () =
+    formatSourceString
+        false
+        """
+match x with
+| Foo f ->
+            "\n"
+            + columnHeadersText
+            + "\n"
+            + seprator
+            + "\n"
+            + itemsText
+| Bar x ->
+                // comment
+                ""
+|||> Some
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(match x with
+ | Foo f ->
+     "\n"
+     + columnHeadersText
+     + "\n"
+     + seprator
+     + "\n"
+     + itemsText
+ | Bar x ->
+     // comment
+     "")
+|||> Some
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1731,8 +1731,12 @@ and genExpr astContext synExpr ctx =
                         +> genExpr astContext e)
 
             let multilineExpr =
+                let operatorText = List.head es |> fun (s, _, _) -> s
+
                 (match e with
-                 | SynExpr.IfThenElse _ -> autoParenthesisIfExpressionExceedsPageWidth (genExpr astContext e)
+                 | SynExpr.IfThenElse _
+                 | SynExpr.Match _ when (ctx.Config.IndentSize <= operatorText.Length) ->
+                     autoParenthesisIfExpressionExceedsPageWidth (genExpr astContext e)
                  | _ -> genExpr astContext e)
                 +> sepNln
                 +> col
@@ -2707,10 +2711,12 @@ and genMultilineInfixExpr astContext e1 operatorText operatorExpr e2 =
     if noBreakInfixOps.Contains(operatorText) then
         genOnelinerInfixExpr astContext e1 operatorText operatorExpr e2
     else
-        let genE1 =
+        let genE1 (ctx: Context) =
             match e1 with
-            | SynExpr.IfThenElse _ -> autoParenthesisIfExpressionExceedsPageWidth (genExpr astContext e1)
-            | _ -> genExpr astContext e1
+            | SynExpr.IfThenElse _
+            | SynExpr.Match _ when (ctx.Config.IndentSize <= operatorText.Length) ->
+                autoParenthesisIfExpressionExceedsPageWidth (genExpr astContext e1) ctx
+            | _ -> genExpr astContext e1 ctx
 
         atCurrentColumn (
             genE1


### PR DESCRIPTION
Fixes #1532