### PR TITLE
Reset IsFirstChild of ASTContext before printing interface members. 

### DIFF
--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4566,6 +4566,9 @@ and genMemberDefn astContext node =
                 +> sepNln
                 +> genMemberDefnList
                     { astContext with
+                          // Reset this property to avoid problems with the generation of the attributes on the members
+                          // See 1668
+                          IsFirstChild = true
                           InterfaceRange = Some range }
                     mds
                 +> unindent)


### PR DESCRIPTION
Fixes #1668.