### PR TITLE
Multiline type parameter arguments inside indentation (#1611)

### DIFF
--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -1870,3 +1870,41 @@ let foobar () =
 
     foo ()
 """
+
+
+[<Test>]
+let ```multiline type parameters in argument, 1611`` () =
+    formatSourceString
+        false
+        """
+module PoorlyIndented = 
+
+    let findThing dependency thingId = 
+     use cmd = 
+      query SomeDatabase.CreateCommand<"
+                       select name
+                       from things
+                       where id = :id
+      "> dependency
+   
+     cmd.AsyncExecute(id = thingId)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module PoorlyIndented =
+
+    let findThing dependency thingId =
+        use cmd =
+            query
+                SomeDatabase.CreateCommand<"
+                    select name
+                    from things
+                    where id = :id
+   "            >
+                dependency
+
+        cmd.AsyncExecute(id = thingId)
+"""

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -1877,16 +1877,16 @@ let ```multiline type parameters in argument, 1611`` () =
     formatSourceString
         false
         """
-module PoorlyIndented = 
+module PoorlyIndented =
 
-    let findThing dependency thingId = 
-     use cmd = 
+    let findThing dependency thingId =
+     use cmd =
       query SomeDatabase.CreateCommand<"
                        select name
                        from things
                        where id = :id
       "> dependency
-   
+
      cmd.AsyncExecute(id = thingId)
 """
         config

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -1871,7 +1871,6 @@ let foobar () =
     foo ()
 """
 
-
 [<Test>]
 let ```multiline type parameters in argument, 1611`` () =
     formatSourceString

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -1900,10 +1900,10 @@ module PoorlyIndented =
         use cmd =
             query
                 SomeDatabase.CreateCommand<"
-                    select name
-                    from things
-                    where id = :id
-   "            >
+                       select name
+                       from things
+                       where id = :id
+      "      >
                 dependency
 
         cmd.AsyncExecute(id = thingId)

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -1903,7 +1903,7 @@ module PoorlyIndented =
                        select name
                        from things
                        where id = :id
-      "      >
+      "         >
                 dependency
 
         cmd.AsyncExecute(id = thingId)

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2843,6 +2843,7 @@ and genGenericTypeParameters astContext ts =
                     { astContext with
                           IsFirstTypeParam = idx = 0 }
                     false)
+        +> indentIfNeeded sepNone
         -- ">"
 
 and genMultilineRecordInstance

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3168,8 +3168,6 @@ and genApp astContext e es ctx =
                 sepSpace
                 sepNone
 
-        let addSpace = indentIfNeeded sepSpace
-
         let genEx e =
             if isCompExpr e then
                 sepSpace
@@ -3184,7 +3182,7 @@ and genApp astContext e es ctx =
         atCurrentColumn (
             genExpr astContext e
             +> addFirstSpace
-            +> col addSpace es genEx
+            +> col sepSpace es genEx
         )
 
     let isParenLambda =

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -780,7 +780,7 @@ let internal indentIfNeeded f (ctx: Context) =
         // this would lead to a compile error for the function application
         let missingSpaces =
             (savedColumn - ctx.FinalizeModel.Column)
-             + ctx.Config.IndentSize
+            + ctx.Config.IndentSize
 
         atIndentLevel true savedColumn (!-(String.replicate missingSpaces " ")) ctx
     else

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -779,8 +779,9 @@ let internal indentIfNeeded f (ctx: Context) =
         // of function expression being applied upon, otherwise (as known up to F# 4.7)
         // this would lead to a compile error for the function application
         let missingSpaces =
-            (savedColumn - ctx.FinalizeModel.Column + ctx.Config.IndentSize)
-
+            (savedColumn - ctx.FinalizeModel.Column)
+             + ctx.Config.IndentSize
+             
         atIndentLevel true savedColumn (!-(String.replicate missingSpaces " ")) ctx
     else
         f ctx

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -781,7 +781,7 @@ let internal indentIfNeeded f (ctx: Context) =
         let missingSpaces =
             (savedColumn - ctx.FinalizeModel.Column)
              + ctx.Config.IndentSize
-             
+
         atIndentLevel true savedColumn (!-(String.replicate missingSpaces " ")) ctx
     else
         f ctx

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -779,7 +779,7 @@ let internal indentIfNeeded f (ctx: Context) =
         // of function expression being applied upon, otherwise (as known up to F# 4.7)
         // this would lead to a compile error for the function application
         let missingSpaces =
-            (savedColumn - ctx.FinalizeModel.Column + 1)
+            (savedColumn - ctx.FinalizeModel.Column + ctx.Config.IndentSize)
 
         atIndentLevel true savedColumn (!-(String.replicate missingSpaces " ")) ctx
     else

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -770,7 +770,7 @@ let internal sepCloseT = !- ")"
 // we need to make sure each expression in the function application has offset at least greater than
 // indentation of the function expression itself
 // we replace sepSpace in such case
-// remarks: https://github.com/fsprojects/fantomas/issues/545
+// remarks: https://github.com/fsprojects/fantomas/issues/1611
 let internal indentIfNeeded f (ctx: Context) =
     let savedColumn = ctx.WriterModel.AtColumn
 


### PR DESCRIPTION
Fixes #1611 following the suggestion by @nojaf.

I went a little further and changed the `indentIfNeeded` function so that, when it does trigger, it adds an extra indent level instead of just one space.

It seems to make sense to me, it looks better, and it didn't break any test, but the only other place where the function is invoked is in the very high-level `genApp` function so I'm not sure if there's a specific case in mind where indenting by exactly 1 was the preferred behaviour. If so, I could add an extra argument to the function.