### PR TITLE
Fix FSharp compiler docs link for SynExpr

### DIFF
--- a/docs/Formatting-Elmish-code.md
+++ b/docs/Formatting-Elmish-code.md
@@ -14,7 +14,7 @@ To keep things focused, the scope is currently limited to the Fable.React and Fe
 
 ## Key concepts
 
-There are two active patterns for [SynExpr](https://fsharp.github.io/FSharp.Compiler.Service/reference/fsharp-compiler-syntaxtree-synexpr.html) that capture the shapes in the Elmish DSL.
+There are two active patterns for [SynExpr](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-syntax-synexpr.html) that capture the shapes in the Elmish DSL.
 
 See [SourceParser](../src/Fantomas/SourceParser.fs#:~:text=elmishreactwithoutchildren):
  


### PR DESCRIPTION
Fixed the link for the [SynExpr Type](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-syntax-synexpr.html) in the FSharp compiler docs. The [current link](https://fsharp.github.io/FSharp.Compiler.Service/reference/fsharp-compiler-syntaxtree-synexpr.html) is broken.