### PR TITLE
Read editorconfig settings before overwriting settings with request configuration.

### DIFF
--- a/src/Fantomas.CoreGlobalTool/Daemon.fs
+++ b/src/Fantomas.CoreGlobalTool/Daemon.fs
@@ -49,7 +49,9 @@ type FantomasDaemon(sender: Stream, reader: Stream) as this =
             else
                 let config =
                     match request.Config with
-                    | Some configProperties -> parseOptionsFromEditorConfig configProperties
+                    | Some configProperties ->
+                        let config = readConfiguration request.FilePath
+                        parseOptionsFromEditorConfig config configProperties
                     | None -> readConfiguration request.FilePath
 
                 try
@@ -76,7 +78,9 @@ type FantomasDaemon(sender: Stream, reader: Stream) as this =
         async {
             let config =
                 match request.Config with
-                | Some configProperties -> parseOptionsFromEditorConfig configProperties
+                | Some configProperties ->
+                    let config = readConfiguration request.FilePath
+                    parseOptionsFromEditorConfig config configProperties
                 | None -> readConfiguration request.FilePath
 
             let range =

--- a/src/Fantomas.Extras/EditorConfig.fs
+++ b/src/Fantomas.Extras/EditorConfig.fs
@@ -57,8 +57,8 @@ let toEditorConfigName value =
         else
             sprintf "fsharp_%s" name
 
-let private fantomasFields =
-    Reflection.getRecordFields FormatConfig.Default
+let private getFantomasFields (fallbackConfig: FormatConfig) =
+    Reflection.getRecordFields fallbackConfig
     |> Array.map
         (fun (recordField, defaultValue) ->
             let editorConfigName =
@@ -81,8 +81,11 @@ let private (|Boolean|_|) b =
     elif b = "false" then Some(box false)
     else None
 
-let parseOptionsFromEditorConfig (editorConfigProperties: IReadOnlyDictionary<string, string>) : FormatConfig =
-    fantomasFields
+let parseOptionsFromEditorConfig
+    (fallbackConfig: FormatConfig)
+    (editorConfigProperties: IReadOnlyDictionary<string, string>)
+    : FormatConfig =
+    getFantomasFields fallbackConfig
     |> Array.map
         (fun (ecn, dv) ->
             match editorConfigProperties.TryGetValue(ecn) with
@@ -124,7 +127,7 @@ let tryReadConfiguration (fsharpFile: string) : FormatConfig option =
     if editorConfigSettings.Properties.Count = 0 then
         None
     else
-        Some(parseOptionsFromEditorConfig editorConfigSettings.Properties)
+        Some(parseOptionsFromEditorConfig FormatConfig.Default editorConfigSettings.Properties)
 
 let readConfiguration (fsharpFile: string) : FormatConfig =
     tryReadConfiguration fsharpFile


### PR DESCRIPTION
Always first apply the editor config settings before overruling them.