### PR TITLE
Add  copy_local: true for Ionide.KeepAChangelog.Tasks and Dotnet.ReproducibleBuilds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Comment after equals in record type is lost. [#2001](https://github.com/fsprojects/fantomas/issues/2001)
 * Comment after match keyword is lost. [#1851](https://github.com/fsprojects/fantomas/issues/1851)
 * Preserve in keyword on next line. [#1182](https://github.com/fsprojects/fantomas/issues/1182)
+* Remove Ionide.KeepAChangelog.Tasks and Dotnet.ReproducibleBuilds as NuGet dependencies. [#2131](https://github.com/fsprojects/fantomas/pull/2131)
 
 ## [4.7.0] - 2022-03-04
 

--- a/src/Fantomas.Client/paket.references
+++ b/src/Fantomas.Client/paket.references
@@ -1,5 +1,5 @@
-Ionide.KeepAChangelog.Tasks
-Dotnet.ReproducibleBuilds
+Ionide.KeepAChangelog.Tasks copy_local: true
+Dotnet.ReproducibleBuilds copy_local: true
 
 group client
 FSharp.Core

--- a/src/Fantomas.CoreGlobalTool/paket.references
+++ b/src/Fantomas.CoreGlobalTool/paket.references
@@ -4,5 +4,5 @@ Argu
 StreamJsonRpc
 Thoth.Json.Net
 SerilogTraceListener
-Ionide.KeepAChangelog.Tasks
-Dotnet.ReproducibleBuilds
+Ionide.KeepAChangelog.Tasks copy_local: true
+Dotnet.ReproducibleBuilds copy_local: true

--- a/src/Fantomas.Extras/paket.references
+++ b/src/Fantomas.Extras/paket.references
@@ -1,6 +1,5 @@
 FSharp.Core
-Ionide.KeepAChangelog.Tasks
-Dotnet.ReproducibleBuilds
+Ionide.KeepAChangelog.Tasks copy_local: true
+Dotnet.ReproducibleBuilds copy_local: true
 editorconfig
 MAB.DotIgnore
-Microsoft.SourceLink.GitHub

--- a/src/Fantomas/paket.references
+++ b/src/Fantomas/paket.references
@@ -1,4 +1,4 @@
 FSharp.Compiler.Service
 FSharp.Core
-Ionide.KeepAChangelog.Tasks
-Dotnet.ReproducibleBuilds
+Ionide.KeepAChangelog.Tasks copy_local: true
+Dotnet.ReproducibleBuilds copy_local: true


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2621499/157111527-d3421674-b558-4de6-b602-606aa472dea9.png)

I noticed `Ionide.KeepAChangelog.Tasks` and `Dotnet.ReproducibleBuilds` are listed as dependencies, this should not be the case.
This PR tries to rectify that.