### PR TITLE
Bump Paket for net6

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "fake-cli": {
-      "version": "5.20.4",
+      "version": "5.21.1",
       "commands": [
         "fake"
       ]


### PR DESCRIPTION
I didn't want to force an opinion on whether to test for net6, so I've got a bunch of changes locally to allow me to operate with net6, but this one seems pretty reasonable to go straight in. See discussion at https://github.com/fsprojects/FAKE/issues/2564; basically this version of FAKE has a Paket bundled that works on net6.

I'm relying on the CI to let me know if this has broken net5!