### PR TITLE
Add Regression test for variants with modules lose comments

### DIFF
--- a/src/Fantomas.Core.Tests/UnionTests.fs
+++ b/src/Fantomas.Core.Tests/UnionTests.fs
@@ -880,6 +880,25 @@ type Foo = // comment
 """
 
 [<Test>]
+let ``comment after variants with modules`` () =
+    formatSourceString
+        false
+        """
+type X = 
+  | A of int // This comment survives
+  | B of C.D // This comment survives
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type X =
+    | A of int // This comment survives
+    | B of C.D // This comment survives
+"""
+
+[<Test>]
 let ``comment after equals in union`` () =
     formatSourceString
         false


### PR DESCRIPTION
This PR adds a Regression test for #2103 as this is fixed in the upcoming v5 

 