### PR TITLE
Only print union case fields when there are any. 

### DIFF
--- a/src/Fantomas.Tests/UnionTests.fs
+++ b/src/Fantomas.Tests/UnionTests.fs
@@ -822,3 +822,45 @@ type SynTypeConstraint =
     /// F# syntax: is 'typar: struct
     | WhereTyparIsValueType of typar: SynTypar * range: range
 """
+
+[<Test>]
+let ``long union case with attributes without fields, 1796`` () =
+    formatSourceString
+        false
+        """
+type TransactionType =
+    | [<CompiledName "External Credit Balance Refund">] ExternalCreditBalanceRefund
+    | [<CompiledName "Credit Balance Adjustment (Applied from Credit Balance)">] CreditBalanceAdjustmentAppliedFromCreditBalance
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type TransactionType =
+    | [<CompiledName "External Credit Balance Refund">] ExternalCreditBalanceRefund
+    | [<CompiledName "Credit Balance Adjustment (Applied from Credit Balance)">] CreditBalanceAdjustmentAppliedFromCreditBalance
+"""
+
+[<Test>]
+let ``long union case with attributes without fields, signature file`` () =
+    formatSourceString
+        true
+        """
+namespace X
+
+type TransactionType =
+    | [<CompiledName "External Credit Balance Refund">] ExternalCreditBalanceRefund
+    | [<CompiledName "Credit Balance Adjustment (Applied from Credit Balance)">] CreditBalanceAdjustmentAppliedFromCreditBalance
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+namespace X
+
+type TransactionType =
+    | [<CompiledName "External Credit Balance Refund">] ExternalCreditBalanceRefund
+    | [<CompiledName "Credit Balance Adjustment (Applied from Credit Balance)">] CreditBalanceAdjustmentAppliedFromCreditBalance
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4093,7 +4093,7 @@ and genUnionCase astContext (hasVerticalBar: bool) (UnionCase (ats, px, _, s, Un
     +> ifElse hasVerticalBar sepBar sepNone
     +> genOnelinerAttributes astContext ats
     -- s
-    +> expressionFitsOnRestOfLine shortExpr longExpr
+    +> onlyIf (List.isNotEmpty fs) (expressionFitsOnRestOfLine shortExpr longExpr)
     |> genTriviaFor UnionCase_ node.Range
 
 and genEnumCase astContext (EnumCase (ats, px, _, (_, _)) as node) =


### PR DESCRIPTION
Fixes #1796.