### PR TITLE
Print members after explicit class/end.

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -968,3 +968,53 @@ type public DerivedExceptionWithLongNaaaaaaaaameException
 
     override this.SomeMethod() = ()
 """
+
+[<Test>]
+let ``explicit class/end/with, 1940`` () =
+    formatSourceString
+        false
+        """
+type C() =
+  class
+   member x.P = 1
+  end
+  with
+    member _.Run() = 1
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type C() =
+    class
+        member x.P = 1
+    end
+
+    member _.Run() = 1
+"""
+
+[<Test>]
+let ``explicit class/end with members, idempotent`` () =
+    formatSourceString
+        false
+        """
+type C() =
+    class
+        member x.P = 1
+    end
+
+    member _.Run() = 1
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type C() =
+    class
+        member x.P = 1
+    end
+
+    member _.Run() = 1
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3701,6 +3701,20 @@ and genTypeDefn
         +> genMemberDefnList astContext others
         +> unindent
         ++ "end"
+        +> (fun ctx ->
+            match ms with
+            | [] -> ctx
+            | h :: _ ->
+                let attrs =
+                    getRangesFromAttributesFromSynMemberDefinition h
+
+                let sepNlnBeforeMember =
+                    sepNlnConsideringTriviaContentBeforeWithAttributesFor (synMemberDefnToFsAstType h) h.Range attrs
+
+                (sepNln
+                 +> sepNlnBeforeMember
+                 +> genMemberDefnList astContext ms)
+                    ctx)
         +> unindent
 
     | ObjectModel (TCSimple TCStruct as tdk, MemberDefnList (impCtor, others), _) ->


### PR DESCRIPTION
Fixes #1940.