### PR TITLE
Always add newline if expression lambda body expression is multiline in MultiLineLambdaClosingNewline setting.

### DIFF
--- a/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -688,3 +688,127 @@ module Foo =
             | false -> id
         )
 """
+
+[<Test>]
+let ``inner let binding inside lambda, 1741`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+
+    let bar () =
+        []
+        |> Seq.iter(fun (a, b) ->
+            let blah =
+                fieldInfos
+                |> Seq.groupBy (fun fi -> fi.Name)
+                |> Seq.filter (fst >> foo >> not)
+                |> Seq.choose (fun (name, fieldInfos) ->
+                    let fieldTypes = fieldInfos |> Seq.map (fun fi -> TypeId fi.TypeInfo.Id) |> Seq.distinct |> Seq.toList
+                    match fieldTypes with
+                    | [ fieldType ] -> // hi!
+                        let parents = fieldInfos |> Seq.cache
+                        Some (name, fieldType, parents)
+                    | _ -> // differing
+                        None
+                )
+            ()
+        )
+"""
+        { config with
+              MultiLineLambdaClosingNewline = true
+              KeepIndentInBranch = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+
+    let bar () =
+        []
+        |> Seq.iter (fun (a, b) ->
+            let blah =
+                fieldInfos
+                |> Seq.groupBy (fun fi -> fi.Name)
+                |> Seq.filter (fst >> foo >> not)
+                |> Seq.choose (fun (name, fieldInfos) ->
+                    let fieldTypes =
+                        fieldInfos
+                        |> Seq.map (fun fi -> TypeId fi.TypeInfo.Id)
+                        |> Seq.distinct
+                        |> Seq.toList
+
+                    match fieldTypes with
+                    | [ fieldType ] -> // hi!
+                        let parents = fieldInfos |> Seq.cache
+                        Some(name, fieldType, parents)
+                    | _ -> // differing
+                        None
+                )
+
+            ()
+        )
+"""
+
+[<Test>]
+let ``inner let binding inside lambda, multiple arguments`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+
+    let bar () =
+        []
+        |> Seq.fold (fun (a, b) ->
+            let blah =
+                fieldInfos
+                |> Seq.groupBy (fun fi -> fi.Name)
+                |> Seq.filter (fst >> foo >> not)
+                |> Seq.choose (fun (name, fieldInfos) ->
+                    let fieldTypes = fieldInfos |> Seq.map (fun fi -> TypeId fi.TypeInfo.Id) |> Seq.distinct |> Seq.toList
+                    match fieldTypes with
+                    | [ fieldType ] -> // hi!
+                        let parents = fieldInfos |> Seq.cache
+                        Some (name, fieldType, parents)
+                    | _ -> // differing
+                        None
+                )
+            ()
+        ) meh
+"""
+        { config with
+              MultiLineLambdaClosingNewline = true
+              KeepIndentInBranch = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+
+    let bar () =
+        []
+        |> Seq.fold
+            (fun (a, b) ->
+                let blah =
+                    fieldInfos
+                    |> Seq.groupBy (fun fi -> fi.Name)
+                    |> Seq.filter (fst >> foo >> not)
+                    |> Seq.choose (fun (name, fieldInfos) ->
+                        let fieldTypes =
+                            fieldInfos
+                            |> Seq.map (fun fi -> TypeId fi.TypeInfo.Id)
+                            |> Seq.distinct
+                            |> Seq.toList
+
+                        match fieldTypes with
+                        | [ fieldType ] -> // hi!
+                            let parents = fieldInfos |> Seq.cache
+                            Some(name, fieldType, parents)
+                        | _ -> // differing
+                            None
+                    )
+
+                ()
+            )
+            meh
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3190,18 +3190,12 @@ and genApp astContext e es ctx =
                             let sepCloseTFor r =
                                 tokN (Option.defaultValue e.Range r) RPAREN sepCloseT
 
-                            let genExprAfterArrow (e: SynExpr) ctx =
-                                if Option.isSome (findTriviaTokenFromName RARROW e.Range ctx) then
-                                    genExprKeepIndentInBranch astContext e ctx
-                                else
-                                    autoNlnIfExpressionExceedsPageWidth (genExprKeepIndentInBranch astContext e) ctx
-
                             leadingExpressionIsMultiline
                                 (sepOpenTFor lpr -- "fun "
                                  +> pats
                                  +> indent
                                  +> triviaAfterArrow arrowRange
-                                 +> genExprAfterArrow bodyExpr
+                                 +> autoNlnIfExpressionExceedsPageWidth (genExprKeepIndentInBranch astContext bodyExpr)
                                  +> unindent)
                                 (fun isMultiline -> onlyIf isMultiline sepNln +> sepCloseTFor rpr)
                             |> genTriviaFor SynExpr_Paren pr
@@ -3226,17 +3220,11 @@ and genApp astContext e es ctx =
                             let sepCloseTFor r =
                                 tokN (Option.defaultValue e.Range r) RPAREN sepCloseT
 
-                            let genExprAfterArrow (e: SynExpr) ctx =
-                                match findTriviaTokenFromName RARROW e.Range ctx with
-                                | Some _ -> genExprKeepIndentInBranch astContext e ctx
-                                | None ->
-                                    autoNlnIfExpressionExceedsPageWidth (genExprKeepIndentInBranch astContext e) ctx
-
                             sepOpenTFor lpr -- "fun "
                             +> pats
                             +> indent
                             +> triviaAfterArrow arrowRange
-                            +> genExprAfterArrow bodyExpr
+                            +> autoNlnIfExpressionExceedsPageWidth (genExprKeepIndentInBranch astContext bodyExpr)
                             +> unindent
                             +> sepNln
                             +> sepCloseTFor rpr


### PR DESCRIPTION
 Fixes #1741.