### PR TITLE
Multiline parentheses objectExpression in indexer expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Multiline parentheses objectExpression in indexer expression. [#2176](https://github.com/fsprojects/fantomas/issues/2176)
+
 ## [4.7.6] - 2022-04-04
 
 ### Fixed

--- a/src/Fantomas.Tests/DotIndexedGetTests.fs
+++ b/src/Fantomas.Tests/DotIndexedGetTests.fs
@@ -127,3 +127,42 @@ a
     )
     .Meh().[0]
 """
+
+[<Test>]
+let ``multiline parentheses objectExpression in indexer expression, 2176`` () =
+    formatSourceString
+        false
+        """
+namespace FSX.Infrastructure
+
+module Unix =
+
+    let GrabTheFirstStringBeforeTheFirstColon (lines: seq<string>) =
+        seq {
+            for line in lines do
+                yield
+                    (line.Split(
+                        [| ":" |],
+                        StringSplitOptions.RemoveEmptyEntries
+                    )).[0]
+        }
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+namespace FSX.Infrastructure
+
+module Unix =
+
+    let GrabTheFirstStringBeforeTheFirstColon (lines: seq<string>) =
+        seq {
+            for line in lines do
+                yield
+                    (line.Split(
+                        [| ":" |],
+                        StringSplitOptions.RemoveEmptyEntries
+                    )).[0]
+        }
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -2453,7 +2453,12 @@ and genExpr astContext synExpr ctx =
 
             expressionFitsOnRestOfLine (short +> idx) (long +> idx)
         | DotIndexedGet (objectExpr, indexArgs) ->
-            addParenIfAutoNln objectExpr (genExpr astContext)
+            let isParen =
+                match objectExpr with
+                | Paren _ -> true
+                | _ -> false
+
+            ifElse isParen (genExpr astContext objectExpr) (addParenIfAutoNln objectExpr (genExpr astContext))
             -- "."
             +> sepOpenLFixed
             +> genExpr astContext indexArgs


### PR DESCRIPTION
Idempotency problem when using lower MaxLineLength than default and fantomas needs to split lines

 Fixes https://github.com/fsprojects/fantomas/issues/2176