### PR TITLE
apply spacing between operators and all SynExpr.Const

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -489,7 +489,7 @@ Target.create
         if result.ExitCode = 0 then
             Trace.log "No files need formatting"
         elif result.ExitCode = 99 then
-            failwith "Some files need formatting, check output for more info"
+            failwith "Some files need formatting, run `dotnet fake build -t Format` to format them"
         else
             Trace.logf "Errors while formatting: %A" result.Errors)
 

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -1226,3 +1226,40 @@ module Foo =
             | true -> id
             | false -> id)
 """
+
+let operator_application_literal_values =
+    [ "-86y"
+      "86uy"
+      "-86s"
+      "86us"
+      "-86"
+      "-86l"
+      "86u"
+      "86ul"
+      "-123n"
+      "0x00002D3Fun"
+      "-86L"
+      "86UL"
+      "-4.41F"
+      "-4.14"
+      "-12456I"
+      "-0.7833M"
+      "'a'"
+      "\"text\""
+      "'a'B"
+      "\"text\"B" ]
+
+[<TestCaseSource("operator_application_literal_values")>]
+let ``operators maintain spacing from literal values`` (literalValue: string) =
+    formatSourceString
+        false
+        $"""
+let subtractTwo = + {literalValue}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        $"""
+let subtractTwo = + {literalValue}
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1711,7 +1711,7 @@ and genExpr astContext synExpr ctx =
         | PrefixApp (s, e) ->
             let extraSpaceBeforeString =
                 match e with
-                | String _
+                | SynExpr.Const _
                 | SynExpr.InterpolatedString _ -> sepSpace
                 | _ -> sepNone
 


### PR DESCRIPTION
Closes #1979 by forcing the use of a space between all Prefix Applications (typically operators) and any SynExpr.Const arguments.

This is a bit broader of a change than strictly speaking would be required. The only required change to prevent soundness bugs would be to detect if the const was a negative number in some form and apply spacing then, because the core bug is that removing the spacing transforms the expression from `+ (-2)` to `+- 2` in meaning, so the operator being applied changes.  I think it's reasonable to enforce a single-space everywhere, and if necessary we could encode this in the style guide.