### PR TITLE
solution-level props and targets

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -16,5 +16,4 @@ remote_url="$2"
 # done
 
 # ensure that formatting is correct before pushing to the remote repository
-dotnet tool restore
-dotnet fake build -t CheckFormat
+dotnet build -t:CheckFormat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Restore tools
       run: dotnet tool restore
     - name: Restore
-      run: dotnet restore
+      run: dotnet paket restore && dotnet restore
     - name: Build
       run: "dotnet build /t:All -bl" 
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,15 +18,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: ${{ matrix.dotnet }}
-    - name: Install local tools
-      run: dotnet tool restore
-    - name: Paket restore
-      run: dotnet paket restore
     - name: Build
-      run: dotnet fake run build.fsx
+      run: dotnet build /t:All
       env:
         CI: true
         TABLE_STORAGE_CONNECTION_STRING: ${{ secrets.TABLE_STORAGE_CONNECTION_STRING }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Build
-      run: dotnet build /t:All
+      run: "dotnet build /t:All"
       env:
         CI: true
         TABLE_STORAGE_CONNECTION_STRING: ${{ secrets.TABLE_STORAGE_CONNECTION_STRING }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Restore tools
       run: dotnet tool restore
+    - name: Restore
+      run: dotnet restore
     - name: Build
       run: "dotnet build /t:All"
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,14 @@ jobs:
     - name: Restore
       run: dotnet restore
     - name: Build
-      run: "dotnet build /t:All"
+      run: "dotnet build /t:All -bl" 
       env:
         CI: true
-        TABLE_STORAGE_CONNECTION_STRING: ${{ secrets.TABLE_STORAGE_CONNECTION_STRING }}
+    - uses: actions/upload-artifact@v3
+      with:
+        name: binlog
+        path: msbuild.binlog
+      if: failure()
     - name: "trigger fantomas-tools action"
       if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/master'
       run: "curl -H 'Accept: application/vnd.github.everest-preview+json' -H 'Authorization: token ${{secrets.FANTOMAS_TOOLS_TOKEN}}' --request POST --data '{\"event_type\": \"fantomas-commit-on-master\"}' https://api.github.com/repos/fsprojects/fantomas-tools/dispatches"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: ${{ matrix.dotnet }}
+    - name: Restore tools
+      run: dotnet tool restore
     - name: Build
       run: "dotnet build /t:All"
       env:

--- a/Directory.Solution.props
+++ b/Directory.Solution.props
@@ -1,31 +1,3 @@
 <Project>
-    <PropertyGroup>
-        <!-- Set up version and package release note generation from this changelog. -->
-        <ChangelogFile>$(MSBuildThisFileDirectory)CHANGELOG.md</ChangelogFile>
-        <!-- Common packaging properties for all packages in this repo -->
-        <Authors>Florian Verdonck, Jindřich Ivánek</Authors>
-        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <Description>
-This library aims at formatting F# source files based on a given configuration.
-Fantomas will ensure correct indentation and consistent spacing between elements in the source files.
-Some common use cases include:
-(1) Reformatting a code base to conform a universal page width
-(2) Converting legacy code from verbose syntax to light syntax
-(3) Formatting auto-generated F# signatures.
-</Description>
-        <Copyright>Copyright © $([System.DateTime]::UtcNow.Year)</Copyright>
-        <PackageTags>F# fsharp formatting beautifier indentation indenter</PackageTags>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <DebugType>embedded</DebugType>
-        <PackageIcon>fantomas_logo.png</PackageIcon>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-    </PropertyGroup>
-
-    <ItemGroup Condition="'$(IsPackable)' == 'true'">
-        <None Include="$(MSBuildThisFileDirectory)fantomas_logo.png" Visible="false" Pack="true" PackagePath="" />
-        <None Include="$(MSBuildThisFileDirectory)README.md" Visible="false" Pack="true" PackagePath="" />
-    </ItemGroup>
+    <Import Project="Directory.Build.props" />
 </Project>

--- a/Directory.Solution.props
+++ b/Directory.Solution.props
@@ -1,0 +1,31 @@
+<Project>
+    <PropertyGroup>
+        <!-- Set up version and package release note generation from this changelog. -->
+        <ChangelogFile>$(MSBuildThisFileDirectory)CHANGELOG.md</ChangelogFile>
+        <!-- Common packaging properties for all packages in this repo -->
+        <Authors>Florian Verdonck, Jindřich Ivánek</Authors>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Description>
+This library aims at formatting F# source files based on a given configuration.
+Fantomas will ensure correct indentation and consistent spacing between elements in the source files.
+Some common use cases include:
+(1) Reformatting a code base to conform a universal page width
+(2) Converting legacy code from verbose syntax to light syntax
+(3) Formatting auto-generated F# signatures.
+</Description>
+        <Copyright>Copyright © $([System.DateTime]::UtcNow.Year)</Copyright>
+        <PackageTags>F# fsharp formatting beautifier indentation indenter</PackageTags>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <DebugType>embedded</DebugType>
+        <PackageIcon>fantomas_logo.png</PackageIcon>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(IsPackable)' == 'true'">
+        <None Include="$(MSBuildThisFileDirectory)fantomas_logo.png" Visible="false" Pack="true" PackagePath="" />
+        <None Include="$(MSBuildThisFileDirectory)README.md" Visible="false" Pack="true" PackagePath="" />
+    </ItemGroup>
+</Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -64,6 +64,7 @@
     </Target>
 
     <Target Name="Benchmark">
+        <Exec Command="dotnet build -c Release src/Fantomas.Benchmarks" />
         <Exec Command="dotnet src/Fantomas.Benchmarks/bin/Release/net6.0/Fantomas.Benchmarks.dll" IgnoreStandardErrorWarningFormat="true" />
     </Target>
 </Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -4,6 +4,12 @@
     </Target>
 
     <Target
+            Name="Restore_EnsureTools"
+            BeforeTargets="_GenerateRestoreGraph">
+        <CallTarget Targets="RestoreTools" />
+    </Target>
+
+    <Target
             Name="DiscoverSourceFiles"
             Outputs="FormatSources"
             Returns="FormatSources">
@@ -11,7 +17,9 @@
             <FormatSources
                     Include="src/**/*.fs"
                     Exclude="src/**/obj/**/*.fs;src/Fantomas.FCS/generated/netstandard2.0/*.fs" />
-            <FormatSources Include="src/**/*.fsi" Exclude="src/Fantomas.FCS/generated/netstandard2.0/*.fsi" />
+            <FormatSources
+                    Include="src/**/*.fsi"
+                    Exclude="src/Fantomas.FCS/generated/netstandard2.0/*.fsi" />
             <FormatSources Include="build.fsx" />
             <FormatSources Include="docs/**/*.fsx" />
         </ItemGroup>
@@ -65,26 +73,48 @@
     </Target>
 
     <Target Name="Benchmark">
-        <MSBuild Projects="src/Fantomas.Benchmarks/Fantomas.Benchmarks.fsproj" Targets="Build" Properties="Configuration=Release">
+        <MSBuild
+                Projects="src/Fantomas.Benchmarks/Fantomas.Benchmarks.fsproj"
+                Targets="Build"
+                Properties="Configuration=Release">
             <Output
-                TaskParameter="TargetOutputs"
-                ItemName="BenchmarkAssemblies" />
+                    TaskParameter="TargetOutputs"
+                    ItemName="BenchmarkAssemblies" />
         </MSBuild>
-        <Exec Command="dotnet @(BenchmarkAssemblies)" IgnoreStandardErrorWarningFormat="true" />
-    </Target>
-    
-    <Target Name="All">
-        <CallTarget Targets="RestoreTools" />
-        <MSBuild Projects="fantomas.sln" Targets="Clean" />
-        <CallTarget Targets="CheckFormat" />
-        <MSBuild Projects="fantomas.sln" Targets="Build" Properties="Configuration=Release" />
-        <MSBuild Projects="fantomas.sln" Targets="VSTest" Properties="Configuration=Release" />
-        <CallTarget Targets="BenchMark" />
-        <MSBuild Projects="fantomas.sln" Targets="Pack" Properties="Configuration=Release;PackageOutputPath=$(MSBuildThisFileDirectory)bin"/>
+        <Exec
+                Command="dotnet @(BenchmarkAssemblies)"
+                IgnoreStandardErrorWarningFormat="true" />
     </Target>
 
-    <Target Name="Docs" DependsOnTargets="RestoreTools">
-        <Exec Command="dotnet fsi docs/.style/style.fsx" IgnoreStandardErrorWarningFormat="true" />
-        <Exec Command="dotnet fsdocs build --clean --properties Configuration=Release" IgnoreStandardErrorWarningFormat="true" />
+    <Target Name="All">
+        <CallTarget Targets="RestoreTools" />
+        <MSBuild
+                Projects="fantomas.sln"
+                Targets="Clean" />
+        <CallTarget Targets="CheckFormat" />
+        <MSBuild
+                Projects="fantomas.sln"
+                Targets="Build"
+                Properties="Configuration=Release" />
+        <MSBuild
+                Projects="fantomas.sln"
+                Targets="VSTest"
+                Properties="Configuration=Release" />
+        <CallTarget Targets="BenchMark" />
+        <MSBuild
+                Projects="fantomas.sln"
+                Targets="Pack"
+                Properties="Configuration=Release;PackageOutputPath=$(MSBuildThisFileDirectory)bin" />
+    </Target>
+
+    <Target
+            Name="Docs"
+            DependsOnTargets="RestoreTools">
+        <Exec
+                Command="dotnet fsi docs/.style/style.fsx"
+                IgnoreStandardErrorWarningFormat="true" />
+        <Exec
+                Command="dotnet fsdocs build --clean --properties Configuration=Release"
+                IgnoreStandardErrorWarningFormat="true" />
     </Target>
 </Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -74,6 +74,7 @@
     </Target>
     
     <Target Name="All">
+        <CallTarget Targets="RestoreTools" />
         <MSBuild Projects="fantomas.sln" Targets="Clean" />
         <CallTarget Targets="CheckFormat" />
         <MSBuild Projects="fantomas.sln" Targets="Build" Properties="Configuration=Release" />

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -10,8 +10,8 @@
         <ItemGroup>
             <FormatSources
                     Include="src/**/*.fs"
-                    Exclude="src/**/obj/**/*.fs;src/Fantomas.FCS/generated/netstandard2.0/*.*" />
-            <FormatSources Include="src/**/*.fsi" />
+                    Exclude="src/**/obj/**/*.fs;src/Fantomas.FCS/generated/netstandard2.0/*.fs" />
+            <FormatSources Include="src/**/*.fsi" Exclude="src/Fantomas.FCS/generated/netstandard2.0/*.fsi" />
             <FormatSources Include="build.fsx" />
         </ItemGroup>
     </Target>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -1,0 +1,16 @@
+<Project>
+    <ItemGroup>
+        <FormatItems Include="src/**/*.fs" Exclude="src/**/obj/**/*.fs;src/Fantomas.FCS/generated/netstandard2.0/*.*" />
+        <FormatItems Include="src/**/*.fsi" />
+        <FormatItems Include="build.fsx" />
+    </ItemGroup>
+    <Target Name="RestoreTools">
+        <Exec Command="dotnet tool restore" />
+    </Target>
+    <Target Name="Format" DependsOnTargets="RestoreTools">
+        <PropertyGroup>
+            <_ItemList>%(FormatItems.Identity)</_ItemList>
+        </PropertyGroup>
+        <Exec Command="dotnet fantomas @(FormatItems, ' ')" />
+    </Target>
+</Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -64,6 +64,6 @@
     </Target>
 
     <Target Name="Benchmark">
-        <Exec Command="dotnet src/Fantomas.Benchmarks/bin/Release/net6.0/Fantomas.Benchmarks.dll" />
+        <Exec Command="dotnet src/Fantomas.Benchmarks/bin/Release/net6.0/Fantomas.Benchmarks.dll" IgnoreStandardErrorWarningFormat="true" />
     </Target>
 </Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -2,13 +2,48 @@
     <Target Name="RestoreTools">
         <Exec Command="dotnet tool restore" />
     </Target>
-    <Target Name="Format" DependsOnTargets="RestoreTools">
+    <Target
+            Name="Format"
+            DependsOnTargets="RestoreTools">
         <ItemGroup>
-            <FormatItems Include="src/**/*.fs" Exclude="src/**/obj/**/*.fs;src/Fantomas.FCS/generated/netstandard2.0/*.*" />
+            <FormatItems
+                    Include="src/**/*.fs"
+                    Exclude="src/**/obj/**/*.fs;src/Fantomas.FCS/generated/netstandard2.0/*.*" />
             <FormatItems Include="src/**/*.fsi" />
             <FormatItems Include="build.fsx" />
         </ItemGroup>
-        
+
         <Exec Command="dotnet fantomas @(FormatItems, ' ')" />
+    </Target>
+
+    <Target
+            Name="_GetChangedFilesInWorkingCopy"
+            Outputs="ChangedFiles"
+            Returns="ChangedFiles">
+        <Exec
+                Command="git diff --name-only"
+                ConsoleToMsBuild="true"
+                EchoOff="true">
+            <Output
+                    TaskParameter="ConsoleOutput"
+                    ItemName="ChangedFiles" />
+        </Exec>
+
+    </Target>
+
+    <Target
+            Name="FormatChanged"
+            DependsOnTargets="RestoreTools;_GetChangedFilesInWorkingCopy">
+        <ItemGroup>
+            <SourceFiles
+                    Include="%(ChangedFiles.Identity)"
+                    Condition="@(ChangedFiles->StartsWith('src'))" />
+            <FormatItems
+                    Include="@(SourceFiles)"
+                    Condition="'%(SourceFiles.Extension)' == '.fs' or '%(SourceFiles.Extension)' == '.fsi'" />
+        </ItemGroup>
+        <Exec
+                Command="dotnet fantomas @(FormatItems, ' ')"
+                Condition="@(FormatItems->Count()) > 0" />
     </Target>
 </Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -90,7 +90,8 @@
         <CallTarget Targets="RestoreTools" />
         <MSBuild
                 Projects="fantomas.sln"
-                Targets="Clean" />
+                Targets="Clean"
+                Properties="Configuration=Release" />
         <CallTarget Targets="CheckFormat" />
         <MSBuild
                 Projects="fantomas.sln"

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -58,4 +58,12 @@
                 Command="dotnet fantomas @(FormatItems, ' ')"
                 Condition="@(FormatItems->Count()) > 0" />
     </Target>
+
+    <Target Name="EnsureRepoConfig">
+        <Exec Command="git config core.hooksPath .githooks" />
+    </Target>
+
+    <Target Name="Benchmark">
+        <Exec Command="dotnet src/Fantomas.Benchmarks/bin/Release/net6.0/Fantomas.Benchmarks.dll" />
+    </Target>
 </Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -1,16 +1,14 @@
 <Project>
-    <ItemGroup>
-        <FormatItems Include="src/**/*.fs" Exclude="src/**/obj/**/*.fs;src/Fantomas.FCS/generated/netstandard2.0/*.*" />
-        <FormatItems Include="src/**/*.fsi" />
-        <FormatItems Include="build.fsx" />
-    </ItemGroup>
     <Target Name="RestoreTools">
         <Exec Command="dotnet tool restore" />
     </Target>
     <Target Name="Format" DependsOnTargets="RestoreTools">
-        <PropertyGroup>
-            <_ItemList>%(FormatItems.Identity)</_ItemList>
-        </PropertyGroup>
+        <ItemGroup>
+            <FormatItems Include="src/**/*.fs" Exclude="src/**/obj/**/*.fs;src/Fantomas.FCS/generated/netstandard2.0/*.*" />
+            <FormatItems Include="src/**/*.fsi" />
+            <FormatItems Include="build.fsx" />
+        </ItemGroup>
+        
         <Exec Command="dotnet fantomas @(FormatItems, ' ')" />
     </Target>
 </Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -2,18 +2,30 @@
     <Target Name="RestoreTools">
         <Exec Command="dotnet tool restore" />
     </Target>
+
     <Target
-            Name="Format"
-            DependsOnTargets="RestoreTools">
+            Name="DiscoverSourceFiles"
+            Outputs="FormatSources"
+            Returns="FormatSources">
         <ItemGroup>
-            <FormatItems
+            <FormatSources
                     Include="src/**/*.fs"
                     Exclude="src/**/obj/**/*.fs;src/Fantomas.FCS/generated/netstandard2.0/*.*" />
-            <FormatItems Include="src/**/*.fsi" />
-            <FormatItems Include="build.fsx" />
+            <FormatSources Include="src/**/*.fsi" />
+            <FormatSources Include="build.fsx" />
         </ItemGroup>
+    </Target>
 
-        <Exec Command="dotnet fantomas @(FormatItems, ' ')" />
+    <Target
+            Name="Format"
+            DependsOnTargets="RestoreTools;DiscoverSourceFiles">
+        <Exec Command="dotnet fantomas @(FormatSources, ' ')" />
+    </Target>
+
+    <Target
+            Name="CheckFormat"
+            DependsOnTargets="RestoreTools;DiscoverSourceFiles">
+        <Exec Command="dotnet fantomas --check @(FormatSources, ' ')" />
     </Target>
 
     <Target

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -64,16 +64,20 @@
     </Target>
 
     <Target Name="Benchmark">
-        <Exec Command="dotnet build -c Release src/Fantomas.Benchmarks" />
-        <Exec Command="dotnet src/Fantomas.Benchmarks/bin/Release/net6.0/Fantomas.Benchmarks.dll" IgnoreStandardErrorWarningFormat="true" />
+        <MSBuild Projects="src/Fantomas.Benchmarks/Fantomas.Benchmarks.fsproj" Targets="Build" Properties="Configuration=Release">
+            <Output
+                TaskParameter="TargetOutputs"
+                ItemName="BenchmarkAssemblies" />
+        </MSBuild>
+        <Exec Command="dotnet @(BenchmarkAssemblies)" IgnoreStandardErrorWarningFormat="true" />
     </Target>
     
     <Target Name="All">
-        <Exec Command="dotnet clean" />
+        <MSBuild Projects="fantomas.sln" Targets="Clean" />
         <CallTarget Targets="CheckFormat" />
-        <Exec Command="dotnet build -c Release" />
-        <Exec Command="dotnet test -c Release --no-restore --no-build" />
+        <MSBuild Projects="fantomas.sln" Targets="Build" Properties="Configuration=Release" />
+        <MSBuild Projects="fantomas.sln" Targets="VSTest" Properties="Configuration=Release" />
         <CallTarget Targets="BenchMark" />
-        <Exec Command="dotnet pack --no-restore -c Release -o ./bin" />
+        <MSBuild Projects="fantomas.sln" Targets="Pack" Properties="Configuration=Release;PackageOutputPath=$(MSBuildThisFileDirectory)bin"/>
     </Target>
 </Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -67,4 +67,13 @@
         <Exec Command="dotnet build -c Release src/Fantomas.Benchmarks" />
         <Exec Command="dotnet src/Fantomas.Benchmarks/bin/Release/net6.0/Fantomas.Benchmarks.dll" IgnoreStandardErrorWarningFormat="true" />
     </Target>
+    
+    <Target Name="All">
+        <Exec Command="dotnet clean" />
+        <CallTarget Targets="CheckFormat" />
+        <Exec Command="dotnet build -c Release" />
+        <Exec Command="dotnet test -c Release --no-restore --no-build" />
+        <CallTarget Targets="BenchMark" />
+        <Exec Command="dotnet pack --no-restore -c Release -o ./bin" />
+    </Target>
 </Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -13,6 +13,7 @@
                     Exclude="src/**/obj/**/*.fs;src/Fantomas.FCS/generated/netstandard2.0/*.fs" />
             <FormatSources Include="src/**/*.fsi" Exclude="src/Fantomas.FCS/generated/netstandard2.0/*.fsi" />
             <FormatSources Include="build.fsx" />
+            <FormatSources Include="docs/**/*.fsx" />
         </ItemGroup>
     </Target>
 
@@ -79,5 +80,10 @@
         <MSBuild Projects="fantomas.sln" Targets="VSTest" Properties="Configuration=Release" />
         <CallTarget Targets="BenchMark" />
         <MSBuild Projects="fantomas.sln" Targets="Pack" Properties="Configuration=Release;PackageOutputPath=$(MSBuildThisFileDirectory)bin"/>
+    </Target>
+
+    <Target Name="Docs" DependsOnTargets="RestoreTools">
+        <Exec Command="dotnet fsi docs/.style/style.fsx" IgnoreStandardErrorWarningFormat="true" />
+        <Exec Command="dotnet fsdocs build --clean --properties Configuration=Release" IgnoreStandardErrorWarningFormat="true" />
     </Target>
 </Project>

--- a/build.fsx
+++ b/build.fsx
@@ -284,6 +284,15 @@ let git command =
 
 open Microsoft.Azure.Cosmos.Table
 
+Target.create "CheckFormat" (fun _ ->
+    DotNet.build
+        (fun opts -> { opts with MSBuildParams = { opts.MSBuildParams with Targets = [ "CheckFormat" ] } })
+        "fantomas.sln")
+
+Target.create "Benchmark" (fun _ ->
+    DotNet.build
+        (fun opts -> { opts with MSBuildParams = { opts.MSBuildParams with Targets = [ "Benchmark" ] } })
+        "fantomas.sln")
 
 // TODO: the Azure storage account was removed, migrate this to a new solution.
 


### PR DESCRIPTION
Sample of using a solution-level targets file to replace some of the fantomas scripts. Notes/docs may be more forthcoming. Use them like `dotnet build -t:<Target name>`