### PR TITLE
Don't add a newline if there are no additional arguments before lambda.

### DIFF
--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -1069,3 +1069,26 @@ leadingExpressionIsMultiline
      | Ok _ -> true
      | Error _ -> false)
 """
+
+[<Test>]
+let ``multiline lambda argument, 1922`` () =
+    formatSourceString
+        false
+        """
+let g =
+    Array.groupBy
+        (fun { partNumber = p
+               revisionNumber = r
+               processName = pn } -> p, r, pn)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let g =
+    Array.groupBy
+        (fun { partNumber = p
+               revisionNumber = r
+               processName = pn } -> p, r, pn)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2164,7 +2164,7 @@ and genExpr astContext synExpr ctx =
                             +> indent
                             +> sepNln
                             +> col sepNln es (genExpr astContext)
-                            +> sepNln
+                            +> onlyIfNot (List.isEmpty es) sepNln
                             +> (sepOpenTFor lpr
                                 +> (!- "fun "
                                     +> col sepSpace pats (genPat astContext)


### PR DESCRIPTION
Fixes #1922.