### PR TITLE
Keep copyInfo for record fixed at starting column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 * Update .NET SDK to 6.0.200. [#2105](https://github.com/fsprojects/fantomas/pull/2105)
 
+### Fixed
+* Valid input => Formatted content is not valid F# code. [#2109](https://github.com/fsprojects/fantomas/issues/2109)
+
 ## [4.6.5] - 2022-02-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Update .NET SDK to 6.0.200. [#2105](https://github.com/fsprojects/fantomas/pull/2105)
 
 ### Fixed
-* Valid input => Formatted content is not valid F# code. [#2109](https://github.com/fsprojects/fantomas/issues/2109)
+* Keep copyInfo for record fixed at starting column. [#2109](https://github.com/fsprojects/fantomas/issues/2109)
 
 ## [4.6.5] - 2022-02-18
 

--- a/src/Fantomas.Tests/ColMultilineItemTests.fs
+++ b/src/Fantomas.Tests/ColMultilineItemTests.fs
@@ -552,35 +552,3 @@ printfn "%s" "c:\\def\\ghi\\jkl"
 xyz
 *)
 """
-
-
-[<Test>]
-let ``multiline record with idents, 2109`` () =
-    formatSourceString
-        false
-        """
-let defaultTestOptions fwk common (o: DotNet.TestOptions) =
-    { o.WithCommon(
-          (fun o2 ->
-              { o2 with
-                    Verbosity = Some DotNet.Verbosity.Normal })
-          >> common
-      ) with
-          NoBuild = true
-          Framework = fwk // Some "netcoreapp3.0"
-          Configuration = DotNet.BuildConfiguration.Debug }
-"""
-        config
-    |> prepend newline
-    |> should
-        equal
-        """
-let defaultTestOptions fwk common (o: DotNet.TestOptions) =
-    { o.WithCommon(
-          (fun o2 -> { o2 with Verbosity = Some DotNet.Verbosity.Normal })
-          >> common
-      ) with
-        NoBuild = true
-        Framework = fwk // Some "netcoreapp3.0"
-        Configuration = DotNet.BuildConfiguration.Debug }
-"""

--- a/src/Fantomas.Tests/ColMultilineItemTests.fs
+++ b/src/Fantomas.Tests/ColMultilineItemTests.fs
@@ -552,3 +552,35 @@ printfn "%s" "c:\\def\\ghi\\jkl"
 xyz
 *)
 """
+
+
+[<Test>]
+let ``multiline record with idents, 2109`` () =
+    formatSourceString
+        false
+        """
+let defaultTestOptions fwk common (o: DotNet.TestOptions) =
+    { o.WithCommon(
+          (fun o2 ->
+              { o2 with
+                    Verbosity = Some DotNet.Verbosity.Normal })
+          >> common
+      ) with
+          NoBuild = true
+          Framework = fwk // Some "netcoreapp3.0"
+          Configuration = DotNet.BuildConfiguration.Debug }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let defaultTestOptions fwk common (o: DotNet.TestOptions) =
+    { o.WithCommon(
+          (fun o2 -> { o2 with Verbosity = Some DotNet.Verbosity.Normal })
+          >> common
+      ) with
+        NoBuild = true
+        Framework = fwk // Some "netcoreapp3.0"
+        Configuration = DotNet.BuildConfiguration.Debug }
+"""

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -1918,3 +1918,34 @@ let ``anonymous records with comments on record fields, 2067`` () =
    // The bar value.
    BarValue = barValue |}
 """
+
+[<Test>]
+let ``keep copyInfo for record fixed at starting column, 2109`` () =
+    formatSourceString
+        false
+        """
+let defaultTestOptions fwk common (o: DotNet.TestOptions) =
+    { o.WithCommon(
+          (fun o2 ->
+              { o2 with
+                    Verbosity = Some DotNet.Verbosity.Normal })
+          >> common
+      ) with
+          NoBuild = true
+          Framework = fwk // Some "netcoreapp3.0"
+          Configuration = DotNet.BuildConfiguration.Debug }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let defaultTestOptions fwk common (o: DotNet.TestOptions) =
+    { o.WithCommon(
+          (fun o2 -> { o2 with Verbosity = Some DotNet.Verbosity.Normal })
+          >> common
+      ) with
+        NoBuild = true
+        Framework = fwk // Some "netcoreapp3.0"
+        Configuration = DotNet.BuildConfiguration.Debug }
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2986,7 +2986,7 @@ and genMultilineRecordInstance
                         ctx
             | Some e ->
                 genTriviaFor SynExpr_Record_OpeningBrace openingBrace sepOpenS
-                +> genExpr astContext e
+                +> atCurrentColumnIndent (genExpr astContext e)
                 +> !- " with"
                 +> ifIndentLesserThan
                     3


### PR DESCRIPTION
Fixes #2109 
As @nojaf  suggested, it's fixed by wrapping genExpr() in atCurrentColumnIndent()