### PR TITLE
Fix 2151, index syntax without dot on array of arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * DotGet in quotation should be further indented. [#2154](https://github.com/fsprojects/fantomas/issues/2154)
+* Reformatting multiple array index operators (v6 style) adds spaces that are invalid [#2151](https://github.com/fsprojects/fantomas/issues/2151)
 
 ## [4.7.3] - 2022-03-12
 

--- a/src/Fantomas.Tests/IndexSyntaxTests.fs
+++ b/src/Fantomas.Tests/IndexSyntaxTests.fs
@@ -64,6 +64,27 @@ arr[0, 2, 3, 4]
 """
 
 [<Test>]
+let ``index syntax without dot on array of arrays, 2151`` () =
+    formatSourceString
+        false
+        """
+let a = Array.create 10 -1
+let b = Array.create 10 a
+
+printfn "%d -> %d" a[0] (b[0][0])
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = Array.create 10 -1
+let b = Array.create 10 a
+
+printfn "%d -> %d" a[0] (b[0][0])
+"""
+
+[<Test>]
 let ``only add spaces when expressions are atomic`` () =
     formatSourceString
         false

--- a/src/Fantomas/SourceParser.fs
+++ b/src/Fantomas/SourceParser.fs
@@ -1761,8 +1761,9 @@ let (|ElmishReactWithChildren|_|) (e: SynExpr) =
     | SynExpr.App (_,
                    false,
                    SynExpr.App (_, false, OptVar ident, (ArrayOrList _ as attributes), _),
-                   ArrayOrList (sr, isArray, children, er, _),
-                   _) -> Some(ident, attributes, (isArray, sr, children, er))
+                   ArrayOrList (sr, isArray, children, er, r),
+                   _) when (not (RangeHelpers.isAdjacentTo attributes.Range r)) ->
+        Some(ident, attributes, (isArray, sr, children, er))
     | _ -> None
 
 let isIfThenElseWithYieldReturn e =


### PR DESCRIPTION
Fixes #2151 

I think the source of the problem was that `ElmishReactWithChildren` was matching too much, so I restricted it instead of changing `IndexWithoutDotExpr`.