### PR TITLE
Fix spacing for Const and Ident expressions in NamedIndexedPropertySet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Items.Item \<index> <- value gives wrong code. [#2498](https://github.com/fsprojects/fantomas/issues/2498)
+
 ## [5.0.0] - 2022-09-16
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/SynExprSetTests.fs
+++ b/src/Fantomas.Core.Tests/SynExprSetTests.fs
@@ -275,3 +275,22 @@ Log.Logger <-
         .WriteTo.Console()
         .CreateLogger ()
 """
+
+[<Test>]
+let ``const in NamedIndexedPropertySet, 2498`` () =
+    formatSourceString
+        false
+        """
+let xs = [| 42 |]
+
+xs.Items.Item 0 <- 20
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let xs = [| 42 |]
+
+xs.Items.Item 0 <- 20
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2019,13 +2019,14 @@ and genExpr astContext synExpr ctx =
             +> !- "] <- "
             +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) valueExpr
         | NamedIndexedPropertySet (sli, e1, e2) ->
-            let e1IsConst =
+            let needsSep =
                 match e1 with
-                | SynExpr.Const _ -> true
+                | SynExpr.Const _
+                | SynExpr.Ident _ -> true
                 | _ -> false
 
             genSynLongIdent false sli
-            +> ifElse e1IsConst sepSpace id
+            +> ifElse needsSep sepSpace id
             +> genExpr astContext e1
             +> !- " <- "
             +> autoIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e2)

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2019,7 +2019,13 @@ and genExpr astContext synExpr ctx =
             +> !- "] <- "
             +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) valueExpr
         | NamedIndexedPropertySet (sli, e1, e2) ->
+            let e1IsConst =
+                match e1 with
+                | SynExpr.Const _ -> true
+                | _ -> false
+
             genSynLongIdent false sli
+            +> ifElse e1IsConst sepSpace id
             +> genExpr astContext e1
             +> !- " <- "
             +> autoIndentAndNlnIfExpressionExceedsPageWidth (genExpr astContext e2)


### PR DESCRIPTION
Fixes #2498
