### PR TITLE
Fixes 1951 - Single block comment in namespace is disappearing

### DIFF
--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -937,6 +937,27 @@ type substring =
 """
 
 [<Test>]
+let ``Single block comment in namespace, 1951`` () =
+    formatSourceString
+        false
+        """
+namespace ASTViewer.Server
+(* open Microsoft.Azure.Functions.Worker.Http
+open Microsoft.Azure.Functions.Worker
+open Microsoft.Extensions.Logging *)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+namespace ASTViewer.Server
+(* open Microsoft.Azure.Functions.Worker.Http
+open Microsoft.Azure.Functions.Worker
+open Microsoft.Extensions.Logging *)
+"""
+
+[<Test>]
 let ``line comment after "then"`` () =
     formatSourceString
         false

--- a/src/Fantomas/Trivia.fs
+++ b/src/Fantomas/Trivia.fs
@@ -92,6 +92,13 @@ let private findNodeBeforeLineAndColumn (nodes: TriviaNodeAssigner list) line co
 
             range.StartLine <= line
             && range.StartColumn <= column)
+        |> function
+            | None ->
+                nodes
+                |> List.tryFindBack (fun tn ->
+                    let range = tn.Range
+                    range.StartLine <= line)
+            | Some n -> Some n
 
     match node with
     | Some tokenNode ->


### PR DESCRIPTION
Fixes #1951

Really not sure if lowering the requirements for the node before if none was found in the first run is the right approach, but might be a start.