### PR TITLE
Avoid offset error when a comment appears before a match statement ininfix expression.

### DIFF
--- a/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -655,3 +655,36 @@ module Foo =
             x
             y
 """
+
+[<Test>]
+let ``multiline infix application with piped match expression`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+
+    let bar =
+        baz
+        |> (
+            // Hi!
+            match false with
+            | true -> id
+            | false -> id
+        )
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+
+    let bar =
+        baz
+        |> (
+            // Hi!
+            match false with
+            | true -> id
+            | false -> id
+        )
+"""

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -1191,3 +1191,35 @@ let ``list concat chain using operators, 1188`` () =
 [ 1 .. 86 ]
 @ [ 89 .. 699 ] @ [ 901 .. 912 ] @ [ 988 ]
 """
+
+[<Test>]
+let ``comment above piped match expression, 1711`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+
+    let bar =
+        baz
+        |> (
+            // Hi!
+            match false with
+            | true -> id
+            | false -> id
+        )
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+
+    let bar =
+        baz
+        |> (
+            // Hi!
+            match false with
+            | true -> id
+            | false -> id)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2703,6 +2703,24 @@ and genExprInMultilineInfixExpr astContext e =
                  sepNlnConsideringTriviaContentBeforeForMainNode t r
                  +> genExpr astContext e)
         )
+    | Paren (lpr, (Match _ as mex), rpr, pr) ->
+        fun ctx ->
+            if ctx.Config.MultiLineLambdaClosingNewline then
+                (tokN lpr LPAREN sepOpenT
+                 +> indent
+                 +> sepNln
+                 +> genExpr astContext mex
+                 +> unindent
+                 +> sepNln
+                 +> optSingle (fun rpr -> tokN rpr RPAREN sepCloseT) rpr
+                 |> genTriviaFor SynExpr_Paren pr)
+                    ctx
+            else
+                (tokN lpr LPAREN sepOpenT
+                 +> atCurrentColumnIndent (genExpr astContext mex)
+                 +> optSingle (fun rpr -> tokN rpr RPAREN sepCloseT) rpr
+                 |> genTriviaFor SynExpr_Paren pr)
+                    ctx
     | Paren (_, InfixApp (_, _, DotGet _, _), _, _)
     | Paren (_, DotGetApp _, _, _) -> atCurrentColumnIndent (genExpr astContext e)
     | MatchLambda (cs, _) ->


### PR DESCRIPTION
Fixes #1711.