### PR TITLE
Respect KeepIndentInBranch with multiple levels of nested LetOrUse or Sequential expressions.

### DIFF
--- a/src/Fantomas.Tests/KeepIndentInBranchTests.fs
+++ b/src/Fantomas.Tests/KeepIndentInBranchTests.fs
@@ -1314,3 +1314,182 @@ module Foo =
 
         failwith ""
 """
+
+[<Test>]
+let ``multiple nested Sequential expressions, 1714`` () =
+    formatSourceString
+        false
+        """
+namespace Foo
+
+module Bar =
+
+    [<EntryPoint>]
+    let main argv =
+        let args = foo
+        printfn ""
+        printfn ""
+        printfn ""
+        let m = ""
+        if foo then
+            printfn "aborting"
+            1
+        else
+
+        printfn "blah"
+        let m = ""
+        if foo then
+            printfn "aborting"
+            1
+        else
+
+        let fs = FileSystem ()
+        use f = fs.File.Open("")
+        0
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+namespace Foo
+
+module Bar =
+
+    [<EntryPoint>]
+    let main argv =
+        let args = foo
+        printfn ""
+        printfn ""
+        printfn ""
+        let m = ""
+
+        if foo then
+            printfn "aborting"
+            1
+        else
+
+        printfn "blah"
+        let m = ""
+
+        if foo then
+            printfn "aborting"
+            1
+        else
+
+        let fs = FileSystem()
+        use f = fs.File.Open("")
+        0
+"""
+
+[<Test>]
+let ``multiple nested LetOrUse expressions, 1717`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let main (args : _) =
+        let fs = FileSystem()
+        let ab = ThingOne.make fs (ThingFour.defaultFoo args.Args.ThingOne)
+
+        let thingFive = ThingFive.thingFive fs ab
+
+        use loggerFactory = Logging.make thingFive LogEventLevel.Verbose LogEventLevel.Information
+        let log = loggerFactory.CreateLogger "foo"
+        log.LogDebug("Command line options used: {CommandLine}", args)
+        log.LogInformation("Thing One: {ThingOne}", ThingOne.getFoo ab)
+
+        let thing, cd =
+            args.Thing
+            |> Args.render loggerFactory thingFive
+
+        let skipBehaviour =
+            if defaultArg args.Skip then
+                Options.Exclude
+            else
+                Options.Include
+
+        let thing, errors = Information.make fs ab thing
+        use thing = thing
+
+        let operationToDo =
+            Operations.operation loggerFactory fs ab tp thing (DUCase args.Thing) args.Info skipBehaviour
+
+        match ThingEight.defaultFun args.DryRun with
+        | DryRunMode.Dry ->
+            log.LogInformation("No changes made due to --dry-run.")
+            0
+        | DryRunMode.Wet ->
+
+        match operationToDo with
+        | None ->
+            log.LogWarning("No changes required; no action taken.")
+            0
+        | Some thingsToDo ->
+
+        thingsToDo
+        |> Operations.perform loggerFactory (errors |> Map.keys)
+        |> Seq.map (fun i -> i.Name)
+        |> String.concat "\n"
+        |> fun i -> log.LogInformation("Completed operation:\n{Result}", i)
+        0
+"""
+        { config with
+              MultiLineLambdaClosingNewline = true
+              MultilineBlockBracketsOnSameColumn = true
+              AlternativeLongMemberDefinitions = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let main (args: _) =
+        let fs = FileSystem()
+
+        let ab =
+            ThingOne.make fs (ThingFour.defaultFoo args.Args.ThingOne)
+
+        let thingFive = ThingFive.thingFive fs ab
+
+        use loggerFactory =
+            Logging.make thingFive LogEventLevel.Verbose LogEventLevel.Information
+
+        let log = loggerFactory.CreateLogger "foo"
+        log.LogDebug("Command line options used: {CommandLine}", args)
+        log.LogInformation("Thing One: {ThingOne}", ThingOne.getFoo ab)
+
+        let thing, cd =
+            args.Thing |> Args.render loggerFactory thingFive
+
+        let skipBehaviour =
+            if defaultArg args.Skip then
+                Options.Exclude
+            else
+                Options.Include
+
+        let thing, errors = Information.make fs ab thing
+        use thing = thing
+
+        let operationToDo =
+            Operations.operation loggerFactory fs ab tp thing (DUCase args.Thing) args.Info skipBehaviour
+
+        match ThingEight.defaultFun args.DryRun with
+        | DryRunMode.Dry ->
+            log.LogInformation("No changes made due to --dry-run.")
+            0
+        | DryRunMode.Wet ->
+
+        match operationToDo with
+        | None ->
+            log.LogWarning("No changes required; no action taken.")
+            0
+        | Some thingsToDo ->
+
+        thingsToDo
+        |> Operations.perform loggerFactory (errors |> Map.keys)
+        |> Seq.map (fun i -> i.Name)
+        |> String.concat "\n"
+        |> fun i -> log.LogInformation("Completed operation:\n{Result}", i)
+
+        0
+"""

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -1748,52 +1748,6 @@ module Foo =
 """
 
 [<Test>]
-let ``mhex xx 2`` () =
-    formatSourceString
-        false
-        """
-module Foo =
-    let bar () =
-
-        let f1 = ()
-
-        let runTest () =
-            let (Thing f) =
-                [ a ; b ] |> Blah.tryConcat |> Option.get in f () |> ignore
-
-        Assert.Throws<exn> runTest |> ignore
-"""
-        { config with
-              MaxLineLength = 100
-              SpaceBeforeUppercaseInvocation = true
-              SpaceBeforeClassConstructor = true
-              SpaceBeforeMember = true
-              SpaceBeforeColon = true
-              SpaceBeforeSemicolon = true
-              MultilineBlockBracketsOnSameColumn = true
-              NewlineBetweenTypeDefinitionAndMembers = true
-              KeepIfThenInSameLine = true
-              AlignFunctionSignatureToIndentation = true
-              AlternativeLongMemberDefinitions = true
-              MultiLineLambdaClosingNewline = true
-              KeepIndentInBranch = true }
-    |> prepend newline
-    |> should
-        equal
-        """
-module Foo =
-    let bar () =
-
-        let f1 = ()
-
-        let runTest () =
-            let (Thing f) =
-                [ a ; b ] |> Blah.tryConcat |> Option.get in f () |> ignore
-
-        Assert.Throws<exn> runTest |> ignore
-"""
-
-[<Test>]
 let ``multiline return type followed by type declaration, 1624`` () =
     formatSourceString
         false
@@ -1906,4 +1860,19 @@ module PoorlyIndented =
                 dependency
 
         cmd.AsyncExecute(id = thingId)
+"""
+
+[<Test>]
+let ``short let in`` () =
+    formatSourceString
+        false
+        """
+let a = x in foo x
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = x in foo x
 """


### PR DESCRIPTION
 Fixes #1714.
 Fixes #1717.