### PR TITLE
Construct a more accurate range for SynAttribute 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed: *  Comments lost from multi-line expressions [#2525](https://github.com/fsprojects/fantomas/issues/2525)
+
 ## [5.0.2] - 2022-09-22
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/CommentTests.fs
+++ b/src/Fantomas.Core.Tests/CommentTests.fs
@@ -2515,3 +2515,63 @@ type X =
             // The 'Cancel' member
             (System.IAsyncResult -> unit)
 """
+
+[<Test>]
+let ``should keep mid quotation line comments, related to 2525`` () =
+    formatSourceString
+        false
+        """test
+    <@
+      result
+        .Replace('\r', '\u00FF')
+        .Replace('\n', '\u00FF')
+        .Replace("\u00FF\u00FF", "\u00FF")
+        .Replace("8.12", "8.13") // CRAP score rounding
+        .Replace("4.12", "4.13") // CRAP score rounding
+        .Trim([| '\u00FF' |]) = expected
+        .Replace('\r', '\u00FF')
+        .Replace('\n', '\u00FF')
+        .Replace("\u00FF\u00FF", "\u00FF")
+        .Trim([| '\u00FF' |])
+    @>
+"""
+        config
+    |> should
+        equal
+        """test
+    <@
+        result
+            .Replace('\r', '\u00FF')
+            .Replace('\n', '\u00FF')
+            .Replace("\u00FF\u00FF", "\u00FF")
+            .Replace("8.12", "8.13") // CRAP score rounding
+            .Replace("4.12", "4.13") // CRAP score rounding
+            .Trim([| '\u00FF' |]) = expected
+            .Replace('\r', '\u00FF')
+            .Replace('\n', '\u00FF')
+            .Replace("\u00FF\u00FF", "\u00FF")
+            .Trim([| '\u00FF' |])
+    @>
+"""
+
+[<Test>]
+let ``should keep mid attribute line comments, 2525`` () =
+    formatSourceString
+        false
+        """[<assembly: SuppressMessage("Gendarme.Rules.Performance",
+                            "AvoidRepetitiveCallsToPropertiesRule",
+                            Scope = "member",  // MethodDefinition
+                            Target = "AltCover.Recorder.Instance/I/CallTrack::instance()",
+                            Justification = "Bytecode delta only")>]
+()
+"""
+        config
+    |> should
+        equal
+        """[<assembly: SuppressMessage("Gendarme.Rules.Performance",
+                            "AvoidRepetitiveCallsToPropertiesRule",
+                            Scope = "member", // MethodDefinition
+                            Target = "AltCover.Recorder.Instance/I/CallTrack::instance()",
+                            Justification = "Bytecode delta only")>]
+()
+"""

--- a/src/Fantomas.Core/AstExtensions.fs
+++ b/src/Fantomas.Core/AstExtensions.fs
@@ -230,3 +230,7 @@ type SynField with
         match attrs with
         | [] -> r
         | head :: _ -> unionRanges head.Range r
+
+type SynAttribute with
+
+    member this.FullRange: range = unionRanges this.Range this.ArgExpr.Range

--- a/src/Fantomas.Core/AstExtensions.fsi
+++ b/src/Fantomas.Core/AstExtensions.fsi
@@ -47,6 +47,10 @@ type SynField with
 
     member FullRange: range
 
+type SynAttribute with
+
+    member FullRange: range
+
 val synTypeDefnKindDelegateFullRange: signature: SynType -> signatureInfo: SynValInfo -> range
 
 val longIdentFullRange: li: LongIdent -> Range

--- a/src/Fantomas.Core/AstTransformer.fs
+++ b/src/Fantomas.Core/AstTransformer.fs
@@ -1338,7 +1338,7 @@ and visitSynExceptionDefnRepr (sedr: SynExceptionDefnRepr) : TriviaNode =
                    yield! (Option.map visitLongIdentIncludingFullRange >> Option.toList) longId |])
 
 and visitSynAttribute (attr: SynAttribute) : TriviaNode =
-    { Range = attr.Range
+    { Range = attr.FullRange
       Type = SynAttribute_
       Children = [| yield! visitSynExpr attr.ArgExpr |]
       FSharpASTNode = None }

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -472,7 +472,7 @@ and genAttributesCore astContext (ats: SynAttribute seq) =
             +> genSynLongIdent false sli
             +> argSpacing
             +> genExpr astContext e
-        |> genTriviaFor SynAttribute_ attr.Range
+        |> genTriviaFor SynAttribute_ attr.FullRange
 
     let shortExpression =
         !- "[<"

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -269,8 +269,7 @@ let lineCommentAfterSourceCodeToTriviaInstruction
     let lineNumber = trivia.Range.StartLine
 
     let rec allChildren (c: TriviaNode) =
-        c
-        :: (List.collect allChildren (c.Children |> Seq.cast<TriviaNode> |> Seq.toList))
+        c :: (List.collect allChildren (c.Children |> Seq.toList))
 
     let result =
         containerNode

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -20,15 +20,7 @@ let printTriviaNode (node: TriviaNode) : unit =
     visit 0 node
 
 let rec findNodeWhereRangeFitsIn (root: TriviaNode) (range: range) : TriviaNode option =
-    let rootRange =
-        match root.Type with
-        // hack to work around dotnet/fsharp#13998
-        | SynAttribute_ ->
-            root.Children
-            |> Array.fold (fun range child -> FSharp.Compiler.Text.Range.unionRanges range child.Range) root.Range
-        | _ -> root.Range
-
-    let doesSelectionFitInNode = RangeHelpers.rangeContainsRange rootRange range
+    let doesSelectionFitInNode = RangeHelpers.rangeContainsRange root.Range range
 
     if not doesSelectionFitInNode then
         None

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -268,15 +268,11 @@ let lineCommentAfterSourceCodeToTriviaInstruction
     : TriviaInstruction option =
     let lineNumber = trivia.Range.StartLine
 
-    let rec allChildren (c: TriviaNode) =
-        c :: (List.collect allChildren (c.Children |> Seq.toList))
-
     let result =
-        containerNode
-        |> allChildren
-        |> List.filter (fun node -> node.Range.EndLine = lineNumber)
-        |> List.sortByDescending (fun node -> node.Range.EndColumn)
-        |> List.tryHead
+        containerNode.Children
+        |> Array.filter (fun node -> node.Range.EndLine = lineNumber)
+        |> Array.sortByDescending (fun node -> node.Range.StartColumn)
+        |> Array.tryHead
 
     result
     |> Option.map (fun node ->

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -20,7 +20,15 @@ let printTriviaNode (node: TriviaNode) : unit =
     visit 0 node
 
 let rec findNodeWhereRangeFitsIn (root: TriviaNode) (range: range) : TriviaNode option =
-    let doesSelectionFitInNode = RangeHelpers.rangeContainsRange root.Range range
+    let rootRange =
+        match root.Type with
+        // hack to work around dotnet/fsharp#13998
+        | SynAttribute_ ->
+            root.Children
+            |> Array.fold (fun range child -> FSharp.Compiler.Text.Range.unionRanges range child.Range) root.Range
+        | _ -> root.Range
+
+    let doesSelectionFitInNode = RangeHelpers.rangeContainsRange rootRange range
 
     if not doesSelectionFitInNode then
         None


### PR DESCRIPTION
Resolve some line comment issues by improving the heuristics used attach them to the source.

* by scanning children of enclosing nodes
* by making a better selection of enclosing node