### PR TITLE
Emit correct keyword for properties with both getter and setter specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Option parameter name is lost in tuple. [#2144](https://github.com/fsprojects/fantomas/issues/2144)
+* Emit correct keyword for properties with both getter and setter specified [#2129](https://github.com/fsprojects/fantomas/issues/2129)
 
 ## [4.7.2] - 2022-03-11
 

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -464,6 +464,29 @@ let CalculateFine (ticket: SpeedingTicket) =
 """
 
 [<Test>]
+let ``separate-indexed-properties`` () =
+    formatSourceString
+        false
+        """
+type Foo() =
+    member this.Item
+        with get (name: string): obj option = None
+
+    member this.Item
+        with set (name: string) (v: obj option): unit =
+            ()"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Foo() =
+    member this.Item
+        with set (name: string) (v: obj option): unit = ()
+        and get (name: string): obj option = None
+"""
+
+[<Test>]
 let ``indexed properties`` () =
     formatSourceString
         false

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -464,7 +464,7 @@ let CalculateFine (ticket: SpeedingTicket) =
 """
 
 [<Test>]
-let ``separate-indexed-properties`` () =
+let ``separate-indexed-properties, 2129`` () =
     formatSourceString
         false
         """

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -728,8 +728,10 @@ and genPropertyWithGetSet astContext (b1, b2) =
         let a = "and"
 
         let genGetSet =
-            match pk1, pk2 with
-            | Some _, Some (PropertyKeyword.With _) -> genSet w pk1 +> sepNln +> genGet a pk2
+            // regardless of get/set ordering, the second member needs to be rendered as keyword "and", not keyword "with".
+            // therefore, the genGet and genSet helper functions have to take the desired keyword as a parameter.
+            match pk2 with
+            | Some (PropertyKeyword.With _) -> genSet w pk1 +> sepNln +> genGet a pk2
             | _ -> genGet w pk1 +> sepNln +> genSet a pk2
 
         prefix

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -724,8 +724,8 @@ and genPropertyWithGetSet astContext (b1, b2) =
         let genSet okw ikw =
             genProperty astContext (genPropertyKeyword (okw, ikw)) ao2 "set " ps2 SynBinding_Equals eqR2 e2
 
-        let w = Some "with"
-        let a = Some "and"
+        let w = "with"
+        let a = "and"
 
         let genGetSet =
             match pk1, pk2 with
@@ -740,16 +740,22 @@ and genPropertyWithGetSet astContext (b1, b2) =
         +> unindent
     | _ -> sepNone
 
-and genPropertyKeyword (outputKeyword: string option, inputKeyword: PropertyKeyword option) (ctx: Context) =
-    match outputKeyword with
-    | None -> ctx
-    | Some keyword ->
-        let start = keyword + " "
+/// <summary>Generate the keyword <code>and</code> or <code>with</code>, along with any matching syntax trivia, for a given keyword</summary>
+/// <param name="outputKeyword">the keyword that the user wants for the property after writing.</param>
+/// <param name="inputKeyword">the parsed keyword range for the property from the AST. this is used to lookup trivia based on its range, since this range can differ from the output keyword's range.</param>
+/// <param name="ctx">the writing context context, not used inside this function</param>
+/// <remarks>The output keyword and input keyword can be different in the case of a property where the getter and setter are defined separately.
+/// Fantomas will combine the definitions, each of which are defined as <code>member blah with get</code>, <code>member blah with get</code>,
+/// into a combined getter and setter on a single member. This means that one of the <code>with</code> must be rewritten as an <code>and</code>,
+/// but we need to preserve the trivia.</remarks>
+/// <returns>A function that will transform and rewrite the member property keywords.</returns>
+and genPropertyKeyword (outputKeyword: string, inputKeyword: PropertyKeyword option) (ctx: Context) =
+    let start = outputKeyword + " "
 
-        match inputKeyword with
-        | None -> ctx
-        | Some (PropertyKeyword.And r) -> (!-start |> genTriviaFor SynPat_LongIdent_And r) ctx
-        | Some (PropertyKeyword.With r) -> (!-start |> genTriviaFor SynPat_LongIdent_With r) ctx
+    match inputKeyword with
+    | None -> ctx
+    | Some (PropertyKeyword.And r) -> (!-start |> genTriviaFor SynPat_LongIdent_And r) ctx
+    | Some (PropertyKeyword.With r) -> (!-start |> genTriviaFor SynPat_LongIdent_With r) ctx
 
 and genMemberBindingList astContext node =
     let rec collectItems


### PR DESCRIPTION
When property getters and setters are emitted, if we're emitting two properties then the second one, getter or setter, needs to be emitted with the `and` keyword. If this isn't done, the emitted code doesn't compile.

This fixes #2129 