### PR TITLE
Verify if DOTNET_CLI_UI_LANGUAGE is already present.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -51,7 +51,7 @@ let owner = "Anh-Dung Phan"
 let tags =
     "F# fsharp formatting beautifier indentation indenter"
 
-let fantomasClientVersion = "0.5.0"
+let fantomasClientVersion = "0.5.1"
 
 // (<solutionFile>.sln is built during the building process)
 let solutionFile = "fantomas"

--- a/src/Fantomas.Client/FantomasToolLocator.fs
+++ b/src/Fantomas.Client/FantomasToolLocator.fs
@@ -63,7 +63,12 @@ let private startProcess (ps: ProcessStartInfo) : Result<Process, ProcessStartEr
 let private runToolListCmd (Folder workingDir: Folder) (globalFlag: bool) : Result<string list, DotNetToolListError> =
     let ps = ProcessStartInfo("dotnet")
     ps.WorkingDirectory <- workingDir
-    ps.EnvironmentVariables.Add("DOTNET_CLI_UI_LANGUAGE", "en-us")
+
+    if ps.EnvironmentVariables.ContainsKey "DOTNET_CLI_UI_LANGUAGE" then
+        ps.EnvironmentVariables.["DOTNET_CLI_UI_LANGUAGE"] <- "en-us"
+    else
+        ps.EnvironmentVariables.Add("DOTNET_CLI_UI_LANGUAGE", "en-us")
+
     ps.CreateNoWindow <- true
 
     ps.Arguments <-


### PR DESCRIPTION
@baronfel this fixes the problem in Ionide where people have https://marketplace.visualstudio.com/items?itemName=formulahendry.dotnet-test-explorer installed.
Setting the environment variable again blows up the whole thing.