### PR TITLE
Remove LBRACE and RBRACE from TokenParser.

### DIFF
--- a/src/Fantomas.Tests/TokenParserTests.fs
+++ b/src/Fantomas.Tests/TokenParserTests.fs
@@ -267,16 +267,6 @@ let ``comment after left brace of record`` () =
     | _ -> failwith "expected line comment after left brace"
 
 [<Test>]
-let ``left brace should be found in tokens`` () =
-    let source = "type R = { A: int }"
-
-    let triviaNodes = tokenize source |> getTriviaNodesFromTokens
-
-    match triviaNodes.[0].Type, triviaNodes.[1].Type, triviaNodes.[2].Type with
-    | Token (EQUALS, _), Token (LBRACE, _), Token (RBRACE, _) -> pass ()
-    | _ -> fail ()
-
-[<Test>]
 let ``leading and trailing whitespaces should be found in tokens`` () =
     let source =
         """

--- a/src/Fantomas.Tests/TriviaTests.fs
+++ b/src/Fantomas.Tests/TriviaTests.fs
@@ -101,7 +101,6 @@ let a = 7
         == expectedComment
     | _ -> fail ()
 
-
 [<Test>]
 let ``comments inside record`` () =
     let source =
@@ -112,7 +111,7 @@ let ``comments inside record`` () =
     let triviaNodes = toTrivia source |> List.head
 
     match triviaNodes with
-    | [ { Type = TriviaNodeType.Token (LBRACE, _)
+    | [ { Type = TriviaNodeType.MainNode SynExpr_Record_OpeningBrace
           ContentAfter = [ Comment (LineCommentAfterSourceCode "// foo") ] } ] -> pass ()
     | _ -> fail ()
 

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -1241,20 +1241,6 @@ let internal leaveNodeFor (mainNodeName: FsAstType) (range: Range) (ctx: Context
         | None -> ctx
     | None -> ctx
 
-let internal leaveLeftToken (tokenName: FsTokenType) (range: Range) (ctx: Context) =
-    (Map.tryFindOrEmptyList tokenName ctx.TriviaTokenNodes)
-    |> List.tryFind (fun tn ->
-        tn.Range.StartLine = range.StartLine
-        && tn.Range.StartColumn = range.StartColumn)
-    |> fun tn ->
-        match tn with
-        | Some { ContentAfter = [ TriviaContent.Comment (LineCommentAfterSourceCode lineComment) ] } ->
-            !-lineComment +> sepNln
-        | _ -> id
-    <| ctx
-
-let internal leaveLeftBrace = leaveLeftToken LBRACE
-
 let internal hasPrintableContent (trivia: TriviaContent list) =
     trivia
     |> List.exists (fun tn ->

--- a/src/Fantomas/RangeHelpers.fs
+++ b/src/Fantomas/RangeHelpers.fs
@@ -39,3 +39,8 @@ module RangeHelpers =
             Range.mkRange r.FileName (Position.mkPos r.EndLine (r.EndColumn - size)) r.End
 
         startRange, endRange
+
+module RangePatterns =
+    let (|StartEndRange|) (size: int) (range: range) =
+        let o, c = RangeHelpers.mkStartEndRange size range
+        o, range, c

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -1120,9 +1120,7 @@ let getTriviaFromTokens (mkRange: MkRange) (tokens: Token list) =
     |> List.sortBy (fun t -> t.Range.StartLine, t.Range.StartColumn)
 
 let private tokenNames =
-    [ "LBRACE"
-      "RBRACE"
-      "LPAREN"
+    [ "LPAREN"
       "RPAREN"
       "EQUALS"
       "BAR"
@@ -1165,7 +1163,6 @@ let internal getFsToken tokenName =
     | "INFIX_STAR_DIV_MOD_OP" -> INFIX_STAR_DIV_MOD_OP
     | "INFIX_STAR_STAR_OP" -> INFIX_STAR_STAR_OP
     | "INT32_DOT_DOT" -> INT32_DOT_DOT
-    | "LBRACE" -> LBRACE
     | "LESS" -> LESS
     | "LPAREN" -> LPAREN
     | "LPAREN_STAR_RPAREN" -> LPAREN_STAR_RPAREN
@@ -1176,7 +1173,6 @@ let internal getFsToken tokenName =
     | "PREFIX_OP" -> PREFIX_OP
     | "QMARK" -> QMARK
     | "QMARK_QMARK" -> QMARK_QMARK
-    | "RBRACE" -> RBRACE
     | "RPAREN" -> RPAREN
     | "THEN" -> THEN
     | "TRY" -> TRY

--- a/src/Fantomas/TriviaTypes.fs
+++ b/src/Fantomas/TriviaTypes.fs
@@ -32,7 +32,6 @@ type FsTokenType =
     | INFIX_STAR_DIV_MOD_OP
     | INFIX_STAR_STAR_OP
     | INT32_DOT_DOT
-    | LBRACE
     | LESS
     | LPAREN
     | LPAREN_STAR_RPAREN
@@ -43,7 +42,6 @@ type FsTokenType =
     | PREFIX_OP
     | QMARK
     | QMARK_QMARK
-    | RBRACE
     | RPAREN
     | THEN
     | TRY
@@ -118,6 +116,8 @@ type FsAstType =
     | SynExpr_Tuple
     | SynExpr_StructTuple
     | SynExpr_Record
+    | SynExpr_Record_OpeningBrace
+    | SynExpr_Record_ClosingBrace
     | SynExpr_AnonRecd
     | SynExpr_New
     | SynExpr_ObjExpr
@@ -129,6 +129,8 @@ type FsAstType =
     | SynExpr_ArrayOrList_OpeningDelimiter
     | SynExpr_ArrayOrList_ClosingDelimiter
     // | SynExpr_ComputationExpr use first nested SynExpr
+    | SynExpr_ComputationExpr_OpeningBrace
+    | SynExpr_ComputationExpr_ClosingBrace
     | SynExpr_Lambda
     | SynExpr_Lambda_Arrow
     | SynExpr_MatchLambda
@@ -297,6 +299,8 @@ type FsAstType =
     | SynTypeDefnSimpleRepr_Union
     | SynTypeDefnSimpleRepr_Enum
     | SynTypeDefnSimpleRepr_Record
+    | SynTypeDefnSimpleRepr_Record_OpeningBrace
+    | SynTypeDefnSimpleRepr_Record_ClosingBrace
     | SynTypeDefnSimpleRepr_General
     | SynTypeDefnSimpleRepr_LibraryOnlyILAssembly
     | SynTypeDefnSimpleRepr_TypeAbbrev


### PR DESCRIPTION
Similar to #2033, we don't need to find the opening and closing brace in the F# tokens, as we can calculate them from main nodes.