### PR TITLE
Don't add unnecessary parenthesis around SynPat.IsInst. 

### DIFF
--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -1706,3 +1706,51 @@ let a =
 #endif
     | B -> ())
 """
+
+[<Test>]
+let ``don't add unnecessary parenthesis around SynPat.IsInst, 1660`` () =
+    formatSourceString
+        false
+        """
+        match other with
+        | :? Queue<'T> as y ->
+            if this.Length <> y.Length then
+                false
+            else if this.GetHashCode() <> y.GetHashCode() then
+                false
+            else
+                Seq.forall2 Unchecked.equals this y
+        | _ -> false
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+match other with
+| :? Queue<'T> as y ->
+    if this.Length <> y.Length then
+        false
+    else if this.GetHashCode() <> y.GetHashCode() then
+        false
+    else
+        Seq.forall2 Unchecked.equals this y
+| _ -> false
+"""
+
+[<Test>]
+let ``keep existing parenthesis around SynPat.IsInst`` () =
+    formatSourceString
+        false
+        """
+match x with
+| :? (int)   as  i -> ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+match x with
+| :? (int) as i -> ()
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4842,16 +4842,7 @@ and genPat astContext pat =
             let size = getRecordSize ctx xs
             isSmallExpression size smallRecordExpr multilineExpressionIfAlignBrackets ctx
     | PatConst (c, r) -> genConst c r
-    | PatIsInst (TApp (_, [ _ ], _) as t)
-    | PatIsInst (TArray _ as t) ->
-        // special case for things like ":? (int seq) ->"
-        !- ":? "
-        +> sepOpenT
-        +> genType astContext false t
-        +> sepCloseT
-    | PatIsInst t ->
-        // Should have brackets around in the type test patterns
-        !- ":? " +> genType astContext true t
+    | PatIsInst t -> !- ":? " +> genType astContext false t
     // Quotes will be printed by inner expression
     | PatQuoteExpr e -> genExpr astContext e
     | p -> failwithf "Unexpected pattern: %O" p


### PR DESCRIPTION
Fixes #1660.