### PR TITLE
Allow to disable indentation of DU cases

### DIFF
--- a/src/Fantomas.Core.Tests/UnionTests.fs
+++ b/src/Fantomas.Core.Tests/UnionTests.fs
@@ -1132,3 +1132,24 @@ type Foo =
     /// Bar
     | Thing
 """
+
+[<Test>]
+let ``disabling DU case indentation`` () =
+    formatSourceString
+        true
+        """
+type Fruit =
+| Banana
+| Apple
+| Mango
+"""
+        { config with IndentDiscriminatedUnionCases = false }
+    |> prepend newline
+    |> should
+        equal
+        """
+type Fruit =
+| Banana
+| Apple
+| Mango
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3226,7 +3226,13 @@ and genTypeDefn
 
                 expressionFitsOnRestOfLine (indent +> sepSpace +> short) (indent +> sepNln +> long) ctx
             | xs ->
-                indent
+                let maybeIndent =
+                    if ctx.Config.IndentDiscriminatedUnionCases then
+                        indent
+                    else
+                        id
+
+                maybeIndent
                 +> sepNln
                 +> (opt sepNln ao' genAccess +> col sepNln xs (genUnionCase astContext true))
                 <| ctx

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -198,6 +198,10 @@ type FormatConfig =
       BarBeforeDiscriminatedUnionDeclaration: bool
 
       [<Category("Convention")>]
+      [<DisplayName("Indent Discriminated Union cases")>]
+      IndentDiscriminatedUnionCases: bool
+
+      [<Category("Convention")>]
       [<DisplayName("Format braces using Stroustrup Style where possible.")>]
       [<Description("Experimental feature, use at your own risk.")>]
       ExperimentalStroustrupStyle: bool
@@ -246,6 +250,7 @@ type FormatConfig =
           ExperimentalKeepIndentInBranch = false
           BlankLinesAroundNestedMultilineExpressions = true
           BarBeforeDiscriminatedUnionDeclaration = false
+          IndentDiscriminatedUnionCases = true
           ExperimentalStroustrupStyle = false
           KeepMaxNumberOfBlankLines = 100
           StrictMode = false }


### PR DESCRIPTION
First PR here, sorry for any blunders.

We are in the process of adopting Fantomas into our code base, and need some additional configuration options to make the auto-formatted code compatible with our code guide. From the docs I couldn't quite figure out how strong your stance is on "only official formatting!", but it seems that you allowed some customizations (like stroustrup style, which is awesome!), so hopefully what I'm trying to do is okay.

Question: even though the code update works on the CLI, I could not get the unit test I wrote to pass, and can't figure out why. Please help.