### PR TITLE
Don't remove newlines when comparing hash chunks. 

### DIFF
--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -1675,3 +1675,34 @@ let GenApp (cenv: cenv) cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel =
 
         ()
 """
+
+[<Test>]
+let ``match clause that is short or long depending on compiler define, 1484`` () =
+    formatSourceString
+        false
+        """
+let a = (fun _ -> function
+    | A ->
+        ()
+#if DEBUG
+        f()
+#endif
+    | B ->
+        ()
+)
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let a =
+  (fun _ ->
+    function
+    | A ->
+      ()
+#if DEBUG
+      f ()
+#endif
+    | B -> ())
+"""

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -2603,3 +2603,87 @@ type SomeTypeWithQuiteTheLongNameThere
     /// This is the member
     member _.Sum() = a + b
 """
+
+[<Test>]
+let ``short or long member depending on compiler define, 1589`` () =
+    formatSourceString
+        false
+        """
+type X =
+    /// Indicates if the entity is a generated provided type definition, i.e. not erased.
+    member x.IsProvidedGeneratedTycon =
+        match x.TypeReprInfo with
+        | TProvidedTypeExtensionPoint info -> info.IsGenerated
+        | _ -> false
+
+    /// Indicates if the entity is erased, either a measure definition, or an erased provided type definition
+    member x.IsErased =
+        x.IsMeasureableReprTycon
+#if !NO_EXTENSIONTYPING
+        || x.IsProvidedErasedTycon
+#endif
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type X =
+    /// Indicates if the entity is a generated provided type definition, i.e. not erased.
+    member x.IsProvidedGeneratedTycon =
+        match x.TypeReprInfo with
+        | TProvidedTypeExtensionPoint info -> info.IsGenerated
+        | _ -> false
+
+    /// Indicates if the entity is erased, either a measure definition, or an erased provided type definition
+    member x.IsErased =
+        x.IsMeasureableReprTycon
+#if !NO_EXTENSIONTYPING
+        || x.IsProvidedErasedTycon
+#endif
+"""
+
+[<Test>]
+let ``short or long member depending on compiler define, followed by next member`` () =
+    formatSourceString
+        false
+        """
+type X =
+    /// Indicates if the entity is a generated provided type definition, i.e. not erased.
+    member x.IsProvidedGeneratedTycon =
+        match x.TypeReprInfo with
+        | TProvidedTypeExtensionPoint info -> info.IsGenerated
+        | _ -> false
+
+    /// Indicates if the entity is erased, either a measure definition, or an erased provided type definition
+    member x.IsErased =
+        x.IsMeasureableReprTycon
+#if !NO_EXTENSIONTYPING
+        || x.IsProvidedErasedTycon
+#endif
+
+    /// Get a blob of data indicating how this type is nested inside other namespaces, modules and types.
+    member x.CompilationPathOpt = x.entity_cpath
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type X =
+    /// Indicates if the entity is a generated provided type definition, i.e. not erased.
+    member x.IsProvidedGeneratedTycon =
+        match x.TypeReprInfo with
+        | TProvidedTypeExtensionPoint info -> info.IsGenerated
+        | _ -> false
+
+    /// Indicates if the entity is erased, either a measure definition, or an erased provided type definition
+    member x.IsErased =
+        x.IsMeasureableReprTycon
+#if !NO_EXTENSIONTYPING
+        || x.IsProvidedErasedTycon
+#endif
+
+    /// Get a blob of data indicating how this type is nested inside other namespaces, modules and types.
+    member x.CompilationPathOpt = x.entity_cpath
+"""

--- a/src/Fantomas.Tests/UnionTests.fs
+++ b/src/Fantomas.Tests/UnionTests.fs
@@ -729,3 +729,26 @@ type Foo =
     | Bar = 3 // Foo
     | Baz = 5 // Eee
 """
+
+[<Test>]
+let ``union type with one of two cases depending on compiler define, 1483`` () =
+    formatSourceString
+        false
+        """
+type A =
+    | B
+#if DEBUG
+    |  C
+#endif
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type A =
+    | B
+#if DEBUG
+    | C
+#endif
+"""

--- a/src/Fantomas/Utils.fs
+++ b/src/Fantomas/Utils.fs
@@ -25,13 +25,7 @@ module String =
     let startsWithOrdinal (prefix: string) (str: string) =
         str.StartsWith(prefix, StringComparison.Ordinal)
 
-    let private lengthWithoutSpaces (str: string) =
-        normalizeNewLine str
-        |> fun s ->
-            s
-                .Replace("\n", String.Empty)
-                .Replace(" ", String.Empty)
-        |> String.length
+    let private lengthWithoutSpaces (str: string) = str.Replace(" ", String.Empty).Length
 
     let private hashRegex = @"^\s*#(if|elseif|else|endif).*"
 


### PR DESCRIPTION
Fixes #1589.
Fixes #1484.
Fixes #1483.