### PR TITLE
add space around binary operators in units of measure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Superfluous space between negate and RationalConst. [#2265](https://github.com/fsprojects/fantomas/issues/2265)
 * Idempotency problem with ParsedHashDirective in signature file. [#2258](https://github.com/fsprojects/fantomas/issues/2258)
 * Keyword 'override' gets changed to 'member'. [#2221](https://github.com/fsprojects/fantomas/issues/2221)
+* Spaces around binary operators in units of measure. [#2207](https://github.com/fsprojects/fantomas/issues/2207)
 
 ### Changed
 * Formatting of multi-constrained SRTP functions needs improvement. [#2230](https://github.com/fsprojects/fantomas/issues/2230)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Spaces around binary operators in units of measure. [#2207](https://github.com/fsprojects/fantomas/issues/2207)
+
 ## [5.0.0-alpha-008] - 2022-05-28
 
 ### Fixed
 * Superfluous space between negate and RationalConst. [#2265](https://github.com/fsprojects/fantomas/issues/2265)
 * Idempotency problem with ParsedHashDirective in signature file. [#2258](https://github.com/fsprojects/fantomas/issues/2258)
 * Keyword 'override' gets changed to 'member'. [#2221](https://github.com/fsprojects/fantomas/issues/2221)
-* Spaces around binary operators in units of measure. [#2207](https://github.com/fsprojects/fantomas/issues/2207)
 
 ### Changed
 * Formatting of multi-constrained SRTP functions needs improvement. [#2230](https://github.com/fsprojects/fantomas/issues/2230)

--- a/src/Fantomas.Core.Tests/OperatorTests.fs
+++ b/src/Fantomas.Core.Tests/OperatorTests.fs
@@ -1322,3 +1322,23 @@ module TopLevelOpIsolation3 =
         <@ (.. ..) 1 2 3 4 @> |> decompile
         =! "TopLevelOpIsolation3.(.. ..) 1 2 3 4"
 """
+
+[<Test>]
+let ``add space around binary operators in units of measure, 2207`` () =
+    formatSourceString
+        false
+        """
+type Test =
+    { WorkHoursPerWeek: uint<hr*(staff weeks)> }
+    static member create =
+    { WorkHoursPerWeek = 40u<hr*(staff weeks)> }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Test =
+    { WorkHoursPerWeek: uint<hr * (staff weeks)> }
+    static member create = { WorkHoursPerWeek = 40u<hr * (staff weeks)> }
+"""

--- a/src/Fantomas.Core.Tests/SynConstTests.fs
+++ b/src/Fantomas.Core.Tests/SynConstTests.fs
@@ -141,7 +141,7 @@ namespace Krach
 
 module Runner =
 
-    let mPerSecond = 1000<m/second> // foo
+    let mPerSecond = 1000<m / second> // foo
 
     [<Measure>]
     type ProcessId =

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -5792,8 +5792,8 @@ and genMeasure (measure: SynMeasure) =
         | SynMeasure.Var (Typar (s, _), _) -> !-s.idText
         | SynMeasure.Anon _ -> !- "_"
         | SynMeasure.One -> !- "1"
-        | SynMeasure.Product (m1, m2, _) -> loop m1 +> !- "*" +> loop m2
-        | SynMeasure.Divide (m1, m2, _) -> loop m1 +> !- "/" +> loop m2
+        | SynMeasure.Product (m1, m2, _) -> loop m1 +> !- " * " +> loop m2
+        | SynMeasure.Divide (m1, m2, _) -> loop m1 +> !- " / " +> loop m2
         | SynMeasure.Power (m, RationalConst n, _) -> loop m +> !- $"^{n}"
         | SynMeasure.Seq (ms, _) -> col sepSpace ms loop
         | SynMeasure.Named (lid, _) -> genLongIdent lid


### PR DESCRIPTION
Fixes still open part of #2207

As Don has already [agreed](https://github.com/fsharp/fslang-design/issues/660#issuecomment-1138847319) to do it like this and there is a [PR](https://github.com/dotnet/docs/pull/29657) pending for the style guide clarification, I think we can move on with this.

I changed the test to use `*` instead of `/` because we have another test which already covers SynMeasure.Divide.