### PR TITLE
Add fable_modules to the directories always excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+* Add `fable_modules` to the directories which are always excluded. [Fable 3.4](https://github.com/fable-compiler/Fable/releases/tag/3.4.0)
+
 ## [4.7.8] - 2022-04-25
 
 ### Fixed

--- a/src/Fantomas.CoreGlobalTool/Program.fs
+++ b/src/Fantomas.CoreGlobalTool/Program.fs
@@ -71,6 +71,7 @@ type OutputPath =
 let isInExcludedDir (fullPath: string) =
     set [| "obj"
            ".fable"
+           "fable_modules"
            "node_modules" |]
     |> Set.map (fun dir -> sprintf "%c%s%c" Path.DirectorySeparatorChar dir Path.DirectorySeparatorChar)
     |> Set.exists fullPath.Contains


### PR DESCRIPTION
As of release [3.4](https://github.com/fable-compiler/Fable/releases/tag/3.4.0) Fable uses the `fable_modules` directory instead of `.fable`. So I think it makes sense to add it to the list of always excluded directories.