### PR TITLE
Optimize comment after source code detection.

### DIFF
--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -1311,3 +1311,175 @@ let a =  b
 (* meh *)
 let a = b
 """
+
+[<Test>]
+let ``comment right after first token`` () =
+    formatSourceString
+        false
+        """
+1//
+// next line
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+1 //
+// next line
+"""
+
+[<Test>]
+[<Ignore("line comment after block comment currently not supported")>]
+let ``block comment followed by line comment`` () =
+    formatSourceString
+        false
+        """
+(* foo *)// bar
+let a = 0
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(* foo *) // bar
+let a = 0
+"""
+
+[<Test>]
+let ``line comment after source code`` () =
+    formatSourceString
+        false
+        """
+__SOURCE_DIRECTORY__ // comment
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+__SOURCE_DIRECTORY__ // comment
+"""
+
+[<Test>]
+let ``line comment after hash define`` () =
+    formatSourceString
+        false
+        """
+#if FOO // MEH
+#endif
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#if FOO // MEH
+#endif
+"""
+
+[<Test>]
+let ``line comment after interpolated string`` () =
+    formatSourceString
+        false
+        """
+$"{meh}.." // foo
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+$"{meh}.." // foo
+"""
+
+[<Test>]
+let ``line comment after negative constant`` () =
+    formatSourceString
+        false
+        """
+-1.0 // foo
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+-1.0 // foo
+"""
+
+[<Test>]
+let ``line comment after trivia number`` () =
+    formatSourceString
+        false
+        """
+1. // bar
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+1. // bar
+"""
+
+[<Test>]
+let ``line comment after infix operator in full words`` () =
+    formatSourceString
+        false
+        """
+op_LessThan // meh
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+op_LessThan // meh
+"""
+
+[<Test>]
+let ``line comment after ident between ticks`` () =
+    formatSourceString
+        false
+        """
+``foo oo`` // bar
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+``foo oo`` // bar
+"""
+
+[<Test>]
+let ``line comment after special char`` () =
+    formatSourceString
+        false
+        """
+'\u0000' // foo
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+'\u0000' // foo
+"""
+
+[<Test>]
+let ``line comment after embedded il`` () =
+    formatSourceString
+        false
+        """
+(# "" x : 'U #) // bar
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(# "" x : 'U #) // bar
+"""

--- a/src/Fantomas.Tests/TriviaTests.fs
+++ b/src/Fantomas.Tests/TriviaTests.fs
@@ -247,10 +247,9 @@ x
     let triviaNodes = toTrivia source |> List.head
 
     match triviaNodes with
-    | [ { ContentBefore = [ Comment (BlockComment (fooComment, _, true)); Comment (BlockComment (barComment, _, true)) ] } ] ->
-        fooComment == "(* foo *)"
-        barComment == "(* bar *)"
-    | _ -> fail ()
+    | [ { ContentBefore = [ Comment (BlockComment (combinedComment, _, true)) ] } ] ->
+        combinedComment == "(* foo *)\n(* bar *)"
+    | _ -> Assert.Fail(sprintf "Unexpected trivia %A" triviaNodes)
 
 [<Test>]
 let ``block comment inside line comment parsed correctly`` () =

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1600,7 +1600,7 @@ and genExpr astContext synExpr ctx =
             +> sepSpace
             +> genExpr astContext e
 
-        | Paren (_, ILEmbedded r, _, _) ->
+        | Paren (_, ILEmbedded r, rpr, _) ->
             fun ctx ->
                 let expr =
                     Map.tryFindOrEmptyList SynExpr_LibraryOnlyILAssembly ctx.TriviaMainNodes
@@ -1616,7 +1616,9 @@ and genExpr astContext synExpr ctx =
                     |> Option.map (!-)
                     |> Option.defaultValue sepNone
 
-                expr ctx
+                (expr
+                 +> optSingle (fun r -> leaveNodeTokenByName r RPAREN) rpr)
+                    ctx
         | Paren (lpr, e, rpr, pr) ->
             match e with
             | LetOrUses _ ->

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -58,8 +58,7 @@ type FsTokenType =
 type Token =
     { TokenInfo: FSharpTokenInfo
       LineNumber: int
-      Content: string
-      Index: int }
+      Content: string }
 
 type Comment =
     | LineCommentAfterSourceCode of comment: string


### PR DESCRIPTION
Fixes #1671, depends on #1656.

Improved the trivia detection via the F# tokens.
Specifically, the detection if a code comment is on a single line or after the source.