### PR TITLE
Don't add additional space for multiline AlternativeLongMemberDefinitions constructor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Additional space before equals sign. [#2548](https://github.com/fsprojects/fantomas/issues/2548)
+
 ## [5.0.3] - 2022-09-29
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -3162,3 +3162,35 @@ type ('key, 'value) map when 'key: comparison = Map<'key, 'value>
         """
 type ('key, 'value) map when 'key: comparison = Map<'key, 'value>
 """
+
+[<Test>]
+let ``don't add additional space before equals sign in long alternative constuctor`` () =
+    formatSourceString
+        false
+        """
+type LdapClaimsTransformation(
+                                 ldapSearcher : ILdapSearcher,
+                                 options : ILdapClaimsTransformationOptions
+                             ) =
+
+    interface IClaimsTransformation with
+        member __.TransformAsync principle =
+            3
+"""
+        { config with
+            MaxLineLength = 100
+            AlternativeLongMemberDefinitions = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+type LdapClaimsTransformation
+    (
+        ldapSearcher: ILdapSearcher,
+        options: ILdapClaimsTransformationOptions
+    )
+    =
+
+    interface IClaimsTransformation with
+        member __.TransformAsync principle = 3
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3394,8 +3394,13 @@ and genTypeDefn
 
     | ObjectModel (_, MemberDefnList (impCtor, others), _) ->
         typeName
-        +> opt sepNone impCtor (fun mdf -> sepSpaceBeforeClassConstructor +> genMemberDefn astContext mdf)
-        +> genEq SynTypeDefn_Equals equalsRange
+        +> leadingExpressionIsMultiline
+            (opt sepNone impCtor (fun mdf -> sepSpaceBeforeClassConstructor +> genMemberDefn astContext mdf))
+            (fun isMultiline ctx ->
+                if ctx.Config.AlternativeLongMemberDefinitions && isMultiline then
+                    genEqFixed SynTypeDefn_Equals equalsRange ctx
+                else
+                    genEq SynTypeDefn_Equals equalsRange ctx)
         +> indentSepNlnUnindent (genMemberDefnList astContext others)
 
     | ExceptionRepr (ExceptionDefRepr (ats, px, ao, uc)) -> genExceptionBody astContext ats px ao uc


### PR DESCRIPTION
Fixes #2548