### PR TITLE
Don't add spaces for single op_Multiply operator name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Splitting list results in code that doesn't compile. [#2201](https://github.com/fsprojects/fantomas/issues/2201)
 * Idempotency problem when using a list with interpolated strings. [#2242](https://github.com/fsprojects/fantomas/issues/2242)
 * Idempotency problem when using set and spread syntax. [#2392](https://github.com/fsprojects/fantomas/issues/2392)
+* Formatting (*) returns ( * ). [#2452](https://github.com/fsprojects/fantomas/issues/2452)
 
 ## [5.0.0-beta-007] - 2022-08-19
 

--- a/src/Fantomas.Core.Tests/OperatorTests.fs
+++ b/src/Fantomas.Core.Tests/OperatorTests.fs
@@ -1415,3 +1415,18 @@ fun sum count -> sum / float count
         """
 (fun sum count -> sum / float count) <*| sum xs <*| count
 """
+
+[<Test>]
+let ``single star operator, 2452`` () =
+    formatSourceString
+        false
+        """
+let (*) x y = x + y
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let (*) x y = x + y
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -4926,12 +4926,18 @@ and genSynBindingValue
 // The idea is to solve this only where this can occur and not at the SynIdent level.
 and genSynBindingFunctionName (functionName: SynLongIdent) =
     match functionName with
-    | OperatorNameWithStar (text, synIdentRange, synLongIdentRange) ->
-        !- $"( {text} )"
+    | OperatorNameWithStar (lpr, text, rpr, synIdentRange, synLongIdentRange) ->
+        sepOpenTFor lpr +> sepSpace +> !-text +> sepSpace +> sepCloseTFor (Some rpr)
         |> genTriviaFor SynIdent_ synIdentRange
         |> genTriviaFor SynLongIdent_ synLongIdentRange
-    | PrefixedOperatorNameWithStar (prefix, text, synIdentRange, synLongIdentRange) ->
-        genSynIdent false prefix +> sepDot +> !- $"( {text} )"
+    | PrefixedOperatorNameWithStar (prefix, lpr, text, rpr, synIdentRange, synLongIdentRange) ->
+        genSynIdent false prefix
+        +> sepDot
+        +> sepOpenTFor lpr
+        +> sepSpace
+        +> !-text
+        +> sepSpace
+        +> sepCloseTFor (Some rpr)
         |> genTriviaFor SynIdent_ synIdentRange
         |> genTriviaFor SynLongIdent_ synLongIdentRange
     | _ -> genSynLongIdent false functionName

--- a/src/Fantomas.Core/SourceParser.fs
+++ b/src/Fantomas.Core/SourceParser.fs
@@ -1202,12 +1202,10 @@ let (|PatLongIdent|_|) =
 
 let (|OperatorNameWithStar|PrefixedOperatorNameWithStar|NotAnOperatorNameWithStar|) (synLongIdent: SynLongIdent) =
     match synLongIdent.IdentsWithTrivia with
-    | [ SynIdent (_, Some (IdentTrivia.OriginalNotationWithParen (text = text))) as synIdent ] when text.StartsWith("*") ->
-        OperatorNameWithStar(text, synIdent.FullRange, synLongIdent.FullRange)
-    | [ prefix; SynIdent (_, Some (IdentTrivia.OriginalNotationWithParen (text = text))) as synIdent ] when
-        text.StartsWith("*")
-        ->
-        PrefixedOperatorNameWithStar(prefix, text, synIdent.FullRange, synLongIdent.FullRange)
+    | [ SynIdent(trivia = Some (ParenStarSynIdent (lpr, originalNotation, rpr))) as synIdent ] ->
+        OperatorNameWithStar(lpr, originalNotation, rpr, synIdent.FullRange, synLongIdent.FullRange)
+    | [ prefix; SynIdent(trivia = Some (ParenStarSynIdent (lpr, originalNotation, rpr))) as synIdent ] ->
+        PrefixedOperatorNameWithStar(prefix, lpr, originalNotation, rpr, synIdent.FullRange, synLongIdent.FullRange)
     | _ -> NotAnOperatorNameWithStar
 
 let (|PatParen|_|) =


### PR DESCRIPTION
Fixes #2452