### PR TITLE
Apply genMultilineFunctionApplicationArguments when expression is long inside DotGetApp. 

### DIFF
--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -2235,9 +2235,11 @@ let loadFile n =
         System
             .IO
             .Path
-            .Combine(contentDir,
-                     (n |> System.IO.Path.GetFileNameWithoutExtension)
-                     + ".md")
+            .Combine(
+                contentDir,
+                (n |> System.IO.Path.GetFileNameWithoutExtension)
+                + ".md"
+            )
             .Replace("\\", "/")
 
     ()

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -1042,3 +1042,86 @@ services
         """
 services.AddIdentityCore(fun options -> ()).AddUserManager<UserManager<web.ApplicationUser>>()
 """
+
+[<Test>]
+let ``parenthesis argument expression inside DotGetApp chain, 1651`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let bar () =
+        let saveDir =
+            fs.DirectoryInfo.FromDirectoryName(fs.Path.Combine((ThingThing.rootRoot fs thingThing).FullName, "tada!")).EnumerateDirectories()
+            |> Seq.exactlyOne
+        ()
+"""
+        { config with
+              MaxLineLength = 100
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeClassConstructor = true
+              SpaceBeforeMember = true
+              SpaceBeforeColon = true
+              SpaceBeforeSemicolon = true
+              MultilineBlockBracketsOnSameColumn = true
+              AlignFunctionSignatureToIndentation = true
+              MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let bar () =
+        let saveDir =
+            fs
+                .DirectoryInfo
+                .FromDirectoryName(
+                    fs.Path.Combine ((ThingThing.rootRoot fs thingThing).FullName, "tada!")
+                )
+                .EnumerateDirectories ()
+            |> Seq.exactlyOne
+
+        ()
+"""
+
+[<Test>]
+let ``parenthesis argument expression inside DotGetApp chain, max line 80`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let bar () =
+        let saveDir =
+            fs.DirectoryInfo.FromDirectoryName(fs.Path.Combine((ThingThing.rootRoot fs thingThing).FullName, "tada!")).EnumerateDirectories()
+            |> Seq.exactlyOne
+        ()
+"""
+        { config with
+              MaxLineLength = 80
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeClassConstructor = true
+              SpaceBeforeMember = true
+              SpaceBeforeColon = true
+              SpaceBeforeSemicolon = true
+              MultilineBlockBracketsOnSameColumn = true
+              AlignFunctionSignatureToIndentation = true
+              MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let bar () =
+        let saveDir =
+            fs
+                .DirectoryInfo
+                .FromDirectoryName(
+                    fs.Path.Combine (
+                        (ThingThing.rootRoot fs thingThing).FullName,
+                        "tada!"
+                    )
+                )
+                .EnumerateDirectories ()
+            |> Seq.exactlyOne
+
+        ()
+"""

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -531,24 +531,25 @@ type Database =
     static member Default() =
         Database
             .Lowdb
-            .defaults({ Version = CurrentVersion
-                        Questions =
-                            [| { Id = 0
-                                 AuthorId = 1
-                                 Title = \"What is the average wing speed of an unladen swallow?\"
-                                 Description =
-                                     \"\"\"
+            .defaults(
+                { Version = CurrentVersion
+                  Questions =
+                      [| { Id = 0
+                           AuthorId = 1
+                           Title = \"What is the average wing speed of an unladen swallow?\"
+                           Description =
+                               \"\"\"
 Hello, yesterday I saw a flight of swallows and was wondering what their **average wing speed** is?
 
 If you know the answer please share it.
                              \"\"\"
-                                 Answers =
-                                     [| { Id = 0
-                                          CreatedAt = DateTime.Parse \"2017-09-14T19:57:33.103Z\"
-                                          AuthorId = 0
-                                          Score = 2
-                                          Content =
-                                              \"\"\"
+                           Answers =
+                               [| { Id = 0
+                                    CreatedAt = DateTime.Parse \"2017-09-14T19:57:33.103Z\"
+                                    AuthorId = 0
+                                    Score = 2
+                                    Content =
+                                        \"\"\"
 > What do you mean, an African or European Swallow?
 >
 > Monty Python’s: The Holy Grail
@@ -557,12 +558,12 @@ Ok I must admit, I use google to search the question and found a post explaining
 
 I thought you were asking it seriously, well done.
                                     x\"\"\" }
-                                        { Id = 1
-                                          CreatedAt = DateTime.Parse \"2017-09-14T20:07:27.103Z\"
-                                          AuthorId = 2
-                                          Score = 1
-                                          Content =
-                                              \"\"\"
+                                  { Id = 1
+                                    CreatedAt = DateTime.Parse \"2017-09-14T20:07:27.103Z\"
+                                    AuthorId = 2
+                                    Score = 1
+                                    Content =
+                                        \"\"\"
 Maxime,
 
 I believe you found [this blog post](http://www.saratoga.com/how-should-i-know/2013/07/what-is-the-average-air-speed-velocity-of-a-laden-swallow/).
@@ -571,35 +572,36 @@ And so Robin, the conclusion of the post is:
 
 > In the end, it’s concluded that the airspeed velocity of a (European) unladen swallow is about 24 miles per hour or 11 meters per second.
                                     \"\"\" } |]
-                                 CreatedAt = DateTime.Parse \"2017-09-14T17:44:28.103Z\" }
-                               { Id = 1
-                                 AuthorId = 0
-                                 Title = \"Why did you create Fable?\"
-                                 Description =
-                                     \"\"\"
+                           CreatedAt = DateTime.Parse \"2017-09-14T17:44:28.103Z\" }
+                         { Id = 1
+                           AuthorId = 0
+                           Title = \"Why did you create Fable?\"
+                           Description =
+                               \"\"\"
 Hello Alfonso,
 
 I wanted to know why you created Fable. Did you always plan to use F#? Or were you thinking in others languages?
                              \"\"\"
-                                 Answers = [||]
-                                 CreatedAt = DateTime.Parse \"2017-09-12T09:27:28.103Z\" } |]
-                        Users =
-                            [| { Id = 0
-                                 Firstname = \"Maxime\"
-                                 Surname = \"Mangel\"
-                                 Avatar = \"maxime_mangel.png\" }
-                               { Id = 1
-                                 Firstname = \"Robin\"
-                                 Surname = \"Munn\"
-                                 Avatar = \"robin_munn.png\" }
-                               { Id = 2
-                                 Firstname = \"Alfonso\"
-                                 Surname = \"Garciacaro\"
-                                 Avatar = \"alfonso_garciacaro.png\" }
-                               { Id = 3
-                                 Firstname = \"Guest\"
-                                 Surname = \"\"
-                                 Avatar = \"guest.png\" } |] })
+                           Answers = [||]
+                           CreatedAt = DateTime.Parse \"2017-09-12T09:27:28.103Z\" } |]
+                  Users =
+                      [| { Id = 0
+                           Firstname = \"Maxime\"
+                           Surname = \"Mangel\"
+                           Avatar = \"maxime_mangel.png\" }
+                         { Id = 1
+                           Firstname = \"Robin\"
+                           Surname = \"Munn\"
+                           Avatar = \"robin_munn.png\" }
+                         { Id = 2
+                           Firstname = \"Alfonso\"
+                           Surname = \"Garciacaro\"
+                           Avatar = \"alfonso_garciacaro.png\" }
+                         { Id = 3
+                           Firstname = \"Guest\"
+                           Surname = \"\"
+                           Avatar = \"guest.png\" } |] }
+            )
             .write ()
 
         Logger.debug \"Database restored\"

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1887,6 +1887,13 @@ and genExpr astContext synExpr ctx =
         | DotGetApp (e, es) ->
             let genLongFunctionName =
                 match e with
+                | AppOrTypeApp (LongIdentPieces lids, ts, [ Paren _ as px ]) when (List.moreThanOne lids) ->
+                    genFunctionNameWithMultilineLids
+                        (optSingle (genGenericTypeParameters astContext) ts
+                         +> expressionFitsOnRestOfLine
+                             (genExpr astContext px)
+                             (genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext px))
+                        lids
                 | AppOrTypeApp (LongIdentPieces lids, ts, [ e2 ]) when (List.moreThanOne lids) ->
                     genFunctionNameWithMultilineLids
                         (optSingle (genGenericTypeParameters astContext) ts
@@ -4313,7 +4320,7 @@ and genTypeList astContext node =
                     col
                         sepBefore
                         (Seq.zip args (Seq.map snd ts'))
-                        (fun ((ArgInfo (ats, so, isOpt)), t) ->
+                        (fun (ArgInfo (ats, so, isOpt), t) ->
                             genOnelinerAttributes astContext ats
                             +> opt
                                 sepColon


### PR DESCRIPTION
Fixes #1651.