### PR TITLE
Add parenthesis if necessary in multiline if/then/else followed by infix operator. 

### DIFF
--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -2446,3 +2446,46 @@ module Foo =
         else
             Some "hi"
 """
+
+[<Test>]
+let ``multiline if/then/else followed by infix, 1757`` () =
+    formatSourceString
+        false
+        """
+           let name =
+                if typ.GenericParameter.IsSolveAtCompileTime then "^" else "'"
+                + typ.GenericParameter.Name
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let name =
+  (if typ.GenericParameter.IsSolveAtCompileTime then
+     "^"
+   else
+     "'")
+  + typ.GenericParameter.Name
+"""
+
+[<Test>]
+let ``multiline if/then/else followed by infix, no parenthesis needed`` () =
+    formatSourceString
+        false
+        """
+           let name =
+                if typ.GenericParameter.IsSolveAtCompileTime then "^" else "'"
+                + typ.GenericParameter.Name
+"""
+        { config with
+              IndentSize = 2
+              MaxIfThenElseShortWidth = 9000 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let name =
+  if typ.GenericParameter.IsSolveAtCompileTime then "^" else "'"
+  + typ.GenericParameter.Name
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2603,7 +2603,8 @@ and genOnelinerInfixExpr astContext e1 operatorText operatorExpr e2 =
 and genMultilineInfixExpr astContext e1 operatorText operatorExpr e2 =
     let genE1 (ctx: Context) =
         match e1 with
-        | SynExpr.IfThenElse _
+        | SynExpr.IfThenElse _ when (ctx.Config.IndentSize - 1 <= operatorText.Length) ->
+            autoParenthesisIfExpressionExceedsPageWidth (genExpr astContext e1) ctx
         | SynExpr.Match _ when (ctx.Config.IndentSize <= operatorText.Length) ->
             let ctxAfterMatch = genExpr astContext e1 ctx
 


### PR DESCRIPTION
Fixes #1757.