### PR TITLE
Config documentation

### DIFF
--- a/src/Fantomas/FormatConfig.fs
+++ b/src/Fantomas/FormatConfig.fs
@@ -1,6 +1,7 @@
 module Fantomas.FormatConfig
 
 open System
+open System.ComponentModel
 
 let satSolveMaxStepsMaxSteps = 100
 
@@ -56,47 +57,164 @@ type EndOfLineStyle =
 
 // NOTE: try to keep this list below in sync with the docs (e.g. Documentation.md)
 type FormatConfig =
-    { /// Number of spaces for each indentation
+    { [<Category("Indentation")>]
+      [<DisplayName("Indent spaces")>]
+      [<Description("Number of spaces to use for indentation")>]
       IndentSize: Num
-      /// The column where we break to new lines
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Maximum line length")>]
+      [<Description("The column where we break to new lines")>]
       MaxLineLength: Num
+
+      [<Category("Convention")>]
+      [<DisplayName("Semicolon at end-of-line")>]
+      [<Description("Forces a semicolon to be added to the end of a line")>]
       SemicolonAtEndOfLine: bool
+
+      [<Category("Spacing")>]
+      [<DisplayName("Before parameter")>]
       SpaceBeforeParameter: bool
+
+      [<Category("Spacing")>]
+      [<DisplayName("Before lowercase invocation")>]
       SpaceBeforeLowercaseInvocation: bool
+
+      [<Category("Spacing")>]
+      [<DisplayName("Before uppercase invocation")>]
       SpaceBeforeUppercaseInvocation: bool
+
+      [<Category("Spacing")>]
+      [<DisplayName("Before class constructor")>]
       SpaceBeforeClassConstructor: bool
+
+      [<Category("Spacing")>]
+      [<DisplayName("Before member")>]
       SpaceBeforeMember: bool
+
+      [<Category("Spacing")>]
+      [<DisplayName("Before colon")>]
       SpaceBeforeColon: bool
+
+      [<Category("Spacing")>]
+      [<DisplayName("After comma")>]
       SpaceAfterComma: bool
+
+      [<Category("Spacing")>]
+      [<DisplayName("Before semicolon")>]
       SpaceBeforeSemicolon: bool
+
+      [<Category("Spacing")>]
+      [<DisplayName("After semicolon")>]
       SpaceAfterSemicolon: bool
+
+      [<Category("Indentation")>]
+      [<DisplayName("Indent try-with")>]
       IndentOnTryWith: bool
+
+      [<Category("Spacing")>]
+      [<DisplayName("Around delimiter")>]
       SpaceAroundDelimiter: bool
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Maximum if-then-else width")>]
       MaxIfThenElseShortWidth: Num
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Maximum infix-operator expression")>]
       MaxInfixOperatorExpression: Num
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Maximum record width")>]
       MaxRecordWidth: Num
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Maximum items in a record")>]
       MaxRecordNumberOfItems: Num
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Multi-line formatter for records")>]
       RecordMultilineFormatter: MultilineFormatterType
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Maximum array or list width")>]
       MaxArrayOrListWidth: Num
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Maximum number of items in array/list")>]
       MaxArrayOrListNumberOfItems: Num
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Multi-line formatter for array/list")>]
       ArrayOrListMultilineFormatter: MultilineFormatterType
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Maximum value-binding width")>]
       MaxValueBindingWidth: Num
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Maximum function-binding width")>]
       MaxFunctionBindingWidth: Num
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Maximum dot get expression width")>]
       MaxDotGetExpressionWidth: Num
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Multiline-block brackets on same column")>]
       MultilineBlockBracketsOnSameColumn: bool
+
+      [<Category("Convention")>]
+      [<DisplayName("Newline between type definition and members")>]
       NewlineBetweenTypeDefinitionAndMembers: bool
+
+      [<Category("Convention")>]
+      [<DisplayName("Keep If-Then in same line")>]
       KeepIfThenInSameLine: bool
+
+      [<Category("Elmish")>]
+      [<DisplayName("Maximum width for elmish syntax")>]
       MaxElmishWidth: Num
+
+      [<Category("Convention")>]
+      [<DisplayName("Single-argument web mode")>]
       SingleArgumentWebMode: bool
+
+      [<Category("Convention")>]
+      [<DisplayName("Align function signature to indentation")>]
       AlignFunctionSignatureToIndentation: bool
+
+      [<Category("Convention")>]
+      [<DisplayName("Alternative long member definitions")>]
       AlternativeLongMemberDefinitions: bool
+
+      [<Category("Boundaries")>]
+      [<DisplayName("MultiLine-lambda has closing newline")>]
       MultiLineLambdaClosingNewline: bool
+
+      [<Category("Elmish")>]
+      [<DisplayName("Disable support for elmish syntax")>]
       DisableElmishSyntax: bool
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Line-ending style")>]
       EndOfLine: EndOfLineStyle
+
+      [<Category("Indentation")>]
+      [<DisplayName("Keep indent in branch")>]
       KeepIndentInBranch: bool
+
+      [<Category("Convention")>]
+      [<DisplayName("Keep empty lines around nested multi-line expressions")>]
       BlankLinesAroundNestedMultilineExpressions: bool
+
+      [<Category("Convention")>]
+      [<DisplayName("Add a bar before DU declarations")>]
       BarBeforeDiscriminatedUnionDeclaration: bool
-      /// Pretty printing based on ASTs only
+
+      [<Category("Convention")>]
+      [<DisplayName("Strict mode")>]
+      [<Description("Pretty printing based on ASTs only")>]
       StrictMode: bool }
 
     static member Default =

--- a/src/Fantomas/FormatConfig.fs
+++ b/src/Fantomas/FormatConfig.fs
@@ -170,13 +170,14 @@ type FormatConfig =
 
       [<Category("Convention")>]
       [<DisplayName("Keep If-Then in same line")>]
+      [<Description("Obsolete setting, this no longer has any effect and will be removed in the next major version.")>]
       KeepIfThenInSameLine: bool
 
       [<Category("Elmish")>]
       [<DisplayName("Maximum width for elmish syntax")>]
       MaxElmishWidth: Num
 
-      [<Category("Convention")>]
+      [<Category("Elmish")>]
       [<DisplayName("Single-argument web mode")>]
       SingleArgumentWebMode: bool
 
@@ -202,6 +203,7 @@ type FormatConfig =
 
       [<Category("Indentation")>]
       [<DisplayName("Keep indent in branch")>]
+      [<Description("Experimental feature, use at your own risk.")>]
       KeepIndentInBranch: bool
 
       [<Category("Convention")>]
@@ -209,12 +211,12 @@ type FormatConfig =
       BlankLinesAroundNestedMultilineExpressions: bool
 
       [<Category("Convention")>]
-      [<DisplayName("Add a bar before DU declarations")>]
+      [<DisplayName("Add a bar before Discriminated Union declarations")>]
       BarBeforeDiscriminatedUnionDeclaration: bool
 
       [<Category("Convention")>]
       [<DisplayName("Strict mode")>]
-      [<Description("Pretty printing based on ASTs only")>]
+      [<Description("Pretty printing based on ASTs only.\nPlease do not use this setting for formatting hand written code!")>]
       StrictMode: bool }
 
     static member Default =


### PR DESCRIPTION
This adds the configuration meta information to the Fantomas Daemon.
The configuration response would look like:
```json
{
    "settings": {
        "indent_size": {
            "type": "number",
            "defaultValue": "4",
            "category": "Indentation",
            "displayName": "Indent spaces",
            "description": "Number of spaces to use for indentation"
        },
        "max_line_length": {
            "type": "number",
            "defaultValue": "120",
            "category": "Boundaries",
            "displayName": "Maximum line length",
            "description": "The column where we break to new lines"
        },
        "fsharp_semicolon_at_end_of_line": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Convention",
            "displayName": "Semicolon at end-of-line",
            "description": "Forces a semicolon to be added to the end of a line"
        },
        "fsharp_space_before_parameter": {
            "type": "boolean",
            "defaultValue": "true",
            "category": "Spacing",
            "displayName": "Before parameter"
        },
        "fsharp_space_before_lowercase_invocation": {
            "type": "boolean",
            "defaultValue": "true",
            "category": "Spacing",
            "displayName": "Before lowercase invocation"
        },
        "fsharp_space_before_uppercase_invocation": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Spacing",
            "displayName": "Before uppercase invocation"
        },
        "fsharp_space_before_class_constructor": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Spacing",
            "displayName": "Before class constructor"
        },
        "fsharp_space_before_member": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Spacing",
            "displayName": "Before member"
        },
        "fsharp_space_before_colon": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Spacing",
            "displayName": "Before colon"
        },
        "fsharp_space_after_comma": {
            "type": "boolean",
            "defaultValue": "true",
            "category": "Spacing",
            "displayName": "After comma"
        },
        "fsharp_space_before_semicolon": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Spacing",
            "displayName": "Before semicolon"
        },
        "fsharp_space_after_semicolon": {
            "type": "boolean",
            "defaultValue": "true",
            "category": "Spacing",
            "displayName": "After semicolon"
        },
        "fsharp_indent_on_try_with": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Indentation",
            "displayName": "Indent try-with"
        },
        "fsharp_space_around_delimiter": {
            "type": "boolean",
            "defaultValue": "true",
            "category": "Spacing",
            "displayName": "Around delimiter"
        },
        "fsharp_max_if_then_else_short_width": {
            "type": "number",
            "defaultValue": "40",
            "category": "Boundaries",
            "displayName": "Maximum if-then-else width"
        },
        "fsharp_max_infix_operator_expression": {
            "type": "number",
            "defaultValue": "50",
            "category": "Boundaries",
            "displayName": "Maximum infix-operator expression"
        },
        "fsharp_max_record_width": {
            "type": "number",
            "defaultValue": "40",
            "category": "Boundaries",
            "displayName": "Maximum record width"
        },
        "fsharp_max_record_number_of_items": {
            "type": "number",
            "defaultValue": "1",
            "category": "Boundaries",
            "displayName": "Maximum items in a record"
        },
        "fsharp_record_multiline_formatter": {
            "type": "multilineFormatterType",
            "defaultValue": "character_width",
            "category": "Boundaries",
            "displayName": "Multi-line formatter for records"
        },
        "fsharp_max_array_or_list_width": {
            "type": "number",
            "defaultValue": "40",
            "category": "Boundaries",
            "displayName": "Maximum array or list width"
        },
        "fsharp_max_array_or_list_number_of_items": {
            "type": "number",
            "defaultValue": "1",
            "category": "Boundaries",
            "displayName": "Maximum number of items in array/list"
        },
        "fsharp_array_or_list_multiline_formatter": {
            "type": "multilineFormatterType",
            "defaultValue": "character_width",
            "category": "Boundaries",
            "displayName": "Multi-line formatter for array/list"
        },
        "fsharp_max_value_binding_width": {
            "type": "number",
            "defaultValue": "80",
            "category": "Boundaries",
            "displayName": "Maximum value-binding width"
        },
        "fsharp_max_function_binding_width": {
            "type": "number",
            "defaultValue": "40",
            "category": "Boundaries",
            "displayName": "Maximum function-binding width"
        },
        "fsharp_max_dot_get_expression_width": {
            "type": "number",
            "defaultValue": "50",
            "category": "Boundaries",
            "displayName": "Maximum dot get expression width"
        },
        "fsharp_multiline_block_brackets_on_same_column": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Boundaries",
            "displayName": "Multiline-block brackets on same column"
        },
        "fsharp_newline_between_type_definition_and_members": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Convention",
            "displayName": "Newline between type definition and members"
        },
        "fsharp_keep_if_then_in_same_line": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Convention",
            "displayName": "Keep If-Then in same line",
            "description": "Obsolete setting, this no longer has any effect and will be removed in the next major version."
        },
        "fsharp_max_elmish_width": {
            "type": "number",
            "defaultValue": "40",
            "category": "Elmish",
            "displayName": "Maximum width for elmish syntax"
        },
        "fsharp_single_argument_web_mode": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Elmish",
            "displayName": "Single-argument web mode"
        },
        "fsharp_align_function_signature_to_indentation": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Convention",
            "displayName": "Align function signature to indentation"
        },
        "fsharp_alternative_long_member_definitions": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Convention",
            "displayName": "Alternative long member definitions"
        },
        "fsharp_multi_line_lambda_closing_newline": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Boundaries",
            "displayName": "MultiLine-lambda has closing newline"
        },
        "fsharp_disable_elmish_syntax": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Elmish",
            "displayName": "Disable support for elmish syntax"
        },
        "end_of_line": {
            "type": "endOfLineStyle",
            "defaultValue": "crlf",
            "category": "Boundaries",
            "displayName": "Line-ending style"
        },
        "fsharp_keep_indent_in_branch": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Indentation",
            "displayName": "Keep indent in branch",
            "description": "Experimental feature, use at your own risk."
        },
        "fsharp_blank_lines_around_nested_multiline_expressions": {
            "type": "boolean",
            "defaultValue": "true",
            "category": "Convention",
            "displayName": "Keep empty lines around nested multi-line expressions"
        },
        "fsharp_bar_before_discriminated_union_declaration": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Convention",
            "displayName": "Add a bar before Discriminated Union declarations"
        },
        "fsharp_strict_mode": {
            "type": "boolean",
            "defaultValue": "false",
            "category": "Convention",
            "displayName": "Strict mode",
            "description": "Pretty printing based on ASTs only.\nPlease do not use this setting for formatting hand written code!"
        }
    },
    "enumOptions": {
        "multilineFormatterType": [
            "character_width",
            "number_of_items"
        ],
        "endOfLineStyle": [
            "lf",
            "crlf"
        ]
    }
}
```
You cannot assume that `category`, `displayName` or `description` will be present as there are versions out in the wild that don't contain these fields.

@deviousasti I'm going to close #1931 in favour of this PR.
This does not mean we cannot revisit certain descriptions or other values.