### PR TITLE
WIP: ifdef removed when used on inline keyword in function

### DIFF
--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -658,3 +658,29 @@ let isUnix =
 
     getDefines source
     == [ "NETSTANDARD1_6"; "NETSTANDARD2_0" ]
+
+
+
+[<Test>]
+[<Category("Oracle")>]
+let ``ifdef for inline keyword`` () =
+
+    formatSourceString
+        false
+        """
+    let 
+#if !DEBUG
+        inline
+#endif
+        map f ar = Async.map (Result.map f) ar
+"""
+        config
+    |> should
+        equal
+        """
+    let 
+#if !DEBUG
+        inline
+#endif
+        map f ar = Async.map (Result.map f) ar
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -5136,8 +5136,17 @@ and genSynBindingFunction
             (pref +> genOnelinerAttributes astContext ats)
 
     let afterLetKeyword =
+        let estimateRange = 
+            
+            let foo = ctx.TriviaTokenNodes |> Seq.tryHead
+            foo
+            |> Option.map(fun x -> x.Value)
+            |> Option.bind Seq.tryHead
+            |> Option.map(fun x -> x.Range)
+            |> Option.defaultValue Range.Zero
+        let xyz = tokN estimateRange INLINE (!- "inline ")
         ifElse isMutable (!- "mutable ") sepNone
-        +> ifElse isInline (!- "inline ") sepNone
+        +> ifElse isInline xyz sepNone
         +> opt sepSpace ao genAccess
 
     let genFunctionName =

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -1200,7 +1200,8 @@ let private tokenNames =
       "WITH"
       "MEMBER"
       "AND_BANG"
-      "IN" ]
+      "IN"
+      "INLINE" ]
 
 let private tokenKinds = [ FSharpTokenCharKind.Operator ]
 
@@ -1234,6 +1235,7 @@ let internal getFsToken tokenName =
     | "INFIX_COMPARE_OP" -> INFIX_COMPARE_OP
     | "INFIX_STAR_DIV_MOD_OP" -> INFIX_STAR_DIV_MOD_OP
     | "INFIX_STAR_STAR_OP" -> INFIX_STAR_STAR_OP
+    | "INLINE" -> INLINE
     | "INT32_DOT_DOT" -> INT32_DOT_DOT
     | "LBRACE" -> LBRACE
     | "LBRACK" -> LBRACK

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -32,6 +32,7 @@ type FsTokenType =
     | INFIX_COMPARE_OP
     | INFIX_STAR_DIV_MOD_OP
     | INFIX_STAR_STAR_OP
+    | INLINE
     | INT32_DOT_DOT
     | LBRACE
     | LBRACK


### PR DESCRIPTION
Closes #2017 

Currently WIP since I don't have this working yet and wanted to share what I have.