### PR TITLE
Fix record definition using Stroustrup style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 * Record definition with accessibility modifier error using stroustrup style [#2481](https://github.com/fsprojects/fantomas/issues/2481)
 
 ## [5.0.0-beta-009] - 2022-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+* Record definition with accessibility modifier error using stroustrup style [#2481](https://github.com/fsprojects/fantomas/issues/2481)
+
 ## [5.0.0-beta-009] - 2022-09-02
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
@@ -144,27 +144,6 @@ type Person = { FirstName: string; LastName: string }
 """
 
 [<Test>]
-let ``record definition with accessibility modifier with added whitespace, 2481`` () =
-    formatSourceString
-        false
-        """
-type Person =      private    {
-    FirstName: string
-    LastName: string
-}
-"""
-        config
-    |> prepend newline
-    |> should
-        equal
-        """
-type Person = private {
-    FirstName: string
-    LastName: string
-}
-"""
-
-[<Test>]
 let ``record definition with accessibility modifier with incorrect format, 2481`` () =
     formatSourceString
         false

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
@@ -82,3 +82,85 @@ type V =
     }
     member this.Coordinate = (this.X, this.Y, this.Z)
 """
+
+[<Test>]
+let ``record definition with accessibility modifier, 2481`` () =
+    formatSourceString
+        false
+        """
+type Person = private {
+    FirstName: string
+    LastName: string
+}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Person = private {
+    FirstName: string
+    LastName: string
+}
+"""
+
+[<Test>]
+let ``record definition without accessibility modifier, 2481`` () =
+    formatSourceString
+        false
+        """
+type Person = {
+    FirstName: string
+    LastName: string
+}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Person = { FirstName: string; LastName: string }
+"""
+
+[<Test>]
+let ``record definition with accessibility modifier with added whitespace, 2481`` () =
+    formatSourceString
+        false
+        """
+type Person =      private    {
+    FirstName: string
+    LastName: string
+}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Person = private {
+    FirstName: string
+    LastName: string
+}
+"""
+
+[<Test>]
+let ``record definition with accessibility modifier with incorrect format, 2481`` () =
+    formatSourceString
+        false
+        """
+type Person = 
+    private {
+        FirstName: string
+        LastName: string
+    }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Person = private {
+    FirstName: string
+    LastName: string
+}
+"""

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
@@ -126,24 +126,6 @@ type Person = internal {
 """
 
 [<Test>]
-let ``record definition without accessibility modifier, 2481`` () =
-    formatSourceString
-        false
-        """
-type Person = {
-    FirstName: string
-    LastName: string
-}
-"""
-        config
-    |> prepend newline
-    |> should
-        equal
-        """
-type Person = { FirstName: string; LastName: string }
-"""
-
-[<Test>]
 let ``record definition with accessibility modifier with incorrect format, 2481`` () =
     formatSourceString
         false

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
@@ -84,7 +84,7 @@ type V =
 """
 
 [<Test>]
-let ``record definition with accessibility modifier, 2481`` () =
+let ``record definition with private accessibility modifier, 2481`` () =
     formatSourceString
         false
         """
@@ -99,6 +99,27 @@ type Person = private {
         equal
         """
 type Person = private {
+    FirstName: string
+    LastName: string
+}
+"""
+
+[<Test>]
+let ``record definition with internal accessibility modifier, 2481`` () =
+    formatSourceString
+        false
+        """
+type Person = internal {
+    FirstName: string
+    LastName: string
+}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Person = internal {
     FirstName: string
     LastName: string
 }

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3412,9 +3412,7 @@ and genMultilineSimpleRecordTypeDefn astContext openingBrace withKeyword ms ao' 
 
 and genMultilineSimpleRecordTypeDefnAlignBrackets astContext openingBrace withKeyword ms ao' fs closingBrace =
     // the typeName is already printed
-    ifStroustrupElse
-        (opt (sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace) ao' genAccess)
-        (opt (indent +> sepNln) ao' genAccess)
+    ifStroustrupElse (opt (sepSpace) ao' genAccess) (opt (indent +> sepNln) ao' genAccess)
     +> enterNodeFor SynTypeDefnSimpleRepr_Record_OpeningBrace openingBrace
     +> sepOpenSFixed
     +> indentSepNlnUnindent (

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3412,7 +3412,9 @@ and genMultilineSimpleRecordTypeDefn astContext openingBrace withKeyword ms ao' 
 
 and genMultilineSimpleRecordTypeDefnAlignBrackets astContext openingBrace withKeyword ms ao' fs closingBrace =
     // the typeName is already printed
-    opt (indent +> sepNln) ao' genAccess
+    ifStroustrupElse
+        (opt (sepNlnWhenWriteBeforeNewlineNotEmpty sepSpace) ao' genAccess)
+        (opt (indent +> sepNln) ao' genAccess)
     +> enterNodeFor SynTypeDefnSimpleRepr_Record_OpeningBrace openingBrace
     +> sepOpenSFixed
     +> indentSepNlnUnindent (


### PR DESCRIPTION
Adjusted the formatting for record definitions with accessibility modifiers using the Stroustrup style.
This may or may not be a naive approach to solving this problem, any feedback would be much appreciated!
This will fix #2481

I'm not sure what the "correct" format is here. I went with my original example in the issue
```fsharp
type Person = private {
    FirstName: string
    LastName: string
}
```