### PR TITLE
Wrap lambda and if/then/else expressions in parenthesis in single line infix compositions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 * `abstract` with docstring and comment gets split up. [#2433](https://github.com/fsprojects/fantomas/issues/2433)
 * Invalid removal of space in operator which starts with `*`. [#2434](https://github.com/fsprojects/fantomas/issues/2434)
+* Incorrect concatenation of lines with functions. [#2435](https://github.com/fsprojects/fantomas/issues/2435)
 
 ## [5.0.0-beta-006] - 2022-08-12
 

--- a/src/Fantomas.Core.Tests/OperatorTests.fs
+++ b/src/Fantomas.Core.Tests/OperatorTests.fs
@@ -1363,3 +1363,55 @@ let ( */) = (+)
         """
 let ( */ ) = (+)
 """
+
+[<Test>]
+let ``piped lambda on a single line`` () =
+    formatSourceString
+        false
+        """
+let a : (unit -> int) list =
+    fun () -> failwith "" : int
+    |> List.singleton
+    |> id
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a: (unit -> int) list = (fun () -> failwith "": int) |> List.singleton |> id
+"""
+
+[<Test>]
+let ``piped tuple on a single line`` () =
+    formatSourceString
+        false
+        """
+fun i -> sprintf "%i" i, fun () -> i
+|> List.init foo
+|> Map.ofList
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(fun i -> sprintf "%i" i, (fun () -> i)) |> List.init foo |> Map.ofList
+"""
+
+[<Test>]
+let ``lambda piped into non newlineInfixApp`` () =
+    formatSourceString
+        false
+        """
+fun sum count -> sum / float count
+<*| sum xs
+<*| count
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(fun sum count -> sum / float count) <*| sum xs <*| count
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1333,7 +1333,9 @@ and genExpr astContext synExpr ctx =
 
         | NewlineInfixApps (e, es) ->
             let shortExpr =
-                genExpr astContext e
+                onlyIf (isSynExprLambdaOrIfThenElse e) sepOpenT
+                +> genExpr astContext e
+                +> onlyIf (isSynExprLambdaOrIfThenElse e) sepCloseT
                 +> sepSpace
                 +> col sepSpace es (fun (_s, oe, e) ->
                     genSynLongIdent false oe
@@ -1356,9 +1358,16 @@ and genExpr astContext synExpr ctx =
 
         | SameInfixApps (e, es) ->
             let shortExpr =
-                genExpr astContext e
+                onlyIf (isSynExprLambdaOrIfThenElse e) sepOpenT
+                +> genExpr astContext e
+                +> onlyIf (isSynExprLambdaOrIfThenElse e) sepCloseT
                 +> sepSpace
-                +> col sepSpace es (fun (_s, oe, e) -> genSynLongIdent false oe +> sepSpace +> genExpr astContext e)
+                +> col sepSpace es (fun (_s, oe, e) ->
+                    genSynLongIdent false oe
+                    +> sepSpace
+                    +> onlyIf (isSynExprLambdaOrIfThenElse e) sepOpenT
+                    +> genExpr astContext e
+                    +> onlyIf (isSynExprLambdaOrIfThenElse e) sepCloseT)
 
             let multilineExpr =
                 genExpr astContext e


### PR DESCRIPTION
Fixes #2435.