### PR TITLE
Mark config as optional in public API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+* Don't mark optional parameters as required in public API. [#2350](https://github.com/fsprojects/fantomas/pull/2350)
+
 ## [5.0.0-alpha-011] - 2022-07-08
 
 ### Changed

--- a/src/Fantomas.Core.Tests/FormatAstTests.fs
+++ b/src/Fantomas.Core.Tests/FormatAstTests.fs
@@ -5,23 +5,23 @@ open FsUnit
 open Fantomas.Core
 open Fantomas.Core.Tests.TestHelper
 
-let parseAndFormat fn sourceCode =
+let parseAndFormat sourceCode =
     let ast =
-        CodeFormatter.ParseAsync(false, sourceCode)
+        CodeFormatter.ParseAsync(false, source = sourceCode)
         |> Async.RunSynchronously
         |> Seq.head
         |> fst
 
     let formattedCode =
-        CodeFormatter.FormatASTAsync(ast, fn sourceCode, config)
+        CodeFormatter.FormatASTAsync(ast, source = sourceCode)
         |> Async.RunSynchronously
         |> String.normalizeNewLine
         |> fun s -> s.TrimEnd('\n')
 
     formattedCode
 
-let formatAstWithSourceCode code = parseAndFormat Some code
-let formatAst code = parseAndFormat (fun _ -> None) code
+let formatAstWithSourceCode code = parseAndFormat code
+let formatAst code = parseAndFormat code
 
 [<Test>]
 let ``format the ast works correctly with no source code`` () = formatAst "()" |> should equal "()"

--- a/src/Fantomas.Core.Tests/SynLongIdentTests.fs
+++ b/src/Fantomas.Core.Tests/SynLongIdentTests.fs
@@ -397,10 +397,10 @@ let ``backticks can be added from AST only scenarios`` () =
 
     CodeFormatter.FormatASTAsync(
         tree,
-        None,
-        { config with
-            StrictMode = true
-            InsertFinalNewline = false }
+        config =
+            { config with
+                StrictMode = true
+                InsertFinalNewline = false }
     )
     |> Async.RunSynchronously
     |> should equal "``new``"

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -9,7 +9,7 @@ type CodeFormatter =
         CodeFormatterImpl.getSourceText source
         |> CodeFormatterImpl.parse isSignature
 
-    static member FormatASTAsync(ast: ParsedInput, source, ?config) : Async<string> =
+    static member FormatASTAsync(ast: ParsedInput, ?source, ?config) : Async<string> =
         let sourceAndTokens = Option.map CodeFormatterImpl.getSourceText source
         let config = Option.defaultValue FormatConfig.FormatConfig.Default config
 

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -9,19 +9,22 @@ type CodeFormatter =
         CodeFormatterImpl.getSourceText source
         |> CodeFormatterImpl.parse isSignature
 
-    static member FormatASTAsync(ast: ParsedInput, source, config) : Async<string> =
+    static member FormatASTAsync(ast: ParsedInput, source, ?config) : Async<string> =
         let sourceAndTokens = Option.map CodeFormatterImpl.getSourceText source
+        let config = Option.defaultValue FormatConfig.FormatConfig.Default config
 
         CodeFormatterImpl.formatAST ast sourceAndTokens config None
         |> async.Return
 
     static member FormatDocumentAsync(isSignature, source, config) =
+        let config = Option.defaultValue FormatConfig.FormatConfig.Default config
+
         CodeFormatterImpl.getSourceText source
         |> CodeFormatterImpl.formatDocument config isSignature
 
-    // TODO: should this return the range of the actual formatted node
-    // The selection might have been larger than the actual formatted node
     static member FormatSelectionAsync(isSignature, source, selection, config) =
+        let config = Option.defaultValue FormatConfig.FormatConfig.Default config
+
         CodeFormatterImpl.getSourceText source
         |> Selection.formatSelection config isSignature selection
 

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -10,7 +10,7 @@ type CodeFormatter =
     static member ParseAsync: isSignature: bool * source: string -> Async<(ParsedInput * string list) array>
 
     /// Format an abstract syntax tree using an optional source for trivia processing
-    static member FormatASTAsync: ast: ParsedInput * source: string option * ?config: FormatConfig -> Async<string>
+    static member FormatASTAsync: ast: ParsedInput * ?source: string * ?config: FormatConfig -> Async<string>
 
     /// Format a source string using an optional config
     static member FormatDocumentAsync: isSignature: bool * source: string * ?config: FormatConfig -> Async<string>

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -10,15 +10,15 @@ type CodeFormatter =
     static member ParseAsync: isSignature: bool * source: string -> Async<(ParsedInput * string list) array>
 
     /// Format an abstract syntax tree using an optional source for trivia processing
-    static member FormatASTAsync: ast: ParsedInput * source: string option * config: FormatConfig -> Async<string>
+    static member FormatASTAsync: ast: ParsedInput * source: string option * ?config: FormatConfig -> Async<string>
 
-    /// Format a source string using given config
-    static member FormatDocumentAsync: isSignature: bool * source: string * config: FormatConfig -> Async<string>
+    /// Format a source string using an optional config
+    static member FormatDocumentAsync: isSignature: bool * source: string * ?config: FormatConfig -> Async<string>
 
     /// Format a part of source string using given config, and return the (formatted) selected part only.
     /// Beware that the range argument is inclusive. The closest expression inside the selection will be formatted if possible.
     static member FormatSelectionAsync:
-        isSignature: bool * source: string * selection: Range * config: FormatConfig -> Async<string * range>
+        isSignature: bool * source: string * selection: Range * ?config: FormatConfig -> Async<string * range>
 
     /// Check whether an input string is invalid in F# by attempting to parse the code.
     static member IsValidFSharpCodeAsync: isSignature: bool * source: string -> Async<bool>


### PR DESCRIPTION
The main motivation for this is the `FormatASTAsync` function, which is used primarily by projects that generate code. They do not have any source input and typically don't care about the output so use they use the default configuration.