### PR TITLE
Fix idempotency problem with multiline quotation expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Idempotency problem with multiline quotation expressions. [#2203](https://github.com/fsprojects/fantomas/issues/2203)
+
 ## [4.7.8] - 2022-04-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+* Adjusted formatting of quotation expressions to latest F# style guide. [#661](https://github.com/fsharp/fslang-design/issues/661)
+
 ### Fixed
 * Idempotency problem with multiline quotation expressions. [#2203](https://github.com/fsprojects/fantomas/issues/2203)
 

--- a/src/Fantomas.Tests/DotGetTests.fs
+++ b/src/Fantomas.Tests/DotGetTests.fs
@@ -1374,6 +1374,8 @@ let ``dotget inside a quotation, 2154`` () =
         equal
         """
 (fun (Singleton arg) ->
-    <@@ ((%%arg: Indicators) :> IIndicators)
-            .AsyncGetIndicator(indicatorIdVal) @@>)
+    <@@
+        ((%%arg: Indicators) :> IIndicators)
+            .AsyncGetIndicator(indicatorIdVal)
+    @@>)
 """

--- a/src/Fantomas.Tests/QuotationTests.fs
+++ b/src/Fantomas.Tests/QuotationTests.fs
@@ -18,8 +18,10 @@ let ``typed quotations`` () =
     |> should
         equal
         """
-<@ let f x = x + 10
-   f 20 @>
+<@
+    let f x = x + 10
+    f 20
+@>
 """
 
 [<Test>]
@@ -62,14 +64,16 @@ let action =
         equal
         """
 let action =
-    <@ let msg = %httpRequestMessageWithPayload
-       RuntimeHelpers.fillHeaders msg %heads
+    <@
+        let msg = %httpRequestMessageWithPayload
+        RuntimeHelpers.fillHeaders msg %heads
 
-       async {
-           let! response =
-               (%this).HttpClient.SendAsync(msg)
-               |> Async.AwaitTask
+        async {
+            let! response =
+                (%this).HttpClient.SendAsync(msg)
+                |> Async.AwaitTask
 
-           return response.EnsureSuccessStatusCode().Content
-       } @>
+            return response.EnsureSuccessStatusCode().Content
+        }
+    @>
 """

--- a/src/Fantomas.Tests/QuotationTests.fs
+++ b/src/Fantomas.Tests/QuotationTests.fs
@@ -40,3 +40,36 @@ let logger =
         .Returns(())
         .Create()
 """
+
+[<Test>]
+let ``should format multiline quotation expressions idempotent, 2203`` () =
+    formatSourceString
+        false
+        """
+let action =
+    <@
+        let msg = %httpRequestMessageWithPayload
+        RuntimeHelpers.fillHeaders msg %heads
+        async {
+            let! response = (%this).HttpClient.SendAsync(msg) |> Async.AwaitTask
+            return response.EnsureSuccessStatusCode().Content
+        }
+    @>
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let action =
+    <@ let msg = %httpRequestMessageWithPayload
+       RuntimeHelpers.fillHeaders msg %heads
+
+       async {
+           let! response =
+               (%this).HttpClient.SendAsync(msg)
+               |> Async.AwaitTask
+
+           return response.EnsureSuccessStatusCode().Content
+       } @>
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1271,8 +1271,10 @@ and genExpr astContext synExpr ctx =
                 expressionFitsOnRestOfLine
                     (genExpr astContext e2)
                     (indent
-                     +> atCurrentColumnIndent (genExpr astContext e2)
-                     +> unindent)
+                     +> sepNln
+                     +> genExpr astContext e2
+                     +> unindent
+                     +> sepNln)
 
             ifElse
                 isRaw

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -1268,11 +1268,16 @@ and genExpr astContext synExpr ctx =
         // Not sure about the role of e1
         | Quote (_, e2, isRaw) ->
             let e =
-                match e2 with
-                | DotGetApp _ -> atCurrentColumnIndent (genExpr astContext e2)
-                | _ -> genExpr astContext e2
+                expressionFitsOnRestOfLine
+                    (genExpr astContext e2)
+                    (indent
+                     +> atCurrentColumnIndent (genExpr astContext e2)
+                     +> unindent)
 
-            ifElse isRaw (!- "<@@ " +> e -- " @@>") (!- "<@ " +> e -- " @>")
+            ifElse
+                isRaw
+                (!- "<@@" +> sepSpace +> e +> sepSpace +> !- "@@>")
+                (!- "<@" +> sepSpace +> e +> sepSpace +> !- "@>")
         | TypedExpr (TypeTest, e, t) ->
             genExpr astContext e -- " :? "
             +> genType astContext false t


### PR DESCRIPTION
Fixes #2203 
I used a slightly different fix to be more in line with what we do sofar.
Mainly to not put the `<@` on separate lines.
