### PR TITLE
Retain significant whitespace in nested, indented #if directives

### DIFF
--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -2639,3 +2639,24 @@ let isUnix =
     |> fun p -> (p = 4) || (p = 6) || (p = 128)
 #endif
 """
+
+[<Test>]
+let ``indented #if directive inside another non-indented #if directive should format correctly, 1866`` () =
+    formatSourceString
+        false
+        """
+#if FOO
+    #if BAR
+    #endif
+#endif
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#if FOO
+#if BAR
+#endif
+#endif
+"""

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -157,8 +157,14 @@ let rec private getTokenizedHashes (sourceCode: string) : Token list =
                 (fun t ->
                     let info =
                         { t.TokenInfo with
-                              LeftColumn = t.TokenInfo.LeftColumn + hashContentLength
-                              RightColumn = t.TokenInfo.RightColumn + hashContentLength }
+                              LeftColumn =
+                                  t.TokenInfo.LeftColumn
+                                  + hashContentLength
+                                  + offset
+                              RightColumn =
+                                  t.TokenInfo.RightColumn
+                                  + hashContentLength
+                                  + offset }
 
                     { t with
                           LineNumber = lineNumber


### PR DESCRIPTION
This one was tricky to debug, at least for me. The root of the problem was that `getTokenizedHashes`' inner `processLine` function was rewriting some tokens with an offset, but not adjusting others. This meant that the significant whitespace ended up _before_ the `#if` rather than after it where it belonged.

Fixes #1866