### PR TITLE
Use a single place to specify the MSBuild Version property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Version>4.6.4</Version>
+  </PropertyGroup>
+</Project>

--- a/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
+++ b/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
@@ -4,7 +4,6 @@
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <Version>4.6.4</Version>
     <NoWarn>FS0988</NoWarn>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
   </PropertyGroup>

--- a/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
+++ b/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
@@ -8,7 +8,6 @@
     <RollForward>Major</RollForward>
     <ToolCommandName>fantomas</ToolCommandName>
     <PackAsTool>True</PackAsTool>
-    <Version>4.6.4</Version>
     <AssemblyName>fantomas-tool</AssemblyName>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>

--- a/src/Fantomas.Extras/Fantomas.Extras.fsproj
+++ b/src/Fantomas.Extras/Fantomas.Extras.fsproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.6.4</Version>
     <Description>Utility package for Fantomas</Description>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.6.4</Version>
     <NoWarn>FS0988</NoWarn>
     <TargetFramework>net5.0</TargetFramework>
     <WarningsAsErrors>FS0025</WarningsAsErrors>

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.6.4</Version>
     <Description>Source code formatter for F#</Description>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>


### PR DESCRIPTION
This way changing it when releasing a new version is easier.