### PR TITLE
Use function keyword range from AST instead of from token.

### DIFF
--- a/src/Fantomas/AstTransformer.fs
+++ b/src/Fantomas/AstTransformer.fs
@@ -207,9 +207,10 @@ module private Ast =
                           yield! visitSynSimplePats args
                           yield! nodes ]
                         |> finalContinuation)
-            | SynExpr.MatchLambda (_, _, matchClauses, _, range) ->
+            | SynExpr.MatchLambda (_, keywordRange, matchClauses, _, range) ->
                 mkNode SynExpr_MatchLambda range
-                :: (List.collect visitSynMatchClause matchClauses)
+                :: mkNode SynExpr_MatchLambda_Function keywordRange
+                   :: (List.collect visitSynMatchClause matchClauses)
                 |> finalContinuation
             | SynExpr.Match (_, expr, clauses, range) ->
                 visit

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1544,9 +1544,9 @@ and genExpr astContext synExpr ctx =
                 +> sepArrow
                 +> autoIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext expr)
             )
-        | MatchLambda (cs, _) ->
-            !- "function "
-            +> leaveNodeTokenByName synExpr.Range FUNCTION
+        | MatchLambda (keywordRange, cs) ->
+            (!- "function "
+             |> genTriviaFor SynExpr_MatchLambda_Function keywordRange)
             +> sepNln
             +> genClauses astContext cs
         | Match (e, cs) ->
@@ -2599,9 +2599,9 @@ and genExprInMultilineInfixExpr astContext e =
                     ctx
     | Paren (_, InfixApp (_, _, DotGet _, _), _, _)
     | Paren (_, DotGetApp _, _, _) -> atCurrentColumnIndent (genExpr astContext e)
-    | MatchLambda (cs, _) ->
-        !- "function "
-        +> leaveNodeTokenByName e.Range FUNCTION
+    | MatchLambda (keywordRange, cs) ->
+        (!- "function "
+         |> genTriviaFor SynExpr_MatchLambda_Function keywordRange)
         +> indent
         +> sepNln
         +> genClauses astContext cs

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -847,7 +847,7 @@ let (|TernaryApp|_|) =
 
 let (|MatchLambda|_|) =
     function
-    | SynExpr.MatchLambda (isMember, _, pats, _, _) -> Some(pats, isMember)
+    | SynExpr.MatchLambda (_, keywordRange, pats, _, _) -> Some(keywordRange, pats)
     | _ -> None
 
 let (|JoinIn|_|) =

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -1194,7 +1194,6 @@ let private tokenNames =
       "WITH"
       "MEMBER"
       "AND_BANG"
-      "FUNCTION"
       "IN" ]
 
 let private tokenKinds = [ FSharpTokenCharKind.Operator ]
@@ -1221,7 +1220,6 @@ let internal getFsToken tokenName =
     | "ELSE" -> ELSE
     | "EQUALS" -> EQUALS
     | "FINALLY" -> FINALLY
-    | "FUNCTION" -> FUNCTION
     | "GREATER" -> GREATER
     | "IF" -> IF
     | "IN" -> IN

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -24,7 +24,6 @@ type FsTokenType =
     | ELSE
     | EQUALS
     | FINALLY
-    | FUNCTION
     | GREATER
     | IF
     | IN
@@ -135,6 +134,7 @@ type FsAstType =
     // | SynExpr_CompExpr use first nested SynExpr
     | SynExpr_Lambda
     | SynExpr_MatchLambda
+    | SynExpr_MatchLambda_Function
     | SynExpr_Match
     | SynExpr_Do
     | SynExpr_Assert


### PR DESCRIPTION
SynExpr.MatchLambda holds the range of the `function` keyword.
So there is no need to get this information from the F# tokens.