### PR TITLE
Preserve column offset for multiline expression in noBreakInfixOps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Weird split of DotGet TypeApp. [#1863](https://github.com/fsprojects/fantomas/issues/1863)
+
 ## [4.7.3] - 2022-03-12
 
 ### Fixed

--- a/src/Fantomas.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Tests/LetBindingTests.fs
@@ -1231,7 +1231,7 @@ let x =
                tcref.ILTyconRawMetadata.CustomAttrs.AsArray
                |> Array.exists (fun attr ->
                    attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>
-                       .FullName)
+                                                                 .FullName)
            else
                false
 """
@@ -1262,8 +1262,7 @@ let x =
                tcref.ILTyconRawMetadata.CustomAttrs.AsArray
                |> Array.exists
                    (fun attr ->
-                       attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>
-                           .FullName)
+                       attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>.FullName)
            else
                false
 """
@@ -1293,7 +1292,7 @@ let x =
                tcref.ILTyconRawMetadata.CustomAttrs.AsArray
                |> Array.exists (fun attr ->
                    attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>
-                       .FullName)
+                                                                 .FullName)
            else
                false
 """

--- a/src/Fantomas.Tests/OperatorTests.fs
+++ b/src/Fantomas.Tests/OperatorTests.fs
@@ -1277,3 +1277,21 @@ StringPosition.(|A|B|)
 
 let f (|A|B|) = (|A|B|)
 """
+
+[<Test>]
+let ``multiline expressions in equals infix operator, 1863`` () =
+    formatSourceString
+        false
+        """
+
+ let v =       attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>.FullName
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>
+                                                  .FullName
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2747,7 +2747,7 @@ and genOnelinerInfixExpr astContext e1 operatorText operatorExpr e2 =
     +> sepSpace
     +> genInfixOperator operatorText operatorExpr
     +> sepSpace
-    +> genExpr astContext e2
+    +> atCurrentColumnIndent (genExpr astContext e2)
 
 and genMultilineInfixExpr astContext e1 operatorText operatorExpr e2 =
     let genE1 (ctx: Context) =


### PR DESCRIPTION
Fixes #1863.