### PR TITLE
Small fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,9 @@ let ``preserve compile directive between piped functions, 512`` () = ...
 - Not mandatory, but when fixing a bug consider using `fix-<issue-number>` as the git branch name.<br />
 For example, `git checkout -b fix-1404`.
 
+- Code should be formatted to our standard style, using either `dotnet fake run build.fsx -t Format` which works on all files, or
+  `dotnet fake run build.fsx -t FormatChanged` to just change the files in git.
+
 ### Small steps
 
 It is better to create a draft pull request with some initial small changes, and engage conversation, than to spend a lot of effort on a large pull request that was never discussed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,7 +248,7 @@ or in Bash:
 Run a single unit test with `dotnet test --filter`.
 
 > cd .\src\Fantomas.Tests\
-> dotnet test --filter "record declaration"
+> dotnet test --filter 1700
 
 The output looks like:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,7 @@ In PowerShell:
 
 or in Bash:
 
-> VSTEST_HOST_DEBUG=1
+> export VSTEST_HOST_DEBUG=1
 
 Run a single unit test with `dotnet test --filter`.
 


### PR DESCRIPTION
I got a little confused while running through the instructions. This fixes the confusion.

Note that I couldn't find any way to specify `dotnet test --filter 'record declaration'` with a space in the name. I tried `%20`, double quotes, and adding escape characters. I don't know if it works on powershell, but it does not seem to work at all when using bash. The error was:

```
An exception occurred while invoking executor 'executor://nunit3testexecutor/': Unexpected Word 'declaration' at position 7 in selection expression.
```

Instead, I specified an issue number.