### PR TITLE
Change Contributions guideline to right url

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -14,7 +14,7 @@ Fantomas follows two F# style guides: the [F# code formatting guidelines](https:
 
 ## Contributing Guidelines
 
-See the [Contribution Guidelines](https://github.com/fsprojects/fantomas/blob/dbbe2036e166a2e8846d031d2e490fef1e13e38b/CONTRIBUTING.md).
+See the [Contribution Guidelines](https://github.com/fsprojects/fantomas/blob/master/CONTRIBUTING.md).
 
 ## Credits
 We would like to gratefully thank the following persons for their contributions.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -14,7 +14,7 @@ Fantomas follows two F# style guides: the [F# code formatting guidelines](https:
 
 ## Contributing Guidelines
 
-See the [Contribution Guidelines](./CONTRIBUTING.md).
+See the [Contribution Guidelines](https://github.com/fsprojects/fantomas/blob/dbbe2036e166a2e8846d031d2e490fef1e13e38b/CONTRIBUTING.md).
 
 ## Credits
 We would like to gratefully thank the following persons for their contributions.


### PR DESCRIPTION
Currently our index sends to a 404 page instead of the contribution page. I changed it to point to CONTRIBUTING.md of this repository.
If contributors section for the new docs site is ready let me know so I change it to point there instead!