### PR TITLE
Detect multiline clause by UnIndentBy event.

### DIFF
--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -1858,3 +1858,30 @@ match x with
      with e -> printfn "failure %A" e)
 --*-- bar
 """
+
+[<Test>]
+let ``match with single line last clause followed by line comment and infix operator, 1721 `` () =
+    formatSourceString
+        false
+        """
+  let select p =
+    match p with
+    | voo _ -> "v_"
+    | dd -> "dd_"
+    | q -> "q_" // comment
+    |> List.singleton
+    |> instruction "s"
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let select p =
+  match p with
+  | voo _ -> "v_"
+  | dd -> "dd_"
+  | q -> "q_" // comment
+  |> List.singleton
+  |> instruction "s"
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2695,8 +2695,8 @@ and genMultilineInfixExpr astContext e1 operatorText operatorExpr e2 =
                 |> Seq.tryHead
                 |> fun e ->
                     match e with
-                    | Some (Write _) -> true
-                    | _ -> false
+                    | Some (UnIndentBy _) -> false
+                    | _ -> true
 
             if lastClauseIsSingleLine then
                 ctxAfterMatch


### PR DESCRIPTION
Fixes #1721.