### PR TITLE
Add space after parenthesis function call with lambda argument.

### DIFF
--- a/src/Fantomas.Tests/LambdaTests.fs
+++ b/src/Fantomas.Tests/LambdaTests.fs
@@ -1103,3 +1103,37 @@ fun a ->   // foo
 fun a -> // foo
     a
 """
+
+[<Test>]
+let ``parenthesis function call with lambda argument, 2015`` () =
+    formatSourceString
+        false
+        """
+(if true then foo else goo) (fun _ -> 42)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(if true then foo else goo) (fun _ -> 42)
+"""
+
+[<Test>]
+let ``parenthesis function call with long lambda argument`` () =
+    formatSourceString
+        false
+        """
+(if true then foo else goo) (fun _ ->
+                                                        // comment
+                                                        42)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(if true then foo else goo) (fun _ ->
+    // comment
+    42)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1974,13 +1974,19 @@ and genExpr astContext synExpr ctx =
 
         // functionName arg1 arg2 (fun x y z -> ...)
         | AppWithLambda (e, es, lpr, lambda, rpr, pr) ->
-            let sepSpaceAfterFunctionName ctx =
-                match List.tryHead es with
-                | Some (SimpleExpr _) -> sepSpace ctx
-                | _ ->
+            let sepSpaceAfterFunctionName =
+                let sepSpaceBasedOnSetting e =
                     match e with
-                    | UppercaseSynExpr -> onlyIf ctx.Config.SpaceBeforeUppercaseInvocation sepSpace ctx
-                    | LowercaseSynExpr -> onlyIf ctx.Config.SpaceBeforeLowercaseInvocation sepSpace ctx
+                    | UppercaseSynExpr -> (fun ctx -> onlyIf ctx.Config.SpaceBeforeUppercaseInvocation sepSpace ctx)
+                    | LowercaseSynExpr -> (fun ctx -> onlyIf ctx.Config.SpaceBeforeLowercaseInvocation sepSpace ctx)
+
+                match List.tryHead es with
+                | None ->
+                    match e with
+                    | Paren _ -> sepSpace
+                    | _ -> sepSpaceBasedOnSetting e
+                | Some (SimpleExpr _) -> sepSpace
+                | _ -> sepSpaceBasedOnSetting e
 
             let short =
                 genExpr astContext e


### PR DESCRIPTION
 Fixes #2015.

@jindraivanek let me know if you want a release with this fix.