### PR TITLE
Fix 2014:  separate ParsedHashDirective by a newline

### DIFF
--- a/src/Fantomas.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Tests/CompilerDirectivesTests.fs
@@ -2121,6 +2121,27 @@ open Shared
 """
 
 [<Test>]
+let ``namespace under parsed hash directives, 2014`` () =
+    formatSourceString
+        false
+        """
+#load "Types.fsx"
+#load "Project.fsx"
+
+namespace MyNamespace
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#load "Types.fsx"
+#load "Project.fsx"
+
+namespace MyNamespace
+"""
+
+[<Test>]
 let ``empty module with trivia, FAKE`` () =
     formatSourceStringWithDefines
         [ "FAKE" ]

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -89,7 +89,7 @@ and addFinalNewline ctx =
     mns = modules : SynModuleOrNamespace list
 *)
 and genImpFile astContext (ParsedImplFileInput (hs, mns)) =
-    col sepNone hs genParsedHashDirective
+    col sepNln hs genParsedHashDirective
     +> (if hs.IsEmpty then sepNone else sepNln)
     +> col sepNln mns (genModuleOrNamespace astContext)
 


### PR DESCRIPTION
Fixes #2014
