### PR TITLE
Display the fragment count of each defines combination when they differ in length. 

### DIFF
--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -111,7 +111,12 @@ let formatSourceStringWithDefines defines (s: string) config =
         |> Async.RunSynchronously
 
     // merge with itself to make #if go on beginning of line
-    String.merge config.EndOfLine.NewLineString result result
+    let _, fragments =
+        String.splitInFragments config.EndOfLine.NewLineString [ (defines, result) ]
+        |> List.head
+
+    String.merge fragments fragments
+    |> String.concat config.EndOfLine.NewLineString
     |> String.normalizeNewLine
 
 let formatSelectionOnly isFsiFile r (s: string) config =

--- a/src/Fantomas.Tests/UtilsTests.fs
+++ b/src/Fantomas.Tests/UtilsTests.fs
@@ -8,7 +8,13 @@ open FsCheck
 
 let private mergeAndCompare a b expected =
     let result =
-        String.merge Environment.NewLine a b
+        let getFragments code =
+            String.splitInFragments config.EndOfLine.NewLineString [ code ]
+            |> List.head
+            |> snd
+
+        String.merge (getFragments a) (getFragments b)
+        |> String.concat Environment.NewLine
         |> String.normalizeNewLine
 
     let normalizedExpected = String.normalizeNewLine expected
@@ -38,7 +44,7 @@ let ``merging of source code that starts with a hash`` () =
     printfn \"foo\"
 #endif
 """
-    |> mergeAndCompare a b
+    |> mergeAndCompare ([], a) ([ "NOT_DEFINED" ], b)
 
 [<Test>]
 let ``merging of defines content work when source code starts with a newline`` () =
@@ -76,7 +82,7 @@ let private assemblyConfig() =
 #endif
     x
 """
-    |> mergeAndCompare a b
+    |> mergeAndCompare ([], a) ([ "TRACE" ], b)
 
 [<Test>]
 let ``only split on control structure keyword`` () =
@@ -112,7 +118,7 @@ SetupTesting.generateSetupScript __SOURCE_DIRECTORY__
 #load "__setup__.fsx"
 #endif
 """
-    |> mergeAndCompare a b
+    |> mergeAndCompare ([], a) ([ "INTERACTIVE" ], b)
 
 [<Test>]
 let ``when input is empty`` () =

--- a/src/Fantomas/Utils.fs
+++ b/src/Fantomas/Utils.fs
@@ -59,17 +59,14 @@ module String =
         loop hashLineIndexesWithStart id
         |> List.map (String.concat newline)
 
-    let merge (newline: string) (a: string) (b: string) : string =
-        let aChunks = splitWhenHash newline a
-        let bChunks = splitWhenHash newline b
+    let splitInFragments (newline: string) (items: (string list * string) list) : (string list * string list) list =
+        List.map
+            (fun (defines, code) ->
+                let fragments = splitWhenHash newline code
+                defines, fragments)
+            items
 
-        if List.length aChunks <> List.length bChunks then
-            Dbg.print (aChunks, bChunks)
-
-            failwithf
-                """Fantomas is trying to format the input multiple times due to the detect of multiple defines.
-There is a problem with merging all the code back together. Please raise an issue at https://github.com/fsprojects/fantomas/issues."""
-
+    let merge (aChunks: string list) (bChunks: string list) : string list =
         List.zip aChunks bChunks
         |> List.map
             (fun (a', b') ->
@@ -83,7 +80,7 @@ There is a problem with merging all the code back together. Please raise an issu
                 else
                     b')
 
-        |> String.concat newline
+
 
     let empty = String.Empty
 


### PR DESCRIPTION
Fixes #1904.

![image](https://user-images.githubusercontent.com/2621499/136522192-139cbd8c-9005-4d20-8c6d-cfa5f1a0aec3.png)
