### PR TITLE
Long multiline prefix type name should be indented far enough.

### DIFF
--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -1539,3 +1539,36 @@ type Foo =
     /// Hi!
     | Bar of int
 """
+
+[<Test>]
+let ``long multiline prefix type name should be indented far enough, 1687`` () =
+    formatSourceString
+        true
+        """
+namespace Foo
+
+type Bar =
+    member Hello : thing : XLongLongLongLongLongLongLongLong<bool -> 'a, bool -> 'b, bool -> 'c, bool -> 'd, bool -> ('e -> 'f) -> 'g, ('h -> 'i) -> 'j> * item : int list -> LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLong
+"""
+        { config with
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeClassConstructor = true
+              SpaceBeforeMember = true
+              SpaceBeforeColon = true
+              SpaceBeforeSemicolon = true
+              AlignFunctionSignatureToIndentation = true
+              AlternativeLongMemberDefinitions = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+namespace Foo
+
+type Bar =
+    member Hello :
+        thing : XLongLongLongLongLongLongLongLong<bool -> 'a, bool -> 'b, bool -> 'c, bool -> 'd, bool
+                                                      -> ('e -> 'f)
+                                                      -> 'g, ('h -> 'i) -> 'j>
+        * item : int list ->
+        LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLong
+"""

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -2815,7 +2815,7 @@ and [<CustomEquality ; NoComparison>] Bar<'context, 'a> =
                                                     if inner then
                                                         let bv =
                                                             unbox<Foo<'innerContextLongLongLong, 'bb
-                                                                -> 'b>>
+                                                                          -> 'b>>
                                                                 bf
 
                                                         this.InnerEquals af bf cont

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4301,9 +4301,11 @@ and genPrefixTypes astContext node (range: Range) ctx =
             ctx
     | t :: _ ->
         (!- "<"
-         +> addSpaceIfSynTypeStaticConstantHasAtSignBeforeString t
-         +> col sepComma node (genType astContext false)
-         +> addSpaceIfSynTypeStaticConstantHasAtSignBeforeString t
+         +> atCurrentColumnIndent (
+             addSpaceIfSynTypeStaticConstantHasAtSignBeforeString t
+             +> col sepComma node (genType astContext false)
+             +> addSpaceIfSynTypeStaticConstantHasAtSignBeforeString t
+         )
          +> tokN range GREATER (!- ">"))
             ctx
 


### PR DESCRIPTION
Fixes #1687.