### PR TITLE
Honor .fantomasignore file when processing a folder

### DIFF
--- a/src/Fantomas.CoreGlobalTool.Tests/CheckTests.fs
+++ b/src/Fantomas.CoreGlobalTool.Tests/CheckTests.fs
@@ -1,5 +1,6 @@
 module Fantomas.CoreGlobalTool.Tests.CheckTests
 
+open System.IO
 open NUnit.Framework
 open FsUnit
 open Fantomas.CoreGlobalTool.Tests.TestHelpers
@@ -114,3 +115,18 @@ let ``check with file and folder`` () =
             (System.IO.Path.GetFileName(fileFixtureOne.Filename))
 
     output |> should contain needsFormatting
+
+[<Test>]
+let ``honor ignore file when processing a folder`` () =
+    let fileName = "A"
+    let subFolder = System.Guid.NewGuid().ToString("N")
+
+    use ignoreFixture =
+        new TemporaryFileCodeSample("let a =  0", fileName = fileName, subFolder = subFolder)
+
+    use inputFixture = new FantomasIgnoreFile("*.fsx")
+
+    let { Output = output } =
+        runFantomasTool (sprintf "--check .%c%s" Path.DirectorySeparatorChar subFolder)
+
+    output |> should not' (contain "ignored")

--- a/src/Fantomas.CoreGlobalTool.Tests/IgnoreFilesTests.fs
+++ b/src/Fantomas.CoreGlobalTool.Tests/IgnoreFilesTests.fs
@@ -111,3 +111,18 @@ let ``ignore file in folder while checking`` () =
 
     File.ReadAllText inputFixture.Filename
     |> should equal Source
+
+[<Test>]
+let ``honor ignore file when processing a folder`` () =
+    let fileName = "A"
+    let subFolder = System.Guid.NewGuid().ToString("N")
+
+    use ignoreFixture =
+        new TemporaryFileCodeSample(Source, fileName = fileName, subFolder = subFolder)
+
+    use inputFixture = new FantomasIgnoreFile("*.fsx")
+
+    let { Output = output } =
+        runFantomasTool (sprintf ".%c%s" Path.DirectorySeparatorChar subFolder)
+
+    output |> should not' (contain "ignored")

--- a/src/Fantomas.CoreGlobalTool/Program.fs
+++ b/src/Fantomas.CoreGlobalTool/Program.fs
@@ -108,10 +108,11 @@ let private hasByteOrderMark file =
 /// Format a source string using given config and write to a text writer
 let processSourceString isFsiFile s (tw: Choice<TextWriter, string>) config =
     let fileName =
-        if isFsiFile then
-            "/tmp.fsi"
-        else
-            "/tmp.fsx"
+        match tw, isFsiFile with
+        | Choice1Of2 _, isFsi ->
+            let extension = if isFsi then "fsi" else "fs"
+            sprintf "/tmp.%s" extension
+        | Choice2Of2 f, _ -> f
 
     let writeResult (formatted: string) =
         match tw with


### PR DESCRIPTION
When processing an entire folder with a command such as this:

```
fantomas --recurse .
```

the `.fantomasignore` file is effectively useless because the `processSourceString` function is generating a fixed file name of either `tmp.fs` or `tmp.fsi`. This file name is in turn used by a call to `IgnoreFile.isIgnoredFile` by `formatContentInternalAsync`, so a `.fantomasignore` file like this presents an issue:

```
*.fs

!/path/to/important.fs
```

Even when formatting `important.fs`, it will be "seen" as `tmp.fs` by `formatContentInternalAsync` and therefore ignored.

This PR is an intuitive attempt at fixing the issue with minimal change. That said, I do feel like the ignore check is possibly occurring in the wrong place and would be better hoisted to an outer layer of the system. In fact, `Program.fs` seemingly already does the appropriate ignore checks, so the secondary check within `formatContentInternalAsync` seems redundant in this context. However, I haven't enough experience with this system to know that one way or another without a lot of digging (open to feedback on that).