### PR TITLE
Respect end_of_line when formatting multiple code branches. 

### DIFF
--- a/src/Fantomas.CoreGlobalTool.Tests/ConfigTests.fs
+++ b/src/Fantomas.CoreGlobalTool.Tests/ConfigTests.fs
@@ -90,3 +90,26 @@ end_of_line = %s
     let expected = sampleCode newline
 
     result |> should equal expected
+
+[<Test>]
+let ``end_of_line should be respected for ifdef`` () =
+    let source = "#if FOO\n()\n#else\n()\n#endif"
+    use fileFixture = new TemporaryFileCodeSample(source)
+
+    use configFixture =
+        new ConfigurationFile(
+            sprintf
+                """
+[*.fs]
+end_of_line = lf
+"""
+        )
+
+    let exitCode, _ = runFantomasTool fileFixture.Filename
+    exitCode |> should equal 0
+
+    let result =
+        System.IO.File.ReadAllText(fileFixture.Filename)
+
+    result
+    |> should equal "#if FOO\n()\n#else\n()\n#endif\n"

--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -111,7 +111,7 @@ let formatSourceStringWithDefines defines (s: string) config =
         |> Async.RunSynchronously
 
     // merge with itself to make #if go on beginning of line
-    String.merge result result
+    String.merge config.EndOfLine.NewLineString result result
     |> String.normalizeNewLine
 
 let formatSelectionOnly isFsiFile r (s: string) config =

--- a/src/Fantomas.Tests/UtilsTests.fs
+++ b/src/Fantomas.Tests/UtilsTests.fs
@@ -1,12 +1,14 @@
 module Fantomas.Tests.UtilsTests
 
+open System
 open NUnit.Framework
 open Fantomas
 open Fantomas.Tests.TestHelper
 
 let private mergeAndCompare a b expected =
     let result =
-        String.merge a b |> String.normalizeNewLine
+        String.merge Environment.NewLine a b
+        |> String.normalizeNewLine
 
     let normalizedExpected = String.normalizeNewLine expected
     normalizedExpected == result

--- a/src/Fantomas/CodeFormatterImpl.fs
+++ b/src/Fantomas/CodeFormatterImpl.fs
@@ -394,7 +394,12 @@ let formatWith ast defines hashTokens formatContext config =
 
     formattedSourceCode
 
-let format (checker: FSharpChecker) (parsingOptions: FSharpParsingOptions) config formatContext =
+let format
+    (checker: FSharpChecker)
+    (parsingOptions: FSharpParsingOptions)
+    (config: FormatConfig)
+    (formatContext: FormatContext)
+    : Async<string> =
     async {
         let! asts = parse checker parsingOptions formatContext
 
@@ -407,7 +412,7 @@ let format (checker: FSharpChecker) (parsingOptions: FSharpParsingOptions) confi
             match results with
             | [] -> failwith "not possible"
             | [ x ] -> x
-            | all -> List.reduce String.merge all
+            | all -> List.reduce (String.merge config.EndOfLine.NewLineString) all
 
         return merged
     }


### PR DESCRIPTION
Fixes #1673.