### PR TITLE
Multiline bracket aligning for anonymous record types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+[Unreleased]
+
+### Changed
+* Formatting of anonymous record types respects fsharp_multiline_block_brackets_on_same_column. [#1167](https://github.com/fsprojects/fantomas/issues/1167)
+
 ## [5.1.0-alpha-005] - 2022-10-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-[Unreleased]
+## [Unreleased]
 
 ### Changed
 * Formatting of anonymous record types respects fsharp_multiline_block_brackets_on_same_column. [#1167](https://github.com/fsprojects/fantomas/issues/1167)

--- a/src/Fantomas.Core.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
+++ b/src/Fantomas.Core.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
@@ -1320,3 +1320,77 @@ type UnhandledWebException =
 
     new(info : SerializationInfo, context : StreamingContext) = { inherit Exception(info, context) }
 """
+
+[<Test>]
+let ``inline anonymous record type declaration`` () =
+    formatSourceString
+        false
+        """
+type Foo =
+    {
+        Bar : {| X : string; Y : int; A : string; B : string |}
+        Baz : int
+        Blip : string
+    }
+"""
+        config
+    |> prepend newline
+
+    |> should
+        equal
+        """
+type Foo =
+    {
+        Bar :
+            {|
+                X : string
+                Y : int
+                A : string
+                B : string
+            |}
+        Baz : int
+        Blip : string
+    }
+"""
+
+[<Test>]
+let ``anonymous type alias`` () =
+    formatSourceString
+        false
+        """
+type A = {| x: int; y: AReallyLongTypeThatIsMuchLongerThan40Characters |}
+"""
+        config
+    |> prepend newline
+
+    |> should
+        equal
+        """
+type A =
+    {|
+        x : int
+        y : AReallyLongTypeThatIsMuchLongerThan40Characters
+    |}
+"""
+
+[<Test>]
+let ``inline anonymous type in function parameter`` () =
+    formatSourceString
+        false
+        """
+let f (x: {| x: int; y:  AReallyLongTypeThatIsMuchLongerThan40Characters |}) = x
+"""
+        config
+    |> prepend newline
+
+    |> should
+        equal
+        """
+let f
+    (x : {|
+             x : int
+             y : AReallyLongTypeThatIsMuchLongerThan40Characters
+         |})
+    =
+    x
+"""

--- a/src/Fantomas.Core.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
+++ b/src/Fantomas.Core.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
@@ -1387,10 +1387,11 @@ let f (x: {| x: int; y:  AReallyLongTypeThatIsMuchLongerThan40Characters |}) = x
         equal
         """
 let f
-    (x : {|
-             x : int
-             y : AReallyLongTypeThatIsMuchLongerThan40Characters
-         |})
+    (x :
+        {|
+            x : int
+            y : AReallyLongTypeThatIsMuchLongerThan40Characters
+        |})
     =
     x
 """

--- a/src/Fantomas.Core.Tests/NumberOfItemsRecordTests.fs
+++ b/src/Fantomas.Core.Tests/NumberOfItemsRecordTests.fs
@@ -1144,9 +1144,7 @@ type A =
 type B = {| x: AReallyLongTypeThatIsMuchLongerThan40Characters |}
 """
 
-// FIXME: See https://github.com/fsprojects/fantomas/issues/1167
 [<Test>]
-[<Ignore("Issue #1167")>]
 let ``number of items sized anonymous record types with multiline block brackets on same column are formatted properly``
     ()
     =
@@ -1165,18 +1163,21 @@ type B = {| x: AReallyLongTypeThatIsMuchLongerThan40Characters |}
     |> should
         equal
         """
-
-let f (x: {|
-              x : int
-              y : AReallyLongTypeThatIsMuchLongerThan40Characters
-          |}) =
+let f
+    (x:
+        {|
+            x: int
+            y: obj
+        |})
+    =
     x
+
 let g (x: {| x: AReallyLongTypeThatIsMuchLongerThan40Characters |}) = x
 
 type A =
     {|
         x: int
-        y: AReallyLongTypeThatIsMuchLongerThan40Characters
+        y: obj
     |}
 
 type B = {| x: AReallyLongTypeThatIsMuchLongerThan40Characters |}

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -4458,7 +4458,8 @@ and genPat astContext pat =
     | PatTyped (p, t) ->
         genPat astContext p
         +> sepColon
-        +> autoIndentAndNlnIfExpressionExceedsPageWidth (genType astContext t)
+        +> autoIndentAndNlnIfExpressionExceedsPageWidth (atCurrentColumnIndent (genType astContext t))
+
     | PatNamed (ao, SynIdent (_, Some (ParenStarSynIdent (lpr, op, rpr)))) ->
         genAccessOpt ao
         +> sepOpenTFor lpr

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3973,8 +3973,10 @@ and addSpaceIfSynTypeStaticConstantHasAtSignBeforeString (t: SynType) (ctx: Cont
     onlyIf hasAtSign sepSpace ctx
 
 and genAnonRecordFieldType astContext (AnonRecordFieldType (ident, t)) =
-    genIdent ident +> sepColon +> (genType astContext t)
-    
+    genIdent ident
+    +> sepColon
+    +> autoIndentAndNlnIfExpressionExceedsPageWidth (genType astContext t)
+
 and genSingleLineAnonRecordType isStruct fields astContext =
     ifElse isStruct !- "struct " sepNone
     +> sepOpenAnonRecd
@@ -3983,13 +3985,7 @@ and genSingleLineAnonRecordType isStruct fields astContext =
 
 and genMultilineAnonRecordType isStruct fields astContext =
     let fieldsExpr = col sepNln fields (genAnonRecordFieldType astContext)
-    
-    let genRecord =
-        sepOpenAnonRecd
-        +> atCurrentColumnIndent fieldsExpr
-        +> sepCloseAnonRecd
-        +> unindent
-    
+    let genRecord = sepOpenAnonRecd +> atCurrentColumn fieldsExpr +> sepCloseAnonRecd
     ifElse isStruct !- "struct " sepNone +> genRecord
 
 and genMultilineAnonRecordTypeAlignBrackets (isStruct: bool) fields astContext =

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -927,31 +927,11 @@ let autoIndentAndNlnIfExpressionExceedsPageWidth expr (ctx: Context) =
         expr
         ctx
 
-/// try and write the expression on the remainder of the current line
-/// add an indent if the expression is longer
-let autoIndentIfExpressionExceedsPageWidth expr (ctx: Context) =
-    expressionExceedsPageWidth
-        sepNone
-        sepNone // before and after for short expressions
-        indent
-        unindent // before and after for long expressions
-        expr
-        ctx
-
 let sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth expr (ctx: Context) =
     expressionExceedsPageWidth
         sepSpace
         sepNone // before and after for short expressions
         (indent +> sepNln)
-        unindent // before and after for long expressions
-        expr
-        ctx
-
-let sepSpaceOrIndentIfExpressionExceedsPageWidth expr (ctx: Context) =
-    expressionExceedsPageWidth
-        sepSpace
-        sepNone // before and after for short expressions
-        indent
         unindent // before and after for long expressions
         expr
         ctx

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -175,6 +175,7 @@ module WriterEvents =
             | WriteLineBecauseOfTrivia -> true
             | _ -> false)
 
+[<System.Diagnostics.DebuggerDisplay("\"{Dump()}\"")>]
 type internal Context =
     { Config: FormatConfig
       WriterModel: WriterModel
@@ -320,6 +321,12 @@ type Context with
 
     member x.Column = x.WriterModel.Column
     member x.FinalizeModel = finalizeWriterModel x
+
+    member x.Dump() =
+        let m = finalizeWriterModel x
+        let lines = m.WriterModel.Lines |> List.rev
+
+        String.concat x.Config.EndOfLine.NewLineString lines
 
 let writeEventsOnLastLine ctx =
     ctx.WriterEvents
@@ -920,11 +927,31 @@ let autoIndentAndNlnIfExpressionExceedsPageWidth expr (ctx: Context) =
         expr
         ctx
 
+/// try and write the expression on the remainder of the current line
+/// add an indent if the expression is longer
+let autoIndentIfExpressionExceedsPageWidth expr (ctx: Context) =
+    expressionExceedsPageWidth
+        sepNone
+        sepNone // before and after for short expressions
+        indent
+        unindent // before and after for long expressions
+        expr
+        ctx
+
 let sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth expr (ctx: Context) =
     expressionExceedsPageWidth
         sepSpace
         sepNone // before and after for short expressions
         (indent +> sepNln)
+        unindent // before and after for long expressions
+        expr
+        ctx
+
+let sepSpaceOrIndentIfExpressionExceedsPageWidth expr (ctx: Context) =
+    expressionExceedsPageWidth
+        sepSpace
+        sepNone // before and after for short expressions
+        indent
         unindent // before and after for long expressions
         expr
         ctx

--- a/src/Fantomas.Core/SourceParser.fs
+++ b/src/Fantomas.Core/SourceParser.fs
@@ -1616,7 +1616,7 @@ let (|AnonRecordFieldName|) (ident: Ident, eq: range option, e: SynExpr) =
     let range = Range.unionRanges ident.idRange e.Range
     (ident, eq, e, range)
 
-let (|AnonRecordFieldType|) (ident: Ident, ty: SynType) = (ident, ty)
+let (|AnonRecordFieldType|) (ident, t: SynType) = (ident, t)
 
 /// Extract function arguments with their associated info
 let (|FunType|) t =

--- a/src/Fantomas.Core/SourceParser.fs
+++ b/src/Fantomas.Core/SourceParser.fs
@@ -1616,7 +1616,7 @@ let (|AnonRecordFieldName|) (ident: Ident, eq: range option, e: SynExpr) =
     let range = Range.unionRanges ident.idRange e.Range
     (ident, eq, e, range)
 
-let (|AnonRecordFieldType|) (ident, t: SynType) = (ident, t)
+let (|AnonRecordFieldType|) (ident: Ident, ty: SynType) = (ident, ty)
 
 /// Extract function arguments with their associated info
 let (|FunType|) t =


### PR DESCRIPTION
This is an attempt to address the issues in #2412 and #1167 to allow anonymous record types to be formattable with the bracket alignment working like with normal records.