### PR TITLE
Use FullRange for SynExceptionDefnRepr, SynExceptionSig and SynModuleSigDecl. 

### DIFF
--- a/src/Fantomas.Tests/SignatureTests.fs
+++ b/src/Fantomas.Tests/SignatureTests.fs
@@ -1682,3 +1682,32 @@ type FooBar =
     [<Literal>]
     abstract member parenGet: string = ".()"
 """
+
+[<Test>]
+let ``trivia before exception with attributes, 1974`` () =
+    formatSourceString
+        true
+        """
+module internal FSharp.Compiler.ParseHelpers
+
+open FSharp.Compiler.AbstractIL.IL
+
+
+/// The error raised by the parse_error_rich function, which is called by the parser engine
+[<NoEquality; NoComparison>]
+exception SyntaxError of obj * range: range
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module internal FSharp.Compiler.ParseHelpers
+
+open FSharp.Compiler.AbstractIL.IL
+
+
+/// The error raised by the parse_error_rich function, which is called by the parser engine
+[<NoEquality; NoComparison>]
+exception SyntaxError of obj * range: range
+"""

--- a/src/Fantomas/AstExtensions.fs
+++ b/src/Fantomas/AstExtensions.fs
@@ -45,3 +45,26 @@ type SynField with
         | SynField(attributes = []) -> None
         | SynField (attributes = _ :: _; idOpt = None) -> None
         | SynField (attributes = attrs; idOpt = Some ident) -> hasLinesBetweenAttributesAndFirstNode attrs ident.idRange
+
+// TODO: Remove when https://github.com/dotnet/fsharp/pull/12441 is part of FCS
+type SynExceptionDefnRepr with
+    member this.FullRange: range =
+        match this with
+        | SynExceptionDefnRepr (attributes = attrs; range = m) ->
+            match attrs with
+            | h :: _ -> mkRange m.FileName h.Range.Start m.End
+            | _ -> m
+
+type SynExceptionSig with
+    member this.FullRange: range =
+        match this with
+        | SynExceptionSig (exnRepr = exnRepr; members = members; range = m) ->
+            match List.tryLast members with
+            | Some lastMember -> mkRange m.FileName exnRepr.FullRange.Start lastMember.Range.End
+            | None -> exnRepr.FullRange
+
+type SynModuleSigDecl with
+    member this.FullRange: Range =
+        match this with
+        | SynModuleSigDecl.Exception (SynExceptionSig _ as ses, _) -> ses.FullRange
+        | _ -> this.Range

--- a/src/Fantomas/AstTransformer.fs
+++ b/src/Fantomas/AstTransformer.fs
@@ -1088,8 +1088,10 @@ module private Ast =
 
     and visitSynExceptionDefnRepr (sedr: SynExceptionDefnRepr) : TriviaNodeAssigner list =
         match sedr with
-        | SynExceptionDefnRepr (attrs, unionCase, _, _, _, range) ->
-            [ yield mkNode SynExceptionDefnRepr_ range
+        | SynExceptionDefnRepr (attrs, unionCase, _, _, _, _range) ->
+            let fullRange = sedr.FullRange
+
+            [ yield mkNode SynExceptionDefnRepr_ fullRange
               yield! (visitSynAttributeLists attrs)
               yield! visitSynUnionCase unionCase ]
 
@@ -1376,8 +1378,10 @@ module private Ast =
             | SynModuleSigDecl.NamespaceFragment moduleOrNamespace ->
                 visitSynModuleOrNamespaceSig moduleOrNamespace
                 |> finalContinuation
-            | SynModuleSigDecl.Exception (synExceptionSig, range) ->
-                mkNode SynModuleSigDecl_Exception range
+            | SynModuleSigDecl.Exception (synExceptionSig, _range) ->
+                let fullRange = ast.FullRange
+
+                mkNode SynModuleSigDecl_Exception fullRange
                 :: (visitSynExceptionSig synExceptionSig)
                 |> finalContinuation
 
@@ -1385,8 +1389,10 @@ module private Ast =
 
     and visitSynExceptionSig (exceptionDef: SynExceptionSig) : TriviaNodeAssigner list =
         match exceptionDef with
-        | SynExceptionSig (sedr, members, range) ->
-            [ yield mkNode SynExceptionSig_ range
+        | SynExceptionSig (sedr, members, _range) ->
+            let fullRange = exceptionDef.FullRange
+
+            [ yield mkNode SynExceptionSig_ fullRange
               yield! visitSynExceptionDefnRepr sedr
               yield! (members |> List.collect visitSynMemberSig) ]
 

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -268,7 +268,7 @@ and genSigModuleDeclList astContext (e: SynModuleSigDecl list) =
                     |> finalContinuation)
         | s :: rest ->
             let sepNln =
-                sepNlnConsideringTriviaContentBeforeForMainNode (synModuleSigDeclToFsAstType s) s.Range
+                sepNlnConsideringTriviaContentBeforeForMainNode (synModuleSigDeclToFsAstType s) s.FullRange
 
             let expr = genSigModuleDecl astContext s
 
@@ -433,7 +433,7 @@ and genSigModuleDecl astContext node =
         | SynModuleSigDecl.Open (SynOpenDeclTarget.ModuleOrNamespace _, _) ->
             genTriviaFor SynModuleSigDecl_Open node.Range
         | SynModuleSigDecl.Open (SynOpenDeclTarget.Type _, _) -> genTriviaFor SynModuleSigDecl_OpenType node.Range
-        | SynModuleSigDecl.Exception _ -> genTriviaFor SynModuleSigDecl_Exception node.Range
+        | SynModuleSigDecl.Exception _ -> genTriviaFor SynModuleSigDecl_Exception node.FullRange
         | _ -> id)
 
 and genAccess (Access s) = !-s


### PR DESCRIPTION
Fixes #1974.