### PR TITLE
Fixed comments on params with attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Comments get removed for method parameter with attribute [#2585](https://github.com/fsprojects/fantomas/issues/2585)
+
 ## [5.1.0-alpha-007] - 2022-10-14
 
 ### Changed

--- a/src/Fantomas.Core.Tests/CommentTests.fs
+++ b/src/Fantomas.Core.Tests/CommentTests.fs
@@ -2531,3 +2531,43 @@ let Anonymous =
     {| FontFamily = 700 // font-weight
        FontSize = 48. |} // font-weight
 """
+
+[<Test>]
+let ``comments on param with attribute, 2585`` () =
+    formatSourceString
+        false
+        """
+type MyType =
+    member _.MyMethod
+        (
+            [<MyAttribute>] inputA: string, // my comment 1
+            [<MyAttribute>] inputB: string // my comment 2
+        ) =
+        inputA
+
+type MyType2 =
+    member _.MyMethod
+        (
+            [<MyAttribute>] inputA: string // my comment 1
+        ) =
+        inputA
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type MyType =
+    member _.MyMethod
+        (
+            [<MyAttribute>] inputA: string,  // my comment 1
+            [<MyAttribute>] inputB: string // my comment 2
+        ) =
+        inputA
+
+type MyType2 =
+    member _.MyMethod
+        ([<MyAttribute>] inputA: string) // my comment 1
+        =
+        inputA
+"""

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -208,6 +208,7 @@ let rec visitLastChildNode (node: TriviaNode) : TriviaNode =
     | SynTypeDefnSig_
     | SynMemberDefn_Member -> visitLastChildNode (Array.last node.Children)
     | SynPat_LongIdent when not (Array.isEmpty node.Children) -> visitLastChildNode (Array.last node.Children)
+    | SynPat_Attrib when not (Array.isEmpty node.Children) -> visitLastChildNode (Array.last node.Children)
     | _ -> node
 
 let findNodeBeforeLineAndColumn (nodes: TriviaNode seq) line column =

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -206,9 +206,11 @@ let rec visitLastChildNode (node: TriviaNode) : TriviaNode =
     | SynEnumCase_
     | SynTypeDefn_
     | SynTypeDefnSig_
+    | SynPat_Attrib
+    | SynPat_Named
+    | SynPat_Typed
     | SynMemberDefn_Member -> visitLastChildNode (Array.last node.Children)
     | SynPat_LongIdent when not (Array.isEmpty node.Children) -> visitLastChildNode (Array.last node.Children)
-    | SynPat_Attrib when not (Array.isEmpty node.Children) -> visitLastChildNode (Array.last node.Children)
     | _ -> node
 
 let findNodeBeforeLineAndColumn (nodes: TriviaNode seq) line column =


### PR DESCRIPTION
Fixes #2585

Added addtional cases for  `SynPat_Attrib`, `SynPat_Named`, `SynPat_Typed` to `visitLastChildNode`