### PR TITLE
Update max_infix_operator_expression documentation

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -487,8 +487,7 @@ else
 ### fsharp_max_infix_operator_expression
 
 Control the maximum length for which infix expression can be on one line.
-Default = 50. Requires `fsharp_infix_operator_expression_multiline_formatter` to
-be `character_width` to take effect.
+Default = 50.
 
 `defaultConfig`
 


### PR DESCRIPTION
Remove mention of fsharp_infix_operator_expression_multiline_formatter as it was removed (#1232)

Resolves #1884 