### PR TITLE
Fix FSharp compiler docs link for SynExpr.DotGet expression

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -799,7 +799,7 @@ type Triangle() =
 
 ### fsharp_max_dot_get_expression_width
 
-Control the maximum width for which (nested) [SynExpr.DotGet](https://fsharp.github.io/FSharp.Compiler.Service/reference/fsharp-compiler-syntaxtree-synexpr.html) expressions should be in one line.
+Control the maximum width for which (nested) [SynExpr.DotGet](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-syntax-synexpr.html#DotGet) expressions should be in one line.
 Default = 50.
 
 `defaultConfig`


### PR DESCRIPTION
Fixed the link for the [SynExpr.DotGet](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-syntax-synexpr.html#DotGetl) expression, in the FSharp compiler docs. The [current link](https://fsharp.github.io/FSharp.Compiler.Service/reference/fsharp-compiler-syntaxtree-synexpr.html) is broken.

Sorry for not batching this with the [previous PR](https://github.com/fsprojects/fantomas/pull/2082), just found this broken link.