### PR TITLE
Add 'cacheParsingResult' parameter [WIP]

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,10 +1,11 @@
 source https://api.nuget.org/v3/index.json
+source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
 
 framework: netstandard2.0, net5.0, netcoreapp3.1
 storage: none
 
-nuget FSharp.Core
-nuget FSharp.Compiler.Service ~> 39.0
+nuget FSharp.Core 5.0.2-beta.21221.4
+nuget FSharp.Compiler.Service 40.0.0-preview.21221.4
 nuget FsUnit
 nuget FsCheck
 nuget Microsoft.NET.Test.Sdk 16.9.1

--- a/paket.lock
+++ b/paket.lock
@@ -24,50 +24,25 @@ NUGET
     BenchmarkDotNet.Annotations (0.12.1)
     CommandLineParser (2.8)
     editorconfig (0.12.2)
-    FsCheck (2.14.3)
+    FsCheck (2.15.2)
       FSharp.Core (>= 4.2.3)
-    FSharp.Compiler.Service (39.0)
-      FSharp.Core (5.0.1)
-      Microsoft.Build.Framework (>= 16.6)
-      Microsoft.Build.Tasks.Core (>= 16.6)
-      Microsoft.Build.Utilities.Core (>= 16.6)
-      System.Buffers (>= 4.5.1)
-      System.Collections.Immutable (>= 5.0)
-      System.Diagnostics.Process (>= 4.3)
-      System.Diagnostics.TraceSource (>= 4.3)
-      System.Linq.Expressions (>= 4.3)
-      System.Linq.Queryable (>= 4.3)
-      System.Memory (>= 4.5.4)
-      System.Net.Requests (>= 4.3)
-      System.Net.Security (>= 4.3)
-      System.Reflection.Emit (>= 4.3)
-      System.Reflection.Metadata (>= 5.0)
-      System.Reflection.TypeExtensions (>= 4.3)
-      System.Runtime (>= 4.3)
-      System.Runtime.InteropServices (>= 4.3)
-      System.Runtime.Loader (>= 4.3)
-      System.Security.Claims (>= 4.3)
-      System.Security.Cryptography.Algorithms (>= 4.3)
-      System.Security.Principal (>= 4.3)
-      System.Threading.Tasks.Parallel (>= 4.3)
-      System.Threading.Thread (>= 4.3)
-      System.Threading.ThreadPool (>= 4.3)
-    FSharp.Core (5.0.1)
-    FsUnit (4.0.2)
+    FsUnit (4.0.4)
       FSharp.Core (>= 4.3.4)
       NETStandard.Library (>= 2.0.3)
-      NUnit (>= 3.12 < 4.0)
-    Iced (1.7)
+      NUnit (>= 3.13 < 4.0)
+    Iced (1.11.1)
     MAB.DotIgnore (3.0.2)
       NETStandard.Library (>= 1.6.1)
-    Microsoft.Build.Framework (16.8)
+    Microsoft.Bcl.AsyncInterfaces (5.0)
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (&& (== net50) (>= net461)) (&& (== net50) (< netcoreapp2.1) (< netstandard2.1)) (&& (== netcoreapp3.1) (>= net461)) (&& (== netcoreapp3.1) (< netcoreapp2.1) (< netstandard2.1)) (== netstandard2.0)
+    Microsoft.Build.Framework (16.9)
       System.Security.Permissions (>= 4.7)
-    Microsoft.Build.Tasks.Core (16.8)
-      Microsoft.Build.Framework (>= 16.8)
-      Microsoft.Build.Utilities.Core (>= 16.8)
+    Microsoft.Build.Tasks.Core (16.9)
+      Microsoft.Build.Framework (>= 16.9)
+      Microsoft.Build.Utilities.Core (>= 16.9)
       Microsoft.Win32.Registry (>= 4.3)
       System.CodeDom (>= 4.4)
-      System.Collections.Immutable (>= 1.5)
+      System.Collections.Immutable (>= 5.0)
       System.Reflection.Metadata (>= 1.6)
       System.Reflection.TypeExtensions (>= 4.1)
       System.Resources.Extensions (>= 4.6)
@@ -76,59 +51,66 @@ NUGET
       System.Security.Cryptography.Xml (>= 4.7)
       System.Security.Permissions (>= 4.7)
       System.Threading.Tasks.Dataflow (>= 4.9)
-    Microsoft.Build.Utilities.Core (16.8)
-      Microsoft.Build.Framework (>= 16.8)
+    Microsoft.Build.Utilities.Core (16.9)
+      Microsoft.Build.Framework (>= 16.9)
       Microsoft.Win32.Registry (>= 4.3)
-      System.Collections.Immutable (>= 1.5)
+      System.Collections.Immutable (>= 5.0)
       System.Security.Permissions (>= 4.7)
       System.Text.Encoding.CodePages (>= 4.0.1)
-    Microsoft.CodeAnalysis.Analyzers (3.0)
-    Microsoft.CodeAnalysis.Common (3.6)
+    Microsoft.CodeAnalysis.Analyzers (3.3.2)
+    Microsoft.CodeAnalysis.Common (3.9)
       Microsoft.CodeAnalysis.Analyzers (>= 3.0)
-      System.Collections.Immutable (>= 1.5)
-      System.Memory (>= 4.5.3)
-      System.Reflection.Metadata (>= 1.6)
-      System.Runtime.CompilerServices.Unsafe (>= 4.7)
+      System.Collections.Immutable (>= 5.0)
+      System.Memory (>= 4.5.4)
+      System.Reflection.Metadata (>= 5.0)
+      System.Runtime.CompilerServices.Unsafe (>= 5.0)
       System.Text.Encoding.CodePages (>= 4.5.1)
-      System.Threading.Tasks.Extensions (>= 4.5.3)
-    Microsoft.CodeAnalysis.CSharp (3.6)
-      Microsoft.CodeAnalysis.Common (3.6)
-    Microsoft.CodeCoverage (16.9.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= net45)) (&& (== netstandard2.0) (>= netcoreapp1.0))
-    Microsoft.Diagnostics.NETCore.Client (0.2.61701)
-    Microsoft.Diagnostics.Runtime (1.1.127808)
-    Microsoft.Diagnostics.Tracing.TraceEvent (2.0.56)
+      System.Threading.Tasks.Extensions (>= 4.5.4)
+    Microsoft.CodeAnalysis.CSharp (3.9)
+      Microsoft.CodeAnalysis.Common (3.9)
+    Microsoft.CodeCoverage (16.9.4) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= net45)) (&& (== netstandard2.0) (>= netcoreapp1.0))
+    Microsoft.Diagnostics.NETCore.Client (0.2.221401)
+      Microsoft.Bcl.AsyncInterfaces (>= 1.1)
+    Microsoft.Diagnostics.Runtime (2.0.222201)
+      Microsoft.Diagnostics.NETCore.Client (>= 0.2.61701)
+      System.Buffers (>= 4.5.1)
+      System.Collections.Immutable (>= 1.7.1)
+      System.Memory (>= 4.5.4)
+      System.Reflection.Metadata (>= 1.8.1)
+      System.Runtime.CompilerServices.Unsafe (>= 4.7.1)
+    Microsoft.Diagnostics.Tracing.TraceEvent (2.0.67)
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2)
-    Microsoft.DotNet.PlatformAbstractions (3.1.4)
+    Microsoft.DotNet.PlatformAbstractions (3.1.6)
     Microsoft.NET.Test.Sdk (16.9.1)
       Microsoft.CodeCoverage (>= 16.9.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= net45)) (&& (== netstandard2.0) (>= netcoreapp1.0))
       Microsoft.TestPlatform.TestHost (>= 16.9.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0))
-    Microsoft.NETCore.Platforms (3.1)
-    Microsoft.NETCore.Targets (3.1)
-    Microsoft.TestPlatform.ObjectModel (16.9.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0))
+    Microsoft.NETCore.Platforms (5.0.2)
+    Microsoft.NETCore.Targets (5.0)
+    Microsoft.TestPlatform.ObjectModel (16.9.4) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0))
       NuGet.Frameworks (>= 5.0)
       System.Reflection.Metadata (>= 1.6)
-    Microsoft.TestPlatform.TestHost (16.9.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0))
-      Microsoft.TestPlatform.ObjectModel (>= 16.9.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0)) (&& (== netstandard2.0) (>= uap10.0))
+    Microsoft.TestPlatform.TestHost (16.9.4) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0))
+      Microsoft.TestPlatform.ObjectModel (>= 16.9.4) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0)) (&& (== netstandard2.0) (>= uap10.0))
       Newtonsoft.Json (>= 9.0.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0)) (&& (== netstandard2.0) (>= uap10.0))
     Microsoft.Win32.Primitives (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
       System.Runtime (>= 4.3)
-    Microsoft.Win32.Registry (4.7)
-      System.Buffers (>= 4.5) - restriction: || (&& (== net50) (>= monotouch)) (&& (== net50) (< netcoreapp2.0)) (&& (== net50) (>= xamarinios)) (&& (== net50) (>= xamarinmac)) (&& (== net50) (>= xamarintvos)) (&& (== net50) (>= xamarinwatchos)) (&& (== netcoreapp3.1) (>= monotouch)) (&& (== netcoreapp3.1) (< netcoreapp2.0)) (&& (== netcoreapp3.1) (>= xamarinios)) (&& (== netcoreapp3.1) (>= xamarinmac)) (&& (== netcoreapp3.1) (>= xamarintvos)) (&& (== netcoreapp3.1) (>= xamarinwatchos)) (== netstandard2.0)
-      System.Memory (>= 4.5.3) - restriction: || (&& (== net50) (< netcoreapp2.0)) (&& (== net50) (< netcoreapp2.1)) (&& (== net50) (>= uap10.1)) (&& (== netcoreapp3.1) (< netcoreapp2.0)) (&& (== netcoreapp3.1) (< netcoreapp2.1)) (&& (== netcoreapp3.1) (>= uap10.1)) (== netstandard2.0)
-      System.Security.AccessControl (>= 4.7)
-      System.Security.Principal.Windows (>= 4.7)
-    Microsoft.Win32.SystemEvents (4.7) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp3.0))
-      Microsoft.NETCore.Platforms (>= 3.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0))
+    Microsoft.Win32.Registry (5.0)
+      System.Buffers (>= 4.5.1) - restriction: || (&& (== net50) (>= monotouch)) (&& (== net50) (< netcoreapp2.0)) (&& (== net50) (>= xamarinios)) (&& (== net50) (>= xamarinmac)) (&& (== net50) (>= xamarintvos)) (&& (== net50) (>= xamarinwatchos)) (&& (== netcoreapp3.1) (>= monotouch)) (&& (== netcoreapp3.1) (< netcoreapp2.0)) (&& (== netcoreapp3.1) (>= xamarinios)) (&& (== netcoreapp3.1) (>= xamarinmac)) (&& (== netcoreapp3.1) (>= xamarintvos)) (&& (== netcoreapp3.1) (>= xamarinwatchos)) (== netstandard2.0)
+      System.Memory (>= 4.5.4) - restriction: || (&& (== net50) (< netcoreapp2.0)) (&& (== net50) (< netcoreapp2.1)) (&& (== net50) (>= uap10.1)) (&& (== netcoreapp3.1) (< netcoreapp2.0)) (&& (== netcoreapp3.1) (< netcoreapp2.1)) (&& (== netcoreapp3.1) (>= uap10.1)) (== netstandard2.0)
+      System.Security.AccessControl (>= 5.0)
+      System.Security.Principal.Windows (>= 5.0)
+    Microsoft.Win32.SystemEvents (5.0) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp3.0))
+      Microsoft.NETCore.Platforms (>= 5.0) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0))
     NETStandard.Library (2.0.3)
       Microsoft.NETCore.Platforms (>= 1.1)
-    Newtonsoft.Json (12.0.3) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0))
-    NuGet.Frameworks (5.4) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0))
+    Newtonsoft.Json (13.0.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0))
+    NuGet.Frameworks (5.9.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp1.0))
     NUnit (3.13.1)
       NETStandard.Library (>= 2.0)
     NUnit3TestAdapter (4.0.0-beta.1)
-    NunitXml.TestLogger (2.1.80)
+    NunitXml.TestLogger (3.0.97)
     Perfolizer (0.2.1)
       System.Memory (>= 4.5.3)
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
@@ -175,7 +157,7 @@ NUGET
     runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
     runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
     System.Buffers (4.5.1)
-    System.CodeDom (4.7)
+    System.CodeDom (5.0)
     System.Collections (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
@@ -193,15 +175,16 @@ NUGET
       System.Threading.Tasks (>= 4.3)
     System.Collections.Immutable (5.0)
       System.Memory (>= 4.5.4) - restriction: || (&& (== net50) (>= net461)) (&& (== net50) (< netcoreapp2.1)) (&& (== net50) (< netstandard2.0)) (&& (== net50) (>= uap10.1)) (&& (== netcoreapp3.1) (>= net461)) (&& (== netcoreapp3.1) (< netcoreapp2.1)) (&& (== netcoreapp3.1) (< netstandard2.0)) (&& (== netcoreapp3.1) (>= uap10.1)) (== netstandard2.0)
-    System.Configuration.ConfigurationManager (4.7)
-      System.Security.Cryptography.ProtectedData (>= 4.7)
-      System.Security.Permissions (>= 4.7)
+    System.Configuration.ConfigurationManager (5.0)
+      System.Security.Cryptography.ProtectedData (>= 5.0)
+      System.Security.Permissions (>= 5.0)
     System.Diagnostics.Debug (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
       System.Runtime (>= 4.3)
-    System.Diagnostics.DiagnosticSource (4.7.1)
+    System.Diagnostics.DiagnosticSource (5.0.1)
       System.Memory (>= 4.5.4) - restriction: || (&& (== net50) (>= net45) (< netstandard1.3)) (&& (== net50) (>= net46)) (&& (== net50) (< netcoreapp2.1)) (&& (== net50) (< netstandard2.0)) (&& (== net50) (>= uap10.1)) (&& (== netcoreapp3.1) (>= net45) (< netstandard1.3)) (&& (== netcoreapp3.1) (>= net46)) (&& (== netcoreapp3.1) (< netcoreapp2.1)) (&& (== netcoreapp3.1) (< netstandard2.0)) (&& (== netcoreapp3.1) (>= uap10.1)) (== netstandard2.0)
+      System.Runtime.CompilerServices.Unsafe (>= 5.0) - restriction: || (&& (== net50) (>= monotouch)) (&& (== net50) (>= net45) (< netstandard1.3)) (&& (== net50) (>= net46)) (&& (== net50) (< netcoreapp2.1)) (&& (== net50) (< netcoreapp3.0)) (&& (== net50) (< netstandard2.0)) (&& (== net50) (>= uap10.1)) (&& (== netcoreapp3.1) (>= monotouch)) (&& (== netcoreapp3.1) (>= net45) (< netstandard1.3)) (&& (== netcoreapp3.1) (>= net46)) (&& (== netcoreapp3.1) (< netcoreapp2.1)) (&& (== netcoreapp3.1) (< netcoreapp3.0)) (&& (== netcoreapp3.1) (< netstandard2.0)) (&& (== netcoreapp3.1) (>= uap10.1)) (== netstandard2.0)
     System.Diagnostics.Process (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.Win32.Primitives (>= 4.3)
@@ -238,9 +221,8 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
       System.Runtime (>= 4.3)
-    System.Drawing.Common (4.7) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp3.0))
-      Microsoft.NETCore.Platforms (>= 3.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0)) (&& (== netstandard2.0) (>= netcoreapp3.0))
-      Microsoft.Win32.SystemEvents (>= 4.7) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0)) (&& (== netstandard2.0) (>= netcoreapp3.0))
+    System.Drawing.Common (5.0.2) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp3.0))
+      Microsoft.Win32.SystemEvents (>= 5.0) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0)) (&& (== netstandard2.0) (>= netcoreapp3.0))
     System.Formats.Asn1 (5.0)
     System.Globalization (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
@@ -308,10 +290,10 @@ NUGET
       System.Reflection.Extensions (>= 4.3)
       System.Resources.ResourceManager (>= 4.3)
       System.Runtime (>= 4.3)
-    System.Management (4.7)
-      Microsoft.NETCore.Platforms (>= 3.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0))
-      Microsoft.Win32.Registry (>= 4.7) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0))
-      System.CodeDom (>= 4.7)
+    System.Management (5.0)
+      Microsoft.NETCore.Platforms (>= 5.0) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0))
+      Microsoft.Win32.Registry (>= 5.0) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0))
+      System.CodeDom (>= 5.0)
     System.Memory (4.5.4)
       System.Buffers (>= 4.5.1) - restriction: || (&& (== net50) (>= monotouch)) (&& (== net50) (>= net461)) (&& (== net50) (< netcoreapp2.0)) (&& (== net50) (< netstandard1.1)) (&& (== net50) (< netstandard2.0)) (&& (== net50) (>= xamarinios)) (&& (== net50) (>= xamarinmac)) (&& (== net50) (>= xamarintvos)) (&& (== net50) (>= xamarinwatchos)) (&& (== netcoreapp3.1) (>= monotouch)) (&& (== netcoreapp3.1) (>= net461)) (&& (== netcoreapp3.1) (< netcoreapp2.0)) (&& (== netcoreapp3.1) (< netstandard1.1)) (&& (== netcoreapp3.1) (< netstandard2.0)) (&& (== netcoreapp3.1) (>= xamarinios)) (&& (== netcoreapp3.1) (>= xamarinmac)) (&& (== netcoreapp3.1) (>= xamarintvos)) (&& (== netcoreapp3.1) (>= xamarinwatchos)) (== netstandard2.0)
       System.Numerics.Vectors (>= 4.4) - restriction: || (&& (== net50) (< netcoreapp2.0)) (&& (== netcoreapp3.1) (< netcoreapp2.0)) (== netstandard2.0)
@@ -437,7 +419,7 @@ NUGET
     System.Runtime (4.3.1)
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    System.Runtime.CompilerServices.Unsafe (4.7)
+    System.Runtime.CompilerServices.Unsafe (5.0)
     System.Runtime.Extensions (4.3.1)
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
@@ -462,9 +444,9 @@ NUGET
       System.Resources.ResourceManager (>= 4.3)
       System.Runtime (>= 4.3)
       System.Runtime.Extensions (>= 4.3)
-    System.Security.AccessControl (4.7)
-      Microsoft.NETCore.Platforms (>= 3.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0))
-      System.Security.Principal.Windows (>= 4.7)
+    System.Security.AccessControl (5.0)
+      Microsoft.NETCore.Platforms (>= 5.0) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0))
+      System.Security.Principal.Windows (>= 5.0)
     System.Security.Claims (4.3)
       System.Collections (>= 4.3)
       System.Globalization (>= 4.3)
@@ -532,8 +514,8 @@ NUGET
       System.Runtime (>= 4.3)
       System.Threading (>= 4.3)
       System.Threading.Tasks (>= 4.3)
-    System.Security.Cryptography.ProtectedData (4.7)
-      System.Memory (>= 4.5.3) - restriction: || (&& (== net50) (< netcoreapp2.1)) (&& (== netcoreapp3.1) (< netcoreapp2.1)) (== netstandard2.0)
+    System.Security.Cryptography.ProtectedData (5.0)
+      System.Memory (>= 4.5.4) - restriction: || (&& (== net50) (< netcoreapp2.1)) (&& (== netcoreapp3.1) (< netcoreapp2.1)) (== netstandard2.0)
     System.Security.Cryptography.X509Certificates (4.3.2)
       Microsoft.NETCore.Platforms (>= 1.1)
       runtime.native.System (>= 4.3)
@@ -560,22 +542,23 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3)
       System.Text.Encoding (>= 4.3)
       System.Threading (>= 4.3)
-    System.Security.Cryptography.Xml (4.7)
-      System.Security.Cryptography.Pkcs (>= 4.7)
-      System.Security.Permissions (>= 4.7)
-    System.Security.Permissions (4.7)
-      System.Security.AccessControl (>= 4.7)
-      System.Windows.Extensions (>= 4.7) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp3.0))
+    System.Security.Cryptography.Xml (5.0)
+      System.Memory (>= 4.5.4) - restriction: || (&& (== net50) (< netcoreapp2.1)) (&& (== netcoreapp3.1) (< netcoreapp2.1)) (== netstandard2.0)
+      System.Security.Cryptography.Pkcs (>= 5.0)
+      System.Security.Permissions (>= 5.0)
+    System.Security.Permissions (5.0)
+      System.Security.AccessControl (>= 5.0)
+      System.Windows.Extensions (>= 5.0) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp3.0))
     System.Security.Principal (4.3)
       System.Runtime (>= 4.3)
-    System.Security.Principal.Windows (4.7)
+    System.Security.Principal.Windows (5.0)
     System.Text.Encoding (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
       System.Runtime (>= 4.3)
-    System.Text.Encoding.CodePages (4.7)
-      Microsoft.NETCore.Platforms (>= 3.1) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp2.0)) (&& (== netstandard2.0) (>= netcoreapp3.1))
-      System.Runtime.CompilerServices.Unsafe (>= 4.7) - restriction: || (&& (== net50) (>= net461)) (&& (== net50) (< netcoreapp2.0)) (&& (== net50) (< netcoreapp3.1)) (&& (== netcoreapp3.1) (>= net461)) (&& (== netcoreapp3.1) (< netcoreapp2.0)) (== netstandard2.0)
+    System.Text.Encoding.CodePages (5.0)
+      Microsoft.NETCore.Platforms (>= 5.0) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= net50)) (&& (== netstandard2.0) (>= netcoreapp2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 5.0) - restriction: || (&& (== net50) (>= net461)) (&& (== net50) (< netcoreapp2.0)) (== netcoreapp3.1) (== netstandard2.0)
     System.Text.Encoding.Extensions (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
@@ -589,8 +572,8 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1)
       System.Runtime (>= 4.3)
     System.Threading.Tasks.Dataflow (5.0)
-    System.Threading.Tasks.Extensions (4.5.3)
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: || (&& (== net50) (>= net45)) (&& (== net50) (< netcoreapp2.1)) (&& (== net50) (< netstandard1.0)) (&& (== net50) (< netstandard2.0)) (&& (== net50) (>= wp8)) (&& (== netcoreapp3.1) (>= net45)) (&& (== netcoreapp3.1) (< netcoreapp2.1)) (&& (== netcoreapp3.1) (< netstandard1.0)) (&& (== netcoreapp3.1) (< netstandard2.0)) (&& (== netcoreapp3.1) (>= wp8)) (== netstandard2.0)
+    System.Threading.Tasks.Extensions (4.5.4)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (== net50) (>= net461)) (&& (== net50) (< netcoreapp2.1)) (&& (== net50) (< netstandard1.0)) (&& (== net50) (< netstandard2.0)) (&& (== net50) (>= wp8)) (&& (== netcoreapp3.1) (>= net461)) (&& (== netcoreapp3.1) (< netcoreapp2.1)) (&& (== netcoreapp3.1) (< netstandard1.0)) (&& (== netcoreapp3.1) (< netstandard2.0)) (&& (== netcoreapp3.1) (>= wp8)) (== netstandard2.0)
     System.Threading.Tasks.Parallel (4.3)
       System.Collections.Concurrent (>= 4.3)
       System.Diagnostics.Debug (>= 4.3)
@@ -606,8 +589,36 @@ NUGET
       System.Runtime (>= 4.3)
       System.Runtime.Handles (>= 4.3)
     System.ValueTuple (4.5)
-    System.Windows.Extensions (4.7) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp3.0))
-      System.Drawing.Common (>= 4.7) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp3.0))
+    System.Windows.Extensions (5.0) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp3.0))
+      System.Drawing.Common (>= 5.0) - restriction: || (== net50) (== netcoreapp3.1) (&& (== netstandard2.0) (>= netcoreapp3.0))
+  remote: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+    FSharp.Compiler.Service (40.0.0-preview.21221.4)
+      FSharp.Core (5.0.2-beta.21221.4)
+      Microsoft.Build.Framework (>= 16.9)
+      Microsoft.Build.Tasks.Core (>= 16.9)
+      Microsoft.Build.Utilities.Core (>= 16.9)
+      System.Buffers (>= 4.5.1)
+      System.Collections.Immutable (>= 5.0)
+      System.Diagnostics.Process (>= 4.3)
+      System.Diagnostics.TraceSource (>= 4.3)
+      System.Linq.Expressions (>= 4.3)
+      System.Linq.Queryable (>= 4.3)
+      System.Memory (>= 4.5.4)
+      System.Net.Requests (>= 4.3)
+      System.Net.Security (>= 4.3)
+      System.Reflection.Emit (>= 4.3)
+      System.Reflection.Metadata (>= 5.0)
+      System.Reflection.TypeExtensions (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Runtime.Loader (>= 4.3)
+      System.Security.Claims (>= 4.3)
+      System.Security.Cryptography.Algorithms (>= 4.3)
+      System.Security.Principal (>= 4.3)
+      System.Threading.Tasks.Parallel (>= 4.3)
+      System.Threading.Thread (>= 4.3)
+      System.Threading.ThreadPool (>= 4.3)
+    FSharp.Core (5.0.2-beta.21221.4)
 GITHUB
   remote: fsprojects/fantomas
     src/Fantomas/CodePrinter.fs (829faa6ba834f99afed9b4434b3a1680536474b2)
@@ -619,118 +630,118 @@ NUGET
       FSharp.Core (>= 4.0.0.1) - restriction: >= net45
       FSharp.Core (>= 4.2.3) - restriction: && (< net45) (>= netstandard2.0)
       Microsoft.Win32.Registry (>= 4.7) - restriction: && (< net45) (>= netstandard2.0)
-    Fake.Core.CommandLineParsing (5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.CommandLineParsing (5.20.4) - restriction: >= netstandard2.0
       FParsec (>= 1.1.1) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Context (5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.Context (5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Environment (5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.Environment (5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.FakeVar (5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Context (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.FakeVar (5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Context (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Process (5.20.3)
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.FakeVar (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.Process (5.20.4)
+      Fake.Core.Environment (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.FakeVar (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
       System.Collections.Immutable (>= 1.7.1) - restriction: >= netstandard2.0
-    Fake.Core.ReleaseNotes (5.20.3)
-      Fake.Core.SemVer (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.ReleaseNotes (5.20.4)
+      Fake.Core.SemVer (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.SemVer (5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.SemVer (5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.String (5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.String (5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Target (5.20.3)
-      Fake.Core.CommandLineParsing (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Context (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.FakeVar (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.Target (5.20.4)
+      Fake.Core.CommandLineParsing (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Context (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.FakeVar (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Control.Reactive (>= 4.4.2) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Tasks (5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.Tasks (5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Trace (5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.FakeVar (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.Trace (5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.FakeVar (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Xml (5.20.3)
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.Core.Xml (5.20.4)
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.DotNet.Cli (5.20.3)
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.DotNet.MSBuild (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.DotNet.NuGet (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.DotNet.Cli (5.20.4)
+      Fake.Core.Environment (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.DotNet.MSBuild (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.DotNet.NuGet (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
       Mono.Posix.NETStandard (>= 1.0) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 12.0.3) - restriction: >= netstandard2.0
-    Fake.DotNet.MSBuild (5.20.3) - restriction: >= netstandard2.0
+    Fake.DotNet.MSBuild (5.20.4) - restriction: >= netstandard2.0
       BlackFox.VsWhere (>= 1.1) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
       MSBuild.StructuredLogger (>= 2.1.176) - restriction: >= netstandard2.0
-    Fake.DotNet.NuGet (5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.SemVer (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Tasks (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Xml (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Net.Http (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.DotNet.NuGet (5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.SemVer (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Tasks (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Xml (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Net.Http (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 12.0.3) - restriction: >= netstandard2.0
       NuGet.Protocol (>= 5.6) - restriction: >= netstandard2.0
-    Fake.DotNet.Paket (5.20.3)
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.DotNet.Cli (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.DotNet.Paket (5.20.4)
+      Fake.Core.Process (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.DotNet.Cli (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.IO.FileSystem (5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.IO.FileSystem (5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Net.Http (5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.Net.Http (5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Tools.Git (5.20.3)
-      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.SemVer (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
+    Fake.Tools.Git (5.20.4)
+      Fake.Core.Environment (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.SemVer (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
     FParsec (1.1.1) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.3.4) - restriction: || (>= net45) (>= netstandard2.0)
       System.ValueTuple (>= 4.4) - restriction: >= net45
-    FSharp.Control.Reactive (4.5) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: || (>= net46) (>= netstandard2.0)
-      System.Reactive (>= 4.4.1) - restriction: || (>= net46) (>= netstandard2.0)
-    FSharp.Core (5.0) - restriction: >= netstandard2.0
+    FSharp.Control.Reactive (5.0.2) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+      System.Reactive (>= 5.0) - restriction: >= netstandard2.0
+    FSharp.Core (5.0.1) - restriction: >= netstandard2.0
     Microsoft.Azure.Cosmos.Table (1.0.8)
       Microsoft.Azure.DocumentDB.Core (>= 2.11.2) - restriction: >= netstandard2.0
       Microsoft.OData.Core (>= 7.6.4) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 10.0.2) - restriction: >= netstandard2.0
-    Microsoft.Azure.DocumentDB.Core (2.13.1) - restriction: >= netstandard2.0
+    Microsoft.Azure.DocumentDB.Core (2.14) - restriction: >= netstandard2.0
       NETStandard.Library (>= 1.6) - restriction: >= netstandard1.5
       Newtonsoft.Json (>= 9.0.1) - restriction: >= netstandard1.5
       System.Collections.Immutable (>= 1.3) - restriction: >= netstandard1.5
@@ -749,28 +760,28 @@ NUGET
       System.Security.SecureString (>= 4.0) - restriction: >= netstandard1.5
       System.Threading.Tasks.Extensions (>= 4.5.2) - restriction: >= netstandard1.5
       System.ValueTuple (>= 4.5) - restriction: >= netstandard1.5
-    Microsoft.Bcl.AsyncInterfaces (5.0) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
+    Microsoft.Bcl.AsyncInterfaces (5.0) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp2.0) (>= xamarinios)) (&& (< netcoreapp2.0) (>= xamarinmac)) (&& (>= netstandard2.0) (>= uap10.1))
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1))
-    Microsoft.Build (16.8) - restriction: >= netstandard2.0
-      Microsoft.Build.Framework (>= 16.8) - restriction: || (>= net472) (>= netcoreapp2.1)
+    Microsoft.Build (16.9) - restriction: >= netstandard2.0
+      Microsoft.Build.Framework (>= 16.9) - restriction: || (>= net472) (>= netcoreapp2.1)
       Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
       Microsoft.Win32.Registry (>= 4.3) - restriction: >= netcoreapp2.1
-      System.Collections.Immutable (>= 1.5) - restriction: || (>= net472) (>= netcoreapp2.1)
-      System.Memory (>= 4.5.3) - restriction: || (>= net472) (>= netcoreapp2.1)
+      System.Collections.Immutable (>= 5.0) - restriction: || (>= net472) (>= netcoreapp2.1)
+      System.Memory (>= 4.5.4) - restriction: || (>= net472) (>= netcoreapp2.1)
       System.Reflection.Metadata (>= 1.6) - restriction: >= netcoreapp2.1
       System.Security.Principal.Windows (>= 4.7) - restriction: >= netcoreapp2.1
       System.Text.Encoding.CodePages (>= 4.0.1) - restriction: >= netcoreapp2.1
       System.Text.Json (>= 4.7) - restriction: || (>= net472) (>= netcoreapp2.1)
       System.Threading.Tasks.Dataflow (>= 4.9) - restriction: || (>= net472) (>= netcoreapp2.1)
-    Microsoft.Build.Framework (16.8) - restriction: >= netstandard2.0
+    Microsoft.Build.Framework (16.9) - restriction: >= netstandard2.0
       System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
-    Microsoft.Build.Tasks.Core (16.8) - restriction: >= netstandard2.0
-      Microsoft.Build.Framework (>= 16.8) - restriction: >= netstandard2.0
-      Microsoft.Build.Utilities.Core (>= 16.8) - restriction: >= netstandard2.0
+    Microsoft.Build.Tasks.Core (16.9) - restriction: >= netstandard2.0
+      Microsoft.Build.Framework (>= 16.9) - restriction: >= netstandard2.0
+      Microsoft.Build.Utilities.Core (>= 16.9) - restriction: >= netstandard2.0
       Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
       Microsoft.Win32.Registry (>= 4.3) - restriction: && (< net472) (>= netstandard2.0)
       System.CodeDom (>= 4.4) - restriction: && (< net472) (>= netstandard2.0)
-      System.Collections.Immutable (>= 1.5) - restriction: >= netstandard2.0
+      System.Collections.Immutable (>= 5.0) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: && (< net472) (>= netstandard2.0)
       System.Reflection.TypeExtensions (>= 4.1) - restriction: && (< net472) (>= netstandard2.0)
       System.Resources.Extensions (>= 4.6) - restriction: >= netstandard2.0
@@ -779,21 +790,21 @@ NUGET
       System.Security.Cryptography.Xml (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
       System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
       System.Threading.Tasks.Dataflow (>= 4.9) - restriction: >= netstandard2.0
-    Microsoft.Build.Utilities.Core (16.8) - restriction: >= netstandard2.0
-      Microsoft.Build.Framework (>= 16.8) - restriction: >= netstandard2.0
+    Microsoft.Build.Utilities.Core (16.9) - restriction: >= netstandard2.0
+      Microsoft.Build.Framework (>= 16.9) - restriction: >= netstandard2.0
       Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
       Microsoft.Win32.Registry (>= 4.3) - restriction: && (< net472) (>= netstandard2.0)
-      System.Collections.Immutable (>= 1.5) - restriction: >= netstandard2.0
+      System.Collections.Immutable (>= 5.0) - restriction: >= netstandard2.0
       System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
       System.Text.Encoding.CodePages (>= 4.0.1) - restriction: && (< net472) (>= netstandard2.0)
-    Microsoft.NETCore.Platforms (5.0) - restriction: || (&& (< monoandroid) (>= netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= net45) (< netstandard1.3) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netstandard1.0) (>= netstandard2.0) (< portable-net45+win8)) (&& (< netstandard1.0) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.0) (>= netstandard2.0) (< win8)) (&& (< netstandard1.3) (>= netstandard2.0) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard2.0) (>= uap10.0)) (&& (>= netstandard2.0) (< portable-net45+win8+wpa81)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= wp8))
+    Microsoft.NETCore.Platforms (5.0.2) - restriction: || (&& (< monoandroid) (>= netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= net45) (< netstandard1.3) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netstandard1.0) (>= netstandard2.0) (< portable-net45+win8)) (&& (< netstandard1.0) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.0) (>= netstandard2.0) (< win8)) (&& (< netstandard1.3) (>= netstandard2.0) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard2.0) (>= uap10.0)) (&& (>= netstandard2.0) (< portable-net45+win8+wpa81)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= wp8))
     Microsoft.NETCore.Targets (5.0) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8))
-    Microsoft.OData.Core (7.8.1) - restriction: >= netstandard2.0
-      Microsoft.OData.Edm (7.8.1)
-      Microsoft.Spatial (7.8.1)
-    Microsoft.OData.Edm (7.8.1) - restriction: >= netstandard2.0
+    Microsoft.OData.Core (7.8.3) - restriction: >= netstandard2.0
+      Microsoft.OData.Edm (7.8.3)
+      Microsoft.Spatial (7.8.3)
+    Microsoft.OData.Edm (7.8.3) - restriction: >= netstandard2.0
       System.Text.Json (>= 4.6) - restriction: >= netstandard2.0
-    Microsoft.Spatial (7.8.1) - restriction: >= netstandard2.0
+    Microsoft.Spatial (7.8.3) - restriction: >= netstandard2.0
     Microsoft.VisualStudio.Setup.Configuration.Interop (1.16.30) - restriction: >= net472
     Microsoft.Win32.Primitives (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -807,29 +818,29 @@ NUGET
     Microsoft.Win32.SystemEvents (5.0) - restriction: && (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Platforms (>= 5.0) - restriction: >= netcoreapp2.0
     Mono.Posix.NETStandard (1.0) - restriction: >= netstandard2.0
-    MSBuild.StructuredLogger (2.1.303) - restriction: >= netstandard2.0
+    MSBuild.StructuredLogger (2.1.404) - restriction: >= netstandard2.0
       Microsoft.Build (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Framework (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Tasks.Core (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Utilities.Core (>= 16.4) - restriction: >= netstandard2.0
     NETStandard.Library (2.0.3) - restriction: >= netstandard2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
-    Newtonsoft.Json (12.0.3) - restriction: >= netstandard2.0
-    NuGet.Common (5.8.1) - restriction: >= netstandard2.0
-      NuGet.Frameworks (>= 5.8.1) - restriction: || (>= net45) (>= netstandard2.0)
-    NuGet.Configuration (5.8.1) - restriction: >= netstandard2.0
-      NuGet.Common (>= 5.8.1) - restriction: || (>= net45) (>= netstandard2.0)
+    Newtonsoft.Json (13.0.1) - restriction: >= netstandard2.0
+    NuGet.Common (5.9.1) - restriction: >= netstandard2.0
+      NuGet.Frameworks (>= 5.9.1) - restriction: || (>= net45) (>= netstandard2.0)
+    NuGet.Configuration (5.9.1) - restriction: >= netstandard2.0
+      NuGet.Common (>= 5.9.1) - restriction: || (>= net45) (>= netstandard2.0)
       System.Security.Cryptography.ProtectedData (>= 4.4) - restriction: && (< net45) (>= netstandard2.0)
-    NuGet.Frameworks (5.8.1) - restriction: >= netstandard2.0
-    NuGet.Packaging (5.8.1) - restriction: >= netstandard2.0
+    NuGet.Frameworks (5.9.1) - restriction: >= netstandard2.0
+    NuGet.Packaging (5.9.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 9.0.1) - restriction: >= netstandard2.0
-      NuGet.Configuration (>= 5.8.1) - restriction: >= netstandard2.0
-      NuGet.Versioning (>= 5.8.1) - restriction: >= netstandard2.0
+      NuGet.Configuration (>= 5.9.1) - restriction: >= netstandard2.0
+      NuGet.Versioning (>= 5.9.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Cng (>= 5.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net50)
       System.Security.Cryptography.Pkcs (>= 5.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net50)
-    NuGet.Protocol (5.8.1) - restriction: >= netstandard2.0
-      NuGet.Packaging (>= 5.8.1) - restriction: >= netstandard2.0
-    NuGet.Versioning (5.8.1) - restriction: >= netstandard2.0
+    NuGet.Protocol (5.9.1) - restriction: >= netstandard2.0
+      NuGet.Packaging (>= 5.9.1) - restriction: >= netstandard2.0
+    NuGet.Versioning (5.9.1) - restriction: >= netstandard2.0
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
     runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
     runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -873,7 +884,7 @@ NUGET
     runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
     runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
     runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= net50) (< netcoreapp2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
+    System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= net50) (< netcoreapp2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netcoreapp2.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netcoreapp3.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp2.1)) (&& (>= net461) (>= netcoreapp3.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
     System.CodeDom (5.0) - restriction: && (< net472) (>= netstandard2.0)
     System.Collections (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -928,7 +939,7 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Drawing.Common (5.0) - restriction: >= netcoreapp3.0
+    System.Drawing.Common (5.0.2) - restriction: >= netcoreapp3.0
       Microsoft.Win32.SystemEvents (>= 5.0) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     System.Dynamic.Runtime (4.3) - restriction: >= netstandard2.0
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1012,7 +1023,7 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Memory (4.5.4) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1)) (&& (< monoandroid) (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= net50) (< netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.0) (< netstandard2.1)) (&& (< monoandroid) (>= netcoreapp2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net461) (>= xamarinios)) (&& (>= net461) (>= xamarinmac)) (>= net472) (&& (>= net50) (>= uap10.1)) (&& (>= netcoreapp2.0) (>= uap10.1)) (>= netcoreapp2.1) (&& (>= netstandard2.0) (< netstandard2.1) (>= xamarintvos)) (&& (>= netstandard2.0) (< netstandard2.1) (>= xamarinwatchos)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (< netstandard2.1) (>= xamarinios)) (&& (< netstandard2.1) (>= xamarinmac)) (&& (>= uap10.1) (>= xamarinios)) (&& (>= uap10.1) (>= xamarinmac))
+    System.Memory (4.5.4) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= net50) (< netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp3.0) (< netstandard2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= monotouch) (>= netcoreapp2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp3.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net461) (>= xamarinios)) (&& (>= net461) (>= xamarinmac)) (>= net472) (&& (>= net50) (>= uap10.1)) (&& (>= netcoreapp2.0) (>= uap10.1)) (&& (< netcoreapp2.0) (< netstandard2.1) (>= xamarinios)) (&& (< netcoreapp2.0) (< netstandard2.1) (>= xamarinmac)) (>= netcoreapp2.1) (&& (>= netcoreapp3.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= uap10.1) (>= xamarinios)) (&& (>= uap10.1) (>= xamarinmac))
       System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0)) (&& (< monoandroid) (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
       System.Numerics.Vectors (>= 4.4) - restriction: && (< monoandroid) (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Numerics.Vectors (>= 4.5) - restriction: >= net461
@@ -1187,7 +1198,7 @@ NUGET
     System.Runtime (4.3.1) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8))
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Runtime.CompilerServices.Unsafe (5.0) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net50) (>= netcoreapp2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (< netcoreapp2.0) (>= netcoreapp2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (< monoandroid) (>= netcoreapp2.1) (< netstandard1.6)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net45) (>= net46) (>= netstandard2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp2.1)) (&& (>= net461) (>= netstandard2.0)) (&& (>= netcoreapp2.0) (>= uap10.1)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
+    System.Runtime.CompilerServices.Unsafe (5.0) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net50) (>= netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net50) (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.1) (< netstandard1.6)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net45) (>= net46) (>= netstandard2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp2.1)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net461) (>= xamarinios)) (&& (>= net461) (>= xamarinmac)) (&& (>= netcoreapp2.0) (>= uap10.1)) (&& (< netcoreapp2.0) (>= xamarinios)) (&& (< netcoreapp2.0) (>= xamarinmac)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.6) (>= netstandard2.0) (>= xamarintvos)) (&& (< netstandard1.6) (>= netstandard2.0) (>= xamarinwatchos)) (&& (< netstandard1.6) (>= xamarinios)) (&& (< netstandard1.6) (>= xamarinmac)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= uap10.1) (>= xamarinios)) (&& (>= uap10.1) (>= xamarinmac))
     System.Runtime.Extensions (4.3.1) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
@@ -1341,15 +1352,16 @@ NUGET
     System.Text.Encoding.CodePages (5.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= netcoreapp2.1)
       Microsoft.NETCore.Platforms (>= 5.0) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net50)
       System.Runtime.CompilerServices.Unsafe (>= 5.0) - restriction: || (&& (< monoandroid) (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net50) (>= netcoreapp2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461)
-    System.Text.Encodings.Web (5.0) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
-      System.Memory (>= 4.5.4) - restriction: || (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1)) (>= net461) (>= uap10.1)
-    System.Text.Json (5.0.1) - restriction: >= netstandard2.0
-      Microsoft.Bcl.AsyncInterfaces (>= 5.0) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0)) (>= monotouch) (>= net461) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (>= monotouch) (>= net461) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+    System.Text.Encodings.Web (5.0.1) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (< net50) (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp2.0) (>= xamarinios)) (&& (< netcoreapp2.0) (>= xamarinmac)) (&& (>= netstandard2.0) (>= uap10.1))
+      System.Buffers (>= 4.5.1) - restriction: || (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1)) (>= net461)
+      System.Memory (>= 4.5.4) - restriction: || (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1)) (>= uap10.1)
+    System.Text.Json (5.0.2) - restriction: >= netstandard2.0
+      Microsoft.Bcl.AsyncInterfaces (>= 5.0) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= xamarinios)) (&& (< netcoreapp2.0) (>= xamarinmac)) (&& (< netstandard2.0) (>= xamarintvos)) (&& (< netstandard2.0) (>= xamarinwatchos)) (>= uap10.1)
+      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= xamarinios)) (&& (< netcoreapp2.0) (>= xamarinmac)) (&& (< netstandard2.0) (>= xamarintvos)) (&& (< netstandard2.0) (>= xamarinwatchos))
       System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461) (>= uap10.1)
       System.Numerics.Vectors (>= 4.5) - restriction: || (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461)
-      System.Runtime.CompilerServices.Unsafe (>= 5.0) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0)) (>= monotouch) (>= net461) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Text.Encodings.Web (>= 5.0) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0)) (>= monotouch) (>= net461) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Runtime.CompilerServices.Unsafe (>= 5.0) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0)) (&& (< monoandroid) (< net50) (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= xamarinios)) (&& (< netcoreapp2.0) (>= xamarinmac)) (&& (< netstandard2.0) (>= xamarintvos)) (&& (< netstandard2.0) (>= xamarinwatchos)) (>= uap10.1)
+      System.Text.Encodings.Web (>= 5.0.1) - restriction: || (&& (>= monoandroid) (< netcoreapp2.0)) (&& (< monoandroid) (< net50) (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= xamarinios)) (&& (< netcoreapp2.0) (>= xamarinmac)) (&& (< netstandard2.0) (>= xamarintvos)) (&& (< netstandard2.0) (>= xamarinwatchos)) (>= uap10.1)
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461) (>= uap10.1)
       System.ValueTuple (>= 4.5) - restriction: >= net461
     System.Threading (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1365,7 +1377,7 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
     System.Threading.Tasks.Dataflow (5.0) - restriction: >= netstandard2.0
-    System.Threading.Tasks.Extensions (4.5.4) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp2.1)) (&& (>= net461) (>= xamarinios)) (&& (>= net461) (>= xamarinmac)) (&& (< netcoreapp2.1) (< netstandard2.1) (>= xamarinios)) (&& (< netcoreapp2.1) (< netstandard2.1) (>= xamarinmac)) (>= netstandard2.0)
+    System.Threading.Tasks.Extensions (4.5.4) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp2.1)) (&& (>= net461) (>= xamarinios)) (&& (>= net461) (>= xamarinmac)) (&& (< netcoreapp2.0) (< netstandard2.1) (>= xamarinios)) (&& (< netcoreapp2.0) (< netstandard2.1) (>= xamarinmac)) (>= netstandard2.0)
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (>= net461) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
     System.Threading.Thread (4.3) - restriction: && (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)

--- a/src/Fantomas.Benchmarks/Runners.fs
+++ b/src/Fantomas.Benchmarks/Runners.fs
@@ -2,7 +2,7 @@ module Fantomas.Benchmarks.Runners
 
 open BenchmarkDotNet.Attributes
 open System.IO
-open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.CodeAnalysis
 open Fantomas
 open Fantomas.Extras
 

--- a/src/Fantomas.Extras/FakeHelpers.fs
+++ b/src/Fantomas.Extras/FakeHelpers.fs
@@ -2,7 +2,7 @@ module Fantomas.Extras.FakeHelpers
 
 open System
 open System.IO
-open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.CodeAnalysis
 open Fantomas
 open Fantomas.FormatConfig
 open Fantomas.Extras

--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -23,8 +23,8 @@ let private mkRange : MkRange =
     fun (sl, sc) (el, ec) ->
         FSharp.Compiler.Text.Range.mkRange
             "TokenParserTests"
-            (FSharp.Compiler.Text.Pos.mkPos sl sc)
-            (FSharp.Compiler.Text.Pos.mkPos el ec)
+            (FSharp.Compiler.Text.Position.mkPos sl sc)
+            (FSharp.Compiler.Text.Position.mkPos el ec)
 
 let private getTriviaFromTokens = getTriviaFromTokens mkRange
 let private getTriviaNodesFromTokens = getTriviaNodesFromTokens mkRange

--- a/src/Fantomas.Tests/TriviaTests.fs
+++ b/src/Fantomas.Tests/TriviaTests.fs
@@ -10,8 +10,8 @@ let private collectTrivia =
         (fun (sl, sc) (el, ec) ->
             FSharp.Compiler.Text.Range.mkRange
                 "TriviaTests"
-                (FSharp.Compiler.Text.Pos.mkPos sl sc)
-                (FSharp.Compiler.Text.Pos.mkPos el ec))
+                (FSharp.Compiler.Text.Position.mkPos sl sc)
+                (FSharp.Compiler.Text.Position.mkPos el ec))
 
 let private toTrivia source =
     let astWithDefines = parse false source |> Array.toList

--- a/src/Fantomas/AstExtensions.fs
+++ b/src/Fantomas/AstExtensions.fs
@@ -1,6 +1,6 @@
 module Fantomas.AstExtensions
 
-open FSharp.Compiler.SyntaxTree
+open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
 
@@ -8,7 +8,7 @@ type SynTypeDefnSig with
     /// Combines the range of type name and the body.
     member this.FullRange : Range =
         match this with
-        | SynTypeDefnSig.TypeDefnSig (comp, _, _, r) -> mkRange r.FileName comp.Range.Start r.End
+        | SynTypeDefnSig (comp, _, _, r) -> mkRange r.FileName comp.Range.Start r.End
 
 let longIdentFullRange (li: LongIdent) : Range =
     match li with

--- a/src/Fantomas/AstTransformer.fs
+++ b/src/Fantomas/AstTransformer.fs
@@ -1,7 +1,7 @@
 module Fantomas.AstTransformer
 
+open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
-open FSharp.Compiler.SyntaxTree
 open Fantomas.TriviaTypes
 open Fantomas.AstExtensions
 open Fantomas
@@ -567,7 +567,7 @@ module private Ast =
                     (fun nodes ->
                         mkNode SynExpr_Fixed range :: nodes
                         |> finalContinuation)
-            | SynExpr.InterpolatedString (parts, range) ->
+            | SynExpr.InterpolatedString (parts, _, range) ->
                 mkNode SynExpr_InterpolatedString range
                 :: (List.collect visitSynInterpolatedStringPart parts)
                 |> finalContinuation
@@ -618,7 +618,7 @@ module private Ast =
 
     and visitSynMatchClause (mc: SynMatchClause) : TriviaNodeAssigner list =
         match mc with
-        | SynMatchClause.Clause (pat, e1, e2, _range, _) ->
+        | SynMatchClause (pat, e1, e2, _range, _) ->
             mkNode SynMatchClause_Clause mc.Range // _range is the same range as pat, see https://github.com/dotnet/fsharp/issues/10877
             :: [ yield! visitSynPat pat
                  if e1.IsSome then
@@ -629,14 +629,14 @@ module private Ast =
 
     and visitSynInterfaceImpl (ii: SynInterfaceImpl) : TriviaNodeAssigner list =
         match ii with
-        | InterfaceImpl (typ, bindings, range) ->
+        | SynInterfaceImpl (typ, bindings, range) ->
             [ yield mkNode InterfaceImpl_ range
               yield! visitSynType typ
               yield! (bindings |> List.collect visitSynBinding) ]
 
     and visitSynTypeDefn (td: SynTypeDefn) =
         match td with
-        | TypeDefn (sci, stdr, members, range) ->
+        | SynTypeDefn (sci, stdr, members, _, range) ->
             [ yield mkNode TypeDefn_ range
               yield! visitSynComponentInfo sci
               yield! visitSynTypeDefnRepr stdr
@@ -644,7 +644,7 @@ module private Ast =
 
     and visitSynTypeDefnSig (typeDefSig: SynTypeDefnSig) : TriviaNodeAssigner list =
         match typeDefSig with
-        | TypeDefnSig (sci, synTypeDefnSigReprs, memberSig, _) ->
+        | SynTypeDefnSig (sci, synTypeDefnSigReprs, memberSig, _) ->
             [ yield mkNode TypeDefnSig_ typeDefSig.FullRange
               yield! visitSynComponentInfo sci
               yield! visitSynTypeDefnSigRepr synTypeDefnSigReprs
@@ -756,14 +756,14 @@ module private Ast =
 
     and visitSynBinding (binding: SynBinding) : TriviaNodeAssigner list =
         match binding with
-        | Binding (_, kind, _, _, attrs, _, valData, headPat, returnInfo, expr, range, _) ->
+        | SynBinding (_, kind, _, _, attrs, _, valData, headPat, returnInfo, expr, range, _) ->
             let t =
                 match kind with
                 | SynBindingKind.StandaloneExpression -> StandaloneExpression_
-                | SynBindingKind.NormalBinding -> NormalBinding_
-                | SynBindingKind.DoBinding -> DoBinding_
+                | SynBindingKind.Normal -> NormalBinding_
+                | SynBindingKind.Do -> DoBinding_
 
-            [ yield mkNode t binding.RangeOfBindingAndRhs
+            [ yield mkNode t binding.RangeOfBindingWithRhs
               yield! visitSynAttributeLists range attrs
               yield! visitSynValData valData
               yield! visitSynPat headPat
@@ -779,7 +779,7 @@ module private Ast =
 
     and visitSynValSig (svs: SynValSig) : TriviaNodeAssigner list =
         match svs with
-        | ValSpfn (attrs, ident, explicitValDecls, synType, arity, _, _, _, _, expr, range) ->
+        | SynValSig (attrs, ident, explicitValDecls, synType, arity, _, _, _, _, expr, range) ->
             [ yield mkNode ValSpfn_ range
               yield visitIdent ident
               yield! (visitSynAttributeLists range attrs)
@@ -795,13 +795,13 @@ module private Ast =
 
     and visitSynTyparDecl (std: SynTyparDecl) : TriviaNodeAssigner list =
         match std with
-        | TyparDecl (attrs, typar) ->
+        | SynTyparDecl (attrs, typar) ->
             [ yield! (visitSynAttributeLists typar.Range attrs)
               yield! visitSynTypar typar ]
 
     and visitSynTypar (typar: SynTypar) : TriviaNodeAssigner list =
         match typar with
-        | Typar _ -> []
+        | SynTypar _ -> []
 
     and visitTyparStaticReq (tsr: TyparStaticReq) =
         match tsr with
@@ -943,14 +943,14 @@ module private Ast =
 
     and visitSynConstructorArgs (ctorArgs: SynArgPats) : TriviaNodeAssigner list =
         match ctorArgs with
-        | Pats pats -> List.collect visitSynPat pats
-        | NamePatPairs (pats, range) ->
+        | SynArgPats.Pats pats -> List.collect visitSynPat pats
+        | SynArgPats.NamePatPairs (pats, range) ->
             mkNode NamePatPairs_ range
             :: (List.collect (snd >> visitSynPat) pats)
 
     and visitSynComponentInfo (sci: SynComponentInfo) : TriviaNodeAssigner list =
         match sci with
-        | ComponentInfo (attribs, typeParams, _, _, _, _, _, range) ->
+        | SynComponentInfo (attribs, typeParams, _, _, _, _, _, range) ->
             [ yield mkNode ComponentInfo_ range
               yield! (visitSynAttributeLists range attribs)
               yield! (typeParams |> List.collect visitSynTyparDecl) ]
@@ -965,17 +965,17 @@ module private Ast =
 
     and visitSynTypeDefnKind (kind: SynTypeDefnKind) : TriviaNodeAssigner list =
         match kind with
-        | TyconUnspecified
-        | TyconClass
-        | TyconInterface
-        | TyconStruct
-        | TyconRecord
-        | TyconAbbrev
-        | TyconHiddenRepr
-        | TyconAugmentation
-        | TyconUnion
-        | TyconILAssemblyCode -> []
-        | TyconDelegate (typ, valinfo) -> visitSynType typ @ visitSynValInfo valinfo
+        | SynTypeDefnKind.Unspecified
+        | SynTypeDefnKind.Class
+        | SynTypeDefnKind.Interface
+        | SynTypeDefnKind.Struct
+        | SynTypeDefnKind.Record
+        | SynTypeDefnKind.Abbrev
+        | SynTypeDefnKind.Opaque
+        | SynTypeDefnKind.Augmentation
+        | SynTypeDefnKind.Union
+        | SynTypeDefnKind.IL -> []
+        | SynTypeDefnKind.Delegate (typ, valinfo) -> visitSynType typ @ visitSynValInfo valinfo
 
     and visitSynTypeDefnSimpleRepr (arg: SynTypeDefnSimpleRepr) =
         match arg with
@@ -1039,19 +1039,19 @@ module private Ast =
 
     and visitSynUnionCase (uc: SynUnionCase) : TriviaNodeAssigner list =
         match uc with
-        | UnionCase (attrs, _, uct, _, _, range) ->
+        | SynUnionCase (attrs, _, uct, _, _, range) ->
             [ yield mkNode UnionCase_ range
               yield! visitSynUnionCaseType uct
               yield! (visitSynAttributeLists range attrs) ]
 
-    and visitSynUnionCaseType (uct: SynUnionCaseType) =
+    and visitSynUnionCaseType (uct: SynUnionCaseKind) =
         match uct with
-        | UnionCaseFields cases -> List.collect visitSynField cases
-        | UnionCaseFullType (stype, valInfo) -> visitSynType stype @ visitSynValInfo valInfo
+        | SynUnionCaseKind.Fields cases -> List.collect visitSynField cases
+        | SynUnionCaseKind.FullType (stype, valInfo) -> visitSynType stype @ visitSynValInfo valInfo
 
     and visitSynEnumCase (sec: SynEnumCase) : TriviaNodeAssigner list =
         match sec with
-        | EnumCase (attrs, ident, value, _, range) ->
+        | SynEnumCase (attrs, ident, value, _, _, range) ->
             [ yield mkNode EnumCase_ range
               yield! (visitSynAttributeLists range attrs)
               yield visitIdent ident
@@ -1059,7 +1059,7 @@ module private Ast =
 
     and visitSynField (sfield: SynField) : TriviaNodeAssigner list =
         match sfield with
-        | Field (attrs, _, ident, typ, _, _, _, range) ->
+        | SynField (attrs, _, ident, typ, _, _, _, range) ->
             let parentRange =
                 Option.map (fun (i: Ident) -> i.idRange) ident
                 |> Option.defaultValue range
@@ -1218,9 +1218,9 @@ module private Ast =
             | SynConst.Measure _ -> SynConst_Measure
 
         match sc with
-        | SynConst.Measure (n, SynMeasure.Seq (_, mr)) ->
+        | SynConst.Measure (n, _, SynMeasure.Seq (_, mr)) ->
             let numberRange =
-                Range.mkRange mr.FileName parentRange.Start (Pos.mkPos mr.StartLine (mr.StartColumn - 1))
+                Range.mkRange mr.FileName parentRange.Start (Position.mkPos mr.StartLine (mr.StartColumn - 1))
 
             mkNode (t n) numberRange
         | _ -> mkNode (t sc) (sc.Range parentRange)
@@ -1278,7 +1278,7 @@ module private Ast =
                     |> finalContinuation
 
                 Continuation.sequence continuations finalContinuation
-            | SynModuleSigDecl.Val (SynValSig.ValSpfn _ as node, _) -> visitSynValSig node |> finalContinuation
+            | SynModuleSigDecl.Val (SynValSig _ as node, _) -> visitSynValSig node |> finalContinuation
             | SynModuleSigDecl.Types (typeDefs, range) ->
                 mkNode SynModuleSigDecl_Types range
                 :: (List.collect visitSynTypeDefnSig typeDefs)

--- a/src/Fantomas/CodeFormatter.fs
+++ b/src/Fantomas/CodeFormatter.fs
@@ -2,32 +2,40 @@ namespace Fantomas
 
 [<Sealed>]
 type CodeFormatter =
-    static member ParseAsync(fileName, source, parsingOptions, checker) =
+    static member ParseAsync(fileName, source, parsingOptions, checker, ?cache) =
         async {
+            let cache = defaultArg cache true
             let! asts =
-                CodeFormatterImpl.createFormatContext fileName source
+                CodeFormatterImpl.createFormatContext fileName source cache
                 |> CodeFormatterImpl.parse checker parsingOptions
 
             return (Array.map (fun (a, d, _) -> a, d) asts)
         }
 
-    static member FormatASTAsync(ast, fileName, defines, source, config) =
+    static member FormatASTAsync(ast, fileName, defines, source, config, ?cache) =
+        let cache = defaultArg cache true
         let formatContext =
-            CodeFormatterImpl.createFormatContext fileName (Option.defaultValue (SourceOrigin.SourceString "") source)
+            CodeFormatterImpl.createFormatContext
+                fileName
+                (Option.defaultValue (SourceOrigin.SourceString "") source)
+                cache
 
         CodeFormatterImpl.formatAST ast defines formatContext config
         |> async.Return
 
-    static member FormatDocumentAsync(fileName, source, config, parsingOptions, checker) =
-        CodeFormatterImpl.createFormatContext fileName source
+    static member FormatDocumentAsync(fileName, source, config, parsingOptions, checker, ?cache) =
+        let cache = defaultArg cache true
+        CodeFormatterImpl.createFormatContext fileName source cache
         |> CodeFormatterImpl.formatDocument checker parsingOptions config
 
-    static member FormatSelectionAsync(fileName, selection, source, config, parsingOptions, checker) =
-        CodeFormatterImpl.createFormatContext fileName source
+    static member FormatSelectionAsync(fileName, selection, source, config, parsingOptions, checker, ?cache) =
+        let cache = defaultArg cache true
+        CodeFormatterImpl.createFormatContext fileName source cache
         |> CodeFormatterImpl.formatSelection checker parsingOptions selection config
 
-    static member IsValidFSharpCodeAsync(fileName, source, parsingOptions, checker) =
-        CodeFormatterImpl.createFormatContext fileName source
+    static member IsValidFSharpCodeAsync(fileName, source, parsingOptions, checker, ?cache) =
+        let cache = defaultArg cache true
+        CodeFormatterImpl.createFormatContext fileName source cache
         |> CodeFormatterImpl.isValidFSharpCode checker parsingOptions
 
     static member IsValidASTAsync ast =

--- a/src/Fantomas/CodeFormatter.fsi
+++ b/src/Fantomas/CodeFormatter.fsi
@@ -3,19 +3,28 @@ namespace Fantomas
 open Fantomas.FormatConfig
 open Fantomas.SourceOrigin
 open FSharp.Compiler.Text
-open FSharp.Compiler.SourceCodeServices
-open FSharp.Compiler.SyntaxTree
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Syntax
 
 [<Sealed>]
 type CodeFormatter =
     /// Parse a source string using given config
     static member ParseAsync :
-        fileName: string * source: SourceOrigin * parsingOptions: FSharpParsingOptions * checker: FSharpChecker ->
+        fileName: string
+        * source: SourceOrigin
+        * parsingOptions: FSharpParsingOptions
+        * checker: FSharpChecker
+        * ?cacheParsingResult: bool ->
         Async<(ParsedInput * string list) array>
 
     /// Format an abstract syntax tree using an optional source for trivia processing
     static member FormatASTAsync :
-        ast: ParsedInput * fileName: string * defines: string list * source: SourceOrigin option * config: FormatConfig ->
+        ast: ParsedInput
+        * fileName: string
+        * defines: string list
+        * source: SourceOrigin option
+        * config: FormatConfig
+        * ?cacheParsingResult: bool ->
         Async<string>
 
     /// Format a source string using given config
@@ -24,7 +33,8 @@ type CodeFormatter =
         * source: SourceOrigin
         * config: FormatConfig
         * parsingOptions: FSharpParsingOptions
-        * checker: FSharpChecker ->
+        * checker: FSharpChecker
+        * ?cacheParsingResult: bool ->
         Async<string>
 
     /// Format a part of source string using given config, and return the (formatted) selected part only.
@@ -35,12 +45,17 @@ type CodeFormatter =
         * source: SourceOrigin
         * config: FormatConfig
         * parsingOptions: FSharpParsingOptions
-        * checker: FSharpChecker ->
+        * checker: FSharpChecker
+        * ?cacheParsingResult: bool ->
         Async<string>
 
     /// Check whether an input string is invalid in F# by looking for erroneous nodes in ASTs
     static member IsValidFSharpCodeAsync :
-        fileName: string * source: SourceOrigin * parsingOptions: FSharpParsingOptions * checker: FSharpChecker ->
+        fileName: string
+        * source: SourceOrigin
+        * parsingOptions: FSharpParsingOptions
+        * checker: FSharpChecker
+        * ?cacheParsingResult: bool ->
         Async<bool>
 
     static member IsValidASTAsync : ast: ParsedInput -> Async<bool>

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -1,10 +1,10 @@
 module Fantomas.Context
 
 open System
+open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
+open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
-open FSharp.Compiler.Text.Pos
-open FSharp.Compiler.SyntaxTree
 open Fantomas
 open Fantomas.FormatConfig
 open Fantomas.TriviaTypes
@@ -1349,7 +1349,7 @@ let internal sepNlnForEmptyNamespace (namespaceRange: Range) ctx =
     | _ -> sepNln ctx
 
 let internal sepNlnTypeAndMembers
-    (lastPositionBeforeMembers: Pos)
+    (lastPositionBeforeMembers: Position)
     (firstMemberRange: Range)
     (mainNodeType: FsAstType)
     (ctx: Context)

--- a/src/Fantomas/Queue.fs
+++ b/src/Fantomas/Queue.fs
@@ -19,7 +19,7 @@ type Queue<'T>(data: list<'T []>, length: int) =
 
     override this.Equals(other) =
         match other with
-        | :? (Queue<'T>) as y ->
+        | :? Queue<'T> as y ->
             if this.Length <> y.Length then
                 false
             else if this.GetHashCode() <> y.GetHashCode() then

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1,11 +1,12 @@
 module internal Fantomas.SourceParser
 
 open System
-open FSharp.Compiler.SourceCodeServices.PrettyNaming
-open FSharp.Compiler.SourceCodeServices.FSharpKeywords
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Syntax.PrettyNaming
+open FSharp.Compiler.Tokenization.FSharpKeywords
 open FSharp.Compiler.Text
-open FSharp.Compiler.SyntaxTree
-open FSharp.Compiler.XmlDoc
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.CodeAnalysis
 open Fantomas
 open Fantomas.AstExtensions
 open Fantomas.TriviaTypes
@@ -176,7 +177,7 @@ let (|OpNameFull|) (x: Identifier) =
 
 // Type params
 
-let inline (|Typar|) (SynTypar.Typar (Ident s, req, _)) =
+let inline (|Typar|) (SynTypar.SynTypar (Ident s, req, _)) =
     match req with
     | NoStaticReq -> (s, false)
     | HeadTypeStaticReq -> (s, true)
@@ -216,7 +217,7 @@ let (|Measure|) x =
 /// Lose information about kinds of literals
 let rec (|Const|) c =
     match c with
-    | SynConst.Measure (Const c, Measure m) -> c + m
+    | SynConst.Measure (Const c, _, Measure m) -> c + m
     | SynConst.UserNum (num, ty) -> num + ty
     | SynConst.Unit -> "()"
     | SynConst.Bool b -> sprintf "%A" b
@@ -234,7 +235,7 @@ let rec (|Const|) c =
     | SynConst.Double d -> sprintf "%A" d
     | SynConst.Char c -> sprintf "%A" c
     | SynConst.Decimal d -> sprintf "%A" d
-    | SynConst.String (s, _) ->
+    | SynConst.String (s, _, _) ->
         // Naive check for verbatim strings
         if not <| String.IsNullOrEmpty(s)
            && s.Contains("\\")
@@ -242,13 +243,13 @@ let rec (|Const|) c =
             sprintf "@%A" s
         else
             sprintf "%A" s
-    | SynConst.Bytes (bs, _) -> sprintf "%A" bs
+    | SynConst.Bytes (bs, _, _) -> sprintf "%A" bs
     // Auto print may cut off the array
     | SynConst.UInt16s us -> sprintf "%A" us
 
 let (|String|_|) e =
     match e with
-    | SynExpr.Const (SynConst.String (s, _), _) -> Some s
+    | SynExpr.Const (SynConst.String (s, _, _), _) -> Some s
     | _ -> None
 
 let (|Unresolved|) (Const s as c, r) = (c, r, s)
@@ -351,7 +352,7 @@ let (|Types|_|) =
 
 let (|NestedModule|_|) =
     function
-    | SynModuleDecl.NestedModule (SynComponentInfo.ComponentInfo (ats, _, _, LongIdent s, px, _, ao, _),
+    | SynModuleDecl.NestedModule (SynComponentInfo (ats, _, _, LongIdent s, px, _, ao, _),
                                   isRecursive,
                                   xs,
                                   _,
@@ -402,7 +403,7 @@ let (|SigTypes|_|) =
 
 let (|SigNestedModule|_|) =
     function
-    | SynModuleSigDecl.NestedModule (SynComponentInfo.ComponentInfo (ats, _, _, LongIdent s, px, _, ao, _), _, xs, _) ->
+    | SynModuleSigDecl.NestedModule (SynComponentInfo (ats, _, _, LongIdent s, px, _, ao, _), _, xs, _) ->
         Some(ats, px, ao, s, xs)
     | _ -> None
 
@@ -427,17 +428,17 @@ let (|SigExceptionDef|)
     =
     (ats, px, ao, uc, ms)
 
-let (|UnionCase|) (SynUnionCase.UnionCase (ats, Ident s, uct, px, ao, _)) = (ats, px, ao, s, uct)
+let (|UnionCase|) (SynUnionCase (ats, Ident s, uct, px, ao, _)) = (ats, px, ao, s, uct)
 
 let (|UnionCaseType|) =
     function
-    | SynUnionCaseType.UnionCaseFields fs -> fs
-    | SynUnionCaseType.UnionCaseFullType _ -> failwith "UnionCaseFullType should be used internally only."
+    | SynUnionCaseKind.Fields fs -> fs
+    | SynUnionCaseKind.FullType _ -> failwith "UnionCaseFullType should be used internally only."
 
-let (|Field|) (SynField.Field (ats, isStatic, ido, t, isMutable, px, ao, _)) =
+let (|Field|) (SynField (ats, isStatic, ido, t, isMutable, px, ao, _)) =
     (ats, px, ao, isStatic, isMutable, t, Option.map (|Ident|) ido)
 
-let (|EnumCase|) (SynEnumCase.EnumCase (ats, Ident s, c, px, r)) = (ats, px, s, (c, r))
+let (|EnumCase|) (SynEnumCase (ats, Ident s, c, _, px, r)) = (ats, px, s, (c, r))
 
 // Member definitions (11 cases)
 
@@ -488,7 +489,7 @@ let (|MDLetBindings|_|) =
 
 let (|MDAbstractSlot|_|) =
     function
-    | SynMemberDefn.AbstractSlot (ValSpfn (ats, Ident s, tds, t, vi, _, _, px, ao, _, _), mf, _) ->
+    | SynMemberDefn.AbstractSlot (SynValSig (ats, Ident s, tds, t, vi, _, _, px, ao, _, _), mf, _) ->
         Some(ats, px, ao, s, t, vi, tds, mf)
     | _ -> None
 
@@ -505,43 +506,43 @@ let (|MDAutoProperty|_|) =
 
 // Interface impl
 
-let (|InterfaceImpl|) (SynInterfaceImpl.InterfaceImpl (t, bs, range)) = (t, bs, range)
+let (|InterfaceImpl|) (SynInterfaceImpl (t, bs, range)) = (t, bs, range)
 
 // Bindings
 
 let (|PropertyGet|_|) =
     function
-    | MemberKind.PropertyGet -> Some()
+    | SynMemberKind.PropertyGet -> Some()
     | _ -> None
 
 let (|PropertySet|_|) =
     function
-    | MemberKind.PropertySet -> Some()
+    | SynMemberKind.PropertySet -> Some()
     | _ -> None
 
 let (|PropertyGetSet|_|) =
     function
-    | MemberKind.PropertyGetSet -> Some()
+    | SynMemberKind.PropertyGetSet -> Some()
     | _ -> None
 
-let (|MFProperty|_|) (mf: MemberFlags) =
+let (|MFProperty|_|) (mf: SynMemberFlags) =
     match mf.MemberKind with
-    | MemberKind.PropertyGet
-    | MemberKind.PropertySet
-    | MemberKind.PropertyGetSet as mk -> Some mk
+    | SynMemberKind.PropertyGet
+    | SynMemberKind.PropertySet
+    | SynMemberKind.PropertyGetSet as mk -> Some mk
     | _ -> None
 
-let (|MFMemberFlags|) (mf: MemberFlags) = mf.MemberKind
+let (|MFMemberFlags|) (mf: SynMemberFlags) = mf.MemberKind
 
 /// This pattern finds out which keyword to use
-let (|MFMember|MFStaticMember|MFConstructor|MFOverride|) (mf: MemberFlags) =
+let (|MFMember|MFStaticMember|MFConstructor|MFOverride|) (mf: SynMemberFlags) =
     match mf.MemberKind with
-    | MemberKind.ClassConstructor
-    | MemberKind.Constructor -> MFConstructor()
-    | MemberKind.Member
-    | MemberKind.PropertyGet
-    | MemberKind.PropertySet
-    | MemberKind.PropertyGetSet as mk ->
+    | SynMemberKind.ClassConstructor
+    | SynMemberKind.Constructor -> MFConstructor()
+    | SynMemberKind.Member
+    | SynMemberKind.PropertyGet
+    | SynMemberKind.PropertySet
+    | SynMemberKind.PropertyGetSet as mk ->
         if mf.IsInstance && mf.IsOverrideOrExplicitImpl then
             MFOverride mk
         elif mf.IsInstance then
@@ -551,14 +552,14 @@ let (|MFMember|MFStaticMember|MFConstructor|MFOverride|) (mf: MemberFlags) =
 
 let (|DoBinding|LetBinding|MemberBinding|PropertyBinding|ExplicitCtor|) =
     function
-    | SynBinding.Binding (ao, _, _, _, ats, px, SynValData (Some MFConstructor, _, ido), pat, _, expr, _, _) ->
+    | SynBinding (ao, _, _, _, ats, px, SynValData (Some MFConstructor, _, ido), pat, _, expr, _, _) ->
         ExplicitCtor(ats, px, ao, pat, expr, Option.map (|Ident|) ido)
-    | SynBinding.Binding (ao, _, isInline, _, ats, px, SynValData (Some (MFProperty _ as mf), _, _), pat, _, expr, _, _) ->
+    | SynBinding (ao, _, isInline, _, ats, px, SynValData (Some (MFProperty _ as mf), _, _), pat, _, expr, _, _) ->
         PropertyBinding(ats, px, ao, isInline, mf, pat, expr)
-    | SynBinding.Binding (ao, _, isInline, _, ats, px, SynValData (Some mf, synValInfo, _), pat, _, expr, _, _) ->
+    | SynBinding (ao, _, isInline, _, ats, px, SynValData (Some mf, synValInfo, _), pat, _, expr, _, _) ->
         MemberBinding(ats, px, ao, isInline, mf, pat, expr, synValInfo)
-    | SynBinding.Binding (_, DoBinding, _, _, ats, px, _, _, _, expr, _, _) -> DoBinding(ats, px, expr)
-    | SynBinding.Binding (ao, _, isInline, isMutable, attrs, px, SynValData (_, valInfo, _), pat, _, expr, _, _) ->
+    | SynBinding (_, _, _, _, ats, px, _, _, _, expr, _, _) -> DoBinding(ats, px, expr)
+    | SynBinding (ao, _, isInline, isMutable, attrs, px, SynValData (_, valInfo, _), pat, _, expr, _, _) ->
         LetBinding(attrs, px, ao, isInline, isMutable, pat, expr, valInfo)
 
 // Expressions (55 cases, lacking to handle 11 cases)
@@ -1238,9 +1239,9 @@ let (|SimplePats|SPSTyped|) =
 
 let (|RecordField|) =
     function
-    | SynField.Field (ats, _, ido, _, _, px, ao, _) -> (ats, px, ao, Option.map (|Ident|) ido)
+    | SynField (ats, _, ido, _, _, px, ao, _) -> (ats, px, ao, Option.map (|Ident|) ido)
 
-let (|Clause|) (SynMatchClause.Clause (p, eo, e, _, _)) = (p, e, eo)
+let (|Clause|) (SynMatchClause (p, eo, e, _, _)) = (p, e, eo)
 
 /// Process compiler-generated matches in an appropriate way
 let (|Lambda|_|) =
@@ -1249,7 +1250,7 @@ let (|Lambda|_|) =
         // find the body expression from the last lambda
         let rec visit (e: SynExpr) : SynExpr =
             match e with
-            | SynExpr.Match (matchSeqPoint = NoDebugPointAtInvisibleBinding; clauses = [ Clause (_, expr, _) ])
+            | SynExpr.Match (matchSeqPoint = DebugPointAtBinding.NoneAtInvisible; clauses = [ Clause (_, expr, _) ])
             | SynExpr.Lambda (_, _, _, SynExpr.Match(clauses = [ Clause (_, expr, _) ]), _, _) -> visit expr
             | _ -> e
 
@@ -1307,41 +1308,42 @@ type TypeDefnKindSingle =
     | TCRecord
     | TCUnion
     | TCAbbrev
-    | TCHiddenRepr
+    | TCOpaque
     | TCAugmentation
-    | TCILAssemblyCode
+    | TCIL
 
 let (|TCSimple|TCDelegate|) =
     function
-    | TyconUnspecified -> TCSimple TCUnspecified
-    | TyconClass -> TCSimple TCClass
-    | TyconInterface -> TCSimple TCInterface
-    | TyconStruct -> TCSimple TCStruct
-    | TyconRecord -> TCSimple TCRecord
-    | TyconUnion -> TCSimple TCUnion
-    | TyconAbbrev -> TCSimple TCAbbrev
-    | TyconHiddenRepr -> TCSimple TCHiddenRepr
-    | TyconAugmentation -> TCSimple TCAugmentation
-    | TyconILAssemblyCode -> TCSimple TCILAssemblyCode
-    | TyconDelegate (t, vi) -> TCDelegate(t, vi)
+    | SynTypeDefnKind.Unspecified -> TCSimple TCUnspecified
+    | SynTypeDefnKind.Class -> TCSimple TCClass
+    | SynTypeDefnKind.Interface -> TCSimple TCInterface
+    | SynTypeDefnKind.Struct -> TCSimple TCStruct
+    | SynTypeDefnKind.Record -> TCSimple TCRecord
+    | SynTypeDefnKind.Union -> TCSimple TCUnion
+    | SynTypeDefnKind.Abbrev -> TCSimple TCAbbrev
+    | SynTypeDefnKind.Opaque -> TCSimple TCOpaque
+    | SynTypeDefnKind.Augmentation -> TCSimple TCAugmentation
+    | SynTypeDefnKind.IL -> TCSimple TCIL
+    | SynTypeDefnKind.Delegate (t, vi) -> TCDelegate(t, vi)
 
 let (|TypeDef|)
-    (SynTypeDefn.TypeDefn (SynComponentInfo.ComponentInfo (ats, tds, tcs, LongIdent s, px, preferPostfix, ao, _),
-                           tdr,
-                           ms,
-                           _))
+    (SynTypeDefn (SynComponentInfo (ats, tds, tcs, LongIdent s, px, preferPostfix, ao, _),
+                  tdr,
+                  ms,
+                  _,
+                  _))
     =
     (ats, px, ao, tds, tcs, tdr, ms, s, preferPostfix)
 
 let (|SigTypeDef|)
-    (SynTypeDefnSig.TypeDefnSig (SynComponentInfo.ComponentInfo (ats, tds, tcs, LongIdent s, px, preferPostfix, ao, _),
-                                 tdr,
-                                 ms,
-                                 _) as node)
+    (SynTypeDefnSig (SynComponentInfo (ats, tds, tcs, LongIdent s, px, preferPostfix, ao, _),
+                     tdr,
+                     ms,
+                     _) as node)
     =
     (ats, px, ao, tds, tcs, tdr, ms, s, preferPostfix, node.FullRange)
 
-let (|TyparDecl|) (SynTyparDecl.TyparDecl (ats, tp)) = (ats, tp)
+let (|TyparDecl|) (SynTyparDecl (ats, tp)) = (ats, tp)
 
 // Types (15 cases)
 
@@ -1461,15 +1463,15 @@ type SingleTyparConstraintKind =
 
 let (|TyparSingle|TyparDefaultsToType|TyparSubtypeOfType|TyparSupportsMember|TyparIsEnum|TyparIsDelegate|) =
     function
-    | WhereTyparIsValueType (tp, _) -> TyparSingle(TyparIsValueType, tp)
-    | WhereTyparIsReferenceType (tp, _) -> TyparSingle(TyparIsReferenceType, tp)
-    | WhereTyparIsUnmanaged (tp, _) -> TyparSingle(TyparIsUnmanaged, tp)
-    | WhereTyparSupportsNull (tp, _) -> TyparSingle(TyparSupportsNull, tp)
-    | WhereTyparIsComparable (tp, _) -> TyparSingle(TyparIsComparable, tp)
-    | WhereTyparIsEquatable (tp, _) -> TyparSingle(TyparIsEquatable, tp)
-    | WhereTyparDefaultsToType (tp, t, _) -> TyparDefaultsToType(tp, t)
-    | WhereTyparSubtypeOfType (tp, t, _) -> TyparSubtypeOfType(tp, t)
-    | WhereTyparSupportsMember (tps, msg, _) ->
+    | SynTypeConstraint.WhereTyparIsValueType (tp, _) -> TyparSingle(TyparIsValueType, tp)
+    | SynTypeConstraint.WhereTyparIsReferenceType (tp, _) -> TyparSingle(TyparIsReferenceType, tp)
+    | SynTypeConstraint.WhereTyparIsUnmanaged (tp, _) -> TyparSingle(TyparIsUnmanaged, tp)
+    | SynTypeConstraint.WhereTyparSupportsNull (tp, _) -> TyparSingle(TyparSupportsNull, tp)
+    | SynTypeConstraint.WhereTyparIsComparable (tp, _) -> TyparSingle(TyparIsComparable, tp)
+    | SynTypeConstraint.WhereTyparIsEquatable (tp, _) -> TyparSingle(TyparIsEquatable, tp)
+    | SynTypeConstraint.WhereTyparDefaultsToType (tp, t, _) -> TyparDefaultsToType(tp, t)
+    | SynTypeConstraint.WhereTyparSubtypeOfType (tp, t, _) -> TyparSubtypeOfType(tp, t)
+    | SynTypeConstraint.WhereTyparSupportsMember (tps, msg, _) ->
         TyparSupportsMember(
             List.choose
                 (function
@@ -1478,8 +1480,8 @@ let (|TyparSingle|TyparDefaultsToType|TyparSubtypeOfType|TyparSupportsMember|Typ
                 tps,
             msg
         )
-    | WhereTyparIsEnum (tp, ts, _) -> TyparIsEnum(tp, ts)
-    | WhereTyparIsDelegate (tp, ts, _) -> TyparIsDelegate(tp, ts)
+    | SynTypeConstraint.WhereTyparIsEnum (tp, ts, _) -> TyparIsEnum(tp, ts)
+    | SynTypeConstraint.WhereTyparIsDelegate (tp, ts, _) -> TyparIsDelegate(tp, ts)
 
 let (|MSMember|MSInterface|MSInherit|MSValField|MSNestedType|) =
     function
@@ -1490,7 +1492,7 @@ let (|MSMember|MSInterface|MSInherit|MSValField|MSNestedType|) =
     | SynMemberSig.NestedType (tds, _) -> MSNestedType tds
 
 let (|Val|)
-    (ValSpfn (ats, (IdentOrKeyword (OpNameFullInPattern (s, _)) as ident), tds, t, vi, isInline, _, px, ao, _, _))
+    (SynValSig (ats, (IdentOrKeyword (OpNameFullInPattern (s, _)) as ident), tds, t, vi, isInline, _, px, ao, _, _))
     =
     (ats, px, ao, s, ident.idRange, t, vi, isInline, tds)
 
@@ -1539,46 +1541,45 @@ let (|Extern|_|) =
     | _ -> None
 
 let private collectAttributesRanges (a: SynAttributes) =
-    [ yield! (List.map (fun (al: SynAttributeList) -> al.Range) a)
-      yield! (List.collect (fun a -> a.Attributes |> List.map (fun a -> a.Range)) a) ]
+    [ yield! (List.map (fun (al: SynAttributeList) -> al.Range) a) ]
 
 let getRangesFromAttributesFromModuleDeclaration (mdl: SynModuleDecl) : Range list =
     match mdl with
     | SynModuleDecl.Let (_, bindings, _) ->
         bindings
-        |> List.collect (fun (Binding (_, _, _, _, attrs, _, _, _, _, _, _, _)) -> collectAttributesRanges attrs)
+        |> List.collect (fun (SynBinding (_, _, _, _, attrs, _, _, _, _, _, _, _)) -> collectAttributesRanges attrs)
     | SynModuleDecl.Types (types, _) ->
         types
         |> List.collect
             (fun t ->
                 match t with
-                | SynTypeDefn.TypeDefn (SynComponentInfo.ComponentInfo (attrs, _, _, _, _, _, _, _), _, _, _) ->
+                | SynTypeDefn (SynComponentInfo (attrs, _, _, _, _, _, _, _), _, _, _, _) ->
                     collectAttributesRanges attrs)
-    | SynModuleDecl.NestedModule (SynComponentInfo.ComponentInfo (attrs, _, _, _, _, _, _, _), _, _, _, _) ->
+    | SynModuleDecl.NestedModule (SynComponentInfo (attrs, _, _, _, _, _, _, _), _, _, _, _) ->
         collectAttributesRanges attrs
     | _ -> List.empty
 
 let getRangesFromAttributesFromSynModuleSigDeclaration (sdl: SynModuleSigDecl) =
     match sdl with
-    | SynModuleSigDecl.NestedModule (SynComponentInfo.ComponentInfo (attrs, _, _, _, _, _, _, _), _, _, _)
-    | SynModuleSigDecl.Types (SynTypeDefnSig.TypeDefnSig (SynComponentInfo.ComponentInfo (attrs, _, _, _, _, _, _, _),
+    | SynModuleSigDecl.NestedModule (SynComponentInfo (attrs, _, _, _, _, _, _, _), _, _, _)
+    | SynModuleSigDecl.Types (SynTypeDefnSig (SynComponentInfo (attrs, _, _, _, _, _, _, _),
                                                           _,
                                                           _,
                                                           _) :: _,
                               _) -> collectAttributesRanges attrs
     | _ -> List.empty
 
-let getRangesFromAttributesFromSynTypeDefnSig (TypeDefnSig (comp, _, _, _)) =
+let getRangesFromAttributesFromSynTypeDefnSig (SynTypeDefnSig (comp, _, _, _)) =
     match comp with
-    | SynComponentInfo.ComponentInfo (attrs, _, _, _, _, _, _, _) -> collectAttributesRanges attrs
+    | SynComponentInfo (attrs, _, _, _, _, _, _, _) -> collectAttributesRanges attrs
 
 let getRangesFromAttributesFromSynBinding (sb: SynBinding) =
     match sb with
-    | SynBinding.Binding (_, _, _, _, attrs, _, _, _, _, _, _, _) -> attrs |> List.map (fun a -> a.Range)
+    | SynBinding (_, _, _, _, attrs, _, _, _, _, _, _, _) -> attrs |> List.map (fun a -> a.Range)
 
 let getRangesFromAttributesFromSynValSig (valSig: SynValSig) =
     match valSig with
-    | SynValSig.ValSpfn (attrs, _, _, _, _, _, _, _, _, _, _) -> attrs |> List.map (fun a -> a.Range)
+    | SynValSig (attrs, _, _, _, _, _, _, _, _, _, _) -> attrs |> List.map (fun a -> a.Range)
 
 let getRangesFromAttributesFromSynMemberDefinition (mdn: SynMemberDefn) =
     match mdn with

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -1,6 +1,6 @@
 module internal Fantomas.SourceTransformer
 
-open FSharp.Compiler.SyntaxTree
+open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open Fantomas.Context
 open Fantomas.SourceParser
@@ -259,11 +259,11 @@ let rec synExprToFsAstType (expr: SynExpr) : FsAstType * Range =
     | SynExpr.LetOrUse (_, _, bs, e, _) ->
         match bs with
         | [] -> synExprToFsAstType e
-        | SynBinding.Binding (kind = kind) as b :: _ ->
+        | SynBinding (kind = kind) as b :: _ ->
             match kind with
-            | SynBindingKind.StandaloneExpression -> StandaloneExpression_, b.RangeOfBindingAndRhs
-            | SynBindingKind.NormalBinding -> NormalBinding_, b.RangeOfBindingAndRhs
-            | SynBindingKind.DoBinding -> DoBinding_, b.RangeOfBindingAndRhs
+            | SynBindingKind.StandaloneExpression -> StandaloneExpression_, b.RangeOfBindingWithRhs
+            | SynBindingKind.Normal -> NormalBinding_, b.RangeOfBindingWithRhs
+            | SynBindingKind.Do -> DoBinding_, b.RangeOfBindingWithRhs
     | SynExpr.TryWith _ -> SynExpr_TryWith, expr.Range
     | SynExpr.YieldOrReturnFrom _ -> SynExpr_YieldOrReturnFrom, expr.Range
     | SynExpr.While _ -> SynExpr_While, expr.Range
@@ -320,8 +320,8 @@ let synModuleSigDeclToFsAstType =
     | SynModuleSigDecl.NamespaceFragment _ -> SynModuleSigDecl_NamespaceFragment
     | SynModuleSigDecl.ModuleAbbrev _ -> SynModuleSigDecl_ModuleAbbrev
 
-let synBindingToFsAstType (Binding (_, kind, _, _, _, _, _, _, _, _, _, _)) =
+let synBindingToFsAstType (SynBinding (_, kind, _, _, _, _, _, _, _, _, _, _)) =
     match kind with
     | SynBindingKind.StandaloneExpression -> StandaloneExpression_
-    | SynBindingKind.NormalBinding -> NormalBinding_
-    | SynBindingKind.DoBinding -> DoBinding_
+    | SynBindingKind.Normal -> NormalBinding_
+    | SynBindingKind.Do -> DoBinding_

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -2,10 +2,11 @@ module internal Fantomas.TokenParser
 
 open System
 open System.Text
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Tokenization
 open Fantomas
 open Fantomas.TokenParserBoolExpr
 open Fantomas.TriviaTypes
-open FSharp.Compiler.SourceCodeServices
 
 let private whiteSpaceTag = 4
 let private lineCommentTag = 8

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -1,12 +1,12 @@
 module internal Fantomas.Trivia
 
-open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Tokenization
 open Fantomas
 open Fantomas.SourceParser
 open Fantomas.AstTransformer
 open Fantomas.TriviaTypes
 open FSharp.Compiler.Text
-open FSharp.Compiler.SyntaxTree
 
 let isMainNode (node: TriviaNode) =
     match node.Type with

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -1,7 +1,7 @@
 module Fantomas.TriviaTypes
 
-open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.Text
+open FSharp.Compiler.Tokenization
 
 type FsTokenType =
     | AMP


### PR DESCRIPTION
FSharpChecker.Parse File (FCS v40-preview) has an optional 'cache' parameter to cache the parsing results. 
This PR updates the FCS version and adds this parameter to the Fantomas api.