### PR TITLE
Verbatim string is ignore for hash directive scan.

### DIFF
--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -2589,3 +2589,53 @@ type ObjectGraphFormatter(opts: FormatOptions, bindingFlags) =
 
     and arrayValueL depthLim (arr: Array) = ()
 """
+
+[<Test>]
+let ``verbatim string is ignore for hash directive scan,  1794`` () =
+    formatSourceString
+        false
+        """
+let ProgramFilesX86 =
+    match wow64, globalArch with
+    | "AMD64", "AMD64"
+    | null, "AMD64"
+    | "x86", "AMD64" -> Environment.GetEnvironmentVariable "ProgramFiles(x86)"
+    | _ -> Environment.GetEnvironmentVariable "ProgramFiles"
+    |> fun detected -> if detected = null then @"C:\Program Files (x86)\" else detected
+
+let isUnix =
+#if NETSTANDARD1_6 || NETSTANDARD2_0
+    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+        System.Runtime.InteropServices.OSPlatform.Linux) ||
+    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+        System.Runtime.InteropServices.OSPlatform.OSX)
+#else
+    int Environment.OSVersion.Platform |> fun p -> (p = 4) || (p = 6) || (p = 128)
+#endif
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let ProgramFilesX86 =
+    match wow64, globalArch with
+    | "AMD64", "AMD64"
+    | null, "AMD64"
+    | "x86", "AMD64" -> Environment.GetEnvironmentVariable "ProgramFiles(x86)"
+    | _ -> Environment.GetEnvironmentVariable "ProgramFiles"
+    |> fun detected ->
+        if detected = null then
+            @"C:\Program Files (x86)\"
+        else
+            detected
+
+let isUnix =
+#if NETSTANDARD1_6 || NETSTANDARD2_0
+    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux)
+    || System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX)
+#else
+    int Environment.OSVersion.Platform
+    |> fun p -> (p = 4) || (p = 6) || (p = 128)
+#endif
+"""

--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -638,3 +638,21 @@ prinfn \"Debug shizzle\"
     "
 
     getDefines source == [ "DEBUG" ]
+
+[<Test>]
+let ``backslash in verbatim string`` () =
+    let source =
+        "
+let ProgramFilesX86 =
+    if detected = null then @\"C:\Program Files (x86)\\\" else detected
+
+let isUnix =
+#if NETSTANDARD1_6 || NETSTANDARD2_0
+    meh
+#else
+    foo
+#endif
+        "
+
+    getDefines source
+    == [ "NETSTANDARD1_6"; "NETSTANDARD2_0" ]


### PR DESCRIPTION
Fixes #1794.