### PR TITLE
Reset the max line length after printing the interpolated expression.

### DIFF
--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -659,3 +659,52 @@ SomeOtherFunction(
     arg2
 ) // does another thing
 """
+
+[<Test>]
+let ``string interpolation should not affect multiline function applications, 1771`` () =
+    formatSourceString
+        false
+        """
+   let tryDataOperation  =
+
+           let body =
+             let clauses =
+               [ mkSynMatchClause
+                   (mkSynPatLongIdentSimple "Some")
+                   (mkSynExprAppNonAtomic
+                     (mkSynExprLongIdent $"this.{memberName}")
+                     (mkSynExprParen (
+                       mkSynExprTuple
+                         [ mkSynExprIdent "state" ]
+                     ))) ]
+
+             mkSynExprMatch clauses
+
+           mkMember $"this.Try{memberName}" None [ mkSynAttribute "CustomOperation" (mkSynExprConstString $"try{memberName}") ] [ parameters ] (objectStateExpr body)
+"""
+        { config with
+              IndentSize = 2
+              DisableElmishSyntax = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let tryDataOperation =
+
+  let body =
+    let clauses =
+      [ mkSynMatchClause
+          (mkSynPatLongIdentSimple "Some")
+          (mkSynExprAppNonAtomic
+            (mkSynExprLongIdent $"this.{memberName}")
+            (mkSynExprParen (mkSynExprTuple [ mkSynExprIdent "state" ]))) ]
+
+    mkSynExprMatch clauses
+
+  mkMember
+    $"this.Try{memberName}"
+    None
+    [ mkSynAttribute "CustomOperation" (mkSynExprConstString $"try{memberName}") ]
+    [ parameters ]
+    (objectStateExpr body)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2465,17 +2465,19 @@ and genExpr astContext synExpr ctx =
 
                 let genInterpolatedFillExpr expr =
                     fun ctx ->
-                        genExpr
-                            astContext
-                            expr
-                            { ctx with
-                                  Config =
-                                      { ctx.Config with
-                                            // override the max line length for the interpolated expression.
-                                            // this is to avoid scenarios where the long / multiline format of the expresion will be used
-                                            // where the construct is this short
-                                            // see unit test ``construct url with Fable``
-                                            MaxLineLength = ctx.WriterModel.Column + ctx.Config.MaxLineLength } }
+                        let currentConfig = ctx.Config
+
+                        let interpolatedConfig =
+                            { currentConfig with
+                                  // override the max line length for the interpolated expression.
+                                  // this is to avoid scenarios where the long / multiline format of the expresion will be used
+                                  // where the construct is this short
+                                  // see unit test ``construct url with Fable``
+                                  MaxLineLength = ctx.WriterModel.Column + ctx.Config.MaxLineLength }
+
+                        genExpr astContext expr { ctx with Config = interpolatedConfig }
+                        // Restore the existing configuration after printing the interpolated expression
+                        |> fun ctx -> { ctx with Config = currentConfig }
                     |> atCurrentColumnIndent
 
                 let expr =


### PR DESCRIPTION
Fixes #1771.