### PR TITLE
Ensure original 5.0.x behaviour.

### DIFF
--- a/src/Fantomas.Core.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Core.Tests/PatternMatchingTests.fs
@@ -2212,3 +2212,24 @@ let foo =
     | Bar (1 | 2) -> true
     | _ -> false
 """
+
+[<Test>]
+let ``long pattern with named argument`` () =
+    formatSourceString
+        false
+        """
+let addSpaceBeforeParensInFunDef (spaceBeforeSetting: bool) (functionOrMethod: SynLongIdent) args =
+    match functionOrMethod, args with
+    | SynLongIdent(id = [ newIdent ]), _ when newIdent.idText = "new" -> false
+    | _ -> true
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let addSpaceBeforeParensInFunDef (spaceBeforeSetting: bool) (functionOrMethod: SynLongIdent) args =
+    match functionOrMethod, args with
+    | SynLongIdent(id = [ newIdent ]), _ when newIdent.idText = "new" -> false
+    | _ -> true
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -4456,7 +4456,7 @@ and genPat astContext pat =
         +> genSynLongIdent false sli
         +> genValTyparDeclsOpt astContext vtdo
         +> ifElse
-            (hasParenInPat p)
+            (hasParenInPat p || Option.isSome ido)
             (ifElseCtx (fun ctx -> addSpaceBeforeParensInFunDef ctx.Config.SpaceBeforeParameter sli p) sepSpace sepNone)
             sepSpace
         +> ifElse


### PR DESCRIPTION
Restoring something we previously didn't cover in any unit test.