### PR TITLE
Fix power operator in code quotation pattern match

### DIFF
--- a/src/Fantomas.Tests/ActivePatternTests.fs
+++ b/src/Fantomas.Tests/ActivePatternTests.fs
@@ -84,3 +84,18 @@ let (|ParseRegex|_|) regex str =
     else
         None
 """
+
+
+[<Test>]
+let ``ensure spacing around power operator, 1945`` () =
+    formatSourceString
+        false
+        """match expr with
+| SpecificCall <@@ ( ** ) @@> (_, _, [ s1; s2 ]) -> ()"""
+        config
+    |> should
+        equal
+        """match expr with
+| SpecificCall <@@ ( ** ) @@> (_, _, [ s1; s2 ]) -> ()
+"""
+

--- a/src/Fantomas.Tests/ActivePatternTests.fs
+++ b/src/Fantomas.Tests/ActivePatternTests.fs
@@ -85,12 +85,12 @@ let (|ParseRegex|_|) regex str =
         None
 """
 
-
 [<Test>]
 let ``ensure spacing around power operator, 1945`` () =
     formatSourceString
         false
-        """match expr with
+        """
+match expr with
 | SpecificCall <@@ ( ** ) @@> (_, _, [ s1; s2 ]) -> ()"""
         config
     |> prepend newline

--- a/src/Fantomas.Tests/ActivePatternTests.fs
+++ b/src/Fantomas.Tests/ActivePatternTests.fs
@@ -93,9 +93,10 @@ let ``ensure spacing around power operator, 1945`` () =
         """match expr with
 | SpecificCall <@@ ( ** ) @@> (_, _, [ s1; s2 ]) -> ()"""
         config
+    |> prepend newline
     |> should
         equal
-        """match expr with
+        """
+match expr with
 | SpecificCall <@@ ( ** ) @@> (_, _, [ s1; s2 ]) -> ()
 """
-

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -167,7 +167,11 @@ let (|OpNameFull|) (x: Identifier) =
           || IsPrefixOperator s
           || IsTernaryOperator s
           || s = "op_Dynamic" then
-         s'
+         /// Use two spaces for symmetry
+         if String.startsWithOrdinal "*" s' && s' <> "*" then
+             sprintf " %s " s'
+         else
+             s'
      else
          match x with
          | Id (Ident s)


### PR DESCRIPTION
This fixes the issue with power operators in #1945

There is a bit of concerning duplication and divergence between OpName, OpNameFullInPattern, and OpNameFull before and after my change:

https://github.com/fsprojects/fantomas/blob/10f599c2d2cdeddcfb2c00b915aaf45b3a5f9be1/src/Fantomas/SourceParser.fs#L120-L175

that might need a bit of restructuring to avoid this popping up again in a slightly different place but this PR helps move the right way.