### PR TITLE
Always add a space for multiple curried args invocation

### DIFF
--- a/src/Fantomas.Tests/SingleExprTests.fs
+++ b/src/Fantomas.Tests/SingleExprTests.fs
@@ -213,3 +213,22 @@ let ``comment after address of tokens`` () =
 && // comment
     foobar
 """
+
+[<Test>]
+let ``function invocation with multiple curried parameters`` () =
+    formatSourceString
+        false
+        """
+module Foo =
+    let Bar (baz1: int) (baz2: string) (baz3: string) (baz4: string) =
+        FooBarBaz(someFunc x) (someOtherFunc y)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Foo =
+    let Bar (baz1: int) (baz2: string) (baz3: string) (baz4: string) =
+        FooBarBaz (someFunc x) (someOtherFunc y)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -3215,6 +3215,10 @@ and genApp astContext e es ctx =
                 (fun ctx ->
                     match es with
                     | [] -> false
+                    | Paren _ :: rest when es.Length > 1 ->
+                        match rest with
+                        | Paren _ :: _ -> true
+                        | _ -> addSpaceBeforeParensInFunCall e es.Head ctx
                     | [ h ]
                     | h :: _ -> addSpaceBeforeParensInFunCall e h ctx)
                 sepSpace


### PR DESCRIPTION
Addresses https://github.com/dotnet/docs/pull/28141