### PR TITLE
Respect current column when dotget is found in quotation. 

### DIFF
--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -1360,3 +1360,20 @@ module Program =
         builder.Build().RunAsync() |> ignore
         0
 """
+
+[<Test>]
+let ``dotget inside a quotation, 2154`` () =
+    formatSourceString
+        false
+        """
+(fun (Singleton arg) -> <@@ ((%%arg: Indicators) :> IIndicators).AsyncGetIndicator(indicatorIdVal) @@>)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(fun (Singleton arg) ->
+    <@@ ((%%arg: Indicators) :> IIndicators)
+            .AsyncGetIndicator(indicatorIdVal) @@>)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1263,7 +1263,11 @@ and genExpr astContext synExpr ctx =
         | NullExpr -> !- "null"
         // Not sure about the role of e1
         | Quote (_, e2, isRaw) ->
-            let e = genExpr astContext e2
+            let e =
+                match e2 with
+                | DotGetApp _ -> atCurrentColumnIndent (genExpr astContext e2)
+                | _ -> genExpr astContext e2
+
             ifElse isRaw (!- "<@@ " +> e -- " @@>") (!- "<@ " +> e -- " @>")
         | TypedExpr (TypeTest, e, t) ->
             genExpr astContext e -- " :? "


### PR DESCRIPTION
Fixes #2154.