### PR TITLE
Revert multiline app type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.1.0-alpha-007] - 2022-10-14
+
+### Changed
+* Revert multiline alternative for prefix types. [#2582](https://github.com/fsprojects/fantomas/pull/2582)
+
 ## [5.1.0-alpha-006] - 2022-10-14
 
 ### Changed

--- a/src/Fantomas.Core.Tests/ClassTests.fs
+++ b/src/Fantomas.Core.Tests/ClassTests.fs
@@ -1248,10 +1248,8 @@ module rec Xterm
 [<AllowNullLiteral>]
 type Terminal =
     abstract onKey:
-        IEvent<
-            {| key: string
-               domEvent: KeyboardEvent |}
-        > with get, set
+        IEvent<{| key: string
+                  domEvent: KeyboardEvent |}> with get, set
 
     abstract onLineFeed: IEvent<unit> with get, set
 """

--- a/src/Fantomas.Core.Tests/NewlineBetweenTypeDefinitionAndMembersTests.fs
+++ b/src/Fantomas.Core.Tests/NewlineBetweenTypeDefinitionAndMembersTests.fs
@@ -421,10 +421,10 @@ let ``multiline abstract member without constraints, 2175`` () =
 type FuseSortFunctionItem =
     abstract Item:
         key: string ->
-            U2<
-                {| ``$``: string |},
-                ResizeArray<{| ``$``: string; idx: float |}>
-            > with get, set
+            U2<{| ``$``: string |}, ResizeArray<{| ``$``:
+                                                       string
+                                                   idx:
+                                                       float |}>> with get, set
 
     abstract X: int
 """

--- a/src/Fantomas.Core.Tests/SignatureTests.fs
+++ b/src/Fantomas.Core.Tests/SignatureTests.fs
@@ -1606,14 +1606,9 @@ namespace Foo
 type Bar =
     member Hello :
         thing :
-            XLongLongLongLongLongLongLongLong<
-                bool -> 'a,
-                bool -> 'b,
-                bool -> 'c,
-                bool -> 'd,
-                bool -> ('e -> 'f) -> 'g,
-                ('h -> 'i) -> 'j
-            > *
+            XLongLongLongLongLongLongLongLong<bool -> 'a, bool -> 'b, bool -> 'c, bool -> 'd, bool -> ('e -> 'f) -> 'g, ('h
+                -> 'i)
+                -> 'j> *
         item : int list ->
             LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLong
 """

--- a/src/Fantomas.Core.Tests/TypeAnnotationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeAnnotationTests.fs
@@ -77,11 +77,56 @@ type X =
         equal
         """
 type X =
-    Teq<
-        int,
-        list int,
-        System.DateTime array,
-        //
-        int
-    >
+    Teq<int, list int, System.DateTime array,
+    //
+    int>
+"""
+
+[<Test>]
+let ``multiline app type`` () =
+    formatSourceString
+        false
+        """
+type CancellableTaskResultBuilderBase with
+
+    [<NoEagerConstraintApplication>]
+    static member inline BindDynamic< ^TaskLike, 'TResult1, 'TResult2, ^Awaiter, 'TOverall, 'Error
+        when ^TaskLike: (member GetAwaiter: unit -> ^Awaiter)
+        and ^Awaiter :> ICriticalNotifyCompletion
+        and ^Awaiter: (member get_IsCompleted: unit -> bool)
+        and ^Awaiter: (member GetResult: unit -> Result<'TResult1, 'Error>)>
+        (
+            sm:
+                byref<
+                    ResumableStateMachine<
+                        CancellableTaskResultStateMachineData<'TOverall, 'Error>
+                >
+                >,
+            task: CancellationToken -> ^TaskLike,
+            continuation:
+                ('TResult1 -> CancellableTaskResultCode<'TOverall, 'Error, 'TResult2>)
+        ) : bool = true
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+type CancellableTaskResultBuilderBase with
+
+    [<NoEagerConstraintApplication>]
+    static member inline BindDynamic< ^TaskLike, 'TResult1, 'TResult2, ^Awaiter, 'TOverall, 'Error
+        when ^TaskLike: (member GetAwaiter: unit -> ^Awaiter)
+        and ^Awaiter :> ICriticalNotifyCompletion
+        and ^Awaiter: (member get_IsCompleted: unit -> bool)
+        and ^Awaiter: (member GetResult: unit -> Result<'TResult1, 'Error>)>
+        (
+            sm:
+                byref<ResumableStateMachine<CancellableTaskResultStateMachineData<'TOverall, 'Error>>>,
+            task: CancellationToken -> ^TaskLike,
+            continuation:
+                ('TResult1
+                    -> CancellableTaskResultCode<'TOverall, 'Error, 'TResult2>)
+        ) : bool =
+        true
 """

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -2874,10 +2874,8 @@ and [<CustomEquality ; NoComparison>] Bar<'context, 'a> =
                                                 (fun inner ->
                                                     if inner then
                                                         let bv =
-                                                            unbox<Foo<
-                                                                'innerContextLongLongLong,
-                                                                'bb -> 'b
-                                                            >>
+                                                            unbox<Foo<'innerContextLongLongLong, 'bb
+                                                                -> 'b>>
                                                                 bf
 
                                                         this.InnerEquals af bf cont

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3691,12 +3691,9 @@ and genPrefixTypes
          +> genTriviaForOption greaterNodeType greaterRange !- " >")
             ctx
     | t :: _ ->
-        let shortTs = col sepComma ts genType
-        let longTs = indentSepNlnUnindent (col (sepComma +> sepNln) ts genType) +> sepNln
-
         (genTriviaForOption lessNodeType lessRange !- "<"
          +> addSpaceIfSynTypeStaticConstantHasAtSignBeforeString t
-         +> expressionFitsOnRestOfLine shortTs longTs
+         +> col sepComma ts genType
          +> addSpaceIfSynTypeStaticConstantHasAtSignBeforeString t
          +> genTriviaForOption greaterNodeType greaterRange !- ">")
             ctx


### PR DESCRIPTION
In https://github.com/fsprojects/fantomas/commit/be2475cc5976ae5160fbd6a242a09dc37b367b75, the style for multiline prefix types was slightly changed. But this can lead to invalid F# code in certain scenarios. It is safer to revert that change.
//cc @dawedawe 