### PR TITLE
Correct Elif expression range when there is only a single elif.

### DIFF
--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -2386,3 +2386,34 @@ elif startLine = endLine then
 else
     failAndExit ()
 """
+
+[<Test>]
+let ``multiline but not that special if expression`` () =
+    formatSourceString
+        false
+        """
+if
+    List.exists
+        (function
+        | CompExpr _ -> true
+        | _ -> false)
+        es
+then
+    shortExpression ctx
+else
+    expressionFitsOnRestOfLine shortExpression longExpression ctx
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+if List.exists
+    (function
+    | CompExpr _ -> true
+    | _ -> false)
+    es then
+    shortExpression ctx
+else
+    expressionFitsOnRestOfLine shortExpression longExpression ctx
+"""

--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -928,7 +928,7 @@ if // c1
 else // c5
 if // c6
     c // c7
-    then // c8
+then // c8
     d // c9
 else // c10
     e // c11
@@ -2222,4 +2222,126 @@ type internal Foo2 private () =
             printfn "hi"
         else
             failwith ""
+"""
+
+[<Test>]
+let ``multiline else if expression with nested if/then/else in body`` () =
+    formatSourceString
+        false
+        """
+if result.LaunchSuccess && result.ExitCode = 0 then
+    Ok r
+else if result.ExitCode = 1 then
+    let stdout, stderr =
+        output
+        |> List.map
+            (function
+            | StdErr e -> Error e
+            | StdOut l -> Ok l)
+        |> Result.partition
+
+    if not stderr.IsEmpty then
+        failwithf "Got stderr bad bad bad"
+
+    match stdout with
+    | [] -> failwithf "Got no stdout :("
+    | xs when
+        xs
+        |> List.exists (fun i -> i.Contains "magic string goes here!")
+        ->
+        Error(Ok r)
+    | _ -> Error(Error r)
+else
+    failwith ""
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+if result.LaunchSuccess && result.ExitCode = 0 then
+    Ok r
+else if result.ExitCode = 1 then
+    let stdout, stderr =
+        output
+        |> List.map
+            (function
+            | StdErr e -> Error e
+            | StdOut l -> Ok l)
+        |> Result.partition
+
+    if not stderr.IsEmpty then
+        failwithf "Got stderr bad bad bad"
+
+    match stdout with
+    | [] -> failwithf "Got no stdout :("
+    | xs when
+        xs
+        |> List.exists (fun i -> i.Contains "magic string goes here!")
+        ->
+        Error(Ok r)
+    | _ -> Error(Error r)
+else
+    failwith ""
+"""
+
+[<Test>]
+let ``multiline elif expression with nested if/then/else in body`` () =
+    formatSourceString
+        false
+        """
+if result.LaunchSuccess && result.ExitCode = 0 then
+    Ok r
+elif result.ExitCode = 1 then
+    let stdout, stderr =
+        output
+        |> List.map
+            (function
+            | StdErr e -> Error e
+            | StdOut l -> Ok l)
+        |> Result.partition
+
+    if not stderr.IsEmpty then
+        failwithf "Got stderr bad bad bad"
+
+    match stdout with
+    | [] -> failwithf "Got no stdout :("
+    | xs when
+        xs
+        |> List.exists (fun i -> i.Contains "magic string goes here!")
+        ->
+        Error(Ok r)
+    | _ -> Error(Error r)
+else
+    failwith ""
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+if result.LaunchSuccess && result.ExitCode = 0 then
+    Ok r
+elif result.ExitCode = 1 then
+    let stdout, stderr =
+        output
+        |> List.map
+            (function
+            | StdErr e -> Error e
+            | StdOut l -> Ok l)
+        |> Result.partition
+
+    if not stderr.IsEmpty then
+        failwithf "Got stderr bad bad bad"
+
+    match stdout with
+    | [] -> failwithf "Got no stdout :("
+    | xs when
+        xs
+        |> List.exists (fun i -> i.Contains "magic string goes here!")
+        ->
+        Error(Ok r)
+    | _ -> Error(Error r)
+else
+    failwith ""
 """

--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -2345,3 +2345,44 @@ elif result.ExitCode = 1 then
 else
     failwith ""
 """
+
+[<Test>]
+let ``multiple multiline elifs`` () =
+    formatSourceString
+        false
+        """
+        if startWithMember sel then
+            (String.Join(String.Empty, "type T = ", Environment.NewLine, String(' ', startCol), sel), TypeMember)
+        elif String.startsWithOrdinal "and" (sel.TrimStart()) then
+            // Replace "and" by "type" or "let rec"
+            if startLine = endLine then
+                (pattern.Replace(sel, replacement, 1), p)
+            else
+                (String(' ', startCol)
+                 + pattern.Replace(sel, replacement, 1),
+                 p)
+        elif startLine = endLine then
+            (sel, Nothing)
+        else
+            failAndExit ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+if startWithMember sel then
+    (String.Join(String.Empty, "type T = ", Environment.NewLine, String(' ', startCol), sel), TypeMember)
+elif String.startsWithOrdinal "and" (sel.TrimStart()) then
+    // Replace "and" by "type" or "let rec"
+    if startLine = endLine then
+        (pattern.Replace(sel, replacement, 1), p)
+    else
+        (String(' ', startCol)
+         + pattern.Replace(sel, replacement, 1),
+         p)
+elif startLine = endLine then
+    (sel, Nothing)
+else
+    failAndExit ()
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2283,10 +2283,8 @@ and genExpr astContext synExpr ctx =
                                 +> unindent
                                 +> sepNln
                             else
-                                atCurrentColumnIndent (
-                                    sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
-                                    +> genExpr astContext e
-                                )
+                                sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
+                                +> genExpr astContext e
 
                     expressionFitsOnRestOfLine short long
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2283,7 +2283,7 @@ and genExpr astContext synExpr ctx =
                                 +> unindent
                                 +> sepNln
                             else
-                                sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
+                                sepNlnWhenWriteBeforeNewlineNotEmpty sepNone
                                 +> genExpr astContext e
 
                     expressionFitsOnRestOfLine short long

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2158,8 +2158,8 @@ and genExpr astContext synExpr ctx =
                                 if idx = 0 then
                                     e2.Range.End
                                 else
-                                    let _, _, r, _, _ = es.[idx - 1]
-                                    r.End
+                                    let _, e2, _, _, _ = es.[idx - 1]
+                                    e2.Range.End
 
                             let maxRangeBetween =
                                 ctx.MkRange endOfPreviousBranch body.Range.End

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -1123,15 +1123,6 @@ let internal unindentOnWith (ctx: Context) =
 let internal ifAlignBrackets f g =
     ifElseCtx (fun ctx -> ctx.Config.MultilineBlockBracketsOnSameColumn) f g
 
-/// Don't put space before and after these operators
-let internal noSpaceInfixOps = set [ "?" ]
-
-/// Always break into newlines on these operators
-let internal newLineInfixOps = set [ "|>"; "||>"; "|||>"; ">>"; ">>=" ]
-
-/// Never break into newlines on these operators
-let internal noBreakInfixOps = set [ "="; ">"; "<"; "%" ]
-
 let internal printTriviaContent (c: TriviaContent) (ctx: Context) =
     let currentLastLine = lastWriteEventOnLastLine ctx
 
@@ -1429,6 +1420,12 @@ let internal sepNlnWhenWriteBeforeNewlineNotEmpty fallback (ctx: Context) =
         sepNln ctx
     else
         fallback ctx
+
+let internal autoIndentAndNlnWhenWriteBeforeNewlineNotEmpty (f: Context -> Context) (ctx: Context) =
+    if String.isNotNullOrEmpty ctx.WriterModel.WriteBeforeNewline then
+        (indent +> sepNln +> f +> unindent) ctx
+    else
+        f ctx
 
 let internal autoNlnConsideringTriviaIfExpressionExceedsPageWidth
     sepNlnConsideringTriviaContentBefore

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="Dbg.fs" />
     <Compile Include="Utils.fs" />
     <Compile Include="AstExtensions.fs" />
+    <Compile Include="SourceParser.fs" />
     <Compile Include="AstTransformer.fs" />
     <Compile Include="SourceOrigin.fs" />
     <Compile Include="Version.fs" />
@@ -24,7 +25,6 @@
     <Compile Include="TokenParser.fs" />
     <Compile Include="Trivia.fs" />
     <Compile Include="Context.fs" />
-    <Compile Include="SourceParser.fs" />
     <Compile Include="SourceTransformer.fs" />
     <Compile Include="TriviaContext.fs" />
     <Compile Include="CodePrinter.fs" />

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -7,9 +7,17 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.SyntaxTree
 open FSharp.Compiler.XmlDoc
 open Fantomas
-open Fantomas.Context
 open Fantomas.AstExtensions
 open Fantomas.TriviaTypes
+
+/// Don't put space before and after these operators
+let internal noSpaceInfixOps = set [ "?" ]
+
+/// Always break into newlines on these operators
+let internal newLineInfixOps = set [ "|>"; "||>"; "|||>"; ">>"; ">>=" ]
+
+/// Never break into newlines on these operators
+let internal noBreakInfixOps = set [ "="; ">"; "<"; "%" ]
 
 type Composite<'a, 'b> =
     | Pair of 'b * 'b
@@ -1147,8 +1155,7 @@ let (|PatLongIdent|_|) =
                         _) ->
         match xs with
         | SynArgPats.Pats ps -> Some(ao, s, List.map (fun p -> (None, p)) ps, tpso)
-        | SynArgPats.NamePatPairs (nps, _) ->
-            Some(ao, s, List.map (fun ((Ident ident), p) -> (Some ident, p)) nps, tpso)
+        | SynArgPats.NamePatPairs (nps, _) -> Some(ao, s, List.map (fun (Ident ident, p) -> (Some ident, p)) nps, tpso)
     | _ -> None
 
 let (|PatParen|_|) =

--- a/src/Fantomas/TriviaContext.fs
+++ b/src/Fantomas/TriviaContext.fs
@@ -54,8 +54,9 @@ let ``else if / elif`` (rangeOfIfThenElse: Range) (ctx: Context) =
             // formatting from AST
             !- "else if "
         | _ ->
-            failwith
-                "Unexpected scenario when formatting else if / elif, please open an issue via https://jindraivanek.gitlab.io/fantomas-ui"
+            failwithf
+                "Unexpected scenario when formatting else if / elif (near %A), please open an issue via https://fsprojects.github.io/fantomas-tools/#/fantomas/preview"
+                rangeOfIfThenElse
 
     resultExpr ctx
 

--- a/src/Fantomas/TriviaContext.fs
+++ b/src/Fantomas/TriviaContext.fs
@@ -38,38 +38,21 @@ let ``else if / elif`` (rangeOfIfThenElse: Range) (ctx: Context) =
     let resultExpr =
         match keywords with
         | (ELSE, elseTrivia) :: (IF, ifTrivia) :: _ ->
-            let commentAfterElseKeyword =
-                TriviaHelpers.``has line comment after`` elseTrivia
-
-            let commentAfterIfKeyword =
-                TriviaHelpers.``has line comment after`` ifTrivia
-
-            let triviaBeforeIfKeyword =
-                (Map.tryFindOrEmptyList SynExpr_IfThenElse ctx.TriviaMainNodes) // ctx.Trivia
-                |> List.filter
-                    (fun t ->
-                        RangeHelpers.``range contains`` rangeOfIfThenElse t.Range
-                        && (RangeHelpers.``range after`` elseTrivia.Range t.Range))
-                |> List.tryHead
-
-            tokN rangeOfIfThenElse ELSE (!- "else")
-            +> ifElse commentAfterElseKeyword sepNln sepSpace
-            +> opt sepNone triviaBeforeIfKeyword printContentBefore
-            +> tokN rangeOfIfThenElse IF (!- "if ")
-            +> ifElse commentAfterIfKeyword (indent +> sepNln) sepNone
-
+            printContentBefore elseTrivia
+            +> (!- "else")
+            +> printContentAfter elseTrivia
+            +> sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
+            +> printContentBefore ifTrivia
+            +> (!- "if ")
+            +> printContentAfter ifTrivia
         | (ELIF, elifTok) :: _
         | [ (ELIF, elifTok) ] ->
-            let commentAfterElIfKeyword =
-                TriviaHelpers.``has line comment after`` elifTok
-
-            tokN rangeOfIfThenElse ELIF (!- "elif ")
-            +> ifElse commentAfterElIfKeyword (indent +> sepNln) sepNone
-
+            printContentBefore elifTok
+            +> (!- "elif ")
+            +> printContentAfter elifTok
         | [] ->
             // formatting from AST
             !- "else if "
-
         | _ ->
             failwith
                 "Unexpected scenario when formatting else if / elif, please open an issue via https://jindraivanek.gitlab.io/fantomas-ui"


### PR DESCRIPTION
Related to #1648.
This is something I discovered regardless of the `keep indent` question.
