### PR TITLE
Update leftover references to ragnarok

### DIFF
--- a/src/Fantomas.Core.Tests/Stroustrup/MultiLineLambdaClosingNewlineExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/MultiLineLambdaClosingNewlineExpressionTests.fs
@@ -11,7 +11,7 @@ let config =
         ExperimentalStroustrupStyle = true
         MaxArrayOrListWidth = 40 }
 
-// TODO: figure out what should happen when you mix MultiLineLambdaClosingNewline and Ragnarok
+// TODO: figure out what should happen when you mix MultiLineLambdaClosingNewline and Stroustrup
 // From a technical point of view, this is correct behavior but having `})` at the end seems sensible as well.
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynMatchClauseExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynMatchClauseExpressionTests.fs
@@ -184,7 +184,7 @@ match x with
 |]
 """
 
-// TODO: Here, I again feel this is fitting not to have ragnarok.
+// TODO: Here, I again feel this is fitting not to have stroustrup.
 // Similar to long patterns in synbinding functions.
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSigReprSimpleTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSigReprSimpleTests.fs
@@ -63,7 +63,7 @@ type V = // comment
     }
 """
 
-// TODO: I feel like ragnarok should not work when there are members involved
+// TODO: I feel like stroustrup should not work when there are members involved
 // Having members would require the `with` keyword which is not recommended by the style guide: https://docs.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting#formatting-record-declarations
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
@@ -55,7 +55,7 @@ type V = // comment
     }
 """
 
-// TODO: I feel like ragnarok should not work when there are members involved
+// TODO: I feel like stroustrup should not work when there are members involved
 // Having members would require the `with` keyword which is not recommended by the style guide: https://docs.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting#formatting-record-declarations
 
 [<Test>]

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -911,7 +911,7 @@ and genNamedArgumentExpr (astContext: ASTContext) (operatorSli: SynLongIdent) e1
         genExpr astContext e1
         +> sepSpace
         +> genSynLongIdent false operatorSli
-        +> autoIndentAndNlnExpressUnlessRagnarok (fun e -> sepSpace +> genExpr astContext e) e2
+        +> autoIndentAndNlnExpressUnlessStroustrup (fun e -> sepSpace +> genExpr astContext e) e2
 
     expressionFitsOnRestOfLine short long |> genTriviaFor SynExpr_App appRange
 
@@ -947,7 +947,7 @@ and genExpr astContext synExpr ctx =
                  | Return _
                  | ReturnFrom _
                  | Do _
-                 | DoBang _ -> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) e
+                 | DoBang _ -> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) e
                  | _ -> autoIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e))
 
             match kind with
@@ -1191,13 +1191,13 @@ and genExpr astContext synExpr ctx =
                     +> genPat astContext pat
                     +> genEq SynExpr_LetOrUseBang_Equals equalsRange
                     +> sepSpace
-                    +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) expr
+                    +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) expr
                 | AndBangStatement (pat, equalsRange, expr, range) ->
                     !- "and! "
                     +> genPat astContext pat
                     +> genEq SynExprAndBang_Equals (Some equalsRange)
                     +> sepSpace
-                    +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) expr
+                    +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) expr
                     |> genTriviaFor SynExprAndBang_ range
                 | OtherStatement expr -> genExpr astContext expr
 
@@ -1272,7 +1272,7 @@ and genExpr astContext synExpr ctx =
                 !- "fun "
                 +> col sepSpace pats (genPat astContext)
                 +> optSingle (fun arrowRange -> sepArrow |> genTriviaFor SynExpr_Lambda_Arrow arrowRange) arrowRange
-                +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) expr
+                +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) expr
             )
         | MatchLambda (keywordRange, cs) ->
             (!- "function " |> genTriviaFor SynExpr_MatchLambda_Function keywordRange)
@@ -1739,7 +1739,7 @@ and genExpr astContext synExpr ctx =
                         +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e))
                     eo
                 +> genTriviaForOption SynMatchClause_Arrow arrowRange sepArrow
-                +> autoIndentAndNlnExpressUnlessRagnarok (genExpr astContext) catchExpr
+                +> autoIndentAndNlnExpressUnlessStroustrup (genExpr astContext) catchExpr
                 +> leaveNodeFor SynMatchClause_ clauseRange
 
             atCurrentColumn (
@@ -1765,10 +1765,10 @@ and genExpr astContext synExpr ctx =
                 +> genTriviaFor SynExpr_TryWith_With withKeyword (!- "with")
                 +> sepNln
                 +> (fun ctx ->
-                    let hasMultipleClausesWhereOneHasRagnarok =
+                    let hasMultipleClausesWhereOneHasStroustrup =
                         hasMultipleClausesWhereOneHasStroustrup ctx.Config.ExperimentalStroustrupStyle cs
 
-                    col sepNln cs (genClause astContext false hasMultipleClausesWhereOneHasRagnarok) ctx)
+                    col sepNln cs (genClause astContext false hasMultipleClausesWhereOneHasStroustrup) ctx)
             )
 
         | TryFinally (tryKeyword, e1, finallyKeyword, e2) ->
@@ -1937,7 +1937,7 @@ and genExpr astContext synExpr ctx =
         | LongIdentSet (sli, e, _) ->
             genSynLongIdent false sli
             +> !- " <- "
-            +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) e
+            +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) e
         | DotIndexedGet (App (e, [ ConstExpr (SynConst.Unit, _) as ux ]), indexArgs) ->
             genExpr astContext e
             +> genExpr astContext ux
@@ -1979,7 +1979,7 @@ and genExpr astContext synExpr ctx =
                 (appExpr +> idx +> genExpr astContext valueExpr)
                 (appExpr
                  +> idx
-                 +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) valueExpr)
+                 +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) valueExpr)
         | DotIndexedSet (AppSingleParenArg (a, px), indexArgs, valueExpr) ->
             let short = genExpr astContext a +> genExpr astContext px
 
@@ -1997,14 +1997,14 @@ and genExpr astContext synExpr ctx =
                 (short +> idx +> genExpr astContext valueExpr)
                 (long
                  +> idx
-                 +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) valueExpr)
+                 +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) valueExpr)
 
         | DotIndexedSet (objectExpr, indexArgs, valueExpr) ->
             addParenIfAutoNln objectExpr (genExpr astContext)
             +> !- ".["
             +> genExpr astContext indexArgs
             +> !- "] <- "
-            +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) valueExpr
+            +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) valueExpr
         | NamedIndexedPropertySet (sli, e1, e2) ->
             genSynLongIdent false sli
             +> genExpr astContext e1
@@ -2032,12 +2032,12 @@ and genExpr astContext synExpr ctx =
             +> sepDot
             +> genSynLongIdent false sli
             +> !- " <- "
-            +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) e2
+            +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) e2
 
         | SynExpr.Set (e1, e2, _) ->
             addParenIfAutoNln e1 (genExpr astContext)
             +> !- " <- "
-            +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) e2
+            +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) e2
 
         | ParsingError r ->
             raise
@@ -4080,7 +4080,7 @@ and genInterfaceImpl astContext (InterfaceImpl (t, withKeywordRange, bs, members
 and genClause
     (astContext: ASTContext)
     (isLastItem: bool)
-    (hasMultipleClausesWhereOneHasRagnarok: bool)
+    (hasMultipleClausesWhereOneHasStroustrup: bool)
     (Clause (barRange, p, eo, arrowRange, e, clauseRange))
     =
     let patAndBody =
@@ -4114,13 +4114,13 @@ and genClause
                              let long =
                                  match barRange with
                                  | None ->
-                                     autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) e
+                                     autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) e
                                  | Some barRange ->
                                      genKeepIdent barRange e +> sepNln +> genExpr astContext e +> unindent
 
                              expressionFitsOnRestOfLine short long
                          else
-                             autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok (genExpr astContext) e))
+                             autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) e))
                         ctx)
 
     let genBar =
@@ -4130,7 +4130,7 @@ and genClause
 
     (genBar
      +> (fun ctx ->
-         if hasMultipleClausesWhereOneHasRagnarok then
+         if hasMultipleClausesWhereOneHasStroustrup then
              // avoid edge case
              (*
                 match x with
@@ -4682,7 +4682,7 @@ and genSynBindingFunction
             let short = sepSpace +> body
 
             let long =
-                autoIndentAndNlnExpressUnlessRagnarok (fun e -> sepSpace +> genExpr astContext e) e
+                autoIndentAndNlnExpressUnlessStroustrup (fun e -> sepSpace +> genExpr astContext e) e
 
             isShortExpression ctx.Config.MaxFunctionBindingWidth short long
 
@@ -4792,7 +4792,7 @@ and genSynBindingFunctionWithReturnType
             let short = sepSpace +> body
 
             let long =
-                autoIndentAndNlnExpressUnlessRagnarok (fun e -> sepSpace +> genExpr astContext e) e
+                autoIndentAndNlnExpressUnlessStroustrup (fun e -> sepSpace +> genExpr astContext e) e
 
             isShortExpression ctx.Config.MaxFunctionBindingWidth short long
 
@@ -4897,7 +4897,7 @@ and genSynBindingValue
     +> (fun ctx ->
         let prefix = afterLetKeyword +> sepSpace +> genValueName +> genReturnType
         let short = prefix +> genExpr astContext e
-        let long = prefix +> autoIndentAndNlnExpressUnlessRagnarok (genExpr astContext) e
+        let long = prefix +> autoIndentAndNlnExpressUnlessStroustrup (genExpr astContext) e
         isShortExpression ctx.Config.MaxValueBindingWidth short long ctx)
 
 // Example case: let ( *= ) a b = ()
@@ -5074,7 +5074,7 @@ and genLambdaArrowWithTrivia
         if hasWriteBeforeNewlineContent ctx then
             indentSepNlnUnindent (bodyExpr body) ctx
         else
-            autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok bodyExpr body ctx)
+            autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup bodyExpr body ctx)
 
 and addSpaceBeforeClassConstructor expr =
     match expr with

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -572,9 +572,9 @@ let ifElse b (f1: Context -> Context) f2 (ctx: Context) = if b then f1 ctx else 
 
 let ifElseCtx cond (f1: Context -> Context) f2 (ctx: Context) = if cond ctx then f1 ctx else f2 ctx
 
-let ifRagnarokElse = ifElseCtx (fun ctx -> ctx.Config.ExperimentalStroustrupStyle)
+let ifStroustrupElse = ifElseCtx (fun ctx -> ctx.Config.ExperimentalStroustrupStyle)
 
-let ifRagnarok (f1: Context -> Context) =
+let ifStroustrup (f1: Context -> Context) =
     ifElseCtx (fun ctx -> ctx.Config.ExperimentalStroustrupStyle) f1 id
 
 /// apply f only when cond is true
@@ -619,7 +619,7 @@ let sepNlnForTrivia = writerEvent WriteLineBecauseOfTrivia
 let sepNlnUnlessLastEventIsNewline (ctx: Context) =
     if lastWriteEventIsNewline ctx then ctx else sepNln ctx
 
-let sepNlnUnlessLastEventIsNewlineOrRagnarok (ctx: Context) =
+let sepNlnUnlessLastEventIsNewlineOrStroustrup (ctx: Context) =
     if lastWriteEventIsNewline ctx || ctx.Config.ExperimentalStroustrupStyle then
         ctx
     else
@@ -1171,12 +1171,12 @@ let addExtraNewlineIfLeadingWasMultiline leading sepNlnConsideringTriviaContentB
     leadingExpressionIsMultiline leading (fun ml ->
         sepNln +> onlyIf ml sepNlnConsideringTriviaContentBefore +> continuation)
 
-let autoIndentAndNlnExpressUnlessRagnarok (f: SynExpr -> Context -> Context) (e: SynExpr) (ctx: Context) =
+let autoIndentAndNlnExpressUnlessStroustrup (f: SynExpr -> Context -> Context) (e: SynExpr) (ctx: Context) =
     match e with
     | SourceParser.StroustrupStyleExpr ctx.Config.ExperimentalStroustrupStyle e -> f e ctx
     | _ -> indentSepNlnUnindent (f e) ctx
 
-let autoIndentAndNlnIfExpressionExceedsPageWidthUnlessRagnarok
+let autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup
     (f: SynExpr -> Context -> Context)
     (e: SynExpr)
     (ctx: Context)

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -198,7 +198,8 @@ type FormatConfig =
       BarBeforeDiscriminatedUnionDeclaration: bool
 
       [<Category("Convention")>]
-      [<DisplayName("Ragnarok")>]
+      [<DisplayName("Format braces using Stroustrup Style where possible.")>]
+      [<Description("Experimental feature, use at your own risk.")>]
       ExperimentalStroustrupStyle: bool
 
       [<Category("Convention")>]

--- a/src/Fantomas.Core/SourceParser.fs
+++ b/src/Fantomas.Core/SourceParser.fs
@@ -1693,8 +1693,8 @@ let rec (|IndexWithoutDotExpr|NestedIndexWithoutDotExpr|NonAppExpr|) e =
         NestedIndexWithoutDotExpr(identifier, indexExpr, argExpr)
     | _ -> NonAppExpr
 
-let rec (|EndsWithSingleListAppExpr|_|) (isRagnarok: bool) (e: SynExpr) =
-    if not isRagnarok then
+let rec (|EndsWithSingleListAppExpr|_|) (isStroustrup: bool) (e: SynExpr) =
+    if not isStroustrup then
         None
     else
         match e with
@@ -1719,14 +1719,14 @@ let rec (|EndsWithSingleListAppExpr|_|) (isRagnarok: bool) (e: SynExpr) =
             Some(funcExpr, [], lastArg)
         | _ -> None
 
-let (|EndsWithDualListAppExpr|_|) (isRagnarok: bool) (e: SynExpr) =
-    if not isRagnarok then
+let (|EndsWithDualListAppExpr|_|) (isStroustrup: bool) (e: SynExpr) =
+    if not isStroustrup then
         None
     else
         match e with
         | SynExpr.App (ExprAtomicFlag.NonAtomic,
                        false,
-                       EndsWithSingleListAppExpr isRagnarok (e, es, lastButOneArg),
+                       EndsWithSingleListAppExpr isStroustrup (e, es, lastButOneArg),
                        (ArrayOrList _ as lastArg),
                        _) -> Some(e, es, lastButOneArg, lastArg)
         | _ -> None


### PR DESCRIPTION
Not sure if these were intentionally left out of #2251, but I figured for the sake of code clarity these references to the ragnarok code name should probably be updated to actually refer to the stroustrup feature.