### PR TITLE
Include prerelease when verifying a compatible version.

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -132,7 +132,7 @@ group client
     storage: none
     source https://api.nuget.org/v3/index.json
     
-    nuget FSharp.Core 5 content: none
+    nuget FSharp.Core >= 5.0.1 content: none
     nuget StreamJsonRpc
 
     nuget SemanticVersioning

--- a/paket.lock
+++ b/paket.lock
@@ -1056,7 +1056,7 @@ GROUP client
 STORAGE: NONE
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FSharp.Core (5.0) - content: none
+    FSharp.Core (5.0.1) - content: none
     MessagePack (2.3.85) - restriction: >= netstandard2.0
       MessagePack.Annotations (>= 2.3.85) - restriction: >= netstandard2.0
       Microsoft.Bcl.AsyncInterfaces (>= 1.0) - restriction: || (&& (>= netcoreapp2.1) (< netcoreapp3.1)) (&& (< netcoreapp2.1) (>= netstandard2.0))

--- a/paket.lock
+++ b/paket.lock
@@ -1185,12 +1185,12 @@ NUGET
     runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
     SemanticVersioning (2.0.2)
       NETStandard.Library (>= 1.6) - restriction: && (< net35) (>= netstandard1.1) (< netstandard2.0)
-    StreamJsonRpc (2.9.85)
-      MessagePack (>= 2.3.75) - restriction: >= netstandard2.0
+    StreamJsonRpc (2.8.28)
+      MessagePack (>= 2.2.85) - restriction: >= netstandard2.0
       Microsoft.Bcl.AsyncInterfaces (>= 5.0) - restriction: >= netstandard2.0
-      Microsoft.VisualStudio.Threading (>= 16.10.56) - restriction: >= netstandard2.0
-      Nerdbank.Streams (>= 2.8.46) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 13.0.1) - restriction: >= netstandard2.0
+      Microsoft.VisualStudio.Threading (>= 16.9.60) - restriction: >= netstandard2.0
+      Nerdbank.Streams (>= 2.6.81) - restriction: >= netstandard2.0
+      Newtonsoft.Json (>= 12.0.2) - restriction: >= netstandard2.0
       System.Collections.Immutable (>= 5.0) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 5.0.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 5.0.1) - restriction: >= netstandard2.0
@@ -1731,12 +1731,12 @@ NUGET
     Serilog (2.10)
     SerilogTraceListener (3.2)
       Serilog (>= 2.8)
-    StreamJsonRpc (2.9.85)
-      MessagePack (>= 2.3.75)
+    StreamJsonRpc (2.8.28)
+      MessagePack (>= 2.2.85)
       Microsoft.Bcl.AsyncInterfaces (>= 5.0)
-      Microsoft.VisualStudio.Threading (>= 16.10.56)
-      Nerdbank.Streams (>= 2.8.46)
-      Newtonsoft.Json (>= 13.0.1)
+      Microsoft.VisualStudio.Threading (>= 16.9.60)
+      Nerdbank.Streams (>= 2.6.81)
+      Newtonsoft.Json (>= 12.0.2)
       System.Collections.Immutable (>= 5.0)
       System.Diagnostics.DiagnosticSource (>= 5.0.1)
       System.IO.Pipelines (>= 5.0.1)

--- a/src/Fantomas.Client/CHANGELOG.md
+++ b/src/Fantomas.Client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This is the changelog for the Fantomas.Client package specifically. It's distinct from that of the overall libraries and command-line tool.
 
+## 0.5.3 - 2022-05-06
+
+* Lower StreamJsonRpc to match 2.8.28. [#2227](https://github.com/fsprojects/fantomas/pull/2227)
+
 ## 0.5.2 - 2022-05-06
 
 ### Fixed

--- a/src/Fantomas.Client/CHANGELOG.md
+++ b/src/Fantomas.Client/CHANGELOG.md
@@ -2,4 +2,9 @@
 
 This is the changelog for the Fantomas.Client package specifically. It's distinct from that of the overall libraries and command-line tool.
 
+## 0.5.2 - 2022-05-06
+
+### Fixed
+* Include prerelease when verifying a compatible version. [#2227](https://github.com/fsprojects/fantomas/pull/2227)
+
 ## 0.5.1 - 2022-2-1

--- a/src/Fantomas.Client/CHANGELOG.md
+++ b/src/Fantomas.Client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This is the changelog for the Fantomas.Client package specifically. It's distinct from that of the overall libraries and command-line tool.
 
+## 0.5.4 - 2022-05-06
+
+* FSharp.Core 5.0.1 or higher. [#2227](https://github.com/fsprojects/fantomas/pull/2227)
+
 ## 0.5.3 - 2022-05-06
 
 * Lower StreamJsonRpc to match 2.8.28. [#2227](https://github.com/fsprojects/fantomas/pull/2227)

--- a/src/Fantomas.Client/FantomasToolLocator.fs
+++ b/src/Fantomas.Client/FantomasToolLocator.fs
@@ -15,7 +15,7 @@ let private supportedRange = SemanticVersioning.Range(">=v4.6.0-alpha-004")
 let private (|CompatibleVersion|_|) (version: string) =
     match SemanticVersioning.Version.TryParse version with
     | true, parsedVersion ->
-        if supportedRange.IsSatisfied parsedVersion then
+        if supportedRange.IsSatisfied(parsedVersion, includePrerelease = true) then
             Some version
         else
             None


### PR DESCRIPTION
Version 5.0.0-alpha-00X is not being recognised as higher by the `supportedRange.IsSatisfied` function without `includePrerelease = true`.
See https://github.com/adamreeve/semver.net#pre-release-versions

This blocks users from using the next major version in editors.