### PR TITLE
Change style of base constructor calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [5.1.0-alpha-005] - 2022-10-07
 
 ### Changed
 * Control space in pattern by `fsharp_space_before_lowercase_invocation` and `fsharp_space_before_uppercase_invocation`. [fslang-design/issues/712](https://github.com/fsharp/fslang-design/issues/712)
 * Style of base constructor calls. [fsharp/fslang-design#693](https://github.com/fsharp/fslang-design/issues/693)
+* Style of multiline type annotations/ [fsharp/fslang-design#708](https://github.com/fsharp/fslang-design/issues/708)
 
 ### Fixed
 * Comments in SynArgPats.NamePatPairs are lost. [#2541](https://github.com/fsprojects/fantomas/issues/2541)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 ### Changed
 * Control space in pattern by `fsharp_space_before_lowercase_invocation` and `fsharp_space_before_uppercase_invocation`. [fslang-design/issues/712](https://github.com/fsharp/fslang-design/issues/712)
+* Style of base constructor calls. [fsharp/fslang-design#693](https://github.com/fsharp/fslang-design/issues/693)
 
 ### Fixed
 * Comments in SynArgPats.NamePatPairs are lost. [#2541](https://github.com/fsprojects/fantomas/issues/2541)
+* Vanity alignment used inside base ctor call. [#2111](https://github.com/fsprojects/fantomas/issues/2111)
+* Add line break before start of argument list. [#2335](https://github.com/fsprojects/fantomas/issues/2335)
 
 ## [5.1.0-alpha-004] - 2022-10-07
 

--- a/src/Fantomas.Core.Tests/BaseConstructorTests.fs
+++ b/src/Fantomas.Core.Tests/BaseConstructorTests.fs
@@ -1,0 +1,68 @@
+module Fantomas.Core.Tests.BaseConstructorTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelper
+
+[<Test>]
+let ``multiple base constructors in record, 2111`` () =
+    formatSourceString
+        false
+        """
+type UnhandledWebException =
+    inherit Exception
+
+    new(status: WebExceptionStatus, innerException: Exception) =
+        { inherit Exception(SPrintF1
+                                "Backend not prepared for this WebException with Status[%i]"
+                                (int status),
+                            innerException) }
+
+    new(info: SerializationInfo, context: StreamingContext) =
+        { inherit Exception(info, context) }
+"""
+        { config with MaxLineLength = 100 }
+    |> prepend newline
+    |> should
+        equal
+        """
+type UnhandledWebException =
+    inherit Exception
+
+    new(status: WebExceptionStatus, innerException: Exception) =
+        { inherit
+            Exception(
+                SPrintF1 "Backend not prepared for this WebException with Status[%i]" (int status),
+                innerException
+            ) }
+
+    new(info: SerializationInfo, context: StreamingContext) = { inherit Exception(info, context) }
+"""
+
+[<Test>]
+let ``single multiline base constructor, 2335`` () =
+    formatSourceString
+        false
+        """
+type FieldNotFoundException<'T>(obj:'T, field:string, specLink:string) =
+    inherit SwaggerSchemaParseException(
+        sprintf "Object MUST contain field `%s` (See %s for more details).\nObject:%A"
+            field specLink obj)
+"""
+        { config with
+            SpaceBeforeClassConstructor = true
+            MaxLineLength = 90 }
+    |> prepend newline
+    |> should
+        equal
+        """
+type FieldNotFoundException<'T> (obj: 'T, field: string, specLink: string) =
+    inherit
+        SwaggerSchemaParseException (
+            sprintf
+                "Object MUST contain field `%s` (See %s for more details).\nObject:%A"
+                field
+                specLink
+                obj
+        )
+"""

--- a/src/Fantomas.Core.Tests/ClassTests.fs
+++ b/src/Fantomas.Core.Tests/ClassTests.fs
@@ -954,8 +954,8 @@ type public DerivedExceptionWithLongNaaaaaaaaameException
         originalRequest: string,
         originalResponse: string
     ) =
-    inherit BaseExceptionWithLongNaaaameException
-        (
+    inherit
+        BaseExceptionWithLongNaaaameException(
             message,
             code,
             originalRequest,
@@ -991,8 +991,8 @@ type public DerivedExceptionWithLongNaaaaaaaaameException
         originalRequest: string,
         originalResponse: string
     ) =
-    inherit BaseExceptionWithLongNaaaameException
-        (
+    inherit
+        BaseExceptionWithLongNaaaameException(
             message,
             code,
             originalRequest,

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -119,6 +119,7 @@
     <Compile Include="InterfaceStaticMethodTests.fs" />
     <Compile Include="ExternTests.fs" />
     <Compile Include="TypeAnnotationTests.fs" />
+    <Compile Include="BaseConstructorTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Core\Fantomas.Core.fsproj" />

--- a/src/Fantomas.Core.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
+++ b/src/Fantomas.Core.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
@@ -151,13 +151,21 @@ let ``record instance with inherit keyword and no fields`` () =
         """let a =
         { inherit ProjectPropertiesBase<_>(projectTypeGuids, factoryGuid, targetFrameworkIds, dotNetCoreSDK) }
 """
-        config
+        { config with MaxLineLength = 80 }
     |> prepend newline
     |> should
         equal
         """
 let a =
-    { inherit ProjectPropertiesBase<_>(projectTypeGuids, factoryGuid, targetFrameworkIds, dotNetCoreSDK) }
+    {
+        inherit
+            ProjectPropertiesBase<_>(
+                projectTypeGuids,
+                factoryGuid,
+                targetFrameworkIds,
+                dotNetCoreSDK
+            )
+    }
 """
 
 [<Test>]
@@ -177,7 +185,10 @@ let ``type with record instance with inherit keyword`` () =
 type ServerCannotBeResolvedException =
     inherit CommunicationUnsuccessfulException
 
-    new(message) = { inherit CommunicationUnsuccessfulException(message) }
+    new(message) =
+        {
+            inherit CommunicationUnsuccessfulException(message)
+        }
 """
 
 [<Test>]
@@ -1269,4 +1280,43 @@ let ``comment after equals in anonymous record field`` () =
     A = //comment
         B
 |}
+"""
+
+[<Test>]
+let ``multiple base constructors in record`` () =
+    formatSourceString
+        false
+        """
+type UnhandledWebException =
+    inherit Exception
+
+    new(status: WebExceptionStatus, innerException: Exception) =
+        { inherit Exception(SPrintF1
+                                "Backend not prepared for this WebException with Status[%i]"
+                                (int status),
+                            innerException) }
+
+    new(info: SerializationInfo, context: StreamingContext) =
+        { inherit Exception(info, context) }
+"""
+        { config with MaxLineLength = 100 }
+    |> prepend newline
+    |> should
+        equal
+        """
+type UnhandledWebException =
+    inherit Exception
+
+    new(status : WebExceptionStatus, innerException : Exception) =
+        {
+            inherit
+                Exception(
+                    SPrintF1
+                        "Backend not prepared for this WebException with Status[%i]"
+                        (int status),
+                    innerException
+                )
+        }
+
+    new(info : SerializationInfo, context : StreamingContext) = { inherit Exception(info, context) }
 """


### PR DESCRIPTION
Update according to the guidance of https://github.com/fsharp/fslang-design/issues/693.
Fixes https://github.com/fsharp/fslang-design/issues/693.
Fixes https://github.com/fsprojects/fantomas/issues/2111
Fixes https://github.com/fsprojects/fantomas/issues/2335

@Smaug123 there is a minor impact for [MultilineBlockBracketsOnSameColumn](https://fsprojects.github.io/fantomas/docs/end-users/Configuration.html#fsharp_multiline_block_brackets_on_same_column).
I don't think you really use that much. Nevertheless, does it seem acceptable?