### PR TITLE
Restart fantomas-tool when process has exited.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -51,7 +51,7 @@ let owner = "Anh-Dung Phan"
 let tags =
     "F# fsharp formatting beautifier indentation indenter"
 
-let fantomasClientVersion = "0.3.4"
+let fantomasClientVersion = "0.4.0"
 
 // (<solutionFile>.sln is built during the building process)
 let solutionFile = "fantomas"

--- a/src/Fantomas.Client/Fantomas.Client.fsproj
+++ b/src/Fantomas.Client/Fantomas.Client.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.3.4</Version>
+    <Version>0.4.0</Version>
     <Description>Companion library to format using fantomas tool.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarnOn>3390;$(WarnOn)</WarnOn>

--- a/src/Fantomas.Client/FantomasToolLocator.fs
+++ b/src/Fantomas.Client/FantomasToolLocator.fs
@@ -130,7 +130,7 @@ let findFantomasTool (workingDir: Folder) : FantomasToolResult =
         | Ok (CompatibleTool version) -> FoundGlobalTool(workingDir, version)
         | _ -> NoCompatibleVersionFound
 
-let createForWorkingDirectory (Folder workingDirectory) (isGlobal: bool) : JsonRpc =
+let createForWorkingDirectory (Folder workingDirectory) (isGlobal: bool) : RunningFantomasTool =
     let processStart =
         if isGlobal then
             ProcessStartInfo("fantomas")
@@ -150,4 +150,7 @@ let createForWorkingDirectory (Folder workingDirectory) (isGlobal: bool) : JsonR
         new JsonRpc(daemonProcess.StandardInput.BaseStream, daemonProcess.StandardOutput.BaseStream)
 
     do client.StartListening()
-    client
+
+    { RpcClient = client
+      Process = daemonProcess
+      IsGlobal = isGlobal }

--- a/src/Fantomas.Client/LSPFantomasService.fs
+++ b/src/Fantomas.Client/LSPFantomasService.fs
@@ -9,9 +9,6 @@ open Fantomas.Client.Contracts
 open Fantomas.Client.LSPFantomasServiceTypes
 open Fantomas.Client.FantomasToolLocator
 
-let private orDefaultCancellationToken =
-    Option.defaultValue CancellationToken.None
-
 type Msg =
     | GetDaemon of Folder * AsyncReplyChannel<JsonRpc option>
     | Reset of AsyncReplyChannel<unit>
@@ -207,7 +204,7 @@ type LSPFantomasService() =
                     client
                         .InvokeWithCancellationAsync<string>(
                             Methods.Version,
-                            cancellationToken = orDefaultCancellationToken cancellationToken
+                            cancellationToken = Option.defaultValue cts.Token cancellationToken
                         )
                         .ContinueWith(fun (t: Task<string>) ->
                             { Code = int FantomasResponseCode.Version
@@ -229,7 +226,7 @@ type LSPFantomasService() =
                         .InvokeWithParameterObjectAsync<FormatDocumentResponse>(
                             Methods.FormatDocument,
                             argument = formatDocumentOptions,
-                            cancellationToken = orDefaultCancellationToken cancellationToken
+                            cancellationToken = Option.defaultValue cts.Token cancellationToken
                         )
                         .ContinueWith(fun (t: Task<FormatDocumentResponse>) -> t.Result.AsFormatResponse()))
             |> mapResultToResponse formatDocumentOptions.FilePath
@@ -248,7 +245,7 @@ type LSPFantomasService() =
                         .InvokeWithParameterObjectAsync<FormatSelectionResponse>(
                             Methods.FormatSelection,
                             argument = formatSelectionRequest,
-                            cancellationToken = orDefaultCancellationToken cancellationToken
+                            cancellationToken = Option.defaultValue cts.Token cancellationToken
                         )
                         .ContinueWith(fun (t: Task<FormatSelectionResponse>) -> t.Result.AsFormatResponse()))
             |> mapResultToResponse formatSelectionRequest.FilePath
@@ -262,7 +259,7 @@ type LSPFantomasService() =
                     client
                         .InvokeWithCancellationAsync<string>(
                             Methods.Configuration,
-                            cancellationToken = orDefaultCancellationToken cancellationToken
+                            cancellationToken = Option.defaultValue cts.Token cancellationToken
                         )
                         .ContinueWith(fun (t: Task<string>) ->
 


### PR DESCRIPTION
In this PR, I'm adding a check to see if the process is still running.
Theoretically, this can only happen when the user kills the process by itself or something major unforeseen kills the process.
In any case, it worked on my machine.

I've also changed the Dispose implementation slightly as I noticed the processes weren't really killed.
I'm not sure how useful the `isCancellationRequested` check is.

@baronfel would you mind reviewing this one, please?
Thanks! 