### PR TITLE
Add regression test for 1975 and fix double spaces

### DIFF
--- a/src/Fantomas.Core.Tests/CommentTests.fs
+++ b/src/Fantomas.Core.Tests/CommentTests.fs
@@ -2274,7 +2274,7 @@ type IlxUnionRef =
         boxity: ILBoxity *
         ILTypeRef *
         IlxUnionCase[] *
-        bool (* IsNullPermitted *)  *
+        bool (* IsNullPermitted *) *
         IlxUnionHasHelpers (* HasHelpers *)
 
 type IlxUnionSpec =
@@ -2421,4 +2421,26 @@ type ExprFolder<'State> =
       dtreeIntercept: 'State -> DecisionTree -> 'State
       targetIntercept: ('State -> Expr -> 'State) -> 'State -> DecisionTreeTarget -> 'State option
       tmethodIntercept: ('State -> Expr -> 'State) -> 'State -> ObjExprMethod -> 'State option }
+"""
+
+[<Test>]
+let ``block comments in type definition, 1975`` () =
+    formatSourceString
+        true
+        """
+module M
+
+module A =
+    type ProviderGeneratedType = ProviderGeneratedType of (*ilOrigTyRef*)ILTypeRef * (*ilRenamedTyRef*)ILTypeRef * ProviderGeneratedType list
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module M
+
+module A =
+    type ProviderGeneratedType =
+        | ProviderGeneratedType (*ilOrigTyRef*) of ILTypeRef (*ilRenamedTyRef*) * ILTypeRef * ProviderGeneratedType list
 """

--- a/src/Fantomas.Core.Tests/SignatureTests.fs
+++ b/src/Fantomas.Core.Tests/SignatureTests.fs
@@ -1310,7 +1310,7 @@ open FSharp.Compiler.Features
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Text
 
-exception FileNameNotResolved of string (*description of searched locations*)  * string * range (*filename*)
+exception FileNameNotResolved of string (*description of searched locations*) * string * range (*filename*)
 
 exception LoadedSourceNotFoundIgnoring of string * range (*filename*)
 """

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -676,10 +676,6 @@ let whenShortIndent f ctx =
 let rep n (f: Context -> Context) (ctx: Context) =
     [ 1..n ] |> List.fold (fun c _ -> f c) ctx
 
-let wordAnd = !- " and "
-let wordAndFixed = !- "and"
-let wordOr = !- " or "
-let wordOf = !- " of "
 // Separator functions
 let sepNone = id
 let sepDot = !- "."
@@ -718,7 +714,7 @@ let sepNlnUnlessLastEventIsNewlineOrRagnarok (ctx: Context) =
     else
         sepNln ctx
 
-let sepStar = !- " * "
+let sepStar = sepSpace +> !- "* "
 let sepStarFixed = !- "* "
 let sepEq = !- " ="
 let sepEqFixed = !- "="
@@ -813,6 +809,11 @@ let sepOpenT = !- "("
 
 /// closing token of tuple
 let sepCloseT = !- ")"
+
+let wordAnd = sepSpace +> !- "and "
+let wordAndFixed = !- "and"
+let wordOr = sepSpace +> !- "or "
+let wordOf = sepSpace +> !- "of "
 
 // we need to make sure each expression in the function application has offset at least greater than
 // indentation of the function expression itself


### PR DESCRIPTION
While adding the regression test for #1975 I noticed double spaces in some cases.
I moved the wordXXX functions to keep them together and make use of sepSpace like @nojaf suggested.
The existing tests which expected the double spaces were adjusted.