### PR TITLE
Use SynStringKind to restore verbatim string in StrictMode.

### DIFF
--- a/src/Fantomas.Tests/SynConstTests.fs
+++ b/src/Fantomas.Tests/SynConstTests.fs
@@ -669,3 +669,18 @@ a:hover {color: #ecc;}
     let packable = Path.getFullName \"./_Binaries/README.html\"
     xmlform.Save packable
 "
+
+[<Test>]
+let ``verbatim string in AST is preserved, 560`` () =
+    formatSourceString
+        false
+        """
+let s = @"\"
+"""
+        { config with StrictMode = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let s = @"\"
+"""


### PR DESCRIPTION
Fixes #560.

I didn't bother to add more tests for this as people shouldn't use StrictMode, to begin with.
Other than that there are also some vague ideas to restore the original string in the untyped tree.