### PR TITLE
Strip only \r to be able to detect a changed number of newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* --check should fail if the number of newlines is different. [#2461](https://github.com/fsprojects/fantomas/issues/2461)
+
 ## [5.0.0-beta-008] - 2022-08-30
 
 ### Fixed

--- a/src/Fantomas.Tests/CheckTests.fs
+++ b/src/Fantomas.Tests/CheckTests.fs
@@ -19,7 +19,6 @@ let WithErrors = """let a"""
 [<Literal>]
 let CorrectlyFormatted =
     """module A
-
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/Integration/CheckTests.fs
+++ b/src/Fantomas.Tests/Integration/CheckTests.fs
@@ -19,7 +19,6 @@ let WithErrors = """let a ="""
 [<Literal>]
 let CorrectlyFormatted =
     """module A
-
 """
 
 [<Test>]
@@ -135,3 +134,14 @@ let ``honor ignore file when processing a folder`` () =
         runFantomasTool (sprintf "--check .%c%s" Path.DirectorySeparatorChar subFolder)
 
     output |> should not' (contain "ignored")
+
+[<Test>]
+let ``check should fail if the number of newlines is different, 2461`` () =
+    let codeSnippet =
+        """module A
+
+"""
+    use fileFixture = new TemporaryFileCodeSample(codeSnippet)
+
+    let { ExitCode = exitCode } = checkCode [ fileFixture.Filename ]
+    exitCode |> should equal 99

--- a/src/Fantomas.Tests/Integration/CheckTests.fs
+++ b/src/Fantomas.Tests/Integration/CheckTests.fs
@@ -141,6 +141,7 @@ let ``check should fail if the number of newlines is different, 2461`` () =
         """module A
 
 """
+
     use fileFixture = new TemporaryFileCodeSample(codeSnippet)
 
     let { ExitCode = exitCode } = checkCode [ fileFixture.Filename ]

--- a/src/Fantomas/Format.fs
+++ b/src/Fantomas/Format.fs
@@ -54,7 +54,7 @@ let private formatContentInternalAsync
                 let contentChanged =
                     if compareWithoutLineEndings then
                         let stripNewlines (s: string) =
-                            System.Text.RegularExpressions.Regex.Replace(s, @"\n|\r", String.Empty)
+                            System.Text.RegularExpressions.Regex.Replace(s, @"\r", String.Empty)
 
                         (stripNewlines originalContent) <> (stripNewlines formattedContent)
                     else


### PR DESCRIPTION
Fixes #2461 