### PR TITLE
Extend InputPath DU to improve error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+* Show a better error message when the folder does not exist. [#2341](https://github.com/fsprojects/fantomas/issues/2341)
+
 ## [5.0.0-beta-002] - 2022-07-19
 
 ### Fixed

--- a/src/Fantomas.Tests/Integration/CheckTests.fs
+++ b/src/Fantomas.Tests/Integration/CheckTests.fs
@@ -36,6 +36,22 @@ let ``invalid files should report exit code 1`` () =
     exitCode |> should equal 1
 
 [<Test>]
+let ``non-existing file should report exit code 1`` () =
+    let { ExitCode = exitCode } = checkCode [ "somenonexistingfile.fs" ]
+    exitCode |> should equal 1
+
+[<Test>]
+let ``unsupported file should report exit code 1`` () =
+    use fileFixture = new TemporaryFileCodeSample(CorrectlyFormatted, extension = "txt")
+    let { ExitCode = exitCode } = checkCode [ fileFixture.Filename ]
+    exitCode |> should equal 1
+
+[<Test>]
+let ``missing file should report exit code 1`` () =
+    let { ExitCode = exitCode } = checkCode []
+    exitCode |> should equal 1
+
+[<Test>]
 let ``files that need formatting should report exit code 99`` () =
     use fileFixture = new TemporaryFileCodeSample(NeedsFormatting)
 

--- a/src/Fantomas.Tests/Integration/ExitCodeTests.fs
+++ b/src/Fantomas.Tests/Integration/ExitCodeTests.fs
@@ -7,8 +7,30 @@ open Fantomas.Tests.TestHelpers
 [<Literal>]
 let WithErrors = """let a ="""
 
+[<Literal>]
+let CorrectlyFormatted =
+    """module A
+
+"""
+
 [<Test>]
 let ``invalid files should report exit code 1`` () =
     use fileFixture = new TemporaryFileCodeSample(WithErrors)
     let { ExitCode = exitCode } = formatCode [ fileFixture.Filename ]
+    exitCode |> should equal 1
+
+[<Test>]
+let ``non-existing file should report exit code 1`` () =
+    let { ExitCode = exitCode } = formatCode [ "somenonexistingfile.fs" ]
+    exitCode |> should equal 1
+
+[<Test>]
+let ``unsupported file should report exit code 1`` () =
+    use fileFixture = new TemporaryFileCodeSample(CorrectlyFormatted, extension = "txt")
+    let { ExitCode = exitCode } = formatCode [ fileFixture.Filename ]
+    exitCode |> should equal 1
+
+[<Test>]
+let ``missing file should report exit code 1`` () =
+    let { ExitCode = exitCode } = formatCode []
     exitCode |> should equal 1

--- a/src/Fantomas/Program.fs
+++ b/src/Fantomas/Program.fs
@@ -48,6 +48,8 @@ type InputPath =
     | File of string
     | Folder of string
     | Multiple of files: string list * folder: string list
+    | NoFSharpFile of string
+    | NotFound of string
     | Unspecified
 
 [<RequireQualifiedAccess>]
@@ -186,9 +188,15 @@ let runCheckCommand (recurse: bool) (inputPath: InputPath) : int =
             if checkResult.HasErrors then 1 else 99
 
     match inputPath with
+    | InputPath.NoFSharpFile s ->
+        eprintfn "Input path '%s' is unsupported file type" s
+        1
+    | InputPath.NotFound s ->
+        eprintfn "Input path '%s' not found" s
+        1
     | InputPath.Unspecified _ ->
         eprintfn "No input path provided. Nothing to do."
-        0
+        1
     | InputPath.File f when (IgnoreFile.isIgnoredFile (IgnoreFile.current.Force()) f) ->
         printfn "'%s' was ignored" f
         0
@@ -232,8 +240,10 @@ let main argv =
                 InputPath.Folder input
             elif File.Exists input && isFSharpFile input then
                 InputPath.File input
+            elif File.Exists input then
+                InputPath.NoFSharpFile input
             else
-                InputPath.Unspecified
+                InputPath.NotFound input
         | Some inputs ->
             let isFolder (path: string) = Path.GetExtension(path) = ""
 
@@ -353,6 +363,12 @@ let main argv =
     else
         try
             match inputPath, outputPath with
+            | InputPath.NoFSharpFile s, _ ->
+                eprintfn "Input path '%s' is unsupported file type" s
+                exit 1
+            | InputPath.NotFound s, _ ->
+                eprintfn "Input path '%s' not found" s
+                exit 1
             | InputPath.Unspecified, _ ->
                 eprintfn "Input path is missing..."
                 exit 1

--- a/src/Fantomas/Program.fs
+++ b/src/Fantomas/Program.fs
@@ -195,7 +195,7 @@ let runCheckCommand (recurse: bool) (inputPath: InputPath) : int =
         eprintfn "Input path '%s' not found" s
         1
     | InputPath.Unspecified _ ->
-        eprintfn "No input path provided. Nothing to do."
+        eprintfn "No input path provided. Call with --help for usage information."
         1
     | InputPath.File f when (IgnoreFile.isIgnoredFile (IgnoreFile.current.Force()) f) ->
         printfn "'%s' was ignored" f
@@ -364,13 +364,13 @@ let main argv =
         try
             match inputPath, outputPath with
             | InputPath.NoFSharpFile s, _ ->
-                eprintfn "Input path '%s' is unsupported file type" s
+                eprintfn "Input path '%s' is unsupported file type." s
                 exit 1
             | InputPath.NotFound s, _ ->
-                eprintfn "Input path '%s' not found" s
+                eprintfn "Input path '%s' not found." s
                 exit 1
             | InputPath.Unspecified, _ ->
-                eprintfn "Input path is missing..."
+                eprintfn "Input path is missing. Call with --help for usage information."
                 exit 1
             | InputPath.File f, _ when (IgnoreFile.isIgnoredFile (IgnoreFile.current.Force()) f) ->
                 printfn "'%s' was ignored" f


### PR DESCRIPTION
Fixes #2341 

Instead of showing the complete help in case of InputPath.Unspecified, a hint is shown.
Of course, it's subjective, but I somehow prefer CLI tools which don't slap the whole help in my face without me asking for it.