### PR TITLE
Properly collect ColMultilineItems for nested LetOrUse in Sequential

### DIFF
--- a/src/Fantomas.Tests/ColMultilineItemTests.fs
+++ b/src/Fantomas.Tests/ColMultilineItemTests.fs
@@ -368,3 +368,41 @@ printFn ()
 open Foo
 open Bar
 """
+
+[<Test>]
+let ``items should be collected from nested let-or-use in sequentials`` () =
+    formatSourceString
+        false
+        """
+let blah<'a> config : Type =
+//#if DEBUG
+        failwith ""
+//#endif
+        DoThing.doIt ()
+        let result = Runner.Run<'a> config
+        ()
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeClassConstructor = true
+              SpaceBeforeMember = true
+              SpaceBeforeColon = true
+              SpaceBeforeSemicolon = true
+              MultilineBlockBracketsOnSameColumn = true
+              NewlineBetweenTypeDefinitionAndMembers = true
+              KeepIfThenInSameLine = true
+              AlignFunctionSignatureToIndentation = true
+              AlternativeLongMemberDefinitions = true
+              MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let blah<'a> config : Type =
+    //#if DEBUG
+    failwith ""
+    //#endif
+    DoThing.doIt ()
+    let result = Runner.Run<'a> config
+    ()
+"""

--- a/src/Fantomas.Tests/KeepIndentInBranchTests.fs
+++ b/src/Fantomas.Tests/KeepIndentInBranchTests.fs
@@ -1176,3 +1176,141 @@ and [<CustomEquality ; NoComparison>] Bar<'context, 'a> =
                         }
             }
 """
+
+[<Test>]
+let ``ifdef trivia should not influence outcome, 1646`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    [<Foo>]
+    let blah<'a> config : Type =
+#if DEBUG
+        failwith ""
+#endif
+        DoThing.doIt ()
+        let result = Runner.Run<'a> config
+
+        if successful |> List.isEmpty then
+            result
+        else
+
+        let errors =
+            unsuccessful
+            |> List.filter (fun report ->
+                not report.BuildResult.IsBuildSuccess
+                || not report.BuildResult.IsGenerateSuccess
+            )
+            |> List.map (fun report -> report.BuildResult.ErrorMessage)
+
+        failwith ""
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeClassConstructor = true
+              SpaceBeforeMember = true
+              SpaceBeforeColon = true
+              SpaceBeforeSemicolon = true
+              MultilineBlockBracketsOnSameColumn = true
+              NewlineBetweenTypeDefinitionAndMembers = true
+              KeepIfThenInSameLine = true
+              AlignFunctionSignatureToIndentation = true
+              AlternativeLongMemberDefinitions = true
+              MultiLineLambdaClosingNewline = true
+              KeepIndentInBranch = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    [<Foo>]
+    let blah<'a> config : Type =
+#if DEBUG
+        failwith ""
+#endif
+        DoThing.doIt ()
+        let result = Runner.Run<'a> config
+
+        if successful |> List.isEmpty then
+            result
+        else
+
+        let errors =
+            unsuccessful
+            |> List.filter (fun report ->
+                not report.BuildResult.IsBuildSuccess
+                || not report.BuildResult.IsGenerateSuccess
+            )
+            |> List.map (fun report -> report.BuildResult.ErrorMessage)
+
+        failwith ""
+"""
+
+[<Test>]
+let ``ifdef trivia should not influence outcome, idempotent`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    [<Foo>]
+    let blah<'a> config : Type =
+#if DEBUG
+        failwith ""
+#endif
+        DoThing.doIt ()
+        let result = Runner.Run<'a> config
+
+        if successful |> List.isEmpty then
+            result
+        else
+
+        let errors =
+            unsuccessful
+            |> List.filter (fun report ->
+                not report.BuildResult.IsBuildSuccess
+                || not report.BuildResult.IsGenerateSuccess
+            )
+            |> List.map (fun report -> report.BuildResult.ErrorMessage)
+
+        failwith ""
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeClassConstructor = true
+              SpaceBeforeMember = true
+              SpaceBeforeColon = true
+              SpaceBeforeSemicolon = true
+              MultilineBlockBracketsOnSameColumn = true
+              NewlineBetweenTypeDefinitionAndMembers = true
+              KeepIfThenInSameLine = true
+              AlignFunctionSignatureToIndentation = true
+              AlternativeLongMemberDefinitions = true
+              MultiLineLambdaClosingNewline = true
+              KeepIndentInBranch = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    [<Foo>]
+    let blah<'a> config : Type =
+#if DEBUG
+        failwith ""
+#endif
+        DoThing.doIt ()
+        let result = Runner.Run<'a> config
+
+        if successful |> List.isEmpty then
+            result
+        else
+
+        let errors =
+            unsuccessful
+            |> List.filter (fun report ->
+                not report.BuildResult.IsBuildSuccess
+                || not report.BuildResult.IsGenerateSuccess
+            )
+            |> List.map (fun report -> report.BuildResult.ErrorMessage)
+
+        failwith ""
+"""


### PR DESCRIPTION
Fixes #1671, depends on #1672 (yes, I'm aware this is beginning to become a mess).
ColMultilineItems are correctly detected when `SynExpr.LetOrUse` is nested inside a `SynExpr.Sequential`.
This issue was a good catch.