### PR TITLE
Add regression test for #1160, Unexpected indentation in if-else when using keep_if_then_in_same_line=true

### DIFF
--- a/src/Fantomas.Tests/KeepIfThenInSameLineTests.fs
+++ b/src/Fantomas.Tests/KeepIfThenInSameLineTests.fs
@@ -185,3 +185,30 @@ else if fooo then bar
 elif foooo then bar
 else bar
 """
+
+[<Test>]
+let ``indentation with KeepIfThenInSameLine, 1160`` () =
+    formatSourceString
+        false
+        """
+let intermediateModel: IntermediateModel =
+    initialIntermediateModel
+    |> fold caseFold events
+    |> if super long complicated condition that maybe should be factored out then
+           updateActions
+       else
+           id
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let intermediateModel: IntermediateModel =
+    initialIntermediateModel
+    |> fold caseFold events
+    |> if super long complicated condition that maybe should be factored out then
+           updateActions
+       else
+           id
+"""


### PR DESCRIPTION
#1160 is already fixed in current. So here is a regression test to close the issue.