### PR TITLE
Start test names with lowercase where relevant

### DIFF
--- a/src/Fantomas.Tests/DynamicOperatorTests.fs
+++ b/src/Fantomas.Tests/DynamicOperatorTests.fs
@@ -5,7 +5,7 @@ open FsUnit
 open Fantomas.Tests.TestHelper
 
 [<Test>]
-let ``Keep () when dynamic operator is used`` () =
+let ``keep () when dynamic operator is used`` () =
     formatSourceString false "let memoEquals x = x?(k + 1)" config
     |> should
         equal
@@ -13,7 +13,7 @@ let ``Keep () when dynamic operator is used`` () =
 """
 
 [<Test>]
-let ``Remove () when dynamic operator is string`` () =
+let ``remove () when dynamic operator is string`` () =
     formatSourceString false "let memoEquals x = x?k" config
     |> should
         equal

--- a/src/Fantomas.Tests/FormatAstTests.fs
+++ b/src/Fantomas.Tests/FormatAstTests.fs
@@ -38,7 +38,7 @@ let formatAst code =
     parseAndFormat source None
 
 [<Test>]
-let ``Format the ast works correctly with no source code`` () = formatAst "()" |> should equal "()"
+let ``format the ast works correctly with no source code`` () = formatAst "()" |> should equal "()"
 
 [<Test>]
 let ``let in should not be used`` () =

--- a/src/Fantomas.Tests/InterfaceTests.fs
+++ b/src/Fantomas.Tests/InterfaceTests.fs
@@ -219,7 +219,7 @@ type MyLogInteface() =
 """
 
 [<Test>]
-let ``Interface with comment after equal`` () =
+let ``interface with comment after equal`` () =
     formatSourceString
         false
         """

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -169,7 +169,7 @@ let b = "meh"
 """
 
 [<Test>]
-let ``Raw method names with `/` `` () =
+let ``raw method names with `/` `` () =
     formatSourceString false "let ``/ operator combines paths`` = x" config
     |> should
         equal

--- a/src/Fantomas.Tests/ModuleTests.fs
+++ b/src/Fantomas.Tests/ModuleTests.fs
@@ -383,7 +383,7 @@ module private rec Test =
 """
 
 [<Test>]
-let ``Implicit module should not be added to code`` () =
+let ``implicit module should not be added to code`` () =
     let fileName = "60Seconds.fsx"
 
     let sourceCode =

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -1165,7 +1165,7 @@ let ``combining two empty list with at`` () =
 """
 
 [<Test>]
-let ``Appending two lists with at, 1719`` () =
+let ``appending two lists with at, 1719`` () =
     formatSourceString
         false
         """

--- a/src/Fantomas.Tests/SynConstTests.fs
+++ b/src/Fantomas.Tests/SynConstTests.fs
@@ -6,7 +6,7 @@ open Fantomas.Tests.TestHelper
 
 // https://fsharp.github.io/FSharp.Compiler.Service/reference/fsharp-compiler-ast-synconst.html
 [<Test>]
-let ``All known SynConst with trivia`` () =
+let ``all known SynConst with trivia`` () =
     formatSourceString
         false
         """

--- a/src/Fantomas.Tests/TokenParserBoolExprTests.fs
+++ b/src/Fantomas.Tests/TokenParserBoolExprTests.fs
@@ -15,7 +15,7 @@ let getDefineExprs source =
     |> getDefineExprs
 
 [<Test>]
-let ``Get define exprs from complex statements`` () =
+let ``get define exprs from complex statements`` () =
     let source =
         """
 #if !(INTERACTIVE || !(FOO && BAR) || BUZZ)
@@ -39,7 +39,7 @@ let x = 1
         ))
 
 [<Test>]
-let ``Simple compiler directive - else expr`` () =
+let ``simple compiler directive - else expr`` () =
     let source =
         """
 #if A
@@ -218,7 +218,7 @@ type BoolExprGenerator =
             member x.Shrinker t = Seq.empty }
 
 [<Test>]
-let ``Hash if expression parsing property`` () =
+let ``hash if expression parsing property`` () =
     Check.One(
         { verboseConf with
               Arbitrary = [ typeof<BoolExprGenerator> ] },
@@ -231,7 +231,7 @@ let ``Hash if expression parsing property`` () =
     )
 
 [<Test>]
-let ``Hash if expression normalize property`` () =
+let ``hash if expression normalize property`` () =
     Check.One(
         { verboseConf with
               Arbitrary = [ typeof<BoolExprGenerator> ] },
@@ -259,7 +259,7 @@ let isSatisfiable e =
     | _ -> false
 
 [<Test>]
-let ``Hash ifs optimize defines property`` () =
+let ``hash ifs optimize defines property`` () =
     Check.One(
         { verboseConf with
               Arbitrary = [ typeof<BoolExprGenerator> ] },
@@ -293,7 +293,7 @@ let ``Hash ifs optimize defines property`` () =
     )
 
 [<Test>]
-let ``Hash ifs source format property`` () =
+let ``hash ifs source format property`` () =
     Check.One(
         { verboseConf with
               MaxTest = 100

--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -30,7 +30,7 @@ let private getTriviaFromTokens = getTriviaFromTokens mkRange
 let private getTriviaNodesFromTokens = getTriviaNodesFromTokens mkRange
 
 [<Test>]
-let ``Simple compiler directive should be found`` () =
+let ``simple compiler directive should be found`` () =
     let source =
         """
 #if DEBUG
@@ -43,7 +43,7 @@ setupServer true
     getDefines source |> List.length |> should equal 1
 
 [<Test>]
-let ``Simple compiler directive should be DEBUG`` () =
+let ``simple compiler directive should be DEBUG`` () =
     let source =
         """
 #if DEBUG
@@ -58,7 +58,7 @@ setupServer true
     |> should equal "DEBUG"
 
 [<Test>]
-let ``Get defines from complex statements`` () =
+let ``get defines from complex statements`` () =
     let source =
         """
 #if INTERACTIVE || (FOO && BAR) || BUZZ
@@ -70,7 +70,7 @@ let x = 1
     == [ "INTERACTIVE"; "FOO"; "BAR"; "BUZZ" ]
 
 [<Test>]
-let ``Tokens from directive inside a directive are being added`` () =
+let ``tokens from directive inside a directive are being added`` () =
     let source =
         """#if FOO
   #if BAR
@@ -169,7 +169,7 @@ let ``simple line comment should be found in tokens`` () =
     | _ -> failwith "expected comment"
 
 [<Test>]
-let ``Single line block comment should be found in tokens`` () =
+let ``single line block comment should be found in tokens`` () =
     let source = "let foo (* not fonz *) = bar"
     let tokens = tokenize source
     let triviaNodes = getTriviaFromTokens tokens
@@ -239,7 +239,7 @@ printfn bar"""
     | _ -> failwith "expected newline"
 
 [<Test>]
-let ``Only empty spaces in line are also consider as Newline`` () =
+let ``only empty spaces in line are also consider as Newline`` () =
     let source =
         """printfn foo
 
@@ -254,7 +254,7 @@ printfn bar""" // difference is the 4 spaces on line 188
     | _ -> failwith "expected newline"
 
 [<Test>]
-let ``Comment after left brace of record`` () =
+let ``comment after left brace of record`` () =
     let source =
         """let a =
     { // foo

--- a/src/Fantomas.Tests/UnionTests.fs
+++ b/src/Fantomas.Tests/UnionTests.fs
@@ -213,7 +213,7 @@ let col3 =
 """
 
 [<Test>]
-let ``Single case DUs on same line`` () =
+let ``single case DUs on same line`` () =
     formatSourceString
         false
         """
@@ -229,7 +229,7 @@ type CustomerId = CustomerId of int
 """
 
 [<Test>]
-let ``Single case DU with private access modifier`` () =
+let ``single case DU with private access modifier`` () =
     formatSourceString
         false
         """
@@ -267,7 +267,7 @@ type CustomerId =
 """
 
 [<Test>]
-let ``Generic type style should be respected`` () =
+let ``generic type style should be respected`` () =
     formatSourceString
         false
         """
@@ -282,7 +282,7 @@ type 'a Foo = Foo of 'a
 """
 
 [<Test>]
-let ``Generic multiple param type style should be respected`` () =
+let ``generic multiple param type style should be respected`` () =
     formatSourceString
         false
         """

--- a/src/Fantomas.Tests/UtilsTests.fs
+++ b/src/Fantomas.Tests/UtilsTests.fs
@@ -15,7 +15,7 @@ let private mergeAndCompare a b expected =
     normalizedExpected == result
 
 [<Test>]
-let ``Merging of source code that starts with a hash`` () =
+let ``merging of source code that starts with a hash`` () =
     let a =
         """#if NOT_DEFINED
     printfn \"meh\"
@@ -41,7 +41,7 @@ let ``Merging of source code that starts with a hash`` () =
     |> mergeAndCompare a b
 
 [<Test>]
-let ``Merging of defines content work when source code starts with a newline`` () =
+let ``merging of defines content work when source code starts with a newline`` () =
     let a =
         """
 [<Literal>]
@@ -79,7 +79,7 @@ let private assemblyConfig() =
     |> mergeAndCompare a b
 
 [<Test>]
-let ``Only split on control structure keyword`` () =
+let ``only split on control structure keyword`` () =
     let a =
         """
 #if INTERACTIVE


### PR DESCRIPTION
As part of my [previous PR](https://github.com/fsprojects/fantomas/pull/1838), it came to light that there are tests with capitalized names where the guidelines state they should be lowercase. This PR fixes all instances, apart from those test names that start with acronyms or symbol names.