### PR TITLE
Print trivia for SynPat_Paren when member binding is multiline paren tuple. 

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -834,3 +834,65 @@ type ISingleExpressionValue<'p, 'o, 'v when 'p :> IProperty and 'o :> IOperator 
     abstract Operator : 'o
     abstract Value : 'v
 """
+
+[<Test>]
+let ``comment before multiline class member`` () =
+    formatSourceString
+        false
+        """
+type MaybeBuilder () =
+    member inline __.Bind
+// meh
+        (value, binder : 'T -> 'U option) : 'U option =
+        Option.bind binder value
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type MaybeBuilder() =
+    member inline __.Bind
+        // meh
+        (
+            value,
+            binder: 'T -> 'U option
+        ) : 'U option =
+        Option.bind binder value
+"""
+
+[<Test>]
+let ``define hashes around member binding, 1753`` () =
+    formatSourceString
+        false
+        """
+[<Sealed>]
+type MaybeBuilder () =
+    // M<'T> * ('T -> M<'U>) -> M<'U>
+#if DEBUG
+    member __.Bind
+#else
+    member inline __.Bind
+#endif
+        (value, binder : 'T -> 'U option) : 'U option =
+        Option.bind binder value
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<Sealed>]
+type MaybeBuilder() =
+    // M<'T> * ('T -> M<'U>) -> M<'U>
+#if DEBUG
+    member __.Bind
+#else
+    member inline __.Bind
+#endif
+        (
+            value,
+            binder: 'T -> 'U option
+        ) : 'U option =
+        Option.bind binder value
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4991,7 +4991,8 @@ and genSynBindingFunction
         let long (ctx: Context) =
             let genParameters, hasSingleTupledArg =
                 match parameters with
-                | [ _, PatParen (PatTuple ps) ] -> genParenTupleWithIndentAndNewlines ps astContext, true
+                | [ _, (PatParen (PatTuple ps) as pp) ] ->
+                    genParenTupleWithIndentAndNewlines astContext ps pp.Range, true
                 | _ -> col sepNln parameters (genPatWithIdent astContext), false
 
             (genPref
@@ -5100,7 +5101,8 @@ and genSynBindingFunctionWithReturnType
         let long (ctx: Context) =
             let genParameters, hasSingleTupledArg =
                 match parameters with
-                | [ _, PatParen (PatTuple ps) ] -> genParenTupleWithIndentAndNewlines ps astContext, true
+                | [ _, (PatParen (PatTuple ps) as pp) ] ->
+                    genParenTupleWithIndentAndNewlines astContext ps pp.Range, true
                 | _ -> col sepNln parameters (genPatWithIdent astContext), false
 
             (genPref
@@ -5256,7 +5258,7 @@ and genSynBindingValue
             else
                 isShortExpression ctx.Config.MaxValueBindingWidth short long ctx)
 
-and genParenTupleWithIndentAndNewlines ps astContext =
+and genParenTupleWithIndentAndNewlines (astContext: ASTContext) (ps: SynPat list) (pr: range) : Context -> Context =
     sepOpenT
     +> indent
     +> sepNln
@@ -5264,6 +5266,7 @@ and genParenTupleWithIndentAndNewlines ps astContext =
     +> unindent
     +> sepNln
     +> sepCloseT
+    |> genTriviaFor SynPat_Paren pr
 
 and collectMultilineItemForSynExprKeepIndent
     (astContext: ASTContext)


### PR DESCRIPTION
Fixes #1753.