### PR TITLE
Refactor FSharpScriptTests to use helpers from FormatConfigEditorConfigurationFileTests.

### DIFF
--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -50,12 +50,12 @@
     <Compile Include="DynamicOperatorTests.fs" />
     <Compile Include="SynExprSetTests.fs" />
     <Compile Include="SynConstTests.fs" />
-    <Compile Include="FSharpScriptTests.fs" />
     <Compile Include="TupleTests.fs" />
     <Compile Include="ElmishTests.fs" />
     <Compile Include="LambdaTests.fs" />
     <Compile Include="IfThenElseTests.fs" />
     <Compile Include="FormatConfigEditorConfigurationFileTests.fs" />
+    <Compile Include="FSharpScriptTests.fs" />
     <Compile Include="CheckTests.fs" />
     <Compile Include="ContextTests.fs" />
     <Compile Include="SpaceBeforeSemicolonTests.fs" />


### PR DESCRIPTION
Making sure all IO related tests are executed in a newly created subfolder of the temp folder.
Some tests interfered with each other on random occasions due to file locks on the `<TempFolder>\.editorconfig` file.
