### PR TITLE
Don't add space between function application with parentheses in DotSet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [5.0.4] - 2022-10-04
 
 ### Fixed
 * Additional space before equals sign. [#2548](https://github.com/fsprojects/fantomas/issues/2548)
+* Idempotency problem when DotSet / App / Paren. [#2549](https://github.com/fsprojects/fantomas/issues/2549)
 
 ## [5.0.3] - 2022-09-29
 

--- a/src/Fantomas.Core.Tests/DotSetTests.fs
+++ b/src/Fantomas.Core.Tests/DotSetTests.fs
@@ -1,0 +1,40 @@
+module Fantomas.Core.Tests.DotSetTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelper
+
+[<Test>]
+let ``function application with parentheses should not respect SpaceBeforeUppercaseInvocation`` () =
+    formatSourceString
+        false
+        """
+c.P.Add(x).Value <- v
+"""
+        { config with SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+c.P.Add(x).Value <- v
+"""
+
+[<Test>]
+let ``function application with parentheses should remain idempotent, 2549`` () =
+    formatSourceString
+        false
+        """
+let foo =
+    c.P.Add(NpgsqlParameter ("day", NpgsqlTypes.NpgsqlDbType.Date)).Value <- query.Day.Date
+    "fooo"
+"""
+        { config with SpaceBeforeUppercaseInvocation = true }
+    |> fun formatted -> formatSourceString false formatted { config with SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let foo =
+    c.P.Add(NpgsqlParameter ("day", NpgsqlTypes.NpgsqlDbType.Date)).Value <- query.Day.Date
+    "fooo"
+"""

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -115,6 +115,7 @@
     <Compile Include="MaxIfThenShortWidthTests.fs" />
     <Compile Include="CodePrinterHelperFunctionsTests.fs" />
     <Compile Include="ASTTransformerTests.fs" />
+    <Compile Include="DotSetTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Core\Fantomas.Core.fsproj" />

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2040,10 +2040,18 @@ and genExpr astContext synExpr ctx =
             let shortExpr = genExpr astContext e +> genSynLongIdent true sli
 
             let longExpr =
-                //genLongIdentWithMultipleFragmentsMultiline astContext e
                 genExpr astContext e +> indentSepNlnUnindent (genSynLongIdentMultiline true sli)
 
             fun ctx -> isShortExpression ctx.Config.MaxDotGetExpressionWidth shortExpr longExpr ctx
+
+        | DotSet (AppSingleParenArg (e1, px), sli, e2) ->
+            genExpr astContext e1
+            +> genExpr astContext px
+            +> sepDot
+            +> genSynLongIdent false sli
+            +> !- " <- "
+            +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup (genExpr astContext) e2
+
         | DotSet (e1, sli, e2) ->
             addParenIfAutoNln e1 (genExpr astContext)
             +> sepDot


### PR DESCRIPTION
Fixes #2549 