### PR TITLE
Fix 1932: Unexpected newline added before let bang

### DIFF
--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -877,3 +877,31 @@ let Ok (content: string) =
     )
 #endif
 """
+
+[<Test>]
+let ``should not add newline before "let!", 1932`` () =
+    formatSourceString
+        false
+        """
+promise {
+    setItems [||]
+    setFetchingItems true
+    let! items = Api.fetchItems partNumber
+    setFetchingItems false
+}
+|> Promise.start
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+promise {
+    setItems [||]
+    setFetchingItems true
+    let! items = Api.fetchItems partNumber
+    setFetchingItems false
+}
+|> Promise.start
+"""
+

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1633,7 +1633,7 @@ and genExpr astContext synExpr ctx =
         | Paren (lpr, e, rpr, _pr) ->
             match e with
             | LetOrUses _
-            | Sequential (_, LetOrUses _, _) ->
+            | Sequential _ ->
                 sepOpenTFor lpr
                 +> atCurrentColumn (genExpr astContext e)
                 +> sepCloseTFor rpr

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -978,9 +978,7 @@ let rec (|CompExprBody|_|) expr =
     match expr with
     | SynExpr.LetOrUse (_, _, _, CompExprBody _, _)
     | SynExpr.LetOrUseBang _
-    | SynExpr.Sequential (_, _, _, SynExpr.YieldOrReturn _, _)
-    | SynExpr.Sequential (_, _, _, SynExpr.LetOrUse _, _)
-    | SynExpr.Sequential (_, _, _, SynExpr.LetOrUseBang _, _) -> Some(collectComputationExpressionStatements expr id)
+    | SynExpr.Sequential _ -> Some(collectComputationExpressionStatements expr id)
     | _ -> None
 
 let (|ForEach|_|) =


### PR DESCRIPTION
Fixes: #1932 