### PR TITLE
Don't add space between type of array and square brackets (#2192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+* Don't add space between type of array and square brackets. [#2192](https://github.com/fsprojects/fantomas/issues/2192)
+
 ## [5.0.0-alpha-002] - 2022-04-04
 
 ### Changed

--- a/src/Fantomas.Tests/AppTests.fs
+++ b/src/Fantomas.Tests/AppTests.fs
@@ -444,7 +444,7 @@ let ``space between function and argument in DotIndexedGet, 1261`` () =
     formatSourceString
         false
         """
-type Queue<'T>(data: list<'T []>, length: int) =
+type Queue<'T>(data: list<'T[]>, length: int) =
 
     member this.Head =
         if length > 0
@@ -456,7 +456,7 @@ type Queue<'T>(data: list<'T []>, length: int) =
     |> should
         equal
         """
-type Queue<'T>(data: list<'T []>, length: int) =
+type Queue<'T>(data: list<'T[]>, length: int) =
 
     member this.Head =
         if length > 0 then

--- a/src/Fantomas.Tests/CommentTests.fs
+++ b/src/Fantomas.Tests/CommentTests.fs
@@ -91,7 +91,7 @@ let ``comments on let bindings with return type, 2043`` () =
     formatSourceString
         false
         """
-let count: int [] // foo
+let count: int[] // foo
     = [2]
     """
         config
@@ -99,7 +99,7 @@ let count: int [] // foo
     |> should
         equal
         """
-let count: int [] // foo
+let count: int[] // foo
     =
     [ 2 ]
 """
@@ -110,7 +110,7 @@ let ``comments after SynType_Array in record type, 2043`` () =
         false
         """
 type Model =
-    { Flags: bool [] // foo
+    { Flags: bool[] // foo
       Name: string // bar
       Street: string }
     """
@@ -120,7 +120,7 @@ type Model =
         equal
         """
 type Model =
-    { Flags: bool [] // foo
+    { Flags: bool[] // foo
       Name: string // bar
       Street: string }
 """

--- a/src/Fantomas.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Tests/ControlStructureTests.fs
@@ -699,7 +699,7 @@ let ``keep new line before for loop, 1317`` () =
         false
         """
   /// Fold over the array passing the index and element at that index to a folding function
-  let foldi (folder: 'State -> int -> 'T -> 'State) (state: 'State) (array: 'T []) =
+  let foldi (folder: 'State -> int -> 'T -> 'State) (state: 'State) (array: 'T[]) =
     checkNonNull "array" array
 
     if array.Length = 0 then
@@ -722,7 +722,7 @@ let ``keep new line before for loop, 1317`` () =
         equal
         """
 /// Fold over the array passing the index and element at that index to a folding function
-let foldi (folder: 'State -> int -> 'T -> 'State) (state: 'State) (array: 'T []) =
+let foldi (folder: 'State -> int -> 'T -> 'State) (state: 'State) (array: 'T[]) =
     checkNonNull "array" array
 
     if array.Length = 0 then

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -122,7 +122,7 @@ module Services =
     type StreamResolver(storage: Storage.Instance) =
         member __.Resolve
             (
-                codec: FsCodec.IEventCodec<'event, byte [], _>,
+                codec: FsCodec.IEventCodec<'event, byte[], _>,
                 fold: ('state -> 'event seq -> 'state),
                 initial: 'state,
                 snapshot: (('event -> bool) * ('state -> 'event))
@@ -150,7 +150,7 @@ module Services =
     type StreamResolver(storage: Storage.Instance) =
         member __.Resolve
             (
-                codec: FsCodec.IEventCodec<'event, byte [], _>,
+                codec: FsCodec.IEventCodec<'event, byte[], _>,
                 fold: ('state -> 'event seq -> 'state),
                 initial: 'state,
                 snapshot: (('event -> bool) * ('state -> 'event))

--- a/src/Fantomas.Tests/InterfaceTests.fs
+++ b/src/Fantomas.Tests/InterfaceTests.fs
@@ -256,12 +256,12 @@ let ``long abstract member definition, 435`` () =
         false
         """
 type Test =
-    abstract RunJobs: folder:string * ?jobs:string * ?ctm:string * ?createDuplicate:bool * ?hold:bool * ?ignoreCriteria:bool * ?independentFlow:bool * ?orderDate:string * ?orderIntoFolder:string * ?variables:Dictionary<string, string> [] * ?waitForOrderDate:bool
+    abstract RunJobs: folder:string * ?jobs:string * ?ctm:string * ?createDuplicate:bool * ?hold:bool * ?ignoreCriteria:bool * ?independentFlow:bool * ?orderDate:string * ?orderIntoFolder:string * ?variables:Dictionary<string, string>[] * ?waitForOrderDate:bool
      -> string
 
     override this.RunJobs(folder: string, ?jobs: string, ?ctm: string, ?createDuplicate: bool, ?hold: bool,
                           ?ignoreCriteria: bool, ?independentFlow: bool, ?orderDate: string, ?orderIntoFolder: string,
-                          ?variables: Dictionary<string, string> [], ?waitForOrderDate: bool) =
+                          ?variables: Dictionary<string, string>[], ?waitForOrderDate: bool) =
         ""
 """
         config
@@ -280,7 +280,7 @@ type Test =
         ?independentFlow: bool *
         ?orderDate: string *
         ?orderIntoFolder: string *
-        ?variables: Dictionary<string, string> [] *
+        ?variables: Dictionary<string, string>[] *
         ?waitForOrderDate: bool ->
             string
 
@@ -295,7 +295,7 @@ type Test =
             ?independentFlow: bool,
             ?orderDate: string,
             ?orderIntoFolder: string,
-            ?variables: Dictionary<string, string> [],
+            ?variables: Dictionary<string, string>[],
             ?waitForOrderDate: bool
         ) =
         ""

--- a/src/Fantomas.Tests/ListTests.fs
+++ b/src/Fantomas.Tests/ListTests.fs
@@ -199,9 +199,9 @@ let getColumn c (A:_[,]) = flatten A.[*,c..c] |> Seq.toArray"""
     |> should
         equal
         """
-let cast<'a> (A: obj [,]) : 'a [,] = A |> Array2D.map unbox
-let flatten (A: 'a [,]) = A |> Seq.cast<'a>
-let getColumn c (A: _ [,]) = flatten A.[*, c..c] |> Seq.toArray
+let cast<'a> (A: obj[,]) : 'a[,] = A |> Array2D.map unbox
+let flatten (A: 'a[,]) = A |> Seq.cast<'a>
+let getColumn c (A: _[,]) = flatten A.[*, c..c] |> Seq.toArray
 """
 
 [<Test>]
@@ -2134,7 +2134,7 @@ let ``yield inside list that is part of multi line function application, 1191`` 
     formatSourceString
         false
         """
-let private fn (xs: int []) =
+let private fn (xs: int[]) =
     fn2
         ""
         [ let r = Seq.head xs
@@ -2149,7 +2149,7 @@ let private fn (xs: int []) =
     |> should
         equal
         """
-let private fn (xs: int []) =
+let private fn (xs: int[]) =
     fn2
         ""
         [ let r = Seq.head xs
@@ -2281,4 +2281,38 @@ let fns =
       //        deprecated = NotDeprecated }
       // I think the space at the start of the lines above matter
       ]
+"""
+
+[<Test>]
+let ``don't add space between array type and square brackets, 2192`` () =
+    let before =
+        """
+let x: int[] = [ 1, 2, 3 ]
+let x: double[][] = [ [ 1.0, 2.0, 3.0 ] ]
+let foo (x: double[]) (y: object[][]) : string[,] = x :> int[]
+let foo<'T> (x: 'T[]) = x
+"""
+
+    formatSourceString false before config
+    |> prepend newline
+    |> should equal before
+
+let ``remove space between array type and square brackets, 2192`` () =
+    formatSourceString
+        false
+        """
+let x: int [] = [ 1, 2, 3 ]
+let x: double []  [] = [ [ 1.0, 2.0, 3.0 ] ]
+let foo (x: double []) (y: object [] []) : string [,] = x :> int []
+let foo<'T> (x: 'T  []) = x
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x: int[] = [ 1, 2, 3 ]
+let x: double[][] = [ [ 1.0, 2.0, 3.0 ] ]
+let foo (x: double[]) (y: object[][]) : string[,] = x :> int[]
+let foo<'T> (x: 'T[]) = x
 """

--- a/src/Fantomas.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Tests/PatternMatchingTests.fs
@@ -406,14 +406,14 @@ let ``should put brackets around array type tests`` () =
         false
         """
 match item.Item with
-| :? (Instruction []) -> ()"""
+| :? (Instruction[]) -> ()"""
         config
     |> prepend newline
     |> should
         equal
         """
 match item.Item with
-| :? (Instruction []) -> ()
+| :? (Instruction[]) -> ()
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -171,7 +171,7 @@ let ``params arguments`` () =
         false
         """
 type X() =
-    member this.F([<ParamArray>] args: Object []) =
+    member this.F([<ParamArray>] args: Object[]) =
         for arg in args do
             printfn "%A" arg"""
         config
@@ -180,7 +180,7 @@ type X() =
         equal
         """
 type X() =
-    member this.F([<ParamArray>] args: Object []) =
+    member this.F([<ParamArray>] args: Object[]) =
         for arg in args do
             printfn "%A" arg
 """
@@ -1055,14 +1055,14 @@ let ``should preserve attributes on member parameters`` () =
         false
         """
 type ILogger =
-    abstract DebugFormat : format:String * [<ParamArray>]args:Object [] -> unit"""
+    abstract DebugFormat : format:String * [<ParamArray>]args:Object[] -> unit"""
         config
     |> prepend newline
     |> should
         equal
         """
 type ILogger =
-    abstract DebugFormat: format: String * [<ParamArray>] args: Object [] -> unit
+    abstract DebugFormat: format: String * [<ParamArray>] args: Object[] -> unit
 """
 
 [<Test>]
@@ -3062,7 +3062,7 @@ type MethInfo =
 #if NO_EXTENSIONTYPING
     member ProvidedStaticParameterInfo: obj option
 #else
-    member ProvidedStaticParameterInfo: (Tainted<ProvidedMethodBase> * Tainted<ProvidedParameterInfo> []) option
+    member ProvidedStaticParameterInfo: (Tainted<ProvidedMethodBase> * Tainted<ProvidedParameterInfo>[]) option
 #endif
 """
         config
@@ -3081,6 +3081,6 @@ type MethInfo =
 #if NO_EXTENSIONTYPING
     member ProvidedStaticParameterInfo: obj option
 #else
-    member ProvidedStaticParameterInfo: (Tainted<ProvidedMethodBase> * Tainted<ProvidedParameterInfo> []) option
+    member ProvidedStaticParameterInfo: (Tainted<ProvidedMethodBase> * Tainted<ProvidedParameterInfo>[]) option
 #endif
 """

--- a/src/Fantomas.Tests/TypeProviderTests.fs
+++ b/src/Fantomas.Tests/TypeProviderTests.fs
@@ -71,7 +71,7 @@ let ``should handle lines with more than 512 characters`` () =
         equal
         """
 (new CsvFile<string * decimal * decimal>(
-    new Func<obj, string [], string * decimal * decimal>(fun (parent: obj) (row: string []) ->
+    new Func<obj, string[], string * decimal * decimal>(fun (parent: obj) (row: string[]) ->
         CommonRuntime.GetNonOptionalValue(
             "Name",
             CommonRuntime.ConvertString(TextConversions.AsOption(row.[0])),
@@ -87,7 +87,7 @@ let ``should handle lines with more than 512 characters`` () =
             CommonRuntime.ConvertDecimal("", TextConversions.AsOption(row.[2])),
             TextConversions.AsOption(row.[2])
         )),
-    new Func<string * decimal * decimal, string []>(fun (row: string * decimal * decimal) ->
+    new Func<string * decimal * decimal, string[]>(fun (row: string * decimal * decimal) ->
         [| CommonRuntime.ConvertStringBack(CommonRuntime.GetOptionalValue((let x, _, _ = row in x)))
            CommonRuntime.ConvertDecimalBack("", CommonRuntime.GetOptionalValue((let _, x, _ = row in x)))
            CommonRuntime.ConvertDecimalBack("", CommonRuntime.GetOptionalValue((let _, _, x = row in x))) |]),

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -4294,7 +4294,7 @@ and genType astContext outerBracket t =
             +> addSpaceIfSynTypeStaticConstantHasAtSignBeforeString t2
             +> loop t2
         | TArray (t, n, r) ->
-            loop t -- " [" +> rep (n - 1) (!- ",") -- "]"
+            loop t -- "[" +> rep (n - 1) (!- ",") -- "]"
             |> genTriviaFor SynType_Array r
         | TAnon -> sepWild
         | TVar (tp, r) ->


### PR DESCRIPTION
Don't add space between type of array and square brackets.

Fixes #2192.