### PR TITLE
Don't use module or namespace as trivia candidate. 

### DIFF
--- a/src/Fantomas.Tests/AttributeTests.fs
+++ b/src/Fantomas.Tests/AttributeTests.fs
@@ -266,9 +266,11 @@ let ``comments before attributes should be added correctly, issue 422`` () =
           Verified : bool }
 """
         config
+    |> prepend newline
     |> should
         equal
-        """module RecordTypes =
+        """
+module RecordTypes =
 
     /// Records can also be represented as structs via the 'Struct' attribute.
     /// This is helpful in situations where the performance of structs outweighs

--- a/src/Fantomas.Tests/ColMultilineItemTests.fs
+++ b/src/Fantomas.Tests/ColMultilineItemTests.fs
@@ -1,0 +1,352 @@
+module Fantomas.Tests.ColMultilineItemTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Tests.TestHelper
+
+[<Test>]
+let ``two short let binding should not have extra newline`` () =
+    formatSourceString
+        false
+        """
+let a = 2
+let b =  3
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = 2
+let b = 3
+"""
+
+
+[<Test>]
+let ``three short let binding should not have extra newline`` () =
+    formatSourceString
+        false
+        """
+let a = 2
+let b =  3
+let c =   4
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = 2
+let b = 3
+let c = 4
+"""
+
+
+[<Test>]
+let ``short let binding followed by long let binding`` () =
+    formatSourceString
+        false
+        """
+let a =   9
+let b () =
+    printfn "meh"
+    80.7
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = 9
+
+let b () =
+    printfn "meh"
+    80.7
+"""
+
+[<Test>]
+let ``long let binding followed by short let binding`` () =
+    formatSourceString
+        false
+        """
+let b () =
+    printfn "meh"
+    80.7
+let a =   9
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let b () =
+    printfn "meh"
+    80.7
+
+let a = 9
+"""
+
+[<Test>]
+let ``three long let bindings`` () =
+    formatSourceString
+        false
+        """
+let a =
+    // some comment
+    42
+let b (x:int) (y:int):int =
+    printfn "doing b with %i %i" x y
+    x + y
+let c () =
+    try
+        0
+    with ex -> 1
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a =
+    // some comment
+    42
+
+let b (x: int) (y: int) : int =
+    printfn "doing b with %i %i" x y
+    x + y
+
+let c () =
+    try
+        0
+    with ex -> 1
+"""
+
+[<Test>]
+let ``two short let bindings with existing newlines between`` () =
+    formatSourceString
+        false
+        """
+let a = 9
+
+
+let x =  70
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = 9
+
+
+let x = 70
+"""
+
+[<Test>]
+let ``one let binding, newline, long let binding, newline, short let binding`` () =
+    formatSourceString
+        false
+        """
+let a =  0
+
+let b (x: int) (y: int) : int =
+    printfn "doing b with %i %i" x y
+    x +   y
+
+let c =  "a string for a change"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = 0
+
+let b (x: int) (y: int) : int =
+    printfn "doing b with %i %i" x y
+    x + y
+
+let c = "a string for a change"
+"""
+
+[<Test>]
+let ``short let binding, two comments, short let binding`` () =
+    formatSourceString
+        false
+        """
+let a =  7.0
+// some comment
+// other comment
+let b =   0.0908
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = 7.0
+// some comment
+// other comment
+let b = 0.0908
+"""
+
+[<Test>]
+let ``multiline expression, newline, short expression, short expression`` () =
+    formatSourceString
+        false
+        """
+asyncResult {
+      let job =
+        { JobType = EsriBoundaryImport
+          FileToImport = filePath
+          State = state
+          DryRun = args.DryRun }
+
+      importer.ApiMaster <! StartImportCmd job
+      return Ok job
+    }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+asyncResult {
+    let job =
+        { JobType = EsriBoundaryImport
+          FileToImport = filePath
+          State = state
+          DryRun = args.DryRun }
+
+    importer.ApiMaster <! StartImportCmd job
+    return Ok job
+}
+"""
+
+[<Test>]
+let ``inner comment should make item multiline`` () =
+    formatSourceString
+        false
+        """
+    let a =
+        // foo
+        getA()
+    return a
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a =
+    // foo
+    getA ()
+
+return a
+"""
+
+[<Test>]
+let ``leading comment should not make item multiline`` () =
+    formatSourceString
+        false
+        """
+// You can also implement it via an object expression
+let md' =
+    { new MyDim }
+printfn "DIM from C# but via Object Expression: %d" md'.Z
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+// You can also implement it via an object expression
+let md' = { new MyDim }
+printfn "DIM from C# but via Object Expression: %d" md'.Z
+"""
+
+[<Test>]
+let ``leading newline and comment should not make item multiline`` () =
+    formatSourceString
+        false
+        """
+printfn "DIM from C#: %d" md.Z
+
+// You can also implement it via an object expression
+let md' = { new MyDim }
+printfn "DIM from C# but via Object Expression: %d" md'.Z
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+printfn "DIM from C#: %d" md.Z
+
+// You can also implement it via an object expression
+let md' = { new MyDim }
+printfn "DIM from C# but via Object Expression: %d" md'.Z
+"""
+
+[<Test>]
+let ``multiple leading comments should keep short item short`` () =
+    formatSourceString
+        false
+        """
+// #if INTERACTIVE
+// #else
+#load "../FSharpx.TypeProviders/SetupTesting.fsx"
+SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+// #if INTERACTIVE
+// #else
+#load "../FSharpx.TypeProviders/SetupTesting.fsx"
+SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
+"""
+
+[<Test>]
+let ``comment after let binding does not make it multiline`` () =
+    formatSourceString
+        false
+        """
+let a = 7
+let b = 8
+// foo
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = 7
+let b = 8
+// foo
+"""
+
+[<Test>]
+let ``existing blank line between multiline expressions`` () =
+    formatSourceString
+        false
+        """
+open Barry
+printFn ()
+
+open Foo
+open Bar
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+open Barry
+printFn ()
+
+open Foo
+open Bar
+"""

--- a/src/Fantomas.Tests/ColMultilineItemTests.fs
+++ b/src/Fantomas.Tests/ColMultilineItemTests.fs
@@ -41,6 +41,24 @@ let b = 3
 let c = 4
 """
 
+[<Test>]
+let ``two short expressions inside let binding`` () =
+    formatSourceString
+        false
+        """
+let b () =
+    printfn "meh"
+    80.7
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let b () =
+    printfn "meh"
+    80.7
+"""
 
 [<Test>]
 let ``short let binding followed by long let binding`` () =

--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -1297,26 +1297,6 @@ open Something
 """
 
 [<Test>]
-let ``comment after let binding makes it multiline`` () =
-    formatSourceString
-        false
-        """
-let a = 7
-let b = 8
-// foo
-"""
-        config
-    |> prepend newline
-    |> should
-        equal
-        """
-let a = 7
-
-let b = 8
-// foo
-"""
-
-[<Test>]
 let ``block comment above let binding`` () =
     formatSourceString
         false

--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -1297,7 +1297,7 @@ open Something
 """
 
 [<Test>]
-let ``meh 123`` () =
+let ``comment after let binding makes it multiline`` () =
     formatSourceString
         false
         """

--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -1252,3 +1252,82 @@ let a = 8
 let a = 8
 // foobar
 """
+
+[<Test>]
+let ``file end with newline followed by comment, 1649`` () =
+    formatSourceString
+        false
+        """
+#load "Hi.fsx"
+open Something
+
+//// FOO
+[
+    1
+    2
+    3
+]
+
+//// The end
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeClassConstructor = true
+              SpaceBeforeMember = true
+              SpaceBeforeColon = true
+              SpaceBeforeSemicolon = true
+              MultilineBlockBracketsOnSameColumn = true
+              NewlineBetweenTypeDefinitionAndMembers = true
+              KeepIfThenInSameLine = true
+              AlignFunctionSignatureToIndentation = true
+              AlternativeLongMemberDefinitions = true
+              MultiLineLambdaClosingNewline = true
+              KeepIndentInBranch = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+#load "Hi.fsx"
+open Something
+
+//// FOO
+[ 1 ; 2 ; 3 ]
+
+//// The end
+"""
+
+[<Test>]
+let ``meh 123`` () =
+    formatSourceString
+        false
+        """
+let a = 7
+let b = 8
+// foo
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = 7
+
+let b = 8
+// foo
+"""
+
+[<Test>]
+let ``block comment above let binding`` () =
+    formatSourceString
+        false
+        """(* meh *)
+let a =  b
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(* meh *)
+let a = b
+"""

--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -23,7 +23,6 @@ SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
 #if INTERACTIVE
 #load "../FSharpx.TypeProviders/SetupTesting.fsx"
 SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
-
 #load "__setup__.fsx"
 #endif
 """
@@ -49,7 +48,6 @@ SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
 #else
 #load "../FSharpx.TypeProviders/SetupTesting.fsx"
 SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
-
 #load "__setup__.fsx"
 #endif
 """

--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -16,11 +16,14 @@ SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
 #endif
 """
         config
+    |> prepend newline
     |> should
         equal
-        """#if INTERACTIVE
+        """
+#if INTERACTIVE
 #load "../FSharpx.TypeProviders/SetupTesting.fsx"
 SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
+
 #load "__setup__.fsx"
 #endif
 """
@@ -38,12 +41,42 @@ SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
 #endif
 """
         config
+    |> prepend newline
     |> should
         equal
-        """#if INTERACTIVE
+        """
+#if INTERACTIVE
 #else
 #load "../FSharpx.TypeProviders/SetupTesting.fsx"
 SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
+
+#load "__setup__.fsx"
+#endif
+"""
+
+[<Test>]
+let ``should keep compiler directives, idempotent`` () =
+    formatSourceString
+        false
+        """
+#if INTERACTIVE
+#else
+#load "../FSharpx.TypeProviders/SetupTesting.fsx"
+SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
+
+#load "__setup__.fsx"
+#endif
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#if INTERACTIVE
+#else
+#load "../FSharpx.TypeProviders/SetupTesting.fsx"
+SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
+
 #load "__setup__.fsx"
 #endif
 """
@@ -211,7 +244,6 @@ namespace Internal.Utilities.Text.Lexing"""
         """
 #nowarn "47"
 namespace Internal.Utilities.Text.Lexing
-
 """
 
 [<Test>]
@@ -1027,6 +1059,23 @@ let foo = 42
         """
 #if SOMETHING
 let foo = 42
+#endif
+"""
+
+[<Test>]
+let ``no code for inactive define, no defines`` () =
+    formatSourceStringWithDefines
+        []
+        """#if SOMETHING
+let foo = 42
+#endif"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#if SOMETHING
+
 #endif
 """
 

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -86,6 +86,7 @@
     <Compile Include="MultilineFunctionApplicationsInConditionExpressionsTests.fs" />
     <Compile Include="KeepIndentInBranchTests.fs" />
     <Compile Include="BlankLinesAroundNestedMultilineExpressions.fs" />
+    <Compile Include="ColMultilineItemTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Extras\Fantomas.Extras.fsproj" />

--- a/src/Fantomas.Tests/SynConstTests.fs
+++ b/src/Fantomas.Tests/SynConstTests.fs
@@ -504,3 +504,18 @@ long
 triple quotes string thing
 \"\"\"
 "
+
+[<Test>]
+let ``collect keyword string as separate trivia`` () =
+    formatSourceString
+        false
+        """
+__SOURCE_DIRECTORY__
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+__SOURCE_DIRECTORY__
+"""

--- a/src/Fantomas.Tests/TriviaTests.fs
+++ b/src/Fantomas.Tests/TriviaTests.fs
@@ -68,9 +68,9 @@ let ``line comment on same line, is after last AST item`` () =
     let triviaNodes = toTrivia source |> List.head
 
     match triviaNodes with
-    | [ { Type = MainNode SynModuleOrNamespace_AnonModule
+    | [ { Type = MainNode SynConst_Int32
           ContentAfter = [ Comment (LineCommentAfterSourceCode lineComment) ] } ] -> lineComment == "// should be 8"
-    | _ -> fail ()
+    | _ -> Assert.Fail(sprintf "Unexpected trivia %A" triviaNodes)
 
 [<Test>]
 let ``newline pick up before let binding`` () =
@@ -316,16 +316,16 @@ doSomething()
     let withoutDefine = Map.find [] triviaNodes
 
     match withoutDefine with
-    | [ { Type = MainNode SynModuleOrNamespace_AnonModule
+    | [ { Type = MainNode SynModuleDecl_DoExpr
           ContentBefore = [ Directive "#if NOT_DEFINED\n#else" ]
           ContentAfter = [ Directive "#endif" ] } ] -> pass ()
-    | _ -> fail ()
+    | _ -> Assert.Fail(sprintf "Unexpected trivia %A" withoutDefine)
 
     match withDefine with
-    | [ { Type = MainNode SynModuleOrNamespace_AnonModule
+    | [ { Type = MainNode LongIdent_
           ContentBefore = [ Directive "#if NOT_DEFINED"; Directive "#else"; Directive "#endif" ]
           ContentAfter = [] } ] -> pass ()
-    | _ -> fail ()
+    | _ -> Assert.Fail(sprintf "Unexpected trivia %A" withDefine)
 
 [<Test>]
 let ``directive without else clause`` () =
@@ -341,19 +341,19 @@ let x = 1
     let withoutDefine = Map.find [] triviaNodes
 
     match withoutDefine with
-    | [ { Type = MainNode SynModuleOrNamespace_AnonModule
+    | [ { Type = MainNode LongIdent_
           ContentAfter = [ Directive "#if NOT_DEFINED\n\n#endif" ]
           ContentBefore = [] } ] -> pass ()
-    | _ -> fail ()
+    | _ -> Assert.Fail(sprintf "Unexpected trivia %A" withoutDefine)
 
     match withDefine with
-    | [ { Type = MainNode SynModuleOrNamespace_AnonModule
+    | [ { Type = MainNode LongIdent_
           ContentBefore = [ Directive "#if NOT_DEFINED" ]
           ContentAfter = [] };
         { Type = MainNode SynModuleDecl_Let
           ContentBefore = []
           ContentAfter = [ Directive "#endif" ] } ] -> pass ()
-    | _ -> fail ()
+    | _ -> Assert.Fail(sprintf "Unexpected trivia %A" withDefine)
 
 [<Test>]
 let ``unreachable directive should be present in trivia`` () =
@@ -370,7 +370,7 @@ type ExtensibleDumper = A | B
     let trivias = Map.find [ "DEBUG" ] triviaNodes
 
     match trivias with
-    | [ { Type = MainNode Ident_
+    | [ { Type = MainNode LongIdent_
           ContentAfter = [ Directive "#if EXTENSIBLE_DUMPER\n#if DEBUG\n\n#endif\n#endif" ] } ] -> pass ()
     | _ -> Assert.Fail(sprintf "Unexpected trivia %A" trivias)
 
@@ -400,7 +400,7 @@ let foo = 42
         toTriviaWithDefines source |> Map.find []
 
     match trivia with
-    | [ { Type = MainNode SynModuleOrNamespace_AnonModule
+    | [ { Type = MainNode LongIdent_
           ContentAfter = [ Directive "#if SOMETHING\n\n#endif" ] } ] -> pass ()
     | _ -> fail ()
 

--- a/src/Fantomas/AstExtensions.fs
+++ b/src/Fantomas/AstExtensions.fs
@@ -9,3 +9,8 @@ type SynTypeDefnSig with
     member this.FullRange : Range =
         match this with
         | SynTypeDefnSig.TypeDefnSig (comp, _, _, r) -> mkRange r.FileName comp.Range.Start r.End
+
+let longIdentFullRange (li: LongIdent) : Range =
+    match li with
+    | [] -> range.Zero
+    | h :: _ -> unionRanges h.idRange (List.last li).idRange

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1784,8 +1784,8 @@ and genExpr astContext synExpr ctx =
             let long =
                 let functionName =
                     match e with
-                    | LongIdentPieces lids when (List.moreThanOne lids) -> genFunctionNameWithMultilineLids id lids
-                    | TypeApp (LongIdentPieces lids, ts) when (List.moreThanOne lids) ->
+                    | LongIdentPiecesExpr lids when (List.moreThanOne lids) -> genFunctionNameWithMultilineLids id lids
+                    | TypeApp (LongIdentPiecesExpr lids, ts) when (List.moreThanOne lids) ->
                         genFunctionNameWithMultilineLids (genGenericTypeParameters astContext ts) lids
                     | _ -> genExpr astContext e
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -206,8 +206,7 @@ and genModuleDeclList astContext e =
             let sepNln =
                 sepNlnConsideringTriviaContentBeforeForMainNode SynModuleDecl_Open r
 
-            ColMultilineItem(expr, sepNln, r)
-            :: collectItems ys
+            ColMultilineItem(expr, sepNln) :: collectItems ys
         | HashDirectiveL (xs, ys) ->
             let expr = col sepNln xs (genModuleDecl astContext)
 
@@ -216,8 +215,7 @@ and genModuleDeclList astContext e =
             let sepNln =
                 sepNlnConsideringTriviaContentBeforeForMainNode SynModuleDecl_HashDirective r
 
-            ColMultilineItem(expr, sepNln, r)
-            :: collectItems ys
+            ColMultilineItem(expr, sepNln) :: collectItems ys
         | AttributesL (xs, y :: rest) ->
             let attrs =
                 getRangesFromAttributesFromModuleDeclaration y
@@ -232,7 +230,7 @@ and genModuleDeclList astContext e =
             let sepNln =
                 sepNlnConsideringTriviaContentBeforeForMainNode SynModuleDecl_Attributes r
 
-            ColMultilineItem(expr, sepNln, r)
+            ColMultilineItem(expr, sepNln)
             :: collectItems rest
 
         | m :: rest ->
@@ -244,7 +242,7 @@ and genModuleDeclList astContext e =
 
             let expr = genModuleDecl astContext m
 
-            ColMultilineItem(expr, sepNln, m.Range)
+            ColMultilineItem(expr, sepNln)
             :: (collectItems rest)
 
     collectItems e |> colWithNlnWhenItemIsMultiline
@@ -262,8 +260,7 @@ and genSigModuleDeclList astContext (e: SynModuleSigDecl list) =
             let sepNln =
                 sepNlnConsideringTriviaContentBeforeForMainNode SynModuleSigDecl_Open r
 
-            ColMultilineItem(expr, sepNln, r)
-            :: collectItems ys
+            ColMultilineItem(expr, sepNln) :: collectItems ys
         | s :: rest ->
             let attrs =
                 getRangesFromAttributesFromSynModuleSigDeclaration s
@@ -273,7 +270,7 @@ and genSigModuleDeclList astContext (e: SynModuleSigDecl list) =
 
             let expr = genSigModuleDecl astContext s
 
-            ColMultilineItem(expr, sepNln, s.Range)
+            ColMultilineItem(expr, sepNln)
             :: (collectItems rest)
 
     collectItems e |> colWithNlnWhenItemIsMultiline
@@ -694,7 +691,7 @@ and genMemberBindingList astContext node =
             let sepNln =
                 sepNlnConsideringTriviaContentBeforeForMainNode (synBindingToFsAstType mb) r
 
-            ColMultilineItem(expr, sepNln, r)
+            ColMultilineItem(expr, sepNln)
             :: (collectItems rest)
 
     collectItems node |> colWithNlnWhenItemIsMultiline
@@ -1426,7 +1423,7 @@ and genExpr astContext synExpr ctx =
                     let expr = genCompExprStatement astContext ces
                     let r = getRangeOfCompExprStatement ces
                     let sepNln = getSepNln ces r
-                    ColMultilineItem(expr, sepNln, r))
+                    ColMultilineItem(expr, sepNln))
             |> colWithNlnWhenItemIsMultilineUsingConfig
 
         | ArrayOrListOfSeqExpr (isArray, e) as alNode ->
@@ -2038,7 +2035,7 @@ and genExpr astContext synExpr ctx =
                                 let sepNln =
                                     sepNlnConsideringTriviaContentBeforeForMainNode (synBindingToFsAstType x) range
 
-                                ColMultilineItem(expr, sepNln, range))
+                                ColMultilineItem(expr, sepNln))
 
                     let rec synExpr e =
                         match e with
@@ -2049,8 +2046,7 @@ and genExpr astContext synExpr ctx =
 
                             [ ColMultilineItem(
                                   genExpr astContext e,
-                                  sepNlnConsideringTriviaContentBeforeForMainNode t r,
-                                  r
+                                  sepNlnConsideringTriviaContentBeforeForMainNode t r
                               ) ]
 
                     let items = letBindings bs @ synExpr e
@@ -2132,7 +2128,7 @@ and genExpr astContext synExpr ctx =
                         let sepNln =
                             sepConsideringTriviaContentBeforeForMainNode sepSemiNln fsAstType r
 
-                        ColMultilineItem(expr, sepNln, r))
+                        ColMultilineItem(expr, sepNln))
 
             atCurrentColumn (colWithNlnWhenItemIsMultilineUsingConfig items)
 
@@ -4403,7 +4399,7 @@ and genMemberDefnList astContext nodes =
             let sepNln =
                 sepNlnConsideringTriviaContentBeforeWithAttributesFor SynMemberDefn_Member rangeOfFirstMember attrs
 
-            ColMultilineItem(expr, sepNln, rangeOfFirstMember)
+            ColMultilineItem(expr, sepNln)
             :: (collectItems rest)
 
         | m :: rest ->
@@ -4415,7 +4411,7 @@ and genMemberDefnList astContext nodes =
             let sepNln =
                 sepNlnConsideringTriviaContentBeforeWithAttributesFor (synMemberDefnToFsAstType m) m.Range attrs
 
-            ColMultilineItem(expr, sepNln, m.Range)
+            ColMultilineItem(expr, sepNln)
             :: (collectItems rest)
 
     collectItems nodes
@@ -5165,8 +5161,7 @@ and genExprKeepIndentInBranch (astContext: ASTContext) (e: SynExpr) : Context ->
         let genOtherExprItem (e: SynExpr) : ColMultilineItem =
             ColMultilineItem(
                 genExpr astContext e,
-                (let t, r = synExprToFsAstType e in sepNlnConsideringTriviaContentBeforeForMainNode t r),
-                e.Range
+                (let t, r = synExprToFsAstType e in sepNlnConsideringTriviaContentBeforeForMainNode t r)
             )
 
         let genBindingItems (bs: (string * SynBinding) list) : ColMultilineItem list =
@@ -5182,7 +5177,7 @@ and genExprKeepIndentInBranch (astContext: ASTContext) (e: SynExpr) : Context ->
                     let sepNln =
                         sepNlnConsideringTriviaContentBeforeForMainNode (synBindingToFsAstType synBinding) range
 
-                    ColMultilineItem(expr, sepNln, range))
+                    ColMultilineItem(expr, sepNln))
                 bs
 
         let genKeepIndentMatchItem
@@ -5190,8 +5185,7 @@ and genExprKeepIndentInBranch (astContext: ASTContext) (e: SynExpr) : Context ->
             : ColMultilineItem =
             ColMultilineItem(
                 genKeepIndentMatch astContext me clauses matchRange matchTriviaType,
-                sepNlnConsideringTriviaContentBeforeForMainNode matchTriviaType matchRange,
-                matchRange
+                sepNlnConsideringTriviaContentBeforeForMainNode matchTriviaType matchRange
             )
 
         let genKeepIndentIfThenElseItem
@@ -5199,8 +5193,7 @@ and genExprKeepIndentInBranch (astContext: ASTContext) (e: SynExpr) : Context ->
             : ColMultilineItem =
             ColMultilineItem(
                 genKeepIdentIf astContext branches elseBranch ifElseRange,
-                sepNlnConsideringTriviaContentBeforeForMainNode SynExpr_IfThenElse ifElseRange,
-                ifElseRange
+                sepNlnConsideringTriviaContentBeforeForMainNode SynExpr_IfThenElse ifElseRange
             )
 
         match e with

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="TokenParserBoolExpr.fs" />
     <Compile Include="TriviaHelpers.fs" />
     <Compile Include="TokenParser.fs" />
+    <Compile Include="SourceParser.fs" />
     <Compile Include="Trivia.fs" />
     <Compile Include="Context.fs" />
     <Compile Include="SourceTransformer.fs" />

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -23,7 +23,6 @@
     <Compile Include="TokenParserBoolExpr.fs" />
     <Compile Include="TriviaHelpers.fs" />
     <Compile Include="TokenParser.fs" />
-    <Compile Include="SourceParser.fs" />
     <Compile Include="Trivia.fs" />
     <Compile Include="Context.fs" />
     <Compile Include="SourceTransformer.fs" />

--- a/src/Fantomas/Queue.fs
+++ b/src/Fantomas/Queue.fs
@@ -46,8 +46,17 @@ type Queue<'T>(data: list<'T []>, length: int) =
 
     member this.FragmentLength : int = data.Length
 
-    member this.TakeFromFragments(amount: int) : 'T list =
-        List.take amount data |> List.collect Array.toList
+    /// Verify if a range of recently added items matches a predicate
+    member this.RecentItemsContain
+        (skipInitialWhile: 'T [] -> bool)
+        (predicate: 'T [] list -> bool)
+        (fragmentCount: int)
+        : bool =
+        let selection =
+            List.take fragmentCount data
+            |> List.skipWhile skipInitialWhile
+
+        predicate selection
 
     member this.Rev() =
         data

--- a/src/Fantomas/Queue.fs
+++ b/src/Fantomas/Queue.fs
@@ -121,5 +121,5 @@ module Queue =
 
     let inline append (q: Queue<'T>) xs = q.Append xs
 
-    /// Equivalent of q |> Queue.toSeq |> Seq.skip n |> Seq.exists f
+    /// Equivalent of q |> Queue.toSeq |> Seq.skip n |> Seq.skipWhile p |> Seq.exists f
     let inline skipExists (n: int) (f: 'T -> bool) (p: 'T [] -> bool) (q: Queue<'T>) : bool = q.SkipExists n f p

--- a/src/Fantomas/Queue.fs
+++ b/src/Fantomas/Queue.fs
@@ -44,6 +44,11 @@ type Queue<'T>(data: list<'T []>, length: int) =
 
     member this.Length = length
 
+    member this.FragmentLength : int = data.Length
+
+    member this.TakeFromFragments(amount: int) : 'T list =
+        List.take amount data |> List.collect Array.toList
+
     member this.Rev() =
         data
         |> Seq.collect

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -721,6 +721,12 @@ let rec private (|HashTokens|_|) (tokens: Token list) =
         | _ -> Some(head :: tokensFromSameLine, rest)
     | _ -> None
 
+let private (|KeywordString|_|) (token: Token) =
+    if token.TokenInfo.Tag = 192 then
+        Some token
+    else
+        None
+
 let rec private getTriviaFromTokensThemSelves
     (mkRange: MkRange)
     (allTokens: Token list)
@@ -877,6 +883,15 @@ let rec private getTriviaFromTokensThemSelves
             |> List.prependItem foundTrivia
 
         getTriviaFromTokensThemSelves mkRange allTokens nextTokens info
+
+    | KeywordString ks :: rest ->
+        let range = getRangeBetween mkRange ks ks
+
+        let info =
+            Trivia.Create(KeywordString(ks.Content)) range
+            |> List.prependItem foundTrivia
+
+        getTriviaFromTokensThemSelves mkRange allTokens rest info
 
     | headToken :: rest when
         (isOperatorOrKeyword headToken

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -80,6 +80,7 @@ let a = 7
 
 type TriviaContent =
     | Keyword of Token
+    | KeywordString of string
     | Number of string
     | StringContent of string
     | IdentOperatorAsWord of string
@@ -99,10 +100,13 @@ type TriviaIndex = TriviaIndex of int * int
 
 type FsAstType =
     | Ident_
-    | SynModuleOrNamespace_AnonModule
-    | SynModuleOrNamespace_DeclaredNamespace
-    | SynModuleOrNamespace_GlobalNamespace
-    | SynModuleOrNamespace_NamedModule
+    | LongIdent_ // namespace or module identifier
+    // Modules and namespaces cannot really be trusted
+    // Their range can be influenced by non code constructs (like comments)
+    //    | SynModuleOrNamespace_AnonModule
+    //    | SynModuleOrNamespace_DeclaredNamespace
+    //    | SynModuleOrNamespace_GlobalNamespace
+    //    | SynModuleOrNamespace_NamedModule
     | SynModuleDecl_ModuleAbbrev
     | SynModuleDecl_NestedModule
     | SynModuleDecl_Let
@@ -317,10 +321,12 @@ type FsAstType =
     | SynValInfo_
     | SynArgInfo_
     | ParsedHashDirective_
-    | SynModuleOrNamespaceSig_AnonModule
-    | SynModuleOrNamespaceSig_DeclaredNamespace
-    | SynModuleOrNamespaceSig_GlobalNamespace
-    | SynModuleOrNamespaceSig_NamedModule
+    // Modules and namespaces cannot really be trusted
+    // Their range can be influenced by non code constructs (like comments)
+//    | SynModuleOrNamespaceSig_AnonModule
+//    | SynModuleOrNamespaceSig_DeclaredNamespace
+//    | SynModuleOrNamespaceSig_GlobalNamespace
+//    | SynModuleOrNamespaceSig_NamedModule
     | SynModuleSigDecl_ModuleAbbrev
     | SynModuleSigDecl_NestedModule
     | SynModuleSigDecl_Types


### PR DESCRIPTION
Fixes #1649.
This PR has a bit of an impact, I would like to hear your opinion @jindraivanek.

So, in general, modules and namespace can have a bit of a weird range.
For example an empty named module in [a signature file](https://fsprojects.github.io/fantomas-tools/#/ast?data=N4KABGBEAmCmBmBLAdrAzpAXFSAacUiaAYmolmAC4BOArrPhJAMYD2cFkAtu7QDawwxVqwBGAQ2oAdachlTkAekVhWACzBpWXQWy47klSCAC%2BQA).
The range is influenced by the code comment, so that leads to problems here and there.
In short, it is better not to use them as trivia candidates.

To overcome this limitation, I constructed a range based on the `LongIndent` of a `SynModuleOrNamespace` or `SynModuleOrNamespaceSig`.
Trivia can safely be attached to this node, and then printed for the entire module name (keywords included).
See
```fsharp
    let moduleOrNamespace =
        genModuleOrNamespaceKind moduleKind
        +> opt sepSpace ao genAccess
        +> ifElse isRecursive (!- "rec ") sepNone
        +> col (!- ".") lids (fun (lid, r) -> genTriviaFor Ident_ r (!-lid))
        |> genTriviaFor LongIdent_ lidsFullRange
```

This all works quite well yet I encountered one problem with TriviaContent after in:
```fsharp
#if INTERACTIVE
#load "../FSharpx.TypeProviders/SetupTesting.fsx"
SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
#load "__setup__.fsx"
#endif
```

`#endif` is now attached as content after `SynModuleDecl_HashDirective`, which in itself is quite sensible.
It used to be attached to the content after the anonymous module.
The three top-level `decls` are combined using the `colWithNlnWhenItemIsMultiline` helper function.
There we check if the constructs are multiline and we add new lines between them if so.

The problem I encountered is that `SynModuleDecl.HashDirective` now is multiline because of the trivia after it.
So this introduced an extra newline, where there was non.
I'm not sure how to deal with this in any other way.
A `WriteLine` event was detected so we concluded it is multiline.

The good news of these changes is that trivia got a bit simplified. Fewer hacks are necessary to deal with empty modules and namespaces. Newlines and comments on a single line follow the exact same logic in candidate election so that part is definitely a pro.

Does it outweigh the con listed above?

