### PR TITLE
Pre push hook to ensure code is formatted on upload

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# ensure that formatting is correct before pushing to the remote repository
+dotnet fake build -t CheckFormat

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,20 @@
 #!/bin/sh
 
+remote_name="$1"
+remote_url="$2"
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local oid> <remote ref> <remote oid>
+# TODO: read these lines and use the list of 'refs to push' to inspect the 
+# content of those refs and only format the changed files.
+
+# sample read loop:
+# while read local_ref local_oid remote_ref remote_oid
+# do
+#   // use local_ref, local_oid, remote_ref, remote_oid to compute file changes
+# done
+
 # ensure that formatting is correct before pushing to the remote repository
+dotnet tool restore
 dotnet fake build -t CheckFormat

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,11 +86,20 @@ After cloning the repository, you can restore the local .NET tools:
 
 > dotnet tool restore
 
-Next, you can execute FAKE build targets.
+Next, you should run a FAKE target that sets up some git repo-level configuration.
+
+> dotnet fake build -t EnsureRepoConfig
+
+This target makes changes to the local git repository configuration to ensure 
+that formatting of new code is consistent before it is pushed up to a remote repository.
+
+Finally, you can execute FAKE build targets.
 
 > dotnet fake run build.fsx --list
 
 The default target will execute the CI build.
+
+> dotnet fake build
 
 # Pull request ground rules
 

--- a/build.fsx
+++ b/build.fsx
@@ -479,7 +479,11 @@ Target.create "CheckFormat" (fun _ ->
         Trace.logf "Errors while formatting: %A" result.Errors
         failwith "Unknown errors while formatting")
 
-Target.create "EnsureRepoConfig" (fun _ -> Fake.Tools.Git.CommandHelper.gitCommand "" "config core.hooksPath .githooks")
+Target.create "EnsureRepoConfig" (fun _ ->
+    // Configure custom git hooks
+    // * Currently only used to ensure that code is formatted before pushing
+    Fake.Tools.Git.CommandHelper.gitCommand "" "config core.hooksPath .githooks"
+)
 
 // --------------------------------------------------------------------------------------
 // Run all targets by default. Invoke 'build <Target>' to override

--- a/build.fsx
+++ b/build.fsx
@@ -476,7 +476,9 @@ Target.create "CheckFormat" (fun _ ->
     elif result.ExitCode = 99 then
         failwith "Some files need formatting, run `dotnet fake build -t Format` to format them"
     else
-        Trace.logf "Errors while formatting: %A" result.Errors)
+        Trace.logf "Errors while formatting: %A" result.Errors
+        failwith "Unknown errors while formatting"
+   )
 
 Target.create "EnsureRepoConfig" (fun _ ->
     Fake.Tools.Git.CommandHelper.gitCommand "" "config core.hooksPath .githooks"

--- a/build.fsx
+++ b/build.fsx
@@ -477,12 +477,9 @@ Target.create "CheckFormat" (fun _ ->
         failwith "Some files need formatting, run `dotnet fake build -t Format` to format them"
     else
         Trace.logf "Errors while formatting: %A" result.Errors
-        failwith "Unknown errors while formatting"
-   )
+        failwith "Unknown errors while formatting")
 
-Target.create "EnsureRepoConfig" (fun _ ->
-    Fake.Tools.Git.CommandHelper.gitCommand "" "config core.hooksPath .githooks"
-)
+Target.create "EnsureRepoConfig" (fun _ -> Fake.Tools.Git.CommandHelper.gitCommand "" "config core.hooksPath .githooks")
 
 // --------------------------------------------------------------------------------------
 // Run all targets by default. Invoke 'build <Target>' to override

--- a/build.fsx
+++ b/build.fsx
@@ -478,6 +478,10 @@ Target.create "CheckFormat" (fun _ ->
     else
         Trace.logf "Errors while formatting: %A" result.Errors)
 
+Target.create "EnsureRepoConfig" (fun _ ->
+    Fake.Tools.Git.CommandHelper.gitCommand "" "config core.hooksPath .githooks"
+)
+
 // --------------------------------------------------------------------------------------
 // Run all targets by default. Invoke 'build <Target>' to override
 


### PR DESCRIPTION
Feel free to not take this, this is a little experiment.

I added a git hook that fires before commits are pushed to a repo that invokes the `CheckFormat` target.  If that target fails, the push fails.

In order for this to work, by default the hook script would have to live in the `.git/hooks` directory, but this directory isn't sharable/tracked in git. Therefore, I made a new directory to hold the hooks, and added a build script target that can be used to set up this kind of repo-local git config (since the .git/config file can't be shared for the same reason!). One other use of this target might be to set the `.git-blame-ignore-revs` file configuration, for example.

What do you think? I would imagine if you like this I'd need to update the README as well.