### PR TITLE
Fix 2043: Comment after [] is lost

### DIFF
--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -99,7 +99,9 @@ let count: int [] // foo
     |> should
         equal
         """
-let count: int [] = [ 2 ] // foo
+let count: int [] // foo
+    =
+    [ 2 ]
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -86,6 +86,42 @@ let print_30_permut () =
     permutation
 """
 
+[<Test>]
+let ``comments on let bindings with return type, 2043`` () =
+    formatSourceString
+        false
+        """
+let count: int [] // foo
+    = [2]
+    """
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let count: int [] = [ 2 ] // foo
+"""
+
+[<Test>]
+let ``comments after SynType_Array in record type, 2043`` () =
+    formatSourceString
+        false
+        """
+type Model =
+    { Flags: bool [] // foo
+      Name: string // bar
+      Street: string }
+    """
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Model =
+    { Flags: bool [] // foo
+      Name: string // bar
+      Street: string }
+"""
 
 [<Test>]
 let ``xml documentation`` () =

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1450,7 +1450,7 @@ let (|TStaticConstantNamed|_|) =
 
 let (|TArray|_|) =
     function
-    | SynType.Array (n, t, _) -> Some(t, n)
+    | SynType.Array (n, t, r) -> Some(t, n, r)
     | _ -> None
 
 let (|TAnon|_|) =


### PR DESCRIPTION
Fixes #2043 
- comments after let bindings with return types
- comments after SynType_Array in record type