### PR TITLE
Print inline internal keywords in the correct order for val. 

### DIFF
--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -1409,3 +1409,25 @@ and Bar = Bar of string
 /// mehhy
 and Meh = Meh of DateTime
 """
+
+[<Test>]
+let ``val inline internal, 1590`` () =
+    formatSourceString
+        true
+        """
+module internal FSharp.Compiler.TypedTreePickle
+
+/// Deserialize a tuple
+val inline  internal u_tup4 : unpickler<'T2> -> unpickler<'T3> -> unpickler<'T4> -> unpickler<'T5> -> unpickler<'T2 * 'T3 * 'T4 * 'T5>
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module internal FSharp.Compiler.TypedTreePickle
+
+/// Deserialize a tuple
+val inline internal u_tup4 :
+    unpickler<'T2> -> unpickler<'T3> -> unpickler<'T4> -> unpickler<'T5> -> unpickler<'T2 * 'T3 * 'T4 * 'T5>
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -894,8 +894,8 @@ and genVal astContext (Val (ats, px, ao, s, identRange, t, vi, isInline, _) as n
     genPreXmlDoc px
     +> genAttributes astContext ats
     +> (!- "val "
-        +> opt sepSpace ao genAccess
         +> onlyIf isInline (!- "inline ")
+        +> opt sepSpace ao genAccess
         -- s
         +> genericParams
         |> genTriviaFor Ident_ identRange)


### PR DESCRIPTION
Fixes #1590.