### PR TITLE
Apply same alternative formatting for match expression as in if expressions.

### DIFF
--- a/src/Fantomas.Tests/KeepIndentInBranchTests.fs
+++ b/src/Fantomas.Tests/KeepIndentInBranchTests.fs
@@ -1525,15 +1525,16 @@ let x y =
         """
 let x y =
     if
-        not (
-            result.HasResultsFor(
-                [ "label"
-                  "ipv4"
-                  "macAddress"
-                  "medium"
-                  "manufacturer" ]
+        not
+            (
+                result.HasResultsFor(
+                    [ "label"
+                      "ipv4"
+                      "macAddress"
+                      "medium"
+                      "manufacturer" ]
+                )
             )
-        )
     then
         None
     else
@@ -1572,15 +1573,16 @@ let x =
         """
 let x =
     if
-        not (
-            result.HasResultsFor(
-                [ "label"
-                  "ipv4"
-                  "macAddress"
-                  "medium"
-                  "manufacturer" ]
+        not
+            (
+                result.HasResultsFor(
+                    [ "label"
+                      "ipv4"
+                      "macAddress"
+                      "medium"
+                      "manufacturer" ]
+                )
             )
-        )
     then
         None
     else
@@ -1919,4 +1921,127 @@ let nextModel, objectsRemoved =
         )
         state
         []
+"""
+
+[<Test>]
+let ``long multiline if expression, 1812`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let bar =
+
+        if output.Exists && not (output.EnumerateFiles() |> Seq.isEmpty && onlyContainsFoobar output) then
+            Error (FooBarBazError.ErrorCase output)
+        else
+
+        let blah =
+            let x = y
+            None
+
+        {
+            Hi = blah
+        }
+        |> Ok
+"""
+        { config with
+              MaxLineLength = 100
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeClassConstructor = true
+              SpaceBeforeMember = true
+              SpaceBeforeColon = true
+              SpaceBeforeSemicolon = true
+              IndentOnTryWith = true
+              MultilineBlockBracketsOnSameColumn = true
+              NewlineBetweenTypeDefinitionAndMembers = true
+              AlignFunctionSignatureToIndentation = true
+              AlternativeLongMemberDefinitions = true
+              MultiLineLambdaClosingNewline = true
+              DisableElmishSyntax = true
+              KeepIndentInBranch = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let bar =
+
+        if
+            output.Exists
+            && not
+                (
+                    output.EnumerateFiles () |> Seq.isEmpty
+                    && onlyContainsFoobar output
+                )
+        then
+            Error (FooBarBazError.ErrorCase output)
+        else
+
+        let blah =
+            let x = y
+            None
+
+        { Hi = blah } |> Ok
+"""
+
+[<Test>]
+let ``long multiline match expression`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let bar =
+
+        match output.Exists && not (output.EnumerateFiles() |> Seq.isEmpty && onlyContainsFoobar output) with
+        | true ->
+            Error (FooBarBazError.ErrorCase output)
+        | false ->
+
+        let blah =
+            let x = y
+            None
+
+        {
+            Hi = blah
+        }
+        |> Ok
+"""
+        { config with
+              MaxLineLength = 100
+              SpaceBeforeUppercaseInvocation = true
+              SpaceBeforeClassConstructor = true
+              SpaceBeforeMember = true
+              SpaceBeforeColon = true
+              SpaceBeforeSemicolon = true
+              IndentOnTryWith = true
+              MultilineBlockBracketsOnSameColumn = true
+              NewlineBetweenTypeDefinitionAndMembers = true
+              AlignFunctionSignatureToIndentation = true
+              AlternativeLongMemberDefinitions = true
+              MultiLineLambdaClosingNewline = true
+              DisableElmishSyntax = true
+              KeepIndentInBranch = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let bar =
+
+        match
+            output.Exists
+            && not
+                (
+                    output.EnumerateFiles () |> Seq.isEmpty
+                    && onlyContainsFoobar output
+                )
+            with
+        | true -> Error (FooBarBazError.ErrorCase output)
+        | false ->
+
+        let blah =
+            let x = y
+            None
+
+        { Hi = blah } |> Ok
 """

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -1913,3 +1913,28 @@ match
     with
 | _ -> ()
 """
+
+[<Test>]
+let ``multiline infix expression in match bang`` () =
+    formatSourceString
+        false
+        """
+match! structuralTypes |> List.tryFind (fst >> checkIfFieldTypeSupportsComparison tycon >> not) with
+| _ -> ()
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+match!
+  structuralTypes
+  |> List.tryFind
+    (
+      fst
+      >> checkIfFieldTypeSupportsComparison tycon
+      >> not
+    )
+  with
+| _ -> ()
+"""

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -701,7 +701,7 @@ let MethInfoIsUnseen g m ty minfo =
 #else
                   (fun _provAttribs -> None)
 #endif
-               with
+            with
         | Some res -> res
         | None -> false
 
@@ -1887,4 +1887,29 @@ let select p =
   | q -> "q_" // comment
   |> List.singleton
   |> instruction "s"
+"""
+
+[<Test>]
+let ``multiline infix expression in match, 1774`` () =
+    formatSourceString
+        false
+        """
+match structuralTypes |> List.tryFind (fst >> checkIfFieldTypeSupportsComparison tycon >> not) with
+| _ -> ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+match
+    structuralTypes
+    |> List.tryFind
+        (
+            fst
+            >> checkIfFieldTypeSupportsComparison tycon
+            >> not
+        )
+    with
+| _ -> ()
 """

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -935,11 +935,6 @@ and genNamedArgumentExpr (astContext: ASTContext) operatorExpr e1 e2 =
 and genExpr astContext synExpr ctx =
     let kw tokenName f = tokN synExpr.Range tokenName f
 
-    let sepOpenTFor r = tokN r LPAREN sepOpenT
-
-    let sepCloseTFor rpr pr =
-        tokN (Option.defaultValue pr rpr) RPAREN sepCloseT
-
     let expr =
         match synExpr with
         | ElmishReactWithoutChildren (identifier, isArray, children, childrenRange) when
@@ -1193,7 +1188,7 @@ and genExpr astContext synExpr ctx =
                 !- "new "
                 +> genType astContext false t
                 +> sepSpace
-                +> genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext px
+                +> genMultilineFunctionApplicationArguments astContext px
 
             expressionFitsOnRestOfLine short long
         | SynExpr.New (_, t, e, _) ->
@@ -1519,30 +1514,22 @@ and genExpr astContext synExpr ctx =
                 +> expressionFitsOnRestOfLine
                     (genExpr astContext e
                      +> tokN withRange WITH (!- " with"))
-                    (fun ctx ->
-                        match e with
-                        | AppParenArg app ->
-                            (indent
-                             +> sepNln
-                             +> genAlternativeAppWithParenthesis app astContext
-                             +> sepNln
-                             +> tokN withRange WITH (!- "with")
-                             +> unindent)
-                                ctx
-                        | Match _
-                        | MatchBang _ ->
-                            (indent
-                             +> sepNln
-                             +> genExpr astContext e
-                             +> sepNln
-                             +> tokN withRange WITH (!- "with")
-                             +> unindent)
-                                ctx
-                        | _ ->
-                            atCurrentColumnIndent
-                                (genExpr astContext e
-                                 +> tokN withRange WITH (!- " with"))
-                                ctx)
+                    (genExprInIfOrMatch astContext e
+                     +> tokN
+                         withRange
+                         WITH
+                         (fun ctx ->
+                             let hasContentOnLastLine =
+                                 List.tryHead ctx.WriterModel.Lines
+                                 |> Option.map String.isNotNullOrWhitespace
+                                 |> Option.defaultValue false
+
+                             if hasContentOnLastLine then
+                                 // add a space if there is no newline right after the expression
+                                 (!- " with") ctx
+                             else
+                                 // add the indentation in spaces if there is no content on the current line
+                                 (rep ctx.Config.IndentSize (!- " ") +> !- "with") ctx))
 
             atCurrentColumn (genMatchExpr +> sepNln +> genClauses astContext cs)
         | MatchBang (e, cs) ->
@@ -1816,7 +1803,7 @@ and genExpr astContext synExpr ctx =
                     | _ -> genExpr astContext e +> argFn
 
                 let arguments =
-                    genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext px
+                    genMultilineFunctionApplicationArguments astContext px
 
                 functionName arguments
 
@@ -1857,7 +1844,7 @@ and genExpr astContext synExpr ctx =
                     genLidsWithDotsAndNewlines lids
                     +> genGenericTypeParameters astContext ts
                     +> genSpaceBeforeLids idx lastEsIndex lids e
-                    +> genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext e
+                    +> genMultilineFunctionApplicationArguments astContext e
 
                 expressionFitsOnRestOfLine short long
 
@@ -1891,7 +1878,7 @@ and genExpr astContext synExpr ctx =
                         (optSingle (genGenericTypeParameters astContext) ts
                          +> expressionFitsOnRestOfLine
                              (genExpr astContext px)
-                             (genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext px))
+                             (genMultilineFunctionApplicationArguments astContext px))
                         lids
                 | AppOrTypeApp (LongIdentPiecesExpr lids, ts, [ e2 ]) when (List.moreThanOne lids) ->
                     genFunctionNameWithMultilineLids
@@ -1911,7 +1898,7 @@ and genExpr astContext synExpr ctx =
                     let long =
                         genExpr astContext e
                         +> optSingle (genGenericTypeParameters astContext) ts
-                        +> genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext px
+                        +> genMultilineFunctionApplicationArguments astContext px
 
                     expressionFitsOnRestOfLine short long
                 | _ -> genExpr astContext e
@@ -1929,7 +1916,7 @@ and genExpr astContext synExpr ctx =
                     genLidsWithDotsAndNewlines lids
                     +> genGenericTypeParameters astContext ts
                     +> genSpaceBeforeLids idx lastEsIndex lids e
-                    +> genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext e
+                    +> genMultilineFunctionApplicationArguments astContext e
 
                 expressionFitsOnRestOfLine short long
 
@@ -1973,7 +1960,7 @@ and genExpr astContext synExpr ctx =
             let long =
                 genExpr astContext e
                 +> sepSpace
-                +> genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext px
+                +> genMultilineFunctionApplicationArguments astContext px
 
             expressionFitsOnRestOfLine short long
 
@@ -2092,97 +2079,9 @@ and genExpr astContext synExpr ctx =
                     +> sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
                     +> genExpr astContext elf2
 
-                let genIfExpr e astContext =
-                    let short =
-                        sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
-                        +> genExpr astContext e
-
-                    let long =
-                        let hasCommentBeforeExpr () =
-                            TriviaHelpers.``has content before that matches``
-                                (fun tn -> RangeHelpers.rangeEq tn.Range e.Range)
-                                (function
-                                | Comment (LineCommentOnSingleLine _) -> true
-                                | _ -> false)
-                                (Map.tryFindOrEmptyList (synExprToFsAstType e |> fst) ctx.TriviaMainNodes)
-
-                        let indentNlnUnindentNln f =
-                            indent +> sepNln +> f +> unindent +> sepNln
-
-                        match e with
-                        | App (SynExpr.DotGet _, [ (Paren _) ]) -> atCurrentColumn (genExpr astContext e)
-                        | Paren (lpr, (AppSingleParenArg _ as ate), rpr, pr) ->
-                            sepOpenTFor lpr
-                            +> atCurrentColumnIndent (genExpr astContext ate)
-                            +> sepCloseTFor rpr pr
-                        | AppParenArg app ->
-                            genAlternativeAppWithParenthesis app astContext
-                            |> indentNlnUnindentNln
-                        | InfixApp (s, e, (AppParenArg app as e1), e2) ->
-                            (expressionFitsOnRestOfLine
-                                (genExpr astContext e1)
-                                (genAlternativeAppWithParenthesis app astContext)
-                             +> ifElse (noBreakInfixOps.Contains(s)) sepSpace sepNln
-                             +> genInfixOperator s e
-                             +> sepSpace
-                             +> genExpr astContext e2)
-                            |> indentNlnUnindentNln
-                        | InfixApp (s, e, e1, (AppParenArg app as e2)) ->
-                            (genExpr astContext e1
-                             +> sepNln
-                             +> genInfixOperator s e
-                             +> sepSpace
-                             +> expressionFitsOnRestOfLine
-                                 (genExpr astContext e2)
-                                 (genAlternativeAppWithParenthesis app astContext))
-                            |> indentNlnUnindentNln
-                        // very specific fix for 1380
-                        | SameInfixApps (Paren (lpr, AppParenArg e, rpr, pr), es) ->
-                            (sepOpenTFor lpr
-                             +> genAlternativeAppWithParenthesis e astContext
-                             +> sepCloseTFor rpr pr
-                             +> sepNln
-                             +> col
-                                 sepNln
-                                 es
-                                 (fun (opText, opExpr, e) ->
-                                     genInfixOperator opText opExpr
-                                     +> sepSpace
-                                     +> (match e with
-                                         | Paren (lpr, AppParenArg app, rpr, pr) ->
-                                             sepOpenTFor lpr
-                                             +> genAlternativeAppWithParenthesis app astContext
-                                             +> sepCloseTFor rpr pr
-                                         | _ -> genExpr astContext e)))
-                            |> indentNlnUnindentNln
-                        | SynExpr.Match _
-                        | SynExpr.MatchBang _
-                        | SynExpr.TryWith _
-                        | SynExpr.TryFinally _ -> genExpr astContext e |> indentNlnUnindentNln
-                        | DotGetAppParen (DotGetAppParen (e1, px1, lids1), px2, lids2) ->
-                            genExpr astContext e1
-                            +> genExpr astContext px1
-                            +> indent
-                            +> sepNln
-                            +> genLidsWithDotsAndNewlines lids1
-                            +> genExpr astContext px2
-                            +> sepNln
-                            +> genLidsWithDotsAndNewlines lids2
-                            +> unindent
-                            |> genTriviaFor SynExpr_DotGet e.Range
-                            |> indentNlnUnindentNln
-                        | _ ->
-                            if hasCommentBeforeExpr () then
-                                genExpr astContext e |> indentNlnUnindentNln
-                            else
-                                sepNlnWhenWriteBeforeNewlineNotEmpty sepNone
-                                +> genExpr astContext e
-
-                    expressionFitsOnRestOfLine short long
-
                 let genElifMultiLine (elf1: SynExpr, elf2, elifKeywordRange, thenKeywordRange) =
                     (TriviaContext.``else if / elif`` elifKeywordRange)
-                    +> autoIndentAndNlnWhenWriteBeforeNewlineNotEmpty (genIfExpr elf1 astContext)
+                    +> autoIndentAndNlnWhenWriteBeforeNewlineNotEmpty (genExprInIfOrMatch astContext elf1)
                     +> sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
                     +> genThen thenKeywordRange
                     +> indent
@@ -2217,7 +2116,7 @@ and genExpr astContext synExpr ctx =
                     //           x
                     // bool expr x should be indented
                     +> autoIndentAndNlnWhenWriteBeforeNewlineNotEmpty (
-                        genIfExpr e1 astContext
+                        genExprInIfOrMatch astContext e1
                         +> sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
                     )
                     +> genThen synExpr.Range
@@ -2336,7 +2235,7 @@ and genExpr astContext synExpr ctx =
 
             let long =
                 genExpr astContext e
-                +> genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext px
+                +> genMultilineFunctionApplicationArguments astContext px
 
             let idx =
                 !- "."
@@ -2375,7 +2274,7 @@ and genExpr astContext synExpr ctx =
 
             let long =
                 genExpr astContext a
-                +> genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext px
+                +> genMultilineFunctionApplicationArguments astContext px
 
             let idx =
                 !- "."
@@ -2744,7 +2643,7 @@ and genFunctionNameWithMultilineLids f lids =
         +> unindent
     | _ -> sepNone
 
-and genMultilineFunctionApplicationArguments sepOpenTFor sepCloseTFor astContext argExpr =
+and genMultilineFunctionApplicationArguments astContext argExpr =
     let argsInsideParenthesis lpr rpr pr f =
         sepOpenTFor lpr
         +> indent
@@ -3160,11 +3059,6 @@ and genApp astContext e es ctx =
                             (arrowRange: Range)
                             (pr: Range)
                             : Context -> Context =
-                            let sepOpenTFor r = tokN r LPAREN sepOpenT
-
-                            let sepCloseTFor r =
-                                tokN (Option.defaultValue e.Range r) RPAREN sepCloseT
-
                             leadingExpressionIsMultiline
                                 (sepOpenTFor lpr -- "fun "
                                  +> pats
@@ -3172,7 +3066,9 @@ and genApp astContext e es ctx =
                                  +> triviaAfterArrow arrowRange
                                  +> autoNlnIfExpressionExceedsPageWidth (genExprKeepIndentInBranch astContext bodyExpr)
                                  +> unindent)
-                                (fun isMultiline -> onlyIf isMultiline sepNln +> sepCloseTFor rpr)
+                                (fun isMultiline ->
+                                    onlyIf isMultiline sepNln
+                                    +> sepCloseTFor rpr e.Range)
                             |> genTriviaFor SynExpr_Paren pr
 
                         match e with
@@ -3190,11 +3086,6 @@ and genApp astContext e es ctx =
                     es
                     (fun e ->
                         let genLambda pats (bodyExpr: SynExpr) lpr rpr arrowRange =
-                            let sepOpenTFor r = tokN r LPAREN sepOpenT
-
-                            let sepCloseTFor r =
-                                tokN (Option.defaultValue e.Range r) RPAREN sepCloseT
-
                             sepOpenTFor lpr -- "fun "
                             +> pats
                             +> indent
@@ -3202,7 +3093,7 @@ and genApp astContext e es ctx =
                             +> autoNlnIfExpressionExceedsPageWidth (genExprKeepIndentInBranch astContext bodyExpr)
                             +> unindent
                             +> sepNln
-                            +> sepCloseTFor rpr
+                            +> sepCloseTFor rpr e.Range
 
                         match e with
                         | Paren (lpr, Lambda (pats, expr, _range), rpr, _) ->
@@ -3297,6 +3188,90 @@ and genAppWithSingleParenthesisArgument (e, lpr, a, rpr, pr) astContext =
     +> tokN lpr LPAREN sepOpenT
     +> (genExpr astContext a)
     +> tokN (Option.defaultValue pr rpr) RPAREN sepCloseT
+
+and genExprInIfOrMatch astContext (e: SynExpr) (ctx: Context) : Context =
+    let short =
+        sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace
+        +> genExpr astContext e
+
+    let long =
+        let hasCommentBeforeExpr (e: SynExpr) =
+            TriviaHelpers.``has content before that matches``
+                (fun tn -> RangeHelpers.rangeEq tn.Range e.Range)
+                (function
+                | Comment (LineCommentOnSingleLine _) -> true
+                | _ -> false)
+                (Map.tryFindOrEmptyList (synExprToFsAstType e |> fst) ctx.TriviaMainNodes)
+
+        let indentNlnUnindentNln f =
+            indent +> sepNln +> f +> unindent +> sepNln
+
+        match e with
+        | App (SynExpr.DotGet _, [ (Paren _) ]) -> atCurrentColumn (genExpr astContext e)
+        | Paren (lpr, (AppSingleParenArg _ as ate), rpr, pr) ->
+            sepOpenTFor lpr
+            +> atCurrentColumnIndent (genExpr astContext ate)
+            +> sepCloseTFor rpr pr
+        | AppParenArg app ->
+            genAlternativeAppWithParenthesis app astContext
+            |> indentNlnUnindentNln
+        | InfixApp (s, e, (AppParenArg app as e1), e2) ->
+            (expressionFitsOnRestOfLine (genExpr astContext e1) (genAlternativeAppWithParenthesis app astContext)
+             +> ifElse (noBreakInfixOps.Contains(s)) sepSpace sepNln
+             +> genInfixOperator s e
+             +> sepSpace
+             +> genExpr astContext e2)
+            |> indentNlnUnindentNln
+        | InfixApp (s, e, e1, (AppParenArg app as e2)) ->
+            (genExpr astContext e1
+             +> sepNln
+             +> genInfixOperator s e
+             +> sepSpace
+             +> expressionFitsOnRestOfLine (genExpr astContext e2) (genAlternativeAppWithParenthesis app astContext))
+            |> indentNlnUnindentNln
+        // very specific fix for 1380
+        | SameInfixApps (Paren (lpr, AppParenArg e, rpr, pr), es) ->
+            (sepOpenTFor lpr
+             +> genAlternativeAppWithParenthesis e astContext
+             +> sepCloseTFor rpr pr
+             +> sepNln
+             +> col
+                 sepNln
+                 es
+                 (fun (opText, opExpr, e) ->
+                     genInfixOperator opText opExpr
+                     +> sepSpace
+                     +> (match e with
+                         | Paren (lpr, AppParenArg app, rpr, pr) ->
+                             sepOpenTFor lpr
+                             +> genAlternativeAppWithParenthesis app astContext
+                             +> sepCloseTFor rpr pr
+                         | _ -> genExpr astContext e)))
+            |> indentNlnUnindentNln
+        | SynExpr.Match _
+        | SynExpr.MatchBang _
+        | SynExpr.TryWith _
+        | SynExpr.TryFinally _ -> genExpr astContext e |> indentNlnUnindentNln
+        | DotGetAppParen (DotGetAppParen (e1, px1, lids1), px2, lids2) ->
+            genExpr astContext e1
+            +> genExpr astContext px1
+            +> indent
+            +> sepNln
+            +> genLidsWithDotsAndNewlines lids1
+            +> genExpr astContext px2
+            +> sepNln
+            +> genLidsWithDotsAndNewlines lids2
+            +> unindent
+            |> genTriviaFor SynExpr_DotGet e.Range
+            |> indentNlnUnindentNln
+        | _ ->
+            if hasCommentBeforeExpr e then
+                genExpr astContext e |> indentNlnUnindentNln
+            else
+                sepNlnWhenWriteBeforeNewlineNotEmpty sepNone
+                +> genExpr astContext e
+
+    expressionFitsOnRestOfLine short long ctx
 
 and genAlternativeAppWithParenthesis app astContext =
     match app with

--- a/src/Fantomas/TriviaContext.fs
+++ b/src/Fantomas/TriviaContext.fs
@@ -10,6 +10,11 @@ let tokN (range: Range) (tokenName: FsTokenType) f =
     +> f
     +> leaveNodeTokenByName range tokenName
 
+let sepOpenTFor r = tokN r LPAREN sepOpenT
+
+let sepCloseTFor rpr pr =
+    tokN (Option.defaultValue pr rpr) RPAREN sepCloseT
+
 let triviaAfterArrow (range: Range) (ctx: Context) =
     let hasCommentAfterArrow =
         findTriviaTokenFromName RARROW range ctx

--- a/src/Fantomas/Utils.fs
+++ b/src/Fantomas/Utils.fs
@@ -88,6 +88,7 @@ There is a problem with merging all the code back togheter. Please raise an issu
     let empty = String.Empty
 
     let isNotNullOrEmpty = String.IsNullOrEmpty >> not
+    let isNotNullOrWhitespace = String.IsNullOrWhiteSpace >> not
 
     let isMultiline s =
         normalizeNewLine s |> String.exists ((=) '\n')


### PR DESCRIPTION
Fixes #1774.
Fixes #1812.