### PR TITLE
Remove LBRACK, LBRACK_BAR, RBRACK and BAR_RBRACK from TokenParser.

### DIFF
--- a/src/Fantomas/RangeHelpers.fs
+++ b/src/Fantomas/RangeHelpers.fs
@@ -30,3 +30,12 @@ module RangeHelpers =
         r1.FileName = r2.FileName
         && r1.End.Line = r2.Start.Line
         && r1.EndColumn = r2.StartColumn
+
+    let rec mkStartEndRange (size: int) (r: range) : range * range =
+        let startRange =
+            Range.mkRange r.FileName r.Start (Position.mkPos r.StartLine (r.StartColumn + size))
+
+        let endRange =
+            Range.mkRange r.FileName (Position.mkPos r.EndLine (r.EndColumn - size)) r.End
+
+        startRange, endRange

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -206,7 +206,8 @@ let rec synExprToFsAstType (expr: SynExpr) : FsAstType * Range =
     | SynExpr.DoBang _ -> SynExpr_DoBang, expr.Range
     | SynExpr.Paren _ -> SynExpr_Paren, expr.Range
     | SynExpr.AnonRecd _ -> SynExpr_AnonRecd, expr.Range
-    | SynExpr.ArrayOrListComputed _ -> SynExpr_ArrayOrListComputed, expr.Range
+    | SynExpr.ArrayOrList _ -> SynExpr_ArrayOrList, expr.Range
+    | SynExpr.ArrayOrListComputed _ -> SynExpr_ArrayOrList, expr.Range
     | SynExpr.LongIdentSet _ -> SynExpr_LongIdentSet, expr.Range
     | SynExpr.New _ -> SynExpr_New, expr.Range
     | SynExpr.Quote _ -> SynExpr_Quote, expr.Range
@@ -226,7 +227,6 @@ let rec synExprToFsAstType (expr: SynExpr) : FsAstType * Range =
     | SynExpr.Do _ -> SynExpr_Do, expr.Range
     | SynExpr.AddressOf _ -> SynExpr_AddressOf, expr.Range
     | SynExpr.Typed (e, _, _) -> synExprToFsAstType e
-    | SynExpr.ArrayOrList _ -> SynExpr_ArrayOrList, expr.Range
     | SynExpr.ObjExpr _ -> SynExpr_ObjExpr, expr.Range
     | SynExpr.For _ -> SynExpr_For, expr.Range
     | SynExpr.ForEach _ -> SynExpr_ForEach, expr.Range

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -1124,10 +1124,6 @@ let private tokenNames =
       "RBRACE"
       "LPAREN"
       "RPAREN"
-      "LBRACK"
-      "RBRACK"
-      "LBRACK_BAR"
-      "BAR_RBRACK"
       "EQUALS"
       "BAR"
       "TRY"
@@ -1146,7 +1142,6 @@ let internal getFsToken tokenName =
     | "AND_BANG" -> AND_BANG
     | "BAR" -> BAR
     | "BAR_BAR" -> BAR_BAR
-    | "BAR_RBRACK" -> BAR_RBRACK
     | "COLON_COLON" -> COLON_COLON
     | "COLON_EQUALS" -> COLON_EQUALS
     | "COLON_GREATER" -> COLON_GREATER
@@ -1171,8 +1166,6 @@ let internal getFsToken tokenName =
     | "INFIX_STAR_STAR_OP" -> INFIX_STAR_STAR_OP
     | "INT32_DOT_DOT" -> INT32_DOT_DOT
     | "LBRACE" -> LBRACE
-    | "LBRACK" -> LBRACK
-    | "LBRACK_BAR" -> LBRACK_BAR
     | "LESS" -> LESS
     | "LPAREN" -> LPAREN
     | "LPAREN_STAR_RPAREN" -> LPAREN_STAR_RPAREN
@@ -1184,7 +1177,6 @@ let internal getFsToken tokenName =
     | "QMARK" -> QMARK
     | "QMARK_QMARK" -> QMARK_QMARK
     | "RBRACE" -> RBRACE
-    | "RBRACK" -> RBRACK
     | "RPAREN" -> RPAREN
     | "THEN" -> THEN
     | "TRY" -> TRY

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -9,7 +9,6 @@ type FsTokenType =
     | AND_BANG
     | BAR
     | BAR_BAR
-    | BAR_RBRACK
     | COLON_COLON
     | COLON_EQUALS
     | COLON_GREATER
@@ -34,8 +33,6 @@ type FsTokenType =
     | INFIX_STAR_STAR_OP
     | INT32_DOT_DOT
     | LBRACE
-    | LBRACK
-    | LBRACK_BAR
     | LESS
     | LPAREN
     | LPAREN_STAR_RPAREN
@@ -47,7 +44,6 @@ type FsTokenType =
     | QMARK
     | QMARK_QMARK
     | RBRACE
-    | RBRACK
     | RPAREN
     | THEN
     | TRY
@@ -128,8 +124,10 @@ type FsAstType =
     | SynExpr_While
     | SynExpr_For
     | SynExpr_ForEach
-    | SynExpr_ArrayOrListComputed
+    // | SynExpr_ArrayOrListComputed generalized in SynExpr_ArrayOrList
     | SynExpr_ArrayOrList
+    | SynExpr_ArrayOrList_OpeningDelimiter
+    | SynExpr_ArrayOrList_ClosingDelimiter
     // | SynExpr_ComputationExpr use first nested SynExpr
     | SynExpr_Lambda
     | SynExpr_Lambda_Arrow


### PR DESCRIPTION
The range of both `SynExpr.ArrayOrList` and `SynExpr.ArrayOrListComputed` includes the delimiters (`[`,`[|`,`|]`,`]`).
So, these can be added as main nodes instead of detecting them from the Fsharp tokens.
Main nodes are preferable over token types so this refactor optimizes trivia a bit.
It moves the mechanism from TokenParser to ASTTransformer which is a better way to deal with trivia anchors.

We can probably do something similar for records. 