### PR TITLE
Add warning about ASTContext and section on Rider.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,6 +234,16 @@ Often this kind of bug is because Fantomas has added a newline due to some forma
 
 Use a helper function like `sepNlnConsideringTriviaContentBeforeForMainNode` instead of `sepNln` in `CodePrinter.fs` to solve this.
 
+### ASTContext
+
+In [CodePrinter.fs](https://github.com/fsprojects/fantomas/blob/master/src/Fantomas/CodePrinter.fs) the ASTContext record is used to indicate context aware information. This usually is an escape hatch and should be avoided at all times.
+The key issue is that flags of the ASTContext are usually not cleaned up after they served their purpose.
+Leading to very strange situations and unexpected behavior.
+
+## Rider
+
+The core contributors of this project are using JetBrains Rider. Running and debugging unit tests works out of the box and no additional plugins are needed.
+
 ## Ionide
 
 When you want to contribute to this project in VSCode with Ionide, there is a trick you need to know to debug Unit tests.

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -15,6 +15,7 @@ open Fantomas.TriviaContext
 open Fantomas.AstExtensions
 
 /// This type consists of contextual information which is important for formatting
+/// Please avoid using this record as it can be the cause of unexpected behavior when used incorrectly
 type ASTContext =
     { /// Current node is the first child of its parent
       IsFirstChild: bool


### PR DESCRIPTION
Added a small section about ASTContext, it should be avoided and I want to raise some awareness for newcomers.
Also threw in a few lines that Rider can be used, as we have a section on Ionide it could elude that you need to use VSCode which is not the case. //cc @auduchinok 