### PR TITLE
Be more cautious when adding a sepSpace before paren lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 * Rename `fsharp_ragnarok` to `fsharp_experimental_stroupstrup_style` and `fsharp_keep_indent_in_branch` to `fsharp_experimental_keep_indent_in_branch`. [#2251](https://github.com/fsprojects/fantomas/pull/2251)
 * Consider wider default format for record declarations if any XML doc comments are present on fields. [#1879](https://github.com/fsprojects/fantomas/issues/1879)
 
+### Fixed
+* A space was added before paren lambda argument. [#2041](https://github.com/fsprojects/fantomas/issues/2041)
+* Linq method call breaks because of space before paren lambda was added. [#2231](https://github.com/fsprojects/fantomas/issues/2231)
+
 ## [5.0.0-alpha-005] - 2022-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Consider wider default format for record declarations if any XML doc comments are present on fields. [#1879](https://github.com/fsprojects/fantomas/issues/1879)
 
 ### Fixed
+* A space was added before paren lambda argument. [#2041](https://github.com/fsprojects/fantomas/issues/2041)
 * Linq method call breaks because of space before paren lambda was added. [#2231](https://github.com/fsprojects/fantomas/issues/2231)
 
 ## [5.0.0-alpha-005] - 2022-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 * Consider wider default format for record declarations if any XML doc comments are present on fields. [#1879](https://github.com/fsprojects/fantomas/issues/1879)
 
 ### Fixed
-* A space was added before paren lambda argument. [#2041](https://github.com/fsprojects/fantomas/issues/2041)
 * Linq method call breaks because of space before paren lambda was added. [#2231](https://github.com/fsprojects/fantomas/issues/2231)
 
 ## [5.0.0-alpha-005] - 2022-05-07

--- a/src/Fantomas.Core.Tests/DotGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotGetTests.fs
@@ -442,13 +442,13 @@ let getColl2 =
         .ToString()
 
 let getColl3 =
-    GetCollection (fun _ parser ->
+    GetCollection(fun _ parser ->
         let x = 3
         x)
         .Foo
 
 let getColl4 =
-    GetCollection (fun parser ->
+    GetCollection(fun parser ->
         let x = 4
         x)
         .Foo

--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -312,7 +312,7 @@ CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettin
     |> should
         equal
         """
-CloudStorageAccount.SetConfigurationSettingPublisher (fun configName configSettingPublisher ->
+CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettingPublisher ->
     let connectionString =
         if hostedService then
             RoleEnvironment.GetConfigurationSettingValue(configName)
@@ -731,7 +731,7 @@ services.AddHttpsRedirection(Action<HttpsRedirectionOptions>(fun options ->
         equal
         """
 services.AddHttpsRedirection(
-    Action<HttpsRedirectionOptions> (fun options ->
+    Action<HttpsRedirectionOptions>(fun options ->
         // meh
         options.HttpsPort <- Nullable(7002))
 )
@@ -1189,6 +1189,35 @@ let foo () =
         """
 let foo () =
     f () |> (fun x -> if x then 1 else 2) |> g
+"""
+
+[<Test>]
+let ``don't add space before paren lambda argument, 2041`` () =
+    formatSourceString
+        false
+        """
+Task.Run<CommandResult>(fun () ->
+    // long
+    // comment
+    task)
+|> ignore<Task<CommandResult>>
+
+Task.Run<CommandResult> (task)
+|> ignore<Task<CommandResult>>
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+Task.Run<CommandResult>(fun () ->
+    // long
+    // comment
+    task)
+|> ignore<Task<CommandResult>>
+
+Task.Run<CommandResult>(task)
+|> ignore<Task<CommandResult>>
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -312,7 +312,7 @@ CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettin
     |> should
         equal
         """
-CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettingPublisher ->
+CloudStorageAccount.SetConfigurationSettingPublisher (fun configName configSettingPublisher ->
     let connectionString =
         if hostedService then
             RoleEnvironment.GetConfigurationSettingValue(configName)
@@ -731,7 +731,7 @@ services.AddHttpsRedirection(Action<HttpsRedirectionOptions>(fun options ->
         equal
         """
 services.AddHttpsRedirection(
-    Action<HttpsRedirectionOptions>(fun options ->
+    Action<HttpsRedirectionOptions> (fun options ->
         // meh
         options.HttpsPort <- Nullable(7002))
 )
@@ -1189,35 +1189,6 @@ let foo () =
         """
 let foo () =
     f () |> (fun x -> if x then 1 else 2) |> g
-"""
-
-[<Test>]
-let ``don't add space before paren lambda argument, 2041`` () =
-    formatSourceString
-        false
-        """
-Task.Run<CommandResult>(fun () ->
-    // long
-    // comment
-    task)
-|> ignore<Task<CommandResult>>
-
-Task.Run<CommandResult> (task)
-|> ignore<Task<CommandResult>>
-"""
-        config
-    |> prepend newline
-    |> should
-        equal
-        """
-Task.Run<CommandResult>(fun () ->
-    // long
-    // comment
-    task)
-|> ignore<Task<CommandResult>>
-
-Task.Run<CommandResult>(task)
-|> ignore<Task<CommandResult>>
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -312,7 +312,7 @@ CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettin
     |> should
         equal
         """
-CloudStorageAccount.SetConfigurationSettingPublisher (fun configName configSettingPublisher ->
+CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettingPublisher ->
     let connectionString =
         if hostedService then
             RoleEnvironment.GetConfigurationSettingValue(configName)
@@ -731,7 +731,7 @@ services.AddHttpsRedirection(Action<HttpsRedirectionOptions>(fun options ->
         equal
         """
 services.AddHttpsRedirection(
-    Action<HttpsRedirectionOptions> (fun options ->
+    Action<HttpsRedirectionOptions>(fun options ->
         // meh
         options.HttpsPort <- Nullable(7002))
 )
@@ -1189,4 +1189,69 @@ let foo () =
         """
 let foo () =
     f () |> (fun x -> if x then 1 else 2) |> g
+"""
+
+[<Test>]
+let ``don't add space before paren lambda argument, 2041`` () =
+    formatSourceString
+        false
+        """
+Task.Run<CommandResult>(fun () ->
+    // long
+    // comment
+    task)
+|> ignore<Task<CommandResult>>
+
+Task.Run<CommandResult> (task)
+|> ignore<Task<CommandResult>>
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+Task.Run<CommandResult>(fun () ->
+    // long
+    // comment
+    task)
+|> ignore<Task<CommandResult>>
+
+Task.Run<CommandResult>(task)
+|> ignore<Task<CommandResult>>
+"""
+
+[<Test>]
+let ``don't add space before linq lambda and idempotent, 2231`` () =
+    formatSourceString
+        false
+        """
+open System.Linq
+
+type Item() =
+    member val ValidFrom = DateTime.MinValue
+    member val Value = 23.42m
+
+let items = [ Item(); Item(); Item() ]
+
+let firstOrDef = items.FirstOrDefault(fun x ->
+    x.ValidFrom <= DateTime.Now || x.ValidFrom > DateTime.Now).Value
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+open System.Linq
+
+type Item() =
+    member val ValidFrom = DateTime.MinValue
+    member val Value = 23.42m
+
+let items = [ Item(); Item(); Item() ]
+
+let firstOrDef =
+    items.FirstOrDefault(fun x ->
+        x.ValidFrom <= DateTime.Now
+        || x.ValidFrom > DateTime.Now)
+        .Value
 """

--- a/src/Fantomas.Core.Tests/RecordTests.fs
+++ b/src/Fantomas.Core.Tests/RecordTests.fs
@@ -425,7 +425,7 @@ let ``meaningful space should be preserved, 353`` () =
     |> should
         equal
         """
-to'.WithCommon (fun o' ->
+to'.WithCommon(fun o' ->
     { dotnetOptions o' with
         WorkingDirectory = Path.getFullName "RegressionTesting/issue29"
         Verbosity = Some DotNet.Verbosity.Minimal })

--- a/src/Fantomas.Core.Tests/Stroupstrup/ElmishTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/ElmishTests.fs
@@ -511,7 +511,7 @@ let viewEntry todo dispatch =
             valueOrDefault todo.description
             Name "title"
             Id("todo-" + (string todo.id))
-            OnInput (fun ev ->
+            OnInput(fun ev ->
                 UpdateEntry(todo.id, !!ev.target?value)
                 |> dispatch)
             OnBlur(fun _ -> EditingEntry(todo.id, false) |> dispatch)

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -806,7 +806,7 @@ type BlobHelper(Account : CloudStorageAccount) =
         """
 type BlobHelper(Account: CloudStorageAccount) =
     new(configurationSettingName, hostedService) =
-        CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettingPublisher ->
+        CloudStorageAccount.SetConfigurationSettingPublisher (fun configName configSettingPublisher ->
             let connectionString =
                 if hostedService then
                     RoleEnvironment.GetConfigurationSettingValue(configName)

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -806,7 +806,7 @@ type BlobHelper(Account : CloudStorageAccount) =
         """
 type BlobHelper(Account: CloudStorageAccount) =
     new(configurationSettingName, hostedService) =
-        CloudStorageAccount.SetConfigurationSettingPublisher (fun configName configSettingPublisher ->
+        CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettingPublisher ->
             let connectionString =
                 if hostedService then
                     RoleEnvironment.GetConfigurationSettingValue(configName)

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1911,14 +1911,14 @@ and genExpr astContext synExpr ctx =
         | DotGetAppWithLambda ((e, es, lpr, lambda, rpr, pr), lids) ->
             leadingExpressionIsMultiline
                 (genAppWithLambda astContext sepNone (e, es, lpr, lambda, rpr, pr))
-                (fun isMultline ->
-                    if isMultline then
+                (fun isMultiline ->
+                    if isMultiline then
                         (indent
                          +> sepNln
                          +> genSynLongIdent true lids
                          +> unindent)
                     else
-                        (indent >> genSynLongIdent true lids))
+                        genSynLongIdent true lids)
 
         // functionName arg1 arg2 (fun x y z -> ...)
         | AppWithLambda (e, es, lpr, lambda, rpr, pr) ->

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2019,7 +2019,7 @@ and genExpr astContext synExpr ctx =
                             genExpr astContext e
                             +> sepSpaceAfterFunctionName
                             +> col sepSpace es (genExpr astContext)
-                            +> sepSpace
+                            +> onlyIf (List.isNotEmpty es) sepSpace
                             +> enterNodeFor SynExpr_Paren pr
                             +> sepOpenTFor lpr
                             +> enterNodeFor SynExpr_Lambda lambdaRange
@@ -2035,7 +2035,7 @@ and genExpr astContext synExpr ctx =
                             genExpr astContext e
                             +> sepSpaceAfterFunctionName
                             +> col sepSpace es (genExpr astContext)
-                            +> sepSpace
+                            +> onlyIf (List.isNotEmpty es) sepSpace
                             +> (sepOpenTFor lpr
                                 +> (!- "fun "
                                     +> col sepSpace pats (genPat astContext)

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3184,7 +3184,6 @@ and genAppWithLambda (e, es, lpr, lambda, rpr, pr) withSpaceBeforeLambdaParen li
             +> sepNlnWhenWriteBeforeNewlineNotEmpty sepNone
             +> sepCloseTFor rpr
             |> genTriviaFor SynExpr_Paren pr)
-        >> addSynLongIdentIfGiven
 
     let long (ctx: Context) : Context =
         if ctx.Config.MultiLineLambdaClosingNewline then
@@ -3235,8 +3234,7 @@ and genAppWithLambda (e, es, lpr, lambda, rpr, pr) withSpaceBeforeLambdaParen li
 
             (genExpr astContext e
              +> ifElse (List.isEmpty es) sepSpaceAfterFunctionName (indent +> sepNln)
-             +> genArguments
-             +> addSynLongIdentAfterNlnIfGiven)
+             +> genArguments)
                 ctx
         else
             match lambda with
@@ -3270,7 +3268,6 @@ and genAppWithLambda (e, es, lpr, lambda, rpr, pr) withSpaceBeforeLambdaParen li
                         +> sepNlnWhenWriteBeforeNewlineNotEmpty sepNone
                         +> sepCloseTFor rpr
                         |> genTriviaFor SynExpr_Paren pr)
-                    +> addSynLongIdentAfterNlnIfGiven
 
                 let multiLine =
                     genExpr astContext e
@@ -3285,7 +3282,6 @@ and genAppWithLambda (e, es, lpr, lambda, rpr, pr) withSpaceBeforeLambdaParen li
                             |> genTriviaFor SynExpr_Lambda lambdaRange)
                         +> sepCloseTFor rpr
                         |> genTriviaFor SynExpr_Paren pr)
-                    +> addSynLongIdentAfterNlnIfGiven
                     +> unindent
 
                 if futureNlnCheck singleLineTestExpr ctx then
@@ -3320,7 +3316,6 @@ and genAppWithLambda (e, es, lpr, lambda, rpr, pr) withSpaceBeforeLambdaParen li
                         +> sepNlnWhenWriteBeforeNewlineNotEmpty id
                         +> sepCloseTFor rpr)
                     |> genTriviaFor SynExpr_Paren pr
-                    >> addSynLongIdentIfGiven
 
                 let multiLine =
                     genExpr astContext e
@@ -3338,7 +3333,6 @@ and genAppWithLambda (e, es, lpr, lambda, rpr, pr) withSpaceBeforeLambdaParen li
                         )
                         +> sepCloseTFor rpr
                         |> genTriviaFor SynExpr_Paren pr)
-                    +> addSynLongIdentAfterNlnIfGiven
                     +> unindent
 
                 if futureNlnCheck singleLineTestExpr ctx then
@@ -3346,7 +3340,7 @@ and genAppWithLambda (e, es, lpr, lambda, rpr, pr) withSpaceBeforeLambdaParen li
                 else
                     singleLine ctx
 
-    expressionFitsOnRestOfLine short long
+    expressionFitsOnRestOfLine (short +> addSynLongIdentIfGiven) (long +> addSynLongIdentAfterNlnIfGiven)
 
 and genExprInIfOrMatch astContext (e: SynExpr) (ctx: Context) : Context =
     let short =

--- a/src/Fantomas.Core/SourceParser.fs
+++ b/src/Fantomas.Core/SourceParser.fs
@@ -1293,6 +1293,12 @@ let (|AppWithLambda|_|) (e: SynExpr) =
         visit es id
     | _ -> None
 
+// Foo(fun x -> y).Bar
+let (|DotGetAppWithLambda|_|) =
+    function
+    | DotGet (AppWithLambda (e, [], lpr, c, rpr, pr), lids) -> Some((e, [], lpr, c, rpr, pr), lids)
+    | _ -> None
+
 // Type definitions
 
 let (|TDSREnum|TDSRUnion|TDSRRecord|TDSRNone|TDSRTypeAbbrev|TDSRException|) =


### PR DESCRIPTION
Fixes #2231
Fixes #2041

Not super sure about this one and it may need more discussion, but I think we are a bit too liberal adding spaces before the lparen of lambda arguments. This can easily break calls to Linq methods. See the example in #2231