### PR TITLE
Format `x.Member with get()` as regular member binding. 

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -1018,3 +1018,42 @@ type C() =
 
     member _.Run() = 1
 """
+
+[<Test>]
+let ``static member with get unit should be formatted the same as without, 1913`` () =
+    formatSourceString
+        false
+        """
+type Subject<'a> private () =
+
+        /// Represents and object that is both an observable sequence as well as an observer.
+        /// Each notification is broadcasted to all subscribed observers.
+        static member broadcast
+            with get () = new System.Reactive.Subjects.Subject<'a> ()
+
+type Subject<'a> private () =
+
+    /// Represents and object that is both an observable sequence as well as an observer.
+    /// Each notification is broadcasted to all subscribed observers.
+    static member broadcast = new System.Reactive.Subjects.Subject<'a>()
+
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Subject<'a> private () =
+
+    /// Represents and object that is both an observable sequence as well as an observer.
+    /// Each notification is broadcasted to all subscribed observers.
+    static member broadcast =
+        new System.Reactive.Subjects.Subject<'a>()
+
+type Subject<'a> private () =
+
+    /// Represents and object that is both an observable sequence as well as an observer.
+    /// Each notification is broadcasted to all subscribed observers.
+    static member broadcast =
+        new System.Reactive.Subjects.Subject<'a>()
+"""

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -527,8 +527,18 @@ let (|DoBinding|LetBinding|MemberBinding|PropertyBinding|ExplicitCtor|) =
     function
     | SynBinding.Binding (ao, _, _, _, ats, px, SynValData (Some MFConstructor, _, ido), pat, _, expr, _, _) ->
         ExplicitCtor(ats, px, ao, pat, expr, Option.map (|Ident|) ido)
-    | SynBinding.Binding (ao, _, isInline, _, ats, px, SynValData (Some (MFProperty _ as mf), _, _), pat, _, expr, _, _) ->
-        PropertyBinding(ats, px, ao, isInline, mf, pat, expr)
+    | SynBinding.Binding (ao,
+                          _,
+                          isInline,
+                          _,
+                          ats,
+                          px,
+                          SynValData (Some (MFProperty _ as mf), synValInfo, _),
+                          pat,
+                          _,
+                          expr,
+                          _,
+                          _) -> PropertyBinding(ats, px, ao, isInline, mf, pat, expr, synValInfo)
     | SynBinding.Binding (ao, _, isInline, _, ats, px, SynValData (Some mf, synValInfo, _), pat, _, expr, _, _) ->
         MemberBinding(ats, px, ao, isInline, mf, pat, expr, synValInfo)
     | SynBinding.Binding (_, DoBinding, _, _, ats, px, _, _, _, expr, _, _) -> DoBinding(ats, px, expr)

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -100,14 +100,18 @@ let rec (|SigValL|_|) =
 /// Assume that PropertySet comes right after PropertyGet.
 let (|PropertyWithGetSet|_|) =
     function
-    | PropertyBinding (_, _, _, _, MFProperty PropertyGet, PatLongIdent (_, s1, _, _), _) as b1 :: bs ->
+    | PropertyBinding (_, _, _, _, MFProperty PropertyGet, PatLongIdent (_, s1, _, _), _, _) as b1 :: bs ->
         match bs with
-        | PropertyBinding (_, _, _, _, MFProperty PropertySet, PatLongIdent (_, s2, _, _), _) as b2 :: bs when s1 = s2 ->
+        | PropertyBinding (_, _, _, _, MFProperty PropertySet, PatLongIdent (_, s2, _, _), _, _) as b2 :: bs when
+            s1 = s2
+            ->
             Some((b1, b2), bs)
         | _ -> None
-    | PropertyBinding (_, _, _, _, MFProperty PropertySet, PatLongIdent (_, s2, _, _), _) as b2 :: bs ->
+    | PropertyBinding (_, _, _, _, MFProperty PropertySet, PatLongIdent (_, s2, _, _), _, _) as b2 :: bs ->
         match bs with
-        | PropertyBinding (_, _, _, _, MFProperty PropertyGet, PatLongIdent (_, s1, _, _), _) as b1 :: bs when s1 = s2 ->
+        | PropertyBinding (_, _, _, _, MFProperty PropertyGet, PatLongIdent (_, s1, _, _), _, _) as b1 :: bs when
+            s1 = s2
+            ->
             Some((b1, b2), bs)
         | _ -> None
     | _ -> None


### PR DESCRIPTION
Fixes #1913.