### PR TITLE
Style guide lambda

### DIFF
--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -735,7 +735,7 @@ module Foo =
                 | Ok (TestResult.Failure f) -> failwith ""
                 | Error e -> failwith ""
                 | _ -> () // hi!
-                ))
+            ))
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -6,7 +6,7 @@ open Fantomas.Tests.TestHelper
 
 // the current behavior results in a compile error since the |> is merged to the last line
 [<Test>]
-let ``no nln before lambda #503`` () =
+let ``no nln before lambda, #503`` () =
     formatSourceString
         false
         """
@@ -22,11 +22,10 @@ let a =
         """
 let a =
     b
-    |> List.exists
-        (fun p ->
-            p.a
-            && p.b
-               |> List.exists (fun o -> o.a = "lorem ipsum dolor sit amet"))
+    |> List.exists (fun p ->
+        p.a
+        && p.b
+           |> List.exists (fun o -> o.a = "lorem ipsum dolor sit amet"))
 """
 
 // compile error due to expression starting before the beginning of the function expression
@@ -127,21 +126,19 @@ module Caching =
             (address: PublicAddress)
             (currency: Currency)
             : NotFresh<decimal> =
-            lock
-                cacheFiles.CachedNetworkData
-                (fun _ ->
-                    match balance with
-                    | NotAvailable -> NotAvailable
-                    | Cached (balance, time) ->
-                        if compoundBalance < 0.0m then
-                            ReportProblem
-                                compoundBalance
-                                None
-                                currency
-                                address
-                                sessionCachedNetworkData
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then
+                        ReportProblem
+                            compoundBalance
+                            None
+                            currency
+                            address
+                            sessionCachedNetworkData
 
-                        ())
+                    ())
 
             ()
 """
@@ -174,17 +171,15 @@ module Caching =
             (address: PublicAddress)
             (currency: Currency)
             : NotFresh<decimal> =
-            lock
-                cacheFiles.CachedNetworkData
-                (fun _ ->
-                    match balance with
-                    | NotAvailable -> NotAvailable
-                    | Cached (balance, time) ->
-                        if compoundBalance < 0.0m then
-                            ReportProblem
-                                looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then
+                        ReportProblem
+                            looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
 
-                        ())
+                    ())
 
             ()
 """
@@ -214,16 +209,14 @@ let ``should not split parameters over multiple lines when they do not exceed pa
 module Caching =
     type MainCache() =
         member __.RetrieveLastCompoundBalance (address: PublicAddress) (currency: Currency) : NotFresh<decimal> =
-            lock
-                cacheFiles.CachedNetworkData
-                (fun _ ->
-                    match balance with
-                    | NotAvailable -> NotAvailable
-                    | Cached (balance, time) ->
-                        if compoundBalance < 0.0m then
-                            ReportProblem compoundBalance None currency address sessionCachedNetworkData
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then
+                        ReportProblem compoundBalance None currency address sessionCachedNetworkData
 
-                        ())
+                    ())
 
             ()
 """
@@ -253,16 +246,14 @@ let ``should not split single parameter over multiple lines when it does not exc
 module Caching =
     type MainCache() =
         member __.RetrieveLastCompoundBalance (address: PublicAddress) (currency: Currency) : NotFresh<decimal> =
-            lock
-                cacheFiles.CachedNetworkData
-                (fun _ ->
-                    match balance with
-                    | NotAvailable -> NotAvailable
-                    | Cached (balance, time) ->
-                        if compoundBalance < 0.0m then
-                            ReportProblem compoundBalance
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match balance with
+                | NotAvailable -> NotAvailable
+                | Cached (balance, time) ->
+                    if compoundBalance < 0.0m then
+                        ReportProblem compoundBalance
 
-                        ())
+                    ())
 
             ()
 """
@@ -737,16 +728,14 @@ module Foo =
 
     let blah =
         it
-        |> List.iter
-            (fun (_, output) ->
-                thing
-                |> Map.iter
-                    (fun key value ->
-                        match value with
-                        | Ok (TestResult.Failure f) -> failwith ""
-                        | Error e -> failwith ""
-                        | _ -> () // hi!
-                        ))
+        |> List.iter (fun (_, output) ->
+            thing
+            |> Map.iter (fun key value ->
+                match value with
+                | Ok (TestResult.Failure f) -> failwith ""
+                | Error e -> failwith ""
+                | _ -> () // hi!
+                ))
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -52,11 +52,9 @@ let print_30_permut () =
 
     /// declare and initialize
     let permutation: int array =
-        Array.init
-            n
-            (fun i ->
-                Console.Write(i + 1)
-                i)
+        Array.init n (fun i ->
+            Console.Write(i + 1)
+            i)
 
     permutation
 """
@@ -81,11 +79,9 @@ let print_30_permut () =
 
     /// declare and initialize
     let permutation: int array =
-        Array.init
-            n
-            (fun (i, j) ->
-                Console.Write(i + 1)
-                i)
+        Array.init n (fun (i, j) ->
+            Console.Write(i + 1)
+            i)
 
     permutation
 """

--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -671,11 +671,10 @@ type FunctionComponent =
     static member inline Lazy(f: 'Props -> ReactElement, fallback: ReactElement) : LazyFunctionComponent<'Props> =
 #if FABLE_COMPILER
         let elemType =
-            ReactBindings.React.``lazy``
-                (fun () ->
-                    // React.lazy requires a default export
-                    (importValueDynamic f)
-                        .``then`` (fun x -> createObj [ "default" ==> x ]))
+            ReactBindings.React.``lazy`` (fun () ->
+                // React.lazy requires a default export
+                (importValueDynamic f)
+                    .``then`` (fun x -> createObj [ "default" ==> x ]))
 
         fun props ->
             ReactElementType.create
@@ -892,11 +891,10 @@ type FunctionComponent =
     static member inline Lazy(f: 'Props -> ReactElement, fallback: ReactElement) : LazyFunctionComponent<'Props> =
 #if FABLE_COMPILER
         let elemType =
-            ReactBindings.React.``lazy``
-                (fun () ->
-                    // React.lazy requires a default export
-                    (importValueDynamic f)
-                        .``then`` (fun x -> createObj [ "default" ==> x ]))
+            ReactBindings.React.``lazy`` (fun () ->
+                // React.lazy requires a default export
+                (importValueDynamic f)
+                    .``then`` (fun x -> createObj [ "default" ==> x ]))
 
         fun props ->
             ReactElementType.create
@@ -1255,13 +1253,12 @@ let ``endif in lambda`` () =
     |> should
         equal
         """
-foo
-    (fun x ->
-        ()
+foo (fun x ->
+    ()
 #if DEF
-        ()
+    ()
 #endif
-        )
+)
 """
 
 [<Test>]
@@ -2216,41 +2213,40 @@ let getDefaultProxyFor =
         equal
         """
 let getDefaultProxyFor =
-    memoize
-        (fun (url: string) ->
-            let uri = Uri url
+    memoize (fun (url: string) ->
+        let uri = Uri url
 
-            let getDefault () =
+        let getDefault () =
 #if CUSTOM_WEBPROXY
-                let result =
-                    { new IWebProxy with
-                        member __.Credentials = null
+            let result =
+                { new IWebProxy with
+                    member __.Credentials = null
 
-                        member __.Credentials
-                            with set _value = ()
+                    member __.Credentials
+                        with set _value = ()
 
-                        member __.GetProxy _ = null
-                        member __.IsBypassed(_host: Uri) = true }
+                    member __.GetProxy _ = null
+                    member __.IsBypassed(_host: Uri) = true }
 #else
-                let result = WebRequest.GetSystemWebProxy()
+            let result = WebRequest.GetSystemWebProxy()
 #endif
 #if CUSTOM_WEBPROXY
-                let proxy = result
+            let proxy = result
 #else
-                let address = result.GetProxy uri
+            let address = result.GetProxy uri
 
-                if address = uri then
-                    null
-                else
-                    let proxy = WebProxy address
-                    proxy.BypassProxyOnLocal <- true
+            if address = uri then
+                null
+            else
+                let proxy = WebProxy address
+                proxy.BypassProxyOnLocal <- true
 #endif
-                proxy.Credentials <- CredentialCache.DefaultCredentials
-                proxy
+            proxy.Credentials <- CredentialCache.DefaultCredentials
+            proxy
 
-            match calcEnvProxies.Force().TryFind uri.Scheme with
-            | Some p -> if p.GetProxy uri <> uri then p else getDefault ()
-            | None -> getDefault ())
+        match calcEnvProxies.Force().TryFind uri.Scheme with
+        | Some p -> if p.GetProxy uri <> uri then p else getDefault ()
+        | None -> getDefault ())
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Tests/ComputationExpressionTests.fs
@@ -1774,14 +1774,7 @@ let sendPushNotifications =
                 with
                 | :? WebPushException as wpex ->
                     log.LogError(sprintf "Couldn't send notification to %s, %A" user.UserId wpex)
-
-                    do!
-                        filterSubscriptionsAndPersist
-                            managementToken
-                            user.UserId
-                            subscriptions
-                            s.Origin
-                            s.Endpoint
+                    do! filterSubscriptionsAndPersist managementToken user.UserId subscriptions s.Origin s.Endpoint
             }
             :> Task)
         |> Task.WhenAll)

--- a/src/Fantomas.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Tests/ComputationExpressionTests.fs
@@ -1668,23 +1668,21 @@ let initDb () =
 
     let createSql = readSqlFile "create"
 
-    using
-        (connection ())
-        (fun conn ->
-            task {
-                do! conn.OpenAsync()
-                let! _ = conn.ExecuteAsync(createSql)
+    using (connection ()) (fun conn ->
+        task {
+            do! conn.OpenAsync()
+            let! _ = conn.ExecuteAsync(createSql)
 #if DEBUG
-                let! hasClients = hasClients ()
+            let! hasClients = hasClients ()
 
-                if not (hasClients) then
-                    let seedSql = readSqlFile "seed"
-                    let! _ = conn.ExecuteAsync(seedSql)
-                    ()
-#else
+            if not (hasClients) then
+                let seedSql = readSqlFile "seed"
+                let! _ = conn.ExecuteAsync(seedSql)
                 ()
+#else
+            ()
 #endif
-            })
+        })
 """
 
 [<Test>]
@@ -1763,32 +1761,30 @@ let ``don't add extra newline before do bang`` () =
         """
 let sendPushNotifications =
     allSubscriptions
-    |> List.map
-        (fun (user, subscriptions) ->
-            subscriptions
-            |> List.filter (fun s -> s.Origin = origin)
-            |> List.map
-                (fun s ->
-                    task {
-                        try
-                            let ps =
-                                PushSubscription(s.Endpoint, s.P256DH, s.Auth)
+    |> List.map (fun (user, subscriptions) ->
+        subscriptions
+        |> List.filter (fun s -> s.Origin = origin)
+        |> List.map (fun s ->
+            task {
+                try
+                    let ps =
+                        PushSubscription(s.Endpoint, s.P256DH, s.Auth)
 
-                            do! webPushClient.SendNotificationAsync(ps, payload, vapidDetails)
-                        with
-                        | :? WebPushException as wpex ->
-                            log.LogError(sprintf "Couldn't send notification to %s, %A" user.UserId wpex)
+                    do! webPushClient.SendNotificationAsync(ps, payload, vapidDetails)
+                with
+                | :? WebPushException as wpex ->
+                    log.LogError(sprintf "Couldn't send notification to %s, %A" user.UserId wpex)
 
-                            do!
-                                filterSubscriptionsAndPersist
-                                    managementToken
-                                    user.UserId
-                                    subscriptions
-                                    s.Origin
-                                    s.Endpoint
-                    }
-                    :> Task)
-            |> Task.WhenAll)
+                    do!
+                        filterSubscriptionsAndPersist
+                            managementToken
+                            user.UserId
+                            subscriptions
+                            s.Origin
+                            s.Endpoint
+            }
+            :> Task)
+        |> Task.WhenAll)
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Tests/ControlStructureTests.fs
@@ -866,13 +866,12 @@ things
         equal
         """
 things
-|> Seq.map
-    (fun a ->
-        try
-            Some i
-        with
-        | :? Foo
-        | :? Bar as e when true -> None)
+|> Seq.map (fun a ->
+    try
+        Some i
+    with
+    | :? Foo
+    | :? Bar as e when true -> None)
 """
 
 [<Test>]
@@ -896,13 +895,12 @@ things
         equal
         """
 things
-|> Seq.map
-    (fun a ->
-        try
-            Some i
-        with
-        | Foo _
-        | Bar _ as e when true -> None)
+|> Seq.map (fun a ->
+    try
+        Some i
+    with
+    | Foo _
+    | Bar _ as e when true -> None)
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/DisableElmishTests.fs
+++ b/src/Fantomas.Tests/DisableElmishTests.fs
@@ -201,18 +201,17 @@ let counter = React.functionComponent(fun () ->
         equal
         """
 let counter =
-    React.functionComponent
-        (fun () ->
-            let (count, setCount) = React.useState (0)
+    React.functionComponent (fun () ->
+        let (count, setCount) = React.useState (0)
 
-            Html.div
-                [ Html.button
-                    [ prop.style [ style.marginRight 5 ]
-                      prop.onClick (fun _ -> setCount (count + 1))
-                      prop.text "Increment" ]
-                  Html.button
-                      [ prop.style [ style.marginLeft 5 ]
-                        prop.onClick (fun _ -> setCount (count - 1))
-                        prop.text "Decrement" ]
-                  Html.h1 count ])
+        Html.div
+            [ Html.button
+                [ prop.style [ style.marginRight 5 ]
+                  prop.onClick (fun _ -> setCount (count + 1))
+                  prop.text "Increment" ]
+              Html.button
+                  [ prop.style [ style.marginLeft 5 ]
+                    prop.onClick (fun _ -> setCount (count - 1))
+                    prop.text "Decrement" ]
+              Html.h1 count ])
 """

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -443,17 +443,15 @@ let getColl2 =
         .ToString()
 
 let getColl3 =
-    GetCollection
-        (fun _ parser ->
-            let x = 3
-            x)
+    GetCollection (fun _ parser ->
+        let x = 3
+        x)
         .Foo
 
 let getColl4 =
-    GetCollection
-        (fun parser ->
-            let x = 4
-            x)
+    GetCollection (fun parser ->
+        let x = 4
+        x)
         .Foo
 """
 

--- a/src/Fantomas.Tests/ElmishTests.fs
+++ b/src/Fantomas.Tests/ElmishTests.fs
@@ -495,10 +495,9 @@ let viewEntry todo dispatch =
                 valueOrDefault todo.description
                 Name "title"
                 Id("todo-" + (string todo.id))
-                OnInput
-                    (fun ev ->
-                        UpdateEntry(todo.id, !!ev.target?value)
-                        |> dispatch)
+                OnInput (fun ev ->
+                    UpdateEntry(todo.id, !!ev.target?value)
+                    |> dispatch)
                 OnBlur(fun _ -> EditingEntry(todo.id, false) |> dispatch)
                 onEnter (EditingEntry(todo.id, false)) dispatch ]
     ]
@@ -829,25 +828,24 @@ module App
 open Feliz
 
 let counter =
-    React.functionComponent
-        (fun () ->
-            let (count, setCount) = React.useState (0)
+    React.functionComponent (fun () ->
+        let (count, setCount) = React.useState (0)
 
-            Html.div [
-                Html.button [
-                    prop.style [ style.marginRight 5 ]
-                    prop.onClick (fun _ -> setCount (count + 1))
-                    prop.text "Increment"
-                ]
+        Html.div [
+            Html.button [
+                prop.style [ style.marginRight 5 ]
+                prop.onClick (fun _ -> setCount (count + 1))
+                prop.text "Increment"
+            ]
 
-                Html.button [
-                    prop.style [ style.marginLeft 5 ]
-                    prop.onClick (fun _ -> setCount (count - 1))
-                    prop.text "Decrement"
-                ]
+            Html.button [
+                prop.style [ style.marginLeft 5 ]
+                prop.onClick (fun _ -> setCount (count - 1))
+                prop.text "Decrement"
+            ]
 
-                Html.h1 count
-            ])
+            Html.h1 count
+        ])
 
 open Browser.Dom
 
@@ -935,16 +933,15 @@ let drawer =
                 prop.className classes.toolbar
             ]
             props.Items
-            |> List.map
-                (fun s ->
-                    Mui.listItem [
-                        listItem.button true
-                        match state with
-                        | Some t when t = s -> listItem.selected true
-                        | _ -> listItem.selected false
-                        prop.text s
-                        prop.onClick (fun _ -> s |> MenuItemClick |> dispatch)
-                    ])
+            |> List.map (fun s ->
+                Mui.listItem [
+                    listItem.button true
+                    match state with
+                    | Some t when t = s -> listItem.selected true
+                    | _ -> listItem.selected false
+                    prop.text s
+                    prop.onClick (fun _ -> s |> MenuItemClick |> dispatch)
+                ])
             |> Mui.list
         ]
     ]
@@ -1009,24 +1006,22 @@ let private useLocationDetail (auth0 : Auth0Hook) (roles : RolesHook) id =
                 && not (String.IsNullOrWhiteSpace(location.Creator))
             then
                 auth0.getAccessTokenSilently ()
-                |> Promise.bind
-                    (fun authToken ->
-                        let url =
-                            sprintf "%s/users/%s" Common.backendUrl (location.Creator)
+                |> Promise.bind (fun authToken ->
+                    let url =
+                        sprintf "%s/users/%s" Common.backendUrl (location.Creator)
 
-                        fetch
-                            url
-                            [ requestHeaders [ HttpRequestHeaders.ContentType "application/json"
-                                               Common.authHeader authToken
-                                               Common.subscriptionHeader ] ])
+                    fetch
+                        url
+                        [ requestHeaders [ HttpRequestHeaders.ContentType "application/json"
+                                           Common.authHeader authToken
+                                           Common.subscriptionHeader ] ])
                 |> Promise.bind (fun res -> res.text ())
-                |> Promise.iter
-                    (fun json ->
-                        let usersResult = Decode.fromString nameDecoder json
+                |> Promise.iter (fun json ->
+                    let usersResult = Decode.fromString nameDecoder json
 
-                        match usersResult with
-                        | Ok name -> setCreatorName (Some name)
-                        | Error err -> JS.console.log err)),
+                    match usersResult with
+                    | Ok name -> setCreatorName (Some name)
+                    | Error err -> JS.console.log err)),
         [| box roles.Roles
            box location.Creator |]
     )

--- a/src/Fantomas.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Tests/IfThenElseTests.fs
@@ -1437,29 +1437,28 @@ let ``nested if/then/else in short mode, 1243`` () =
         """
 let funcs =
     fse.MembersFunctionsAndValues
-    |> Seq.sortWith
-        (fun n1 n2 ->
-            let modifierScore (f: FSharpMemberOrFunctionOrValue) =
-                if f.IsProperty then
-                    if f.IsInstanceMember then
-                        if f.IsDispatchSlot then 9 else 1
-                    else
-                        8
-                elif f.IsMember then
-                    if f.IsInstanceMember then
-                        if f.IsDispatchSlot then 11 else 2
-                    else
-                        10
+    |> Seq.sortWith (fun n1 n2 ->
+        let modifierScore (f: FSharpMemberOrFunctionOrValue) =
+            if f.IsProperty then
+                if f.IsInstanceMember then
+                    if f.IsDispatchSlot then 9 else 1
                 else
-                    3
-
-            let n1Score = modifierScore n1
-            let n2Score = modifierScore n2
-
-            if n1Score = n2Score then
-                n1.DisplayName.CompareTo n2.DisplayName
+                    8
+            elif f.IsMember then
+                if f.IsInstanceMember then
+                    if f.IsDispatchSlot then 11 else 2
+                else
+                    10
             else
-                n1Score.CompareTo n2Score)
+                3
+
+        let n1Score = modifierScore n1
+        let n2Score = modifierScore n2
+
+        if n1Score = n2Score then
+            n1.DisplayName.CompareTo n2.DisplayName
+        else
+            n1Score.CompareTo n2Score)
 """
 
 [<Test>]
@@ -2054,8 +2053,8 @@ let lessonsForm (f: ValidatedForm<Request.CreateLessons>) dispatch =
                                                                              yield!
                                                                                  [ button.isLoading
                                                                                    prop.disabled true ]
-                                                                         prop.onClick
-                                                                             (fun _ -> CreateLessons |> dispatch) ] ] ] ]
+                                                                         prop.onClick (fun _ ->
+                                                                             CreateLessons |> dispatch) ] ] ] ]
 """
 
 [<Test>]
@@ -2265,8 +2264,7 @@ if result.LaunchSuccess && result.ExitCode = 0 then
 else if result.ExitCode = 1 then
     let stdout, stderr =
         output
-        |> List.map
-            (function
+        |> List.map (function
             | StdErr e -> Error e
             | StdOut l -> Ok l)
         |> Result.partition
@@ -2326,8 +2324,7 @@ if result.LaunchSuccess && result.ExitCode = 0 then
 elif result.ExitCode = 1 then
     let stdout, stderr =
         output
-        |> List.map
-            (function
+        |> List.map (function
             | StdErr e -> Error e
             | StdOut l -> Ok l)
         |> Result.partition

--- a/src/Fantomas.Tests/KeepIndentInBranchTests.fs
+++ b/src/Fantomas.Tests/KeepIndentInBranchTests.fs
@@ -602,14 +602,13 @@ let foo =
         """
 let foo =
     bar
-    |> List.filter
-        (fun i ->
-            if false then
-                false
-            else
+    |> List.filter (fun i ->
+        if false then
+            false
+        else
 
-            let m = quux
-            quux.Success && somethingElse)
+        let m = quux
+        quux.Success && somethingElse)
 """
 
 [<Test>]
@@ -635,14 +634,13 @@ let foo =
         """
 let foo =
     bar
-    |> List.filter
-        (fun { Index = i } ->
-            if false then
-                false
-            else
+    |> List.filter (fun { Index = i } ->
+        if false then
+            false
+        else
 
-            let m = quux
-            quux.Success && somethingElse)
+        let m = quux
+        quux.Success && somethingElse)
 """
 
 [<Test>]
@@ -679,29 +677,27 @@ lock lockingObj (fun () ->
     |> should
         equal
         """
-lock
-    lockingObj
-    (fun () ->
-        if not thing then printfn ""
+lock lockingObj (fun () ->
+    if not thing then printfn ""
 
-        match error with
-        | Some error ->
-            if foo then ()
-            thing ()
-            false
-        | None ->
+    match error with
+    | Some error ->
+        if foo then ()
+        thing ()
+        false
+    | None ->
 
-        match list1, list2, list3 with
-        | [], [], [] ->
-            stuff ()
-            true
-        | [], [], _ ->
-            moreStuff ()
-            true
-        | _ ->
+    match list1, list2, list3 with
+    | [], [], [] ->
+        stuff ()
+        true
+    | [], [], _ ->
+        moreStuff ()
+        true
+    | _ ->
 
-        doMoreThings ()
-        false)
+    doMoreThings ()
+    false)
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -143,15 +143,13 @@ Target.create "Clean" (fun _ ->
     |> should
         equal
         """
-Target.create
-    "Clean"
-    (fun _ ->
-        [ "bin"
-          "src/Fantomas/bin"
-          "src/Fantomas/obj"
-          "src/Fantomas.CoreGlobalTool/bin"
-          "src/Fantomas.CoreGlobalTool/obj" ]
-        |> List.iter Shell.cleanDir)
+Target.create "Clean" (fun _ ->
+    [ "bin"
+      "src/Fantomas/bin"
+      "src/Fantomas/obj"
+      "src/Fantomas.CoreGlobalTool/bin"
+      "src/Fantomas.CoreGlobalTool/obj" ]
+    |> List.iter Shell.cleanDir)
 """
 
 [<Test>]
@@ -955,4 +953,28 @@ module Foo =
         { Foo =
               blah
               |> Struct.map (fun _ (a, _, _) -> filterBackings a) }
+"""
+
+[<Test>]
+let ``multiline SynExpr.MatchLambda`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let bar =
+        []
+        |> List.choose
+            (function
+             | _ -> "")
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let bar =
+        []
+        |> List.choose (function
+            | _ -> "")
 """

--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -991,3 +991,56 @@ let foobar =
 
 let somethingElse = ()
 """
+
+[<Test>]
+let ``multiline non lambda argument`` () =
+    formatSourceString
+        false
+        """
+let argExpr =
+    col sepNln es (fun e ->
+        let genLambda
+            (pats: Context -> Context)
+            (bodyExpr: SynExpr)
+            (lpr: Range)
+            (rpr: Range option)
+            (arrowRange: Range)
+            (pr: Range)
+            : Context -> Context =
+            leadingExpressionIsMultiline (sepOpenTFor lpr -- "fun "
+                                            +> pats
+                                            +> genArrowWithTrivia
+                                                (genExprKeepIndentInBranch astContext bodyExpr)
+                                                arrowRange) (fun isMultiline ->
+                onlyIf isMultiline sepNln
+                +> sepCloseTFor rpr e.Range)
+            |> genTriviaFor SynExpr_Paren pr
+        ()
+    )
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let argExpr =
+    col sepNln es (fun e ->
+        let genLambda
+            (pats: Context -> Context)
+            (bodyExpr: SynExpr)
+            (lpr: Range)
+            (rpr: Range option)
+            (arrowRange: Range)
+            (pr: Range)
+            : Context -> Context =
+            leadingExpressionIsMultiline
+                (sepOpenTFor lpr -- "fun "
+                 +> pats
+                 +> genArrowWithTrivia (genExprKeepIndentInBranch astContext bodyExpr) arrowRange)
+                (fun isMultiline ->
+                    onlyIf isMultiline sepNln
+                    +> sepCloseTFor rpr e.Range)
+            |> genTriviaFor SynExpr_Paren pr
+
+        ())
+"""

--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -1044,3 +1044,28 @@ let argExpr =
 
         ())
 """
+
+[<Test>]
+let ``multiline non lambda argument, match lambda`` () =
+    formatSourceString
+        false
+        """
+leadingExpressionIsMultiline (sepOpenTFor lpr -- "fun "
+                                +> pats
+                                +> genArrowWithTrivia
+                                    (genExprKeepIndentInBranch astContext bodyExpr)
+                                    arrowRange) (function | Ok _ -> true | Error _ -> false)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+leadingExpressionIsMultiline
+    (sepOpenTFor lpr -- "fun "
+     +> pats
+     +> genArrowWithTrivia (genExprKeepIndentInBranch astContext bodyExpr) arrowRange)
+    (function
+     | Ok _ -> true
+     | Error _ -> false)
+"""

--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -18,10 +18,8 @@ let ``keep comment after arrow`` () =
     |> should
         equal
         """
-_Target
-  "FSharpTypesDotNet"
-  (fun _ -> // obsolete
-    ())
+_Target "FSharpTypesDotNet" (fun _ -> // obsolete
+  ())
 """
 
 let ``indent multiline lambda in parenthesis, 523`` () =
@@ -118,10 +116,9 @@ let a =
         """
 let a =
     b
-    |> List.exists
-        (fun p ->
-            x
-            && someVeryLongIdentifierrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrzzzz___________)
+    |> List.exists (fun p ->
+        x
+        && someVeryLongIdentifierrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrzzzz___________)
 """
 
 [<Test>]
@@ -168,12 +165,11 @@ List.filter (fun ({ ContentBefore = contentBefore }) ->
     |> should
         equal
         """
-List.filter
-    (fun ({ ContentBefore = contentBefore }) ->
-        // some comment
-        let a = 8
-        let b = List.length contentBefore
-        a + b)
+List.filter (fun ({ ContentBefore = contentBefore }) ->
+    // some comment
+    let a = 8
+    let b = List.length contentBefore
+    a + b)
 """
 
 [<Test>]
@@ -216,10 +212,9 @@ foo (fun a ->
     |> should
         equal
         """
-foo
-    (fun a ->
-        let b = 8
-        b)
+foo (fun a ->
+    let b = 8
+    b)
 """
 
 [<Test>]
@@ -237,10 +232,9 @@ let ``short ident in nested let binding`` () =
         equal
         """
 let a =
-  foo
-    (fun a ->
-      let b = 8
-      b)
+  foo (fun a ->
+    let b = 8
+    b)
 """
 
 [<Test>]
@@ -258,10 +252,9 @@ let ``longer ident in nested let binding`` () =
         equal
         """
 let a =
-    foobar
-        (fun a ->
-            let b = 8
-            b)
+    foobar (fun a ->
+        let b = 8
+        b)
 """
 
 [<Test>]
@@ -324,17 +317,16 @@ CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettin
     |> should
         equal
         """
-CloudStorageAccount.SetConfigurationSettingPublisher
-    (fun configName configSettingPublisher ->
-        let connectionString =
-            if hostedService then
-                RoleEnvironment.GetConfigurationSettingValue(configName)
-            else
-                ConfigurationManager.ConnectionStrings.[configName]
-                    .ConnectionString
+CloudStorageAccount.SetConfigurationSettingPublisher (fun configName configSettingPublisher ->
+    let connectionString =
+        if hostedService then
+            RoleEnvironment.GetConfigurationSettingValue(configName)
+        else
+            ConfigurationManager.ConnectionStrings.[configName]
+                .ConnectionString
 
-        configSettingPublisher.Invoke(connectionString)
-        |> ignore)
+    configSettingPublisher.Invoke(connectionString)
+    |> ignore)
 """
 
 [<Test>]
@@ -372,15 +364,14 @@ let genMemberFlagsForMemberBinding astContext (mf: MemberFlags) (rangeOfBindingA
             (fun (ctx: Context) -> // trying to get AST trivia
 
                 ctx.Trivia
-                |> List.tryFind
-                    (fun { Type = t; Range = r } -> // trying to get token trivia
+                |> List.tryFind (fun { Type = t; Range = r } -> // trying to get token trivia
 
-                        match t with
-                        | MainNode "SynMemberDefn.Member" -> RangeHelpers.``range contains`` r rangeOfBindingAndRhs
+                    match t with
+                    | MainNode "SynMemberDefn.Member" -> RangeHelpers.``range contains`` r rangeOfBindingAndRhs
 
-                        | Token { TokenInfo = { TokenName = "MEMBER" } } -> r.StartLine = rangeOfBindingAndRhs.StartLine
+                    | Token { TokenInfo = { TokenName = "MEMBER" } } -> r.StartLine = rangeOfBindingAndRhs.StartLine
 
-                        | _ -> false)
+                    | _ -> false)
                 |> Option.defaultValue (!- "override ")
                 <| ctx)
         <| ctx
@@ -400,10 +391,9 @@ List.tryFind (fun { Type = t; Range = r } -> // foo
     |> should
         equal
         """
-List.tryFind
-    (fun { Type = t; Range = r } -> // foo
-        let a = 8
-        a + 9)
+List.tryFind (fun { Type = t; Range = r } -> // foo
+    let a = 8
+    a + 9)
 """
 
 [<Test>]
@@ -491,15 +481,14 @@ let ``don't duplicate new line before LongIdentSet`` () =
         equal
         """
 let options =
-    jsOptions<Vis.Options>
-        (fun o ->
-            let layout =
-                match opts.Layout with
-                | Graph.Free -> createObj []
-                | Graph.HierarchicalLeftRight -> createObj [ "hierarchical" ==> hierOpts "LR" ]
-                | Graph.HierarchicalUpDown -> createObj [ "hierarchical" ==> hierOpts "UD" ]
+    jsOptions<Vis.Options> (fun o ->
+        let layout =
+            match opts.Layout with
+            | Graph.Free -> createObj []
+            | Graph.HierarchicalLeftRight -> createObj [ "hierarchical" ==> hierOpts "LR" ]
+            | Graph.HierarchicalUpDown -> createObj [ "hierarchical" ==> hierOpts "UD" ]
 
-            o.layout <- Some layout)
+        o.layout <- Some layout)
 """
 
 [<Test>]
@@ -559,12 +548,9 @@ Target.create "Install" (fun _ ->
     |> should
         equal
         """
-Target.create
-    "Install"
-    (fun _ ->
-        Yarn.install (fun o -> { o with WorkingDirectory = clientDir })
-        // Paket restore will already happen when the build.fsx dependencies are restored
-        )
+Target.create "Install" (fun _ -> Yarn.install (fun o -> { o with WorkingDirectory = clientDir })
+// Paket restore will already happen when the build.fsx dependencies are restored
+)
 """
 
 [<Test>]
@@ -582,12 +568,9 @@ Target.create "Install" (fun x ->
     |> should
         equal
         """
-Target.create
-    "Install"
-    (fun x ->
-        Yarn.install (fun o -> { o with WorkingDirectory = clientDir })
-        // Paket restore will already happen when the build.fsx dependencies are restored
-        )
+Target.create "Install" (fun x -> Yarn.install (fun o -> { o with WorkingDirectory = clientDir })
+// Paket restore will already happen when the build.fsx dependencies are restored
+)
 """
 
 [<Test>]
@@ -758,10 +741,9 @@ services.AddHttpsRedirection(Action<HttpsRedirectionOptions>(fun options ->
         equal
         """
 services.AddHttpsRedirection(
-    Action<HttpsRedirectionOptions>
-        (fun options ->
-            // meh
-            options.HttpsPort <- Nullable(7002))
+    Action<HttpsRedirectionOptions> (fun options ->
+        // meh
+        options.HttpsPort <- Nullable(7002))
 )
 |> ignore
 """
@@ -977,4 +959,35 @@ module Foo =
         []
         |> List.choose (function
             | _ -> "")
+"""
+
+[<Test>]
+let ``long function application ending in with lambda argument`` () =
+    formatSourceString
+        false
+        """
+let foobar =
+    someFunctionName aFirstLongArgument aSecondLongArgument aThirdLongArgument aFourthLongArgument (fun finallyThatLambdaArgument ->
+        aFirstLongArgument +  aSecondLongArgument -  aThirdLongArgument -  aFourthLongArgument + finallyThatLambdaArgument)
+
+let somethingElse = ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let foobar =
+    someFunctionName
+        aFirstLongArgument
+        aSecondLongArgument
+        aThirdLongArgument
+        aFourthLongArgument
+        (fun finallyThatLambdaArgument ->
+            aFirstLongArgument + aSecondLongArgument
+            - aThirdLongArgument
+            - aFourthLongArgument
+            + finallyThatLambdaArgument)
+
+let somethingElse = ()
 """

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -141,10 +141,9 @@ let x =
         """
 let x =
     [| 1 .. 2 |]
-    |> Array.mapi
-        (fun _ _ ->
-            let num = "".PadLeft(9)
-            num)
+    |> Array.mapi (fun _ _ ->
+        let num = "".PadLeft(9)
+        num)
 """
 
 [<Test>]
@@ -237,16 +236,14 @@ module Card =
     let card (props: CardProps seq) (elems: ReactElement seq) : ReactElement =
         let customProps =
             props
-            |> Seq.collect
-                (function
+            |> Seq.collect (function
                 | Custom props -> props
                 | _ -> List.empty)
             |> keyValueList CaseRules.LowerFirst
 
         let typeProps =
             props
-            |> Seq.choose
-                (function
+            |> Seq.choose (function
                 | Custom _ -> None
                 | prop -> Some prop)
             |> keyValueList CaseRules.LowerFirst
@@ -804,25 +801,22 @@ let useEntries month year =
     let sortMapAndToArray (input: Transaction seq) =
         input
         |> Seq.sortBy (fun ai -> ai.Created)
-        |> Seq.map
-            (fun ai ->
-                {| id = ai.Id
-                   name = ai.Name
-                   amount = ai.Amount |})
+        |> Seq.map (fun ai ->
+            {| id = ai.Id
+               name = ai.Name
+               amount = ai.Amount |})
         |> Seq.toArray
 
     let income =
         events
-        |> Seq.choose
-            (function
+        |> Seq.choose (function
             | Event.AddIncome (ai) when (filter ai.Created && isNotCancelled ai.Id) -> Some ai
             | _ -> None)
         |> sortMapAndToArray
 
     let expenses =
         events
-        |> Seq.choose
-            (function
+        |> Seq.choose (function
             | Event.AddExpense (ae) when (filter ae.Created && isNotCancelled ae.Id) -> Some ae
             | _ -> None)
         |> sortMapAndToArray
@@ -967,32 +961,29 @@ let useOverviewPerMonth () =
 
     let months =
         events
-        |> List.choose
-            (fun msg ->
-                match msg with
-                | Event.AddIncome ({ Created = created })
-                | Event.AddExpense ({ Created = created }) -> Some(created.Month, created.Year)
-                | _ -> None)
+        |> List.choose (fun msg ->
+            match msg with
+            | Event.AddIncome ({ Created = created })
+            | Event.AddExpense ({ Created = created }) -> Some(created.Month, created.Year)
+            | _ -> None)
         |> List.distinct
         |> List.sort
         |> List.groupBy snd
-        |> List.map
-            (fun (year, months) ->
-                let rows =
-                    months
-                    |> List.map
-                        (fun (m, y) ->
-                            {| name = getMonthName m
-                               month = m
-                               balance = Projections.calculateBalance m y events |})
-                    |> List.toArray
+        |> List.map (fun (year, months) ->
+            let rows =
+                months
+                |> List.map (fun (m, y) ->
+                    {| name = getMonthName m
+                       month = m
+                       balance = Projections.calculateBalance m y events |})
+                |> List.toArray
 
-                let balance =
-                    rows |> Array.sumBy (fun mth -> mth.balance)
+            let balance =
+                rows |> Array.sumBy (fun mth -> mth.balance)
 
-                {| name = year
-                   months = rows
-                   balance = balance |})
+            {| name = year
+               months = rows
+               balance = balance |})
         |> List.toArray
 
     months
@@ -1135,17 +1126,16 @@ let merge a b =
 There is a problem with merging all the code back togheter. Please raise an issue at https://github.com/fsprojects/fantomas/issues.\"\"\"
 
     List.zip aChunks bChunks
-    |> List.map
-        (fun (a', b') ->
-            let la = lengthWithoutSpaces a'
-            let lb = lengthWithoutSpaces b'
+    |> List.map (fun (a', b') ->
+        let la = lengthWithoutSpaces a'
+        let lb = lengthWithoutSpaces b'
 
-            if la <> lb then
-                if la > lb then a' else b'
-            else if String.length a' < String.length b' then
-                a'
-            else
-                b')
+        if la <> lb then
+            if la > lb then a' else b'
+        else if String.length a' < String.length b' then
+            a'
+        else
+            b')
 
     |> String.concat Environment.NewLine
 "
@@ -1253,10 +1243,9 @@ let x =
        | _ ->
            if tcref.IsILTycon then
                tcref.ILTyconRawMetadata.CustomAttrs.AsArray
-               |> Array.exists
-                   (fun attr ->
-                       attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>
-                           .FullName)
+               |> Array.exists (fun attr ->
+                   attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>
+                       .FullName)
            else
                false
 """
@@ -1316,10 +1305,9 @@ let x =
        | _ ->
            if tcref.IsILTycon then
                tcref.ILTyconRawMetadata.CustomAttrs.AsArray
-               |> Array.exists
-                   (fun attr ->
-                       attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>
-                           .FullName)
+               |> Array.exists (fun attr ->
+                   attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>
+                       .FullName)
            else
                false
 """

--- a/src/Fantomas.Tests/ListTests.fs
+++ b/src/Fantomas.Tests/ListTests.fs
@@ -2085,18 +2085,16 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
       |> Seq.tryFind (fun (k, _) -> k.ToUpperInvariant() = file.ToUpperInvariant())
 
     project
-    |> Option.map
-         (fun (_, option) ->
-           option,
-           [ yield!
-               options
-               |> Seq.map snd
-               |> Seq.distinctBy (fun o -> o.ProjectFileName)
-               |> Seq.filter
-                    (fun o ->
-                      o.ReferencedProjects
-                      |> Array.map (fun (_, v) -> Path.GetFullPath v.ProjectFileName)
-                      |> Array.contains option.ProjectFileName) ])
+    |> Option.map (fun (_, option) ->
+      option,
+      [ yield!
+          options
+          |> Seq.map snd
+          |> Seq.distinctBy (fun o -> o.ProjectFileName)
+          |> Seq.filter (fun o ->
+            o.ReferencedProjects
+            |> Array.map (fun (_, v) -> Path.GetFullPath v.ProjectFileName)
+            |> Array.contains option.ProjectFileName) ])
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -878,3 +878,29 @@ module Foo =
             )
         )
 """
+
+[<Test>]
+let ``match lambda with other arguments`` () =
+    formatSourceString
+        false
+        """
+let a =
+    Something.foo
+        bar
+        meh
+        (function | Ok x -> true | Error err -> false)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a =
+    Something.foo
+        bar
+        meh
+        (function
+        | Ok x -> true
+        | Error err -> false
+        )
+"""

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -345,12 +345,10 @@ let watchFiles =
         use _ =
             !!(serverPath </> "*.fs")
             ++ (serverPath </> "*.fsproj") // combines fs and fsproj
-            |> ChangeWatcher.run
-                (fun changes ->
-                    printfn "FILE CHANGE %A" changes
-                    // stopFunc()
-                    //Async.Start (startFunc())
-                    )
+            |> ChangeWatcher.run (fun changes -> printfn "FILE CHANGE %A" changes
+            // stopFunc()
+            //Async.Start (startFunc())
+            )
 
         ()
     }
@@ -386,12 +384,10 @@ let watchFiles =
 
         use _ =
             !!(serverPath </> "*.fs") ++ "*.fsproj" // combines fs and fsproj
-            |> ChangeWatcher.run
-                (fun changes ->
-                    printfn "FILE CHANGE %A" changes
-                    // stopFunc()
-                    //Async.Start (startFunc())
-                    )
+            |> ChangeWatcher.run (fun changes -> printfn "FILE CHANGE %A" changes
+            // stopFunc()
+            //Async.Start (startFunc())
+            )
 
         ()
     }
@@ -889,10 +885,9 @@ let shouldIncludeRelationship relName =
         """
 let shouldIncludeRelationship relName =
     req.Includes
-    |> List.exists
-        (fun path ->
-            path.Length >= currentIncludePath.Length + 1
-            && path |> List.take (currentIncludePath.Length + 1) = currentIncludePath @ [ relName ])
+    |> List.exists (fun path ->
+        path.Length >= currentIncludePath.Length + 1
+        && path |> List.take (currentIncludePath.Length + 1) = currentIncludePath @ [ relName ])
 """
 
 [<Test>]
@@ -959,8 +954,7 @@ let isCustomOperationProjectionParameter i (nm: Ident) =
     | Some argInfosForOverloads ->
         let vs =
             argInfosForOverloads
-            |> List.map
-                (function
+            |> List.map (function
                 | None -> false
                 | Some argInfos ->
                     i < argInfos.Length

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -899,17 +899,16 @@ List.tryFind(fun { Type = t; Range = r }  ->
     |> should
         equal
         """
-List.tryFind
-    (fun { Type = t; Range = r } ->
-        match t with
-        | MainNode SynMemberDefn_Member
-        | MainNode SynMemberSig_Member -> // trying to get AST trivia
-            RangeHelpers.``range contains`` r rangeOfBindingAndRhs
+List.tryFind (fun { Type = t; Range = r } ->
+    match t with
+    | MainNode SynMemberDefn_Member
+    | MainNode SynMemberSig_Member -> // trying to get AST trivia
+        RangeHelpers.``range contains`` r rangeOfBindingAndRhs
 
-        | Token (MEMBER, _) -> // trying to get token trivia
-            r.StartLine = rangeOfBindingAndRhs.StartLine
+    | Token (MEMBER, _) -> // trying to get token trivia
+        r.StartLine = rangeOfBindingAndRhs.StartLine
 
-        | _ -> false)
+    | _ -> false)
 """
 
 [<Test>]
@@ -935,8 +934,7 @@ Seq.takeWhile
     |> should
         equal
         """
-Seq.takeWhile
-    (function
+Seq.takeWhile (function
     | Write ""
     // for example:
     // type Foo =

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -427,11 +427,10 @@ let ``meaningful space should be preserved, 353`` () =
     |> should
         equal
         """
-to'.WithCommon
-    (fun o' ->
-        { dotnetOptions o' with
-              WorkingDirectory = Path.getFullName "RegressionTesting/issue29"
-              Verbosity = Some DotNet.Verbosity.Minimal })
+to'.WithCommon (fun o' ->
+    { dotnetOptions o' with
+          WorkingDirectory = Path.getFullName "RegressionTesting/issue29"
+          Verbosity = Some DotNet.Verbosity.Minimal })
     .WithParameters
 """
 

--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -285,11 +285,10 @@ let ``newline in string`` () =
     let triviaNodes =
         tokenize [] source
         |> getTriviaFromTokens
-        |> List.filter
-            (fun { Item = item } ->
-                match item with
-                | StringContent ("\"\n\"") -> true
-                | _ -> false)
+        |> List.filter (fun { Item = item } ->
+            match item with
+            | StringContent ("\"\n\"") -> true
+            | _ -> false)
 
     List.length triviaNodes == 1
 """

--- a/src/Fantomas.Tests/SynConstTests.fs
+++ b/src/Fantomas.Tests/SynConstTests.fs
@@ -648,25 +648,23 @@ a:hover {color: #ecc;}
 
     let kill =
         body.Elements()
-        |> Seq.map
-            (fun x ->
-                match x.Name.LocalName with
-                | \"h2\" ->
-                    keep
-                    := (List.tryFind (fun e -> e = String.Concat(x.Nodes())) eliminate)
-                       |> Option.isNone
-                | \"footer\" -> keep := true
-                | _ -> ()
+        |> Seq.map (fun x ->
+            match x.Name.LocalName with
+            | \"h2\" ->
+                keep
+                := (List.tryFind (fun e -> e = String.Concat(x.Nodes())) eliminate)
+                   |> Option.isNone
+            | \"footer\" -> keep := true
+            | _ -> ()
 
-                if !keep then None else Some x)
+            if !keep then None else Some x)
         |> Seq.toList
 
     kill
-    |> Seq.iter
-        (fun q ->
-            match q with
-            | Some x -> x.Remove()
-            | _ -> ())
+    |> Seq.iter (fun q ->
+        match q with
+        | Some x -> x.Remove()
+        | _ -> ())
 
     let packable =
         Path.getFullName \"./_Binaries/README.html\"

--- a/src/Fantomas.Tests/SynExprSetTests.fs
+++ b/src/Fantomas.Tests/SynExprSetTests.fs
@@ -97,34 +97,33 @@ let ``don't add additional new line after SynExpr.LongIndentSet, 1111`` () =
         equal
         """
 let options =
-    jsOptions<Vis.Options>
-        (fun o ->
-            o.autoResize <- Some true
-            o.edges <- Some(jsOptions<Vis.EdgeOptions> (fun e -> e.arrows <- Some <| U2.Case1 "to"))
+    jsOptions<Vis.Options> (fun o ->
+        o.autoResize <- Some true
+        o.edges <- Some(jsOptions<Vis.EdgeOptions> (fun e -> e.arrows <- Some <| U2.Case1 "to"))
 
-            o.interaction <-
-                Some(
-                    createObj [ "hover" ==> true
-                                "zoomView" ==> true
-                                "hoverConnectedEdges" ==> false ]
-                )
+        o.interaction <-
+            Some(
+                createObj [ "hover" ==> true
+                            "zoomView" ==> true
+                            "hoverConnectedEdges" ==> false ]
+            )
 
-            o.layout <- Some(createObj [ "randomSeed" ==> 0 ])
+        o.layout <- Some(createObj [ "randomSeed" ==> 0 ])
 
-            let hierOpts dir =
-                createObj [ "enabled" ==> true
-                            "levelSeparation" ==> 170
-                            "nodeSpacing" ==> 100
-                            "treeSpacing" ==> 100
-                            "direction" ==> dir ]
+        let hierOpts dir =
+            createObj [ "enabled" ==> true
+                        "levelSeparation" ==> 170
+                        "nodeSpacing" ==> 100
+                        "treeSpacing" ==> 100
+                        "direction" ==> dir ]
 
-            let layout =
-                match opts.Layout with
-                | Graph.Free -> createObj []
-                | Graph.HierarchicalLeftRight -> createObj [ "hierarchical" ==> hierOpts "LR" ]
-                | Graph.HierarchicalUpDown -> createObj [ "hierarchical" ==> hierOpts "UD" ]
+        let layout =
+            match opts.Layout with
+            | Graph.Free -> createObj []
+            | Graph.HierarchicalLeftRight -> createObj [ "hierarchical" ==> hierOpts "LR" ]
+            | Graph.HierarchicalUpDown -> createObj [ "hierarchical" ==> hierOpts "UD" ]
 
-            o.layout <- Some layout)
+        o.layout <- Some layout)
 """
 
 [<Test>]
@@ -214,16 +213,15 @@ let ``keep new line before SynExpr.DotIndexedSet, 1314`` () =
 
               let fs =
                 warnings
-                |> List.choose
-                     (fun w ->
-                       w.Warning.Details.SuggestedFix
-                       |> Option.bind
-                            (fun f ->
-                              let f = f.Force()
-                              let range = fcsRangeToLsp w.Warning.Details.Range
+                |> List.choose (fun w ->
+                   w.Warning.Details.SuggestedFix
+                   |> Option.bind
+                        (fun f ->
+                          let f = f.Force()
+                          let range = fcsRangeToLsp w.Warning.Details.Range
 
-                              f
-                              |> Option.map (fun f -> range, { Range = range; NewText = f.ToText })))
+                          f
+                          |> Option.map (fun f -> range, { Range = range; NewText = f.ToText })))
 
               lintFixes.[uri] <- fs
 """
@@ -241,16 +239,14 @@ match x with
 
     let fs =
         warnings
-        |> List.choose
-            (fun w ->
-                w.Warning.Details.SuggestedFix
-                |> Option.bind
-                    (fun f ->
-                        let f = f.Force()
-                        let range = fcsRangeToLsp w.Warning.Details.Range
+        |> List.choose (fun w ->
+            w.Warning.Details.SuggestedFix
+            |> Option.bind (fun f ->
+                let f = f.Force()
+                let range = fcsRangeToLsp w.Warning.Details.Range
 
-                        f
-                        |> Option.map (fun f -> range, { Range = range; NewText = f.ToText })))
+                f
+                |> Option.map (fun f -> range, { Range = range; NewText = f.ToText })))
 
     lintFixes.[uri] <- fs
 """

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -748,17 +748,16 @@ type BlobHelper(Account : CloudStorageAccount) =
         """
 type BlobHelper(Account: CloudStorageAccount) =
     new(configurationSettingName, hostedService) =
-        CloudStorageAccount.SetConfigurationSettingPublisher
-            (fun configName configSettingPublisher ->
-                let connectionString =
-                    if hostedService then
-                        RoleEnvironment.GetConfigurationSettingValue(configName)
-                    else
-                        ConfigurationManager.ConnectionStrings.[configName]
-                            .ConnectionString
+        CloudStorageAccount.SetConfigurationSettingPublisher (fun configName configSettingPublisher ->
+            let connectionString =
+                if hostedService then
+                    RoleEnvironment.GetConfigurationSettingValue(configName)
+                else
+                    ConfigurationManager.ConnectionStrings.[configName]
+                        .ConnectionString
 
-                configSettingPublisher.Invoke(connectionString)
-                |> ignore)
+            configSettingPublisher.Invoke(connectionString)
+            |> ignore)
 
         BlobHelper(CloudStorageAccount.FromConfigurationSetting(configurationSettingName))
 """
@@ -2228,17 +2227,16 @@ type Auth0User =
       AppMetaData : AppMetaData }
 
     static member Decoder : Decoder<Auth0User> =
-        Decode.object
-            (fun get ->
-                let userId =
-                    get.Required.Field "user_id" Decode.string
+        Decode.object (fun get ->
+            let userId =
+                get.Required.Field "user_id" Decode.string
 
-                let metaData =
-                    get.Optional.Field "app_metadata" AppMetaData.Decoder
-                    |> Option.defaultValue ({ PushNotificationSubscriptions = [] })
+            let metaData =
+                get.Optional.Field "app_metadata" AppMetaData.Decoder
+                |> Option.defaultValue ({ PushNotificationSubscriptions = [] })
 
-                { UserId = userId
-                  AppMetaData = metaData })
+            { UserId = userId
+              AppMetaData = metaData })
 """
 
 [<Test>]

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2042,9 +2042,9 @@ and genExpr astContext synExpr ctx =
                             +> tokN (arrowRange pats body) RARROW sepArrow
                             +> genExprKeepIndentInBranch astContext body
                             |> genTriviaFor SynExpr_Lambda lambdaRange
-                        | Choice2Of2 (cs, range) ->
-                            !- "function "
-                            +> leaveNodeTokenByName e.Range FUNCTION
+                        | Choice2Of2 (keywordRange, cs, range) ->
+                            (!- "function "
+                             |> genTriviaFor SynExpr_MatchLambda_Function keywordRange)
                             +> indent
                             +> sepNln
                             +> genClauses astContext cs
@@ -2071,12 +2071,12 @@ and genExpr astContext synExpr ctx =
                                 +> sepNln
                                 +> sepCloseTFor rpr pr
                                 |> genTriviaFor SynExpr_Paren pr
-                            | Choice2Of2 (cs, matchLambdaRange) ->
+                            | Choice2Of2 (keywordRange, cs, matchLambdaRange) ->
                                 sepOpenTFor lpr
                                 +> indent
                                 +> sepNln
-                                +> (!- "function "
-                                    +> leaveNodeTokenByName e.Range FUNCTION
+                                +> ((!- "function "
+                                     |> genTriviaFor SynExpr_MatchLambda_Function keywordRange)
                                     +> sepNln
                                     +> genClauses astContext cs
                                     |> genTriviaFor SynExpr_MatchLambda matchLambdaRange)
@@ -2091,10 +2091,10 @@ and genExpr astContext synExpr ctx =
                             +> (match lambda with
                                 | Choice1Of2 (pats, bodyExpr, range) ->
                                     genLambdaMultiLineClosingNewline astContext lpr pats bodyExpr range rpr pr
-                                | Choice2Of2 (cs, matchLambdaRange) ->
+                                | Choice2Of2 (keywordRange, cs, matchLambdaRange) ->
                                     (sepOpenTFor lpr
-                                     +> (!- "function "
-                                         +> leaveNodeTokenByName e.Range FUNCTION
+                                     +> ((!- "function "
+                                          |> genTriviaFor SynExpr_MatchLambda_Function keywordRange)
                                          +> sepNln
                                          +> genClauses astContext cs
                                          |> genTriviaFor SynExpr_MatchLambda matchLambdaRange)
@@ -2158,14 +2158,14 @@ and genExpr astContext synExpr ctx =
                         else
                             singleLine ctx
 
-                    | Choice2Of2 (cs, matchLambdaRange) ->
+                    | Choice2Of2 (keywordRange, cs, matchLambdaRange) ->
                         (genExpr astContext e
                          +> sepSpaceAfterFunctionName
                          +> col sepSpace es (genExpr astContext)
                          +> sepSpace
                          +> (sepOpenTFor lpr
-                             +> (!- "function "
-                                 +> leaveNodeTokenByName e.Range FUNCTION
+                             +> ((!- "function "
+                                  |> genTriviaFor SynExpr_MatchLambda_Function keywordRange)
                                  +> indent
                                  +> sepNln
                                  +> genClauses astContext cs

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2153,7 +2153,7 @@ and genExpr astContext synExpr ctx =
                                 |> genTriviaFor SynExpr_Paren pr)
                             +> unindent
 
-                        if exceedsWidth (ctx.Config.MaxLineLength - ctx.Column) singleLineTestExpr ctx then
+                        if futureNlnCheck singleLineTestExpr ctx then
                             multiLine ctx
                         else
                             singleLine ctx

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1275,6 +1275,21 @@ let (|Lambda|_|) =
         Some(pats, getLambdaBodyExpr body, range)
     | _ -> None
 
+let (|AppWithLambda|_|) (e: SynExpr) =
+    match e with
+    | App (e, es) ->
+        let rec visit (es: SynExpr list) (finalContinuation: SynExpr list -> SynExpr list) =
+            match es with
+            | [] -> None
+            | [ Paren (lpr, Lambda (pats, body, range), rpr, pr) ] ->
+                Some(e, finalContinuation [], lpr, (Choice1Of2(pats, body, range)), rpr, pr)
+            | [ Paren (lpr, (MatchLambda (pats) as me), rpr, pr) ] ->
+                Some(e, finalContinuation [], lpr, (Choice2Of2(pats, me.Range)), rpr, pr)
+            | h :: tail -> visit tail (fun leadingArguments -> h :: leadingArguments |> finalContinuation)
+
+        visit es id
+    | _ -> None
+
 // Type definitions
 
 let (|TDSREnum|TDSRUnion|TDSRRecord|TDSRNone|TDSRTypeAbbrev|TDSRException|) =

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1283,8 +1283,8 @@ let (|AppWithLambda|_|) (e: SynExpr) =
             | [] -> None
             | [ Paren (lpr, Lambda (pats, body, range), rpr, pr) ] ->
                 Some(e, finalContinuation [], lpr, (Choice1Of2(pats, body, range)), rpr, pr)
-            | [ Paren (lpr, (MatchLambda pats as me), rpr, pr) ] ->
-                Some(e, finalContinuation [], lpr, (Choice2Of2(pats, me.Range)), rpr, pr)
+            | [ Paren (lpr, (MatchLambda (keywordRange, pats) as me), rpr, pr) ] ->
+                Some(e, finalContinuation [], lpr, (Choice2Of2(keywordRange, pats, me.Range)), rpr, pr)
             | h :: tail ->
                 match h with
                 | Paren (_, Lambda _, _, _)

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1283,9 +1283,13 @@ let (|AppWithLambda|_|) (e: SynExpr) =
             | [] -> None
             | [ Paren (lpr, Lambda (pats, body, range), rpr, pr) ] ->
                 Some(e, finalContinuation [], lpr, (Choice1Of2(pats, body, range)), rpr, pr)
-            | [ Paren (lpr, (MatchLambda (pats) as me), rpr, pr) ] ->
+            | [ Paren (lpr, (MatchLambda pats as me), rpr, pr) ] ->
                 Some(e, finalContinuation [], lpr, (Choice2Of2(pats, me.Range)), rpr, pr)
-            | h :: tail -> visit tail (fun leadingArguments -> h :: leadingArguments |> finalContinuation)
+            | h :: tail ->
+                match h with
+                | Paren (_, Lambda _, _, _)
+                | Paren (_, MatchLambda _, _, _) -> None
+                | _ -> visit tail (fun leadingArguments -> h :: leadingArguments |> finalContinuation)
 
         visit es id
     | _ -> None


### PR DESCRIPTION
Hi @dsyme, in order to follow up on https://github.com/dotnet/docs/issues/25207, I've implemented the change in Fantomas to have a better idea of what the impact would be.

I'll explain the high-level gist of the implementation and perhaps you confirm if I understood the guidance correctly.
So, firstly I believe the guidance was focused around function applications where a lambda (be it SynExpr.Lambda or SynExpr.MatchLambda) is the last argument.

I've captured the nested SynExpr.App in an active pattern `(|AppWithLambda|_|)` and applied new logic to that exact shape of SynExpr. 
First, if the expression is short, we try to put it in one line.

```fsharp
functionName arg1 arg2 arg3 (fun arg4 -> bodyExpr)
```

If the `max_line_length` is crossed or the body is multiline, we apply alternative formatting.
There, we first check if the function name and arguments until the arrow of the lambda fit on the remainder of the line.

So imagine something like:
```fsharp
functionName arg1 arg2 arg3 (fun arg4 ->
```

If this all still fits on the current line, we write it as such and indent the body one level on the next line.
```fsharp
functionName arg1 arg2 arg3 (fun arg4 ->
    bodyExpr)
```

In case this doesn't fit all argument go on the next line with one level of indent:
```fsharp
functionName 
    arg1 
    arg2 
    arg3 
    (fun arg4 ->
        bodyExpr)
```
This makes a lot of sense to me, especially when `arg1, arg2 or arg3` are multiline themselves.

In case the last argument is `SynExpr.MatchLambda` we try the same thing:
```fsharp
functionName arg1 arg2 arg3 (function
    | Choice1of2 x
    | Choice2of2 y)
```

Or if the max_line_length is crossed:
```fsharp
functionName 
    arg1 
    arg2 
    arg3 
    (function
     | Choice1of2 x
     | Choice2of2 y)
```

Notice there is no extra indent on the line after the `function` keyword, the clauses do align with the `function` keyword.

If you look at the implementation, you will see the `MultiLineLambdaClosingNewline` setting.
This is to cope with the [GR style guide](https://github.com/G-Research/fsharp-formatting-conventions#formatting-function-parameter-application), as they do things differently with lambdas.
So, don't mind that 😊.

Let me know what you think, it would be a great help if you could take a look at the expected results in the unit tests.
Thanks in advance!

 
