### PR TITLE
Content after hash directive is lost.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Explicit interface with SpaceBeforeClassConstructor. [#2226](https://github.com/fsprojects/fantomas/issues/2226)
 * Spaces around binary operators in units of measure. [#2207](https://github.com/fsprojects/fantomas/issues/2207)
 * Trivia not restored after long identifier in SynField. [#2290](https://github.com/fsprojects/fantomas/pull/2290)
+* Content after hash directive is lost. [#2297](https://github.com/fsprojects/fantomas/pull/2297)
 
 ## [5.0.0-alpha-008] - 2022-05-28
 

--- a/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
@@ -2525,6 +2525,24 @@ let tcrefObjTy, enclosingDeclaredTypars, renaming, objTy =
 #endif
 """
 
+
+[<Test>]
+let ``comment after endif compiler define`` () =
+    formatSourceString
+        false
+        """
+#if FOOBAR
+#endif // This comment should survive
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#if FOOBAR
+#endif // This comment should survive
+"""
+
 [<Test>]
 let ``defines as trivia for SynExpr.TypeApp, 1543`` () =
     formatSourceString

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -267,7 +267,9 @@ let internal collectTriviaFromDirectives
             { Item = Directive text; Range = r }
 
         | ConditionalDirectiveTrivia.Else r -> { Item = Directive "#else"; Range = r }
-        | ConditionalDirectiveTrivia.EndIf r -> { Item = Directive "#endif"; Range = r })
+        | ConditionalDirectiveTrivia.EndIf r ->
+            let text = source.GetContentAt(r).TrimEnd()
+            { Item = Directive text; Range = r })
 
 let internal collectTriviaFromCodeComments (source: ISourceText) (codeComments: CommentTrivia list) : Trivia list =
     codeComments


### PR DESCRIPTION
Fixes #2293

- Update collectTriviaFromDirectives endif to make it keeps the comments after formatting
