### PR TITLE
Put long multiline constrained SRTP on separate lines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Idempotency problem with ParsedHashDirective in signature file. [#2258](https://github.com/fsprojects/fantomas/issues/2258)
 * Keyword 'override' gets changed to 'member'. [#2221](https://github.com/fsprojects/fantomas/issues/2221)
 
+### Changed
+* Formatting of multi-constrained SRTP functions needs improvement. [#2230](https://github.com/fsprojects/fantomas/issues/2230)
+
 ## [5.0.0-alpha-007] - 2022-05-16
 
 ### Changed

--- a/src/Fantomas.Core.Tests/SignatureTests.fs
+++ b/src/Fantomas.Core.Tests/SignatureTests.fs
@@ -735,8 +735,9 @@ module Foo =
 namespace Blah
 
 module Foo =
-    val inline sum: ('a -> ^value) -> 'a Foo -> ^value
-        when ^value: (static member (+): ^value * ^value -> ^value) and ^value: (static member Zero: ^value)
+    val inline sum:
+        ('a -> ^value) -> 'a Foo -> ^value
+            when ^value: (static member (+): ^value * ^value -> ^value) and ^value: (static member Zero: ^value)
 """
 
 [<Test>]
@@ -1909,8 +1910,9 @@ namespace Microsoft.FSharp.Control
 [<Sealed>]
 [<CompiledName("FSharpAsync")>]
 type Async =
-    static member AwaitEvent: event: IEvent<'Del, 'T> * ?cancelAction: (unit -> unit) -> Async<'T>
-        when 'Del: delegate<'T, unit> and 'Del :> System.Delegate
+    static member AwaitEvent:
+        event: IEvent<'Del, 'T> * ?cancelAction: (unit -> unit) -> Async<'T>
+            when 'Del: delegate<'T, unit> and 'Del :> System.Delegate
 """
 
 [<Test>]
@@ -1934,8 +1936,102 @@ val inline average   : array:^T[] -> ^T
 /// Throws <c>ArgumentException</c>
 /// </example>
 [<CompiledName("Average")>]
-val inline average: array: ^T[] -> ^T
+val inline average:
+    array: ^T[] -> ^T
+        when ^T: (static member (+): ^T * ^T -> ^T)
+        and ^T: (static member DivideByInt: ^T * int -> ^T)
+        and ^T: (static member Zero: ^T)
+"""
+
+[<Test>]
+let ``long curried value with constraints`` () =
+    formatSourceString
+        true
+        """
+[<CompiledName("Average")>]
+val inline average: array: ^T[] -> array: ^T[] -> array: ^T[] -> array: ^T[] -> array: ^T[] -> array: ^T[] -> array: ^T[] -> array: ^T[] -> array: ^T[] -> ^T
     when ^T: (static member (+): ^T * ^T -> ^T)
     and ^T: (static member DivideByInt: ^T * int -> ^T)
     and ^T: (static member Zero: ^T)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<CompiledName("Average")>]
+val inline average:
+    array: ^T[] ->
+    array: ^T[] ->
+    array: ^T[] ->
+    array: ^T[] ->
+    array: ^T[] ->
+    array: ^T[] ->
+    array: ^T[] ->
+    array: ^T[] ->
+    array: ^T[] ->
+        ^T
+        when ^T: (static member (+): ^T * ^T -> ^T)
+        and ^T: (static member DivideByInt: ^T * int -> ^T)
+        and ^T: (static member Zero: ^T)
+"""
+
+[<Test>]
+let ``long tupled value with constraints`` () =
+    formatSourceString
+        true
+        """
+[<CompiledName("Average")>]
+val inline average: array: ^T[] * array: ^T[] * array: ^T[] * array: ^T[] * array: ^T[] * array: ^T[] * array: ^T[] * array: ^T[] * array: ^T[] -> ^T
+    when ^T: (static member (+): ^T * ^T -> ^T)
+    and ^T: (static member DivideByInt: ^T * int -> ^T)
+    and ^T: (static member Zero: ^T)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<CompiledName("Average")>]
+val inline average:
+    array: ^T[] *
+    array: ^T[] *
+    array: ^T[] *
+    array: ^T[] *
+    array: ^T[] *
+    array: ^T[] *
+    array: ^T[] *
+    array: ^T[] *
+    array: ^T[] ->
+        ^T
+        when ^T: (static member (+): ^T * ^T -> ^T)
+        and ^T: (static member DivideByInt: ^T * int -> ^T)
+        and ^T: (static member Zero: ^T)
+"""
+
+[<Test>]
+let ``long mixed curried and tuple value with constraints`` () =
+    formatSourceString
+        true
+        """
+[<CompiledName("Average")>]
+val inline average: array: ^T[] * array: ^T[] * array: ^T[] -> array: ^T[] * array: ^T[] * array: ^T[] -> array: ^T[] * array: ^T[] * array: ^T[] -> ^T
+    when ^T: (static member (+): ^T * ^T -> ^T)
+    and ^T: (static member DivideByInt: ^T * int -> ^T)
+    and ^T: (static member Zero: ^T)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<CompiledName("Average")>]
+val inline average:
+    array: ^T[] * array: ^T[] * array: ^T[] ->
+        array: ^T[] * array: ^T[] * array: ^T[] ->
+            array: ^T[] * array: ^T[] * array: ^T[] ->
+                ^T
+        when ^T: (static member (+): ^T * ^T -> ^T)
+        and ^T: (static member DivideByInt: ^T * int -> ^T)
+        and ^T: (static member Zero: ^T)
 """

--- a/src/Fantomas.Core.Tests/SignatureTests.fs
+++ b/src/Fantomas.Core.Tests/SignatureTests.fs
@@ -1912,3 +1912,30 @@ type Async =
     static member AwaitEvent: event: IEvent<'Del, 'T> * ?cancelAction: (unit -> unit) -> Async<'T>
         when 'Del: delegate<'T, unit> and 'Del :> System.Delegate
 """
+
+[<Test>]
+let ``multi-constrained SRTP functions, 2230`` () =
+    formatSourceString
+        true
+        """
+/// Throws <c>ArgumentException</c>
+/// </example>
+[<CompiledName("Average")>]
+val inline average   : array:^T[] -> ^T   
+                            when ^T : (static member ( + ) : ^T * ^T -> ^T) 
+                            and  ^T : (static member DivideByInt : ^T*int -> ^T) 
+                            and  ^T : (static member Zero : ^T)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+/// Throws <c>ArgumentException</c>
+/// </example>
+[<CompiledName("Average")>]
+val inline average: array: ^T[] -> ^T
+    when ^T: (static member (+): ^T * ^T -> ^T)
+    and ^T: (static member DivideByInt: ^T * int -> ^T)
+    and ^T: (static member Zero: ^T)
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -4125,11 +4125,19 @@ and genConstraints astContext (t: SynType) (vi: SynValInfo) =
                     | _ -> sepNone)
             | _ -> genType astContext false ti
 
+        let genConstraints =
+            let short =
+                ifElse (List.isNotEmpty tcs) (!- "when ") sepSpace
+                +> col wordAnd tcs (genTypeConstraint astContext)
+
+            let long =
+                ifElse (List.isNotEmpty tcs) (!- "when ") sepSpace
+                +> col (sepNln +> wordAndFixed +> sepSpace) tcs (genTypeConstraint astContext)
+
+            expressionFitsOnRestOfLine short long
+
         genType
-        +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (
-            ifElse (List.isNotEmpty tcs) (!- "when ") sepSpace
-            +> col wordAnd tcs (genTypeConstraint astContext)
-        )
+        +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth genConstraints
     | _ -> sepNone
 
 and genTyparDecl astContext (TyparDecl (ats, tp)) =

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -650,6 +650,7 @@ let internal rep n (f: Context -> Context) (ctx: Context) =
     [ 1..n ] |> List.fold (fun c _ -> f c) ctx
 
 let internal wordAnd = !- " and "
+let internal wordAndFixed = !- "and"
 let internal wordOr = !- " or "
 let internal wordOf = !- " of "
 // Separator functions


### PR DESCRIPTION
Could you please review @dsyme if this is in line with the style guide?
I do notice that Fantomas doesn't put a space before the colon in `when ^T :`.
Is this by design for constraints?

Fixes #2230.