### PR TITLE
Maintain column indentation for list of functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Fixed
+* Maintain column indentation for list of functions. [#2158](https://github.com/fsprojects/fantomas/issues/2158) duplicates: [#2195](https://github.com/fsprojects/fantomas/issues/2195), [#2201](https://github.com/fsprojects/fantomas/issues/2201), [#2242](https://github.com/fsprojects/fantomas/issues/2242), [#2392](https://github.com/fsprojects/fantomas/issues/2392).
+
 # Changelog
 
 ## [5.0.0-beta-007] - 2022-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
+# Changelog
+
 ## [Unreleased]
 
 ### Fixed
 * Maintain column indentation for list of functions. [#2158](https://github.com/fsprojects/fantomas/issues/2158) duplicates: [#2195](https://github.com/fsprojects/fantomas/issues/2195), [#2201](https://github.com/fsprojects/fantomas/issues/2201), [#2242](https://github.com/fsprojects/fantomas/issues/2242), [#2392](https://github.com/fsprojects/fantomas/issues/2392).
-
-# Changelog
 
 ## [5.0.0-beta-007] - 2022-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-* Maintain column indentation for list of functions. [#2158](https://github.com/fsprojects/fantomas/issues/2158) duplicates: [#2195](https://github.com/fsprojects/fantomas/issues/2195), [#2201](https://github.com/fsprojects/fantomas/issues/2201), [#2242](https://github.com/fsprojects/fantomas/issues/2242), [#2392](https://github.com/fsprojects/fantomas/issues/2392).
+* Maintain column indentation for list of functions. [#2158](https://github.com/fsprojects/fantomas/issues/2158) duplicates: [#2195](https://github.com/fsprojects/fantomas/issues/2195), [#2201](https://github.com/fsprojects/fantomas/issues/2201), [#2242](https://github.com/fsprojects/fantomas/issues/2242), [#2392](https://github.com/fsprojects/fantomas/issues/2392)
 
 ## [5.0.0-beta-007] - 2022-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## [Unreleased]
 
 ### Fixed
-* Maintain column indentation for list of functions. [#2158](https://github.com/fsprojects/fantomas/issues/2158) duplicates: [#2195](https://github.com/fsprojects/fantomas/issues/2195), [#2201](https://github.com/fsprojects/fantomas/issues/2201), [#2242](https://github.com/fsprojects/fantomas/issues/2242), [#2392](https://github.com/fsprojects/fantomas/issues/2392)
+* List of functions misaligned and breaks (Elmish). [#2158](https://github.com/fsprojects/fantomas/issues/2158)
+* Idempotency problem when Elmish Html. [#2195](https://github.com/fsprojects/fantomas/issues/2195)
+* Splitting list results in code that doesn't compile. [#2201](https://github.com/fsprojects/fantomas/issues/2201)
+* Idempotency problem when using a list with interpolated strings. [#2242](https://github.com/fsprojects/fantomas/issues/2242)
+* Idempotency problem when using set and spread syntax. [#2392](https://github.com/fsprojects/fantomas/issues/2392)
 
 ## [5.0.0-beta-007] - 2022-08-19
 

--- a/src/Fantomas.Core.Tests/ListTests.fs
+++ b/src/Fantomas.Core.Tests/ListTests.fs
@@ -2319,3 +2319,22 @@ let x: double[][] = [ [ 1.0, 2.0, 3.0 ] ]
 let foo (x: double[]) (y: object[][]) : string[,] = x :> int[]
 let foo<'T> (x: 'T[]) = x
 """
+
+[<Test>]
+let ``Maintain indentation on function list, 2158`` () =
+    formatSourceString
+        false
+        """
+let fns =
+    Functions[Checked false
+              OnChange(fun _ -> s |> updateSettings)]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let fns =
+    Functions[Checked false
+              OnChange(fun _ -> s |> updateSettings)]
+"""

--- a/src/Fantomas.Core.Tests/ListTests.fs
+++ b/src/Fantomas.Core.Tests/ListTests.fs
@@ -2321,7 +2321,7 @@ let foo<'T> (x: 'T[]) = x
 """
 
 [<Test>]
-let ``Maintain indentation on function list, 2158`` () =
+let ``maintain indentation on function list, 2158`` () =
     formatSourceString
         false
         """

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1401,10 +1401,17 @@ and genExpr astContext synExpr ctx =
             )
 
         | IndexWithoutDotExpr (identifierExpr, indexExpr) ->
-            genExpr astContext identifierExpr
-            +> sepOpenLFixed
-            +> genExpr astContext indexExpr
-            +> sepCloseLFixed
+            match indexExpr with
+            | Sequential _ ->
+                genExpr astContext identifierExpr
+                +> sepOpenLFixed
+                +> (genExpr astContext indexExpr |> atCurrentColumnIndent)
+                +> sepCloseLFixed
+            | _ ->
+                genExpr astContext identifierExpr
+                +> sepOpenLFixed
+                +> genExpr astContext indexExpr
+                +> sepCloseLFixed
 
         // Result<int, string>.Ok 42
         | App (DotGet (TypeApp (e, lt, ts, gt), sli), es) ->

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1401,17 +1401,13 @@ and genExpr astContext synExpr ctx =
             )
 
         | IndexWithoutDotExpr (identifierExpr, indexExpr) ->
-            match indexExpr with
-            | Sequential _ ->
-                genExpr astContext identifierExpr
-                +> sepOpenLFixed
-                +> (genExpr astContext indexExpr |> atCurrentColumnIndent)
-                +> sepCloseLFixed
-            | _ ->
-                genExpr astContext identifierExpr
-                +> sepOpenLFixed
-                +> genExpr astContext indexExpr
-                +> sepCloseLFixed
+
+            let genIndexExpr = genExpr astContext indexExpr
+
+            genExpr astContext identifierExpr
+            +> sepOpenLFixed
+            +> expressionFitsOnRestOfLine genIndexExpr (atCurrentColumnIndent genIndexExpr)
+            +> sepCloseLFixed
 
         // Result<int, string>.Ok 42
         | App (DotGet (TypeApp (e, lt, ts, gt), sli), es) ->

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1401,7 +1401,6 @@ and genExpr astContext synExpr ctx =
             )
 
         | IndexWithoutDotExpr (identifierExpr, indexExpr) ->
-
             let genIndexExpr = genExpr astContext indexExpr
 
             genExpr astContext identifierExpr


### PR DESCRIPTION
Fixes #2158 

I wasn't sure about the added duplication in `IndexWithoutDotExpr` but factoring the change seemed to add as much complexity. Elsewhere seems to favour mild duplication. Happy to adjust as preferred.

Noticed in the ListTests.fs file the last function isn't marked as a test. I've checked and it runs fine. I have NOT added it to this PR but happy to or add a separate PR to get properly added and running:
 https://github.com/fsprojects/fantomas/blob/2d5db3e6c7b7fb47e374505765ed530dfd934aa2/src/Fantomas.Core.Tests/ListTests.fs#L2302-L2321