### PR TITLE
Print trivia in LongIdentWithDots application.

### DIFF
--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -1318,9 +1318,10 @@ let ``app tuple inside dotget expression`` () =
         """
 (st :> IProvidedCustomAttributeProvider)
     .GetHasTypeProviderEditorHideMethodsAttribute(
-        info.ProvidedType.TypeProvider.PUntaintNoFailure(
-            id
-        )
+        info
+            .ProvidedType
+            .TypeProvider
+            .PUntaintNoFailure(id)
     )
 """
 

--- a/src/Fantomas.Tests/LongIdentWithDotsTests.fs
+++ b/src/Fantomas.Tests/LongIdentWithDotsTests.fs
@@ -303,3 +303,49 @@ let shrinkInput input =
         //stdout.WriteLine("Can't shrink {0} further.", sprintf "%A" input)
         Seq.empty
 """
+
+[<Test>]
+let ``comment in LongIdent application, 2062`` () =
+    formatSourceString
+        false
+        """
+Rollbar
+  .RollbarLocator
+  .RollbarInstance
+  // .AsBlockingLogger(System.TimeSpan.FromSeconds 5)
+  .Error(package, custom)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+Rollbar
+    .RollbarLocator
+    .RollbarInstance
+    // .AsBlockingLogger(System.TimeSpan.FromSeconds 5)
+    .Error(package, custom)
+"""
+
+[<Test>]
+let ``comment inside LongIdentWithDots preserved, 2027`` () =
+    formatSourceString
+        false
+        """
+let path =
+    match normalizedPath with
+    | path ->
+        path  // translate path to Python relative syntax
+            .Replace("../../../", "....")
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let path =
+    match normalizedPath with
+    | path ->
+        path // translate path to Python relative syntax
+            .Replace("../../../", "....")
+"""


### PR DESCRIPTION
Fixes #2027 and fixes #2062.

There is a very minor stylistic impact by this fix.
I'm not sure yet if I'm going to release this as part of the 4.6 series or wait for 4.7.