### PR TITLE
Unwrap SynExpr.Typed when the type matches the type in the SynBindingReturnInfo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Function lambda with type annotation breaks code. [#2295](https://github.com/fsprojects/fantomas/issues/2295)
+
 ## [5.0.4] - 2022-10-04
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Core.Tests/LetBindingTests.fs
@@ -2051,3 +2051,38 @@ let inline NonStructural<'TInput
     : IComparer<'TInput> =
     ()
 """
+
+[<Test>]
+let ``don't  consider typed expression as return type of binding`` () =
+    formatSourceString
+        false
+        """
+let a =
+    0 : int
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = 0: int
+"""
+
+[<Test>]
+let ``typed expression with lambda should always have the type on the next line, 2295`` () =
+    formatSourceString
+        false
+        """
+let f x y : int ->  int = 
+    fun _ -> x + y
+    : int -> int
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let f x y : int -> int =
+    fun _ -> x + y
+    : int -> int
+"""

--- a/src/Fantomas.Core/AstTransformer.fs
+++ b/src/Fantomas.Core/AstTransformer.fs
@@ -1056,6 +1056,7 @@ and visitSynBinding (binding: SynBinding) : TriviaNode =
         let letNode =
             mkNodeForRangeAfterXmlAndAttributes SynBinding_Let preXml attrs trivia.LetKeyword
 
+        let expr = SourceParser.parseExpressionInSynBinding returnInfo expr
         let returnInfo = Option.map visitSynBindingReturnInfo returnInfo
 
         mkNodeWithChildren

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -582,9 +582,9 @@ and genLetBinding astContext pref b =
     let isRecursiveLetOrUseFunction = (pref = "and ")
 
     match b with
-    | LetBinding (ats, px, letKeyword, ao, isInline, isMutable, p, equalsRange, e, valInfo) ->
-        match e, p with
-        | TypedExpr (Typed, e, t), PatLongIdent (ao, sli, ps, tpso) when (List.isNotEmpty ps) ->
+    | LetBinding (ats, px, letKeyword, ao, isInline, isMutable, p, returnInfo, equalsRange, e, valInfo) ->
+        match returnInfo, p with
+        | Some t, PatLongIdent (ao, sli, ps, tpso) when (List.isNotEmpty ps) ->
             genSynBindingFunctionWithReturnType
                 astContext
                 false
@@ -603,7 +603,7 @@ and genLetBinding astContext pref b =
                 valInfo
                 equalsRange
                 e
-        | e, PatLongIdent (ao, sli, ps, tpso) when (List.isNotEmpty ps) ->
+        | None, PatLongIdent (ao, sli, ps, tpso) when (List.isNotEmpty ps) ->
             genSynBindingFunction
                 astContext
                 false
@@ -620,7 +620,7 @@ and genLetBinding astContext pref b =
                 tpso
                 equalsRange
                 e
-        | TypedExpr (Typed, e, t), pat ->
+        | Some t, pat ->
             genSynBindingValue
                 astContext
                 isRecursiveLetOrUseFunction
@@ -731,9 +731,9 @@ and genMemberBindingList astContext ms =
 
 and genMemberBinding astContext b =
     match b with
-    | MemberBinding (ats, px, ao, isInline, mf, p, equalsRange, e, synValInfo) ->
+    | MemberBinding (ats, px, ao, isInline, mf, p, rt, equalsRange, e, synValInfo) ->
         let prefix = genMemberFlags mf
-        genMemberBindingImpl astContext prefix ats px ao isInline p equalsRange e synValInfo
+        genMemberBindingImpl astContext prefix ats px ao isInline p rt equalsRange e synValInfo
 
     | ExplicitCtor (ats, px, ao, p, equalsRange, e, io) ->
         let prefix =
@@ -782,12 +782,13 @@ and genMemberBindingImpl
     (ao: SynAccess option)
     (isInline: bool)
     (p: SynPat)
+    (returnType: SynType option)
     (equalsRange: range option)
     (e: SynExpr)
     (synValInfo: SynValInfo)
     =
-    match e, p with
-    | TypedExpr (Typed, e, t), PatLongIdent (ao, s, ps, tpso) when (List.isNotEmpty ps) ->
+    match returnType, p with
+    | Some t, PatLongIdent (ao, s, ps, tpso) when (List.isNotEmpty ps) ->
         genSynBindingFunctionWithReturnType
             astContext
             true
@@ -806,10 +807,9 @@ and genMemberBindingImpl
             synValInfo
             equalsRange
             e
-    | e, PatLongIdent (ao, s, ps, tpso) when (List.isNotEmpty ps) ->
+    | None, PatLongIdent (ao, s, ps, tpso) when (List.isNotEmpty ps) ->
         genSynBindingFunction astContext true false px ats prefix ao isInline false s p.Range ps tpso equalsRange e
-    | TypedExpr (Typed, e, t), pat ->
-        genSynBindingValue astContext false px ats prefix ao isInline false pat (Some t) equalsRange e
+    | Some t, pat -> genSynBindingValue astContext false px ats prefix ao isInline false pat (Some t) equalsRange e
     | _, pat -> genSynBindingValue astContext false px ats prefix ao isInline false pat None equalsRange e
 
 and genMemberFlags (mf: SynMemberFlags) =
@@ -994,6 +994,7 @@ and genExpr astContext synExpr ctx =
             let longExpr = genExpr astContext e +> sepNln +> !- ":> " +> genType astContext t
 
             expressionFitsOnRestOfLine shortExpr longExpr
+        | TypedExpr (Typed, (Lambda _ as e), t) -> genExpr astContext e +> sepNln +> sepColon +> genType astContext t
         | TypedExpr (Typed, e, t) -> genExpr astContext e +> sepColon +> genType astContext t
         | NewTuple (t, px) ->
             let sepSpace (ctx: Context) =


### PR DESCRIPTION
Fixes #2295