### PR TITLE
Merge DesugaredLambda and Lambda to one active pattern.

### DIFF
--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -171,7 +171,7 @@ List.filter (fun ({ ContentBefore = contentBefore }) ->
         equal
         """
 List.filter
-    (fun { ContentBefore = contentBefore } ->
+    (fun ({ ContentBefore = contentBefore }) ->
         // some comment
         let a = 8
         let b = List.length contentBefore
@@ -196,7 +196,7 @@ let a =
         equal
         """
 let a =
-    (fun { ContentBefore = contentBefore } ->
+    (fun ({ ContentBefore = contentBefore }) ->
         // some comment
         let a = 8
         let b = List.length contentBefore
@@ -800,4 +800,35 @@ fun x -> x * 42)
     )
 
 ( (* comment on first line is OK too *) fun x -> x * 42)
+"""
+
+[<Test>]
+let ``desugared union case, 1631`` () =
+    formatSourceString
+        false
+        """
+      col
+                        (fun (ArgInfo (ats, so, isOpt), t) -> sepNone)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+col (fun (ArgInfo (ats, so, isOpt), t) -> sepNone)
+"""
+
+[<Test>]
+let ``two wild args`` () =
+    formatSourceString
+        false
+        """
+fun _ _ -> ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+fun _ _ -> ()
 """

--- a/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -202,7 +202,7 @@ let myTopLevelFunction v =
             let meh = "foo"
             a
         )
-        (fun { B = b } ->
+        (fun ({ B = b }) ->
             // probably wrong
             42
         )

--- a/src/Fantomas.Tests/StructTests.fs
+++ b/src/Fantomas.Tests/StructTests.fs
@@ -95,7 +95,7 @@ match t with
         """
 type S = S of struct (int * int)
 let g : struct (int * int) = struct (1, 1)
-let z = fun ((S (struct (u, v))): S) -> u + v
+let z = fun (S (struct (u, v)): S) -> u + v
 let t = struct (1, 2)
 
 match t with


### PR DESCRIPTION
Fixes #1631.
```
    | Lambda of
        fromMethod: bool *
        inLambdaSeq: bool *
        args: SynSimplePats *
        body: SynExpr *
        parsedData: (SynPat list * SynExpr) option *
        range: range
```

`parsedData` contains all the information necessary to print out the parameters of a lambda (destructed or not).
This simplifies Fantomas a bit like the whole `ComplexPats` dance can be skipped.

