### PR TITLE
Add spaces around custom operator definition starting with a star.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * `abstract` with docstring and comment gets split up. [#2433](https://github.com/fsprojects/fantomas/issues/2433)
+* Invalid removal of space in operator which starts with `*`. [#2434](https://github.com/fsprojects/fantomas/issues/2434)
 
 ## [5.0.0-beta-006] - 2022-08-12
 

--- a/src/Fantomas.Core.Tests/OperatorTests.fs
+++ b/src/Fantomas.Core.Tests/OperatorTests.fs
@@ -1,6 +1,5 @@
 module Fantomas.Core.Tests.OperatorTests
 
-open System.Net.Http.Headers
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
@@ -1348,4 +1347,19 @@ type Test =
 type Test =
     { WorkHoursPerWeek: uint<hr * (staff weeks)> }
     static member create = { WorkHoursPerWeek = 40u<hr * (staff weeks)> }
+"""
+
+[<Test>]
+let ``custom operator starting with *, 2434`` () =
+    formatSourceString
+        false
+        """
+let ( */) = (+)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let ( */ ) = (+)
 """

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -4453,6 +4453,13 @@ and genPat astContext pat =
              +> sepColon
              +> atCurrentColumnIndent (genType astContext false t))
 
+    | PatNamed (ao, SynIdent (_, Some (ParenStarSynIdent (lpr, op, rpr)))) ->
+        opt sepSpace ao genAccess
+        +> sepOpenTFor lpr
+        +> sepSpace
+        +> !-op
+        +> sepSpace
+        +> sepCloseTFor (Some rpr)
     | PatNamed (ao, si) -> opt sepSpace ao genAccess +> genSynIdent false si
     | PatAs (p1, p2, r) ->
         genPat astContext p1 +> !- " as " +> genPat astContext p2

--- a/src/Fantomas.Core/SourceParser.fs
+++ b/src/Fantomas.Core/SourceParser.fs
@@ -725,15 +725,20 @@ let (|DynamicExpr|_|) =
     | SynExpr.Dynamic (funcExpr, _, argExpr, _) -> Some(funcExpr, argExpr)
     | _ -> None
 
+let (|ParenStarSynIdent|_|) =
+    function
+    | IdentTrivia.OriginalNotationWithParen (lpr, originalNotation, rpr) ->
+        if originalNotation.Length > 1 && originalNotation.StartsWith("*") then
+            Some(lpr, originalNotation, rpr)
+        else
+            None
+    | _ -> None
+
 // Example: ( *** ) a b
 // (*) a b is ok though
 let (|ParenFunctionNameWithStar|_|) =
     function
-    | LongIdentExpr (SynLongIdent ([ _ ],
-                                   [],
-                                   [ Some (IdentTrivia.OriginalNotationWithParen (lpr, originalNotation, rpr)) ])) when
-        (originalNotation.Length > 1 && originalNotation.StartsWith("*"))
-        ->
+    | LongIdentExpr (SynLongIdent ([ _ ], [], [ Some (ParenStarSynIdent (lpr, originalNotation, rpr)) ])) ->
         Some(lpr, originalNotation, rpr)
     | _ -> None
 


### PR DESCRIPTION
Fixes #2434

@Smaug123 I did add a space on both sides of the operator.