### PR TITLE
Print trivia before SynExpr.Lambda when wrapped in parenthesis.

### DIFF
--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -767,3 +767,37 @@ services.AddHttpsRedirection(
 )
 |> ignore
 """
+
+[<Test>]
+let ``comment between opening parenthesis and lambda, 1190`` () =
+    formatSourceString
+        false
+        """
+(
+    (* comment before gets swallowed *)
+    fun x -> x * 42
+)
+
+(
+    fun x -> x * 42
+    (* comment after is OK *)
+)
+
+(   (* comment on first line is OK too *)
+    fun x -> x * 42
+)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+( (* comment before gets swallowed *)
+fun x -> x * 42)
+
+(fun x ->
+    x * 42 (* comment after is OK *)
+    )
+
+( (* comment on first line is OK too *) fun x -> x * 42)
+"""

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -848,8 +848,8 @@ let (|TernaryApp|_|) =
 /// Gather all arguments in lambda
 let rec (|Lambda|_|) =
     function
-    | SynExpr.Lambda (_, _, pats, Lambda (e, patss), _, _) -> Some(e, pats :: patss)
-    | SynExpr.Lambda (_, _, pats, e, _, _) -> Some(e, [ pats ])
+    | SynExpr.Lambda (_, _, pats, Lambda (e, patss, _), _, range) -> Some(e, (pats :: patss), range)
+    | SynExpr.Lambda (_, _, pats, e, _, range) -> Some(e, [ pats ], range)
     | _ -> None
 
 let (|MatchLambda|_|) =
@@ -1271,7 +1271,7 @@ let rec transformPatterns ss =
 /// Process compiler-generated matches in an appropriate way
 let (|DesugaredLambda|_|) =
     function
-    | Lambda (DesugaredMatch (ss, e), spss) -> Some(List.map (fun sp -> transformPatterns ss sp, sp.Range) spss, e)
+    | Lambda (DesugaredMatch (ss, e), spss, _) -> Some(List.map (fun sp -> transformPatterns ss sp, sp.Range) spss, e)
     | _ -> None
 
 // Type definitions


### PR DESCRIPTION
Fixes #1190.