### PR TITLE
KeepIndentInBranch for value bindings.

### DIFF
--- a/src/Fantomas.Tests/KeepIndentInBranchTests.fs
+++ b/src/Fantomas.Tests/KeepIndentInBranchTests.fs
@@ -1540,3 +1540,50 @@ let x y =
     let ipv4 = string result.["ipv4"]
     None
 """
+
+[<Test>]
+let ``value binding, 1728`` () =
+    formatSourceString
+        false
+        """
+let x =
+            if not (
+                result.HasResultsFor(
+                    [ "label"
+                      "ipv4"
+                      "macAddress"
+                      "medium"
+                      "manufacturer" ]
+                )
+            ) then
+                None
+            else
+
+            let label = string result.["label"]
+            let ipv4 = string result.["ipv4"]
+            None
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x =
+    if
+        not (
+            result.HasResultsFor(
+                [ "label"
+                  "ipv4"
+                  "macAddress"
+                  "medium"
+                  "manufacturer" ]
+            )
+        )
+    then
+        None
+    else
+
+    let label = string result.["label"]
+    let ipv4 = string result.["ipv4"]
+    None
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -5305,12 +5305,12 @@ and genSynBindingValue
          +> genReturnType
          +> (fun ctx -> genEqualsInBinding (equalsRange ctx) ctx))
         (fun isMultiline ctx ->
-            let short = genExpr astContext e
+            let short = genExprKeepIndentInBranch astContext e
 
             let long =
                 indent
                 +> sepNln
-                +> genExpr astContext e
+                +> genExprKeepIndentInBranch astContext e
                 +> unindent
 
             if isMultiline then


### PR DESCRIPTION
Fixes #1728.