### PR TITLE
New Index syntax on raw list.

### DIFF
--- a/src/Fantomas.Tests/IndexSyntaxTests.fs
+++ b/src/Fantomas.Tests/IndexSyntaxTests.fs
@@ -99,3 +99,18 @@ for x in 1..2 do
 
 let s = seq { 0..10..100 }
 """
+
+[<Test>]
+let ``index syntax on raw list, 1929`` () =
+    formatSourceString
+        false
+        """
+let y = [ 0; 2; 4 ][ 1 ]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let y = [ 0; 2; 4 ][1]
+"""

--- a/src/Fantomas/RangeHelpers.fs
+++ b/src/Fantomas/RangeHelpers.fs
@@ -25,3 +25,8 @@ module RangeHelpers =
         && r1.EndColumn = r2.EndColumn
 
     let rangeEq = Range.equals
+
+    let isAdjacentTo (r1: Range) (r2: Range) : bool =
+        r1.FileName = r2.FileName
+        && r1.End.Line = r2.Start.Line
+        && r1.EndColumn = r2.StartColumn

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -863,6 +863,12 @@ let (|IndexWithoutDotExpr|_|) =
     function
     | SynExpr.App (ExprAtomicFlag.Atomic, false, identifierExpr, SynExpr.ArrayOrListComputed (false, indexExpr, _), _) ->
         Some(identifierExpr, indexExpr)
+    | SynExpr.App (ExprAtomicFlag.NonAtomic,
+                   false,
+                   identifierExpr,
+                   (SynExpr.ArrayOrListComputed (isArray = false; expr = indexExpr) as argExpr),
+                   _) when (RangeHelpers.isAdjacentTo identifierExpr.Range argExpr.Range) ->
+        Some(identifierExpr, indexExpr)
     | _ -> None
 
 let (|MatchLambda|_|) =


### PR DESCRIPTION
 Fixes #1929.
 @dsyme would you mind verifying if I stole the `isAdjacentTo` logic correctly from:
 https://github.com/dotnet/fsharp/blob/main/src/fsharp/CheckExpressions.fs#L7886-L7901
and https://github.com/dotnet/fsharp/blob/699291aab8a3b5e877d9482cdf1c83808bdd8a9f/src/fsharp/range.fs#L280-L281

Thanks!