### PR TITLE
Put arrow on next line if when expression is multiline.

### DIFF
--- a/src/Fantomas.Tests/MultilineFunctionApplicationsInConditionExpressionsTests.fs
+++ b/src/Fantomas.Tests/MultilineFunctionApplicationsInConditionExpressionsTests.fs
@@ -98,7 +98,8 @@ module ElectrumClient =
                         PROTOCOL_VERSION_SUPPORTED
                 with :? ElectrumServerReturningErrorException as except when
                     except.Message.EndsWith
-                        (PROTOCOL_VERSION_SUPPORTED.ToString()) ->
+                        (PROTOCOL_VERSION_SUPPORTED.ToString())
+                    ->
 
                     failwith "xxx"
 

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -674,7 +674,7 @@ let internal sepStarFixed = !- "* "
 let internal sepEq = !- " ="
 let internal sepEqFixed = !- "="
 let internal sepArrow = !- " -> "
-let internal sepArrowFixed = !- "-> "
+let internal sepArrowFixed = !- "->"
 let internal sepArrowRev = !- " <- "
 let internal sepWild = !- "_"
 


### PR DESCRIPTION
 Fixes #1545.