### PR TITLE
Process function applications the same way as if the DotGet would not have a lambda. 

### DIFF
--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -1264,3 +1264,43 @@ m
     )
     .HasMaxLength
 """
+
+[<Test>]
+let ``dotget chain with a lambda and ending in multiline function application, 1804`` () =
+    formatSourceString
+        false
+        """
+db.Schema.Users.Query
+    .Where(fun x -> x.Role)
+    .Matches(function Role.User companyId -> companyId |_->__)
+    .In(
+        db.Schema.Companies.Query
+            .Where(fun x -> x.LicenceId).Equals(licenceId)
+            .Select(fun x -> x.Id)
+    )
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+db
+    .Schema
+    .Users
+    .Query
+    .Where(fun x -> x.Role)
+    .Matches(
+        function
+        | Role.User companyId -> companyId
+        | _ -> __
+    )
+    .In(
+        db
+            .Schema
+            .Companies
+            .Query
+            .Where(fun x -> x.LicenceId)
+            .Equals(licenceId)
+            .Select(fun x -> x.Id)
+    )
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1846,6 +1846,21 @@ and genExpr astContext synExpr ctx =
 
             let lastEsIndex = es.Length - 1
 
+            let genApp (idx: int) ((lids, e, ts): (string * range) list * SynExpr * SynType list) : Context -> Context =
+                let short =
+                    genLidsWithDots lids
+                    +> genGenericTypeParameters astContext ts
+                    +> genSpaceBeforeLids idx lastEsIndex lids e
+                    +> genExpr astContext e
+
+                let long =
+                    genLidsWithDotsAndNewlines lids
+                    +> genGenericTypeParameters astContext ts
+                    +> genSpaceBeforeLids idx lastEsIndex lids e
+                    +> genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext e
+
+                expressionFitsOnRestOfLine short long
+
             let short =
                 genExpr astContext e
                 +> genExpr astContext px
@@ -1862,14 +1877,7 @@ and genExpr astContext synExpr ctx =
                 genLongFunctionName (genExpr astContext px)
                 +> indent
                 +> sepNln
-                +> coli
-                    sepNln
-                    es
-                    (fun idx (lids, e, ts) ->
-                        genLidsWithDotsAndNewlines lids
-                        +> genGenericTypeParameters astContext ts
-                        +> genSpaceBeforeLids idx lastEsIndex lids e
-                        +> genExpr astContext e)
+                +> coli sepNln es genApp
                 +> unindent
 
             fun ctx -> isShortExpression ctx.Config.MaxDotGetExpressionWidth short long ctx


### PR DESCRIPTION
Fixes #1804.