### PR TITLE
Correct indentation after multi-line base constructor

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -927,3 +927,44 @@ type public DerivedExceptionWithLongNaaaaaaaaameException
             originalResponse
         )
 """
+
+[<Test>]
+let ``correct indentation when calling base constructor, 1942`` () =
+    formatSourceString
+        false
+        """
+type public DerivedExceptionWithLongNaaaaaaaaameException (message: string,
+                                                           code: int,
+                                                           originalRequest: string,
+                                                           originalResponse: string) =
+    inherit BaseExceptionWithLongNaaaameException(message, code, originalRequest, originalResponse)
+
+    let myMethod () =
+        ()
+
+    override this.SomeMethod () =
+        ()"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+type public DerivedExceptionWithLongNaaaaaaaaameException
+    (
+        message: string,
+        code: int,
+        originalRequest: string,
+        originalResponse: string
+    ) =
+    inherit BaseExceptionWithLongNaaaameException
+        (
+            message,
+            code,
+            originalRequest,
+            originalResponse
+        )
+
+    let myMethod () = ()
+
+    override this.SomeMethod() = ()
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4610,7 +4610,6 @@ and genMemberDefn astContext node =
                     +> sepNln
                     +> unindent
                     +> sepCloseTFor rpr pr
-                    +> unindent
                     |> genTriviaFor SynExpr_Paren pr
                 | _ -> genExpr astContext e
 


### PR DESCRIPTION
This is to fix #1942 