### PR TITLE
Add a &nbsp; to help browsers render the space after an em tag

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -172,7 +172,7 @@
                         </div>
                     </div>
                     <div class="carousel-item">
-                        <q class="fs-3 d-block my-2">As a maintainer, Fantomas makes it <em>easy</em> to contribute to my projects - I no longer have to care about spacing or style, Fantomas handles it for me!</q>
+                        <q class="fs-3 d-block my-2">As a maintainer, Fantomas makes it <em>easy</em>&nbsp; to contribute to my projects - I no longer have to care about spacing or style, Fantomas handles it for me!</q>
                         <div class="carousel-caption d-none d-md-block">
                             <h5><i class="bi bi-dash-lg"></i> Chet Husk</h5>
                             <p>F# community hero</p>


### PR DESCRIPTION
This makes the space after the "easy" in Chet's testimonial being rendered.