### PR TITLE
Only format to alternative function application in if expression when application is multiline. 

### DIFF
--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -2489,3 +2489,55 @@ let name =
   if typ.GenericParameter.IsSolveAtCompileTime then "^" else "'"
   + typ.GenericParameter.Name
 """
+
+[<Test>]
+let ``short function application in infix expression, 1795`` () =
+    formatSourceString
+        false
+        """
+if
+        FOOQueryUserToken (uint32 activeSessionId, &token) <> 0u
+      then
+        Some x
+      else
+        None
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+if
+    FOOQueryUserToken(uint32 activeSessionId, &token)
+    <> 0u
+then
+    Some x
+else
+    None
+"""
+
+[<Test>]
+let ``short function application in infix expression, reversed`` () =
+    formatSourceString
+        false
+        """
+if
+      0u   <> FOOQueryUserToken (uint32 activeSessionId, &token)
+      then
+        Some x
+      else
+        None
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+if
+    0u
+    <> FOOQueryUserToken(uint32 activeSessionId, &token)
+then
+    Some x
+else
+    None
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2109,19 +2109,23 @@ and genExpr astContext synExpr ctx =
                         | AppParenArg app ->
                             genAlternativeAppWithParenthesis app astContext
                             |> indentNlnUnindentNln
-                        | InfixApp (s, e, AppParenArg app, e2) ->
-                            (genAlternativeAppWithParenthesis app astContext
+                        | InfixApp (s, e, (AppParenArg app as e1), e2) ->
+                            (expressionFitsOnRestOfLine
+                                (genExpr astContext e1)
+                                (genAlternativeAppWithParenthesis app astContext)
                              +> ifElse (noBreakInfixOps.Contains(s)) sepSpace sepNln
                              +> genInfixOperator s e
                              +> sepSpace
                              +> genExpr astContext e2)
                             |> indentNlnUnindentNln
-                        | InfixApp (s, e, e1, AppParenArg app) ->
+                        | InfixApp (s, e, e1, (AppParenArg app as e2)) ->
                             (genExpr astContext e1
                              +> sepNln
                              +> genInfixOperator s e
                              +> sepSpace
-                             +> genAlternativeAppWithParenthesis app astContext)
+                             +> expressionFitsOnRestOfLine
+                                 (genExpr astContext e2)
+                                 (genAlternativeAppWithParenthesis app astContext))
                             |> indentNlnUnindentNln
                         // very specific fix for 1380
                         | SameInfixApps (Paren (lpr, AppParenArg e, rpr, pr), es) ->


### PR DESCRIPTION
Fixes #1795.