### PR TITLE
if/then/else in infix should always be multiline.

### DIFF
--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -1087,3 +1087,61 @@ let ($) (callee: obj) (args: obj): 'a = jsNative
 /// E.g. `myFn $ (arg1, arg2)` in JS becomes `myFn(arg1, arg2)`
 let ($) (callee: obj) (args: obj) : 'a = jsNative
 """
+
+[<Test>]
+let ``if/then/else in infix should always be multiline, 1609`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let bar () =
+
+        if not <| RuntimeInformation.IsOSPlatform OSPlatform.Windows then
+            raise <| PlatformNotSupportedException ("Blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah")
+
+        lazy (
+            let foo = bar
+            if ret then
+                ""
+            else
+                ""
+            |> log.LogInformation
+            ret
+        )
+"""
+        { config with
+              MaxLineLength = 100
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeClassConstructor = true
+              SpaceBeforeMember = true
+              SpaceBeforeColon = true
+              SpaceBeforeSemicolon = true
+              MultilineBlockBracketsOnSameColumn = true
+              NewlineBetweenTypeDefinitionAndMembers = true
+              KeepIfThenInSameLine = true
+              AlignFunctionSignatureToIndentation = true
+              AlternativeLongMemberDefinitions = true
+              MultiLineLambdaClosingNewline = true
+              KeepIndentInBranch = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let bar () =
+
+        if not
+           <| RuntimeInformation.IsOSPlatform OSPlatform.Windows then
+            raise
+            <| PlatformNotSupportedException (
+                "Blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah"
+            )
+
+        lazy
+            (let foo = bar
+
+             if ret then "" else ""
+             |> log.LogInformation
+
+             ret)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1754,7 +1754,8 @@ and genExpr astContext synExpr ctx =
             +> extraSpaceBeforeString
             +> genExpr astContext e
 
-        | NewlineInfixApp (operatorText, operatorExpr, (Lambda _ as e1), e2) ->
+        | NewlineInfixApp (operatorText, operatorExpr, (Lambda _ as e1), e2)
+        | NewlineInfixApp (operatorText, operatorExpr, (IfThenElse _ as e1), e2) ->
             genMultilineInfixExpr astContext e1 operatorText operatorExpr e2
 
         | NewlineInfixApps (e, es) ->
@@ -2748,6 +2749,7 @@ and genExpr astContext synExpr ctx =
             | SynExpr.JoinIn _ -> genTriviaFor SynExpr_JoinIn synExpr.Range
             | SynExpr.Do _ -> genTriviaFor SynExpr_Do synExpr.Range
             | SynExpr.TypeApp _ -> genTriviaFor SynExpr_TypeApp synExpr.Range
+            | SynExpr.Lazy _ -> genTriviaFor SynExpr_Lazy synExpr.Range
             | _ -> id)
 
     expr ctx


### PR DESCRIPTION
Fixes #1609.