### PR TITLE
Pin Paket version

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,3 +1,4 @@
+version 6.2.1
 source https://api.nuget.org/v3/index.json
 
 framework: netstandard2.0, net6.0, netcoreapp3.1


### PR DESCRIPTION
I did this because of FAKE's instruction (added in https://github.com/fsprojects/FAKE/issues/2193 where FAKE was changed to print out a warning):

```
Hint: Could not find a version in your paket.dependencies file, consider adding 'version 6.2.1' at the top of your dependencies file (/Users/patrick/Documents/GitHub/fantomas/paket.dependencies).
Read https://github.com/fsharp/FAKE/issues/2193 for details.
```