### PR TITLE
Move IndexWithoutDotExpr higher in the genExpr pattern match.

### DIFF
--- a/src/Fantomas.Tests/IndexSyntaxTests.fs
+++ b/src/Fantomas.Tests/IndexSyntaxTests.fs
@@ -114,3 +114,18 @@ let y = [ 0; 2; 4 ][ 1 ]
         """
 let y = [ 0; 2; 4 ][1]
 """
+
+[<Test>]
+let ``index syntax on dotget, 1985`` () =
+    formatSourceString
+        false
+        """
+let segment = System.Uri(ctx.Request.Path.Value).Segments[1]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let segment = System.Uri(ctx.Request.Path.Value).Segments[1]
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1789,6 +1789,12 @@ and genExpr astContext synExpr ctx =
                 +> genExpr astContext e3
             )
 
+        | IndexWithoutDotExpr (identifierExpr, indexExpr) ->
+            genExpr astContext identifierExpr
+            +> sepOpenLFixed
+            +> genExpr astContext indexExpr
+            +> sepCloseLFixed
+
         // Result<int, string>.Ok 42
         | App (DotGet (TypeApp (e, lt, ts, gt), lids), es) ->
             let s = List.map fst lids |> String.concat "."
@@ -2228,12 +2234,6 @@ and genExpr astContext synExpr ctx =
                             singleLine ctx
 
             expressionFitsOnRestOfLine short long
-
-        | IndexWithoutDotExpr (identifierExpr, indexExpr) ->
-            genExpr astContext identifierExpr
-            +> sepOpenLFixed
-            +> genExpr astContext indexExpr
-            +> sepCloseLFixed
 
         // Always spacing in multiple arguments
         | App (e, es) -> genApp astContext e es


### PR DESCRIPTION
Fixes #1985