### PR TITLE
Pipe operator application with lambda is considered long for KeepIndentInBranch. 

### DIFF
--- a/src/Fantomas.Tests/KeepIndentInBranchTests.fs
+++ b/src/Fantomas.Tests/KeepIndentInBranchTests.fs
@@ -2085,3 +2085,39 @@ module Foo =
         leftSet.SymmetricExceptWith(FooBarBaz.keys rightThings)
         |> ignore
 """
+
+[<Test>]
+let ``pipe operator application with lambda is considered long, 2003`` () =
+    formatSourceString
+        false
+        """
+namespace FicroKanSharp.Test
+
+module TestThing =
+
+    let ``Recursive example`` () =
+
+        match Stream.peel rest with
+        | None -> failwith "oh no"
+        | Some longName ->
+            longName
+            |> Map.map (fun _ -> TypedTerm.force<int>)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+namespace FicroKanSharp.Test
+
+module TestThing =
+
+    let ``Recursive example`` () =
+
+        match Stream.peel rest with
+        | None -> failwith "oh no"
+        | Some longName ->
+
+        longName
+        |> Map.map (fun _ -> TypedTerm.force<int>)
+"""

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1758,7 +1758,8 @@ let private shouldNotIndentBranch e es =
         | Match _
         | TryWith _
         | App (_, [ ObjExpr _ ])
-        | NewlineInfixApp (_, _, AppParenTupleArg _, _) -> true
+        | NewlineInfixApp (_, _, AppParenTupleArg _, _)
+        | NewlineInfixApp (_, _, _, App (_, [ Paren (_, Lambda _, _, _) ])) -> true
         | _ -> false
 
     List.forall isShortIfBranch es


### PR DESCRIPTION
Fixes #2003.