### PR TITLE
Correct typo in fsharp_experimental_stroustrup_style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [5.0.0-alpha-007] - 2022-05-16
 
 ### Changed
 * Update FCS to 'Add SynExpr.Dynamic to SyntaxTree.', commit b822e2793bd6387c40cfd5b25d604e002a253257
 * Restore the validation API. [#2236](https://github.com/fsprojects/fantomas/issues/2236)
+* Renamed `fsharp_experimental_stroupstrup_style` to `fsharp_experimental_stroustrup_style`. [#2257](https://github.com/fsprojects/fantomas/pull/2257)
 
 ## [5.0.0-alpha-006] - 2022-05-13
 

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -141,7 +141,7 @@ fsharp_multi_line_lambda_closing_newline=false
 fsharp_experimental_keep_indent_in_branch=false
 fsharp_blank_lines_around_nested_multiline_expressions=true
 fsharp_bar_before_discriminated_union_declaration=false
-fsharp_experimental_stroupstrup_style=false
+fsharp_experimental_stroustrup_style=false
 fsharp_keep_max_number_of_blank_lines=100
 fsharp_strict_mode=false
 ```
@@ -1054,7 +1054,7 @@ type MyDU = Short of int
 type MyDU = | Short of int
 ```
 
-### fsharp_experimental_stroupstrup_style
+### fsharp_experimental_stroustrup_style
 
 Please contribute to https://github.com/fsprojects/fantomas/issues/1408.
 

--- a/src/Fantomas.Core.Tests/FormatConfigEditorConfigurationFileTests.fs
+++ b/src/Fantomas.Core.Tests/FormatConfigEditorConfigurationFileTests.fs
@@ -472,7 +472,7 @@ let ``Stroupstrup style`` () =
         """
 [*.fs]
 fsharp_multiline_block_brackets_on_same_column = true
-fsharp_experimental_stroupstrup_style = true
+fsharp_experimental_stroustrup_style = true
 """
 
     use configFixture =
@@ -483,4 +483,4 @@ fsharp_experimental_stroupstrup_style = true
     let config = EditorConfig.readConfiguration fsharpFile.FSharpFile
 
     Assert.IsTrue config.MultilineBlockBracketsOnSameColumn
-    Assert.IsTrue config.ExperimentalStroupstrupStyle
+    Assert.IsTrue config.ExperimentalStroustrupStyle

--- a/src/Fantomas.Core.Tests/NumberOfItemsListOrArrayTests.fs
+++ b/src/Fantomas.Core.Tests/NumberOfItemsListOrArrayTests.fs
@@ -87,7 +87,7 @@ h [ longValueThatIsALotOfCharactersSoooooLong; longValueThatIsALotOfCharactersSo
         { config with
             ArrayOrListMultilineFormatter = NumberOfItems
             MultilineBlockBracketsOnSameColumn = true
-            ExperimentalStroupstrupStyle = true }
+            ExperimentalStroustrupStyle = true }
     |> prepend newline
     |> should
         equal
@@ -206,7 +206,7 @@ h [ longValueThatIsALotOfCharactersSoooooLong; longValueThatIsALotOfCharactersSo
         { config with
             ArrayOrListMultilineFormatter = NumberOfItems
             MultilineBlockBracketsOnSameColumn = true
-            ExperimentalStroupstrupStyle = true }
+            ExperimentalStroustrupStyle = true }
     |> prepend newline
     |> should
         equal
@@ -241,7 +241,7 @@ h [ longValueThatIsALotOfCharactersSoooooLong; longValueThatIsALotOfCharactersSo
         { config with
             ArrayOrListMultilineFormatter = NumberOfItems
             MultilineBlockBracketsOnSameColumn = true
-            ExperimentalStroupstrupStyle = true }
+            ExperimentalStroustrupStyle = true }
     |> prepend newline
     |> should
         equal
@@ -274,7 +274,7 @@ h [ longValueThatIsALotOfCharactersSoooooLong; longValueThatIsALotOfCharactersSo
         { config with
             ArrayOrListMultilineFormatter = NumberOfItems
             MultilineBlockBracketsOnSameColumn = true
-            ExperimentalStroupstrupStyle = true }
+            ExperimentalStroustrupStyle = true }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/Stroupstrup/DotIndexedSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/DotIndexedSetExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``dotIndexedSet with record instance `` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/DotSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/DotSetExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``dotSet with record instance `` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/ElmishTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/ElmishTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``long named arguments should go on newline`` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/FunctionApplicationDualListTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/FunctionApplicationDualListTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``two short lists`` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/FunctionApplicationSingleListTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/FunctionApplicationSingleListTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``short function application`` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/KeepIndentInBranchExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/KeepIndentInBranchExpressionTests.fs
@@ -8,7 +8,7 @@ let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
         ExperimentalKeepIndentInBranch = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 // There currently is no conflict with this setting, but I'm guessing the case was never brought up.
 // I would conclude that will never clash.

--- a/src/Fantomas.Core.Tests/Stroupstrup/LambdaExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/LambdaExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``lambda with record instance `` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/LetOrUseBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/LetOrUseBangExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``letOrUseBang with record instance`` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/LongIdentSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/LongIdentSetExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``longIdentSet with record instance `` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/MultiLineLambdaClosingNewlineExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/MultiLineLambdaClosingNewlineExpressionTests.fs
@@ -8,7 +8,7 @@ let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
         MultiLineLambdaClosingNewline = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 // TODO: figure out what should happen when you mix MultiLineLambdaClosingNewline and Ragnarok
 // From a technical point of view, this is correct behavior but having `})` at the end seems sensible as well.

--- a/src/Fantomas.Core.Tests/Stroupstrup/NamedArgumentExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/NamedArgumentExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``synExprApp with named argument with record instance`` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/SetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/SetExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``set with record instance `` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/SynBindingFunctionExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/SynBindingFunctionExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``synbinding function with record instance `` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/SynBindingFunctionLongPatternExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/SynBindingFunctionLongPatternExpressionTests.fs
@@ -8,7 +8,7 @@ let config =
     { config with
         MaxLineLength = 80
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 // TODO: conclude on what should happen here
 // This one feels very weird to have `= {` because the pattern is already multiline

--- a/src/Fantomas.Core.Tests/Stroupstrup/SynBindingFunctionWithReturnTypeExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/SynBindingFunctionWithReturnTypeExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``synbinding function with record instance `` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/SynBindingValueExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``synbinding value with record instance `` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/SynExprAndBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/SynExprAndBangExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``andBang with record instance`` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/SynMatchClauseExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/SynMatchClauseExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``synMatchClause in match expression with record instance `` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/SynTypeDefnSigReprSimpleTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/SynTypeDefnSigReprSimpleTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``record type definition`` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/SynTypeDefnSimpleReprRecordTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/SynTypeDefnSimpleReprRecordTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``record type definition`` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/YieldOrReturnBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/YieldOrReturnBangExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``yieldOrReturnBang with record instance`` () =

--- a/src/Fantomas.Core.Tests/Stroupstrup/YieldOrReturnExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroupstrup/YieldOrReturnExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MultilineBlockBracketsOnSameColumn = true
-        ExperimentalStroupstrupStyle = true }
+        ExperimentalStroustrupStyle = true }
 
 [<Test>]
 let ``yieldOrReturn with record instance`` () =

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1926,7 +1926,7 @@ and genExpr astContext synExpr ctx =
             +> genExpr astContext indexExpr
             +> sepCloseLFixed
             +> genExpr astContext argExpr
-        | EndsWithDualListAppExpr ctx.Config.ExperimentalStroupstrupStyle (e, es, props, children) ->
+        | EndsWithDualListAppExpr ctx.Config.ExperimentalStroustrupStyle (e, es, props, children) ->
             // check if everything else beside the last array/list fits on one line
             let singleLineTestExpr =
                 genExpr astContext e
@@ -1974,7 +1974,7 @@ and genExpr astContext synExpr ctx =
             else
                 short
 
-        | EndsWithSingleListAppExpr ctx.Config.ExperimentalStroupstrupStyle (e, es, a) ->
+        | EndsWithSingleListAppExpr ctx.Config.ExperimentalStroustrupStyle (e, es, a) ->
             // check if everything else beside the last array/list fits on one line
             let singleLineTestExpr =
                 genExpr astContext e
@@ -2025,7 +2025,7 @@ and genExpr astContext synExpr ctx =
                 +> sepNln
                 +> (fun ctx ->
                     let hasMultipleClausesWhereOneHasRagnarok =
-                        hasMultipleClausesWhereOneHasStroupstrup ctx.Config.ExperimentalStroupstrupStyle cs
+                        hasMultipleClausesWhereOneHasStroupstrup ctx.Config.ExperimentalStroustrupStyle cs
 
                     col sepNln cs (genClause astContext true hasMultipleClausesWhereOneHasRagnarok) ctx)
             )
@@ -3616,7 +3616,7 @@ and genTypeDefn
                 +> bodyExpr size
                 +> leaveNodeFor SynTypeDefnSimpleRepr_Record tdr.Range
 
-            if ctx.Config.ExperimentalStroupstrupStyle
+            if ctx.Config.ExperimentalStroustrupStyle
                && ms.IsEmpty then
                 (sepSpace +> short) ctx
             else
@@ -3920,7 +3920,7 @@ and genSigTypeDefn
                 +> bodyExpr size
                 +> leaveNodeFor SynTypeDefnSimpleRepr_Record tdr.Range
 
-            if ctx.Config.ExperimentalStroupstrupStyle
+            if ctx.Config.ExperimentalStroustrupStyle
                && ms.IsEmpty then
                 (sepSpace +> short) ctx
             else
@@ -4605,7 +4605,7 @@ and genClauses astContext cs (ctx: Context) =
     col
         sepNln
         cs
-        (genClause astContext true (hasMultipleClausesWhereOneHasStroupstrup ctx.Config.ExperimentalStroupstrupStyle cs))
+        (genClause astContext true (hasMultipleClausesWhereOneHasStroupstrup ctx.Config.ExperimentalStroustrupStyle cs))
         ctx
 
 /// Each multiline member definition has a pre and post new line.
@@ -5493,7 +5493,7 @@ and genKeepIndentMatch
     +> sepNln
     +> (fun ctx ->
         let hasMultipleClausesWhereOneHasRagnarok =
-            hasMultipleClausesWhereOneHasStroupstrup ctx.Config.ExperimentalStroupstrupStyle clauses
+            hasMultipleClausesWhereOneHasStroupstrup ctx.Config.ExperimentalStroustrupStyle clauses
 
         coli
             sepNln

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -630,10 +630,10 @@ let internal ifElse b (f1: Context -> Context) f2 (ctx: Context) = if b then f1 
 let internal ifElseCtx cond (f1: Context -> Context) f2 (ctx: Context) = if cond ctx then f1 ctx else f2 ctx
 
 let internal ifRagnarokElse =
-    ifElseCtx (fun ctx -> ctx.Config.ExperimentalStroupstrupStyle)
+    ifElseCtx (fun ctx -> ctx.Config.ExperimentalStroustrupStyle)
 
 let internal ifRagnarok (f1: Context -> Context) =
-    ifElseCtx (fun ctx -> ctx.Config.ExperimentalStroupstrupStyle) f1 id
+    ifElseCtx (fun ctx -> ctx.Config.ExperimentalStroustrupStyle) f1 id
 
 /// apply f only when cond is true
 let internal onlyIf cond f ctx = if cond then f ctx else ctx
@@ -685,7 +685,7 @@ let internal sepNlnUnlessLastEventIsNewline (ctx: Context) =
 
 let internal sepNlnUnlessLastEventIsNewlineOrRagnarok (ctx: Context) =
     if lastWriteEventIsNewline ctx
-       || ctx.Config.ExperimentalStroupstrupStyle then
+       || ctx.Config.ExperimentalStroustrupStyle then
         ctx
     else
         sepNln ctx
@@ -1280,7 +1280,7 @@ let internal addExtraNewlineIfLeadingWasMultiline leading sepNlnConsideringTrivi
 
 let internal autoIndentAndNlnExpressUnlessRagnarok (f: SynExpr -> Context -> Context) (e: SynExpr) (ctx: Context) =
     match e with
-    | SourceParser.StroupstrupStyleExpr ctx.Config.ExperimentalStroupstrupStyle e -> f e ctx
+    | SourceParser.StroupstrupStyleExpr ctx.Config.ExperimentalStroustrupStyle e -> f e ctx
     | _ -> (indent +> sepNln +> f e +> unindent) ctx
 
 let internal autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok
@@ -1289,7 +1289,7 @@ let internal autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok
     (ctx: Context)
     =
     match e with
-    | SourceParser.StroupstrupStyleExpr ctx.Config.ExperimentalStroupstrupStyle e -> f e ctx
+    | SourceParser.StroupstrupStyleExpr ctx.Config.ExperimentalStroustrupStyle e -> f e ctx
     | _ -> autoIndentAndNlnIfExpressionExceedsPageWidth (f e) ctx
 
 type internal ColMultilineItem =

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -194,7 +194,7 @@ type FormatConfig =
 
       [<Category("Convention")>]
       [<DisplayName("Ragnarok")>]
-      ExperimentalStroupstrupStyle: bool
+      ExperimentalStroustrupStyle: bool
 
       [<Category("Convention")>]
       [<DisplayName("Maximum number of consecutive blank lines to keep")>]
@@ -239,6 +239,6 @@ type FormatConfig =
           ExperimentalKeepIndentInBranch = false
           BlankLinesAroundNestedMultilineExpressions = true
           BarBeforeDiscriminatedUnionDeclaration = false
-          ExperimentalStroupstrupStyle = false
+          ExperimentalStroustrupStyle = false
           KeepMaxNumberOfBlankLines = 100
           StrictMode = false }


### PR DESCRIPTION
`fsharp_experimental_stroupstrup_style` => `fsharp_experimental_stroustrup_style`