### PR TITLE
Fix #1937

### DIFF
--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -1221,9 +1221,23 @@ module Foo =
 """
 
 [<Test>]
-
 let ``qualified name to active pattern, 1937`` () =
-    shouldNotChangeAfterFormat
+    formatSourceString
+        false
+        """
+StringPosition.(|TrimStart|)
+(|TrimStart|)
+StringPosition.(|TrimStart|_|)
+(|TrimStart|_|)
+StringPosition.(|A|B|)
+(|A|B|)
+
+let f (|A|B|) = (|A|B|)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
         """
 StringPosition.(|TrimStart|)
 (|TrimStart|)

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -1219,6 +1219,7 @@ module Foo =
             | true -> id
             | false -> id)
 """
+
 [<Test>]
 
 let ``qualified name to active pattern, 1937`` () =
@@ -1233,4 +1234,3 @@ StringPosition.(|A|B|)
 
 let f (|A|B|) = (|A|B|)
 """
-

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -1219,3 +1219,18 @@ module Foo =
             | true -> id
             | false -> id)
 """
+[<Test>]
+
+let ``qualified name to active pattern, 1937`` () =
+    shouldNotChangeAfterFormat
+        """
+StringPosition.(|TrimStart|)
+(|TrimStart|)
+StringPosition.(|TrimStart|_|)
+(|TrimStart|_|)
+StringPosition.(|A|B|)
+(|A|B|)
+
+let f (|A|B|) = (|A|B|)
+"""
+

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -36,7 +36,7 @@ let (|Ident|) (s: Ident) =
     | "not" -> "not"
     | "params" -> "``params``"
     | "parallel" -> "``parallel``"
-    | _ -> 
+    | _ ->
         if IsActivePatternName ident then
             sprintf "(%s)" (DecompileOpName ident)
         else

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -36,7 +36,11 @@ let (|Ident|) (s: Ident) =
     | "not" -> "not"
     | "params" -> "``params``"
     | "parallel" -> "``parallel``"
-    | _ -> PrettyNaming.AddBackticksToIdentifierIfNeeded ident
+    | _ -> 
+        if IsActivePatternName ident then
+            sprintf "(%s)" (DecompileOpName ident)
+        else
+            PrettyNaming.AddBackticksToIdentifierIfNeeded ident
 
 let (|LongIdent|) (li: LongIdent) =
     li


### PR DESCRIPTION
Fixes #1937.  

Ideally the logic of `PrettyNaming.ConvertValNameToDisplayName/ConvertNameToDisplayName` should be made available from FCS - that is the core implementation of naming logic taking internal identifiers to display identifiers.

The fix goes to 4.6 branch as I wanted to write it in code where `PrettyNaming.AddBackticksToIdentifierIfNeeded` is used