### PR TITLE
Adding 0 to be recognized as one of the escaped characters.

### DIFF
--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -342,5 +342,5 @@ bbb\"\"\"
 
 [<Test>]
 let ``unicode null character should be recognized as a trivia item, 2050`` () =
-    formatSourceString false "let s = \"\000\"" config
-    |> should equal (sprintf "let s = \"%s\"\n" "\000")
+    formatSourceString false "let s = \"\\000\"" config
+    |> should equal "let s = \"\\000\"\n"

--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -339,3 +339,8 @@ let s =
     \"\"\"aaaa   
 bbb\"\"\"
 "
+
+[<Test>]
+let ``unicode null character should be recognized as a trivia item, 2050`` () =
+    formatSourceString false "let s = \"\000\"" config
+    |> should equal (sprintf "let s = \"%s\"\n" "\000")

--- a/src/Fantomas/TokenParser.fs
+++ b/src/Fantomas/TokenParser.fs
@@ -522,7 +522,7 @@ let private (|InterpStringEndOrPartToken|_|) token =
         None
 
 let escapedCharacterRegex =
-    System.Text.RegularExpressions.Regex("(\\\\(a|b|f|n|r|t|u|v|x|'|\\\"|\\\\))+")
+    System.Text.RegularExpressions.Regex("(\\\\(a|b|f|n|r|t|u|v|x|0|'|\\\"|\\\\))+")
 
 let private (|MultipleStringTextTokens|_|) tokens =
     let f _ =


### PR DESCRIPTION
This is a fix when explicit "\000" unicode character is replaced by null character.

The test in this PR works both with "\000" and "?" as expected result however, written with the sprintf the "\000" is converted into "?" when formatting is applied. 

Fixes #2050