### PR TITLE
Tighten the condition for unindent in genMultilineSimpleRecordTypeDefnAlignBrackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Idempotency problem with `struct end`. [#2592](https://github.com/fsprojects/fantomas/issues/2592)
 * Idempotency problem when having a comment in an anonymous record and Stroustrup formatting. [#2566](https://github.com/fsprojects/fantomas/issues/2566)
 * AlternativeLongMemberDefinitions breaks spacing around `type Blah as this`. [#2598](https://github.com/fsprojects/fantomas/issues/2598)
+* Outdenting problem when specifying record with accessibility modifier. [#2597](https://github.com/fsprojects/fantomas/issues/2597)
 
 ## [5.1.0-beta-001] - 2022-10-19
 

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
@@ -175,3 +175,33 @@ type NonEmptyList<'T> =
     member this.Tail = this.List.Tail
     member this.Length = this.List.Length
 """
+
+[<Test>]
+let ``outdenting problem when specifying record with accessibility modifier, 2597`` () =
+    formatSourceString
+        false
+        """
+module OutdentingProblem =
+    type Configuration = private { Setting1: int; Setting2: bool }
+        
+    let withSetting1 value configuration =
+        { configuration with Setting1 = value }
+        
+    let withSetting2 value configuration =
+        { configuration with Setting2 = value }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module OutdentingProblem =
+    type Configuration = private {
+        Setting1: int
+        Setting2: bool
+    }
+
+    let withSetting1 value configuration = { configuration with Setting1 = value }
+
+    let withSetting2 value configuration = { configuration with Setting2 = value }
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3145,9 +3145,10 @@ and genMultilineSimpleRecordTypeDefn openingBrace withKeyword ms ao' fs closingB
     +> genMemberDefnList ms
 
 and genMultilineSimpleRecordTypeDefnAlignBrackets openingBrace withKeyword ms ao' fs closingBrace =
+    let msIsEmpty = List.isEmpty ms
     // the typeName is already printed
     ifElseCtx
-        (fun ctx -> ctx.Config.ExperimentalStroustrupStyle && List.isEmpty ms)
+        (fun ctx -> ctx.Config.ExperimentalStroustrupStyle && msIsEmpty)
         (opt sepSpace ao' genAccess)
         (opt (indent +> sepNln) ao' genAccess)
     +> enterNodeFor SynTypeDefnSimpleRepr_Record_OpeningBrace openingBrace
@@ -3160,8 +3161,10 @@ and genMultilineSimpleRecordTypeDefnAlignBrackets openingBrace withKeyword ms ao
     )
     +> sepNln
     +> genTriviaFor SynTypeDefnSimpleRepr_Record_ClosingBrace closingBrace sepCloseSFixed
-    +> optSingle (fun _ -> unindent) ao'
-    +> onlyIf (List.isNotEmpty ms) sepNln
+    +> onlyIfCtx
+        (fun ctx -> not (ctx.Config.ExperimentalStroustrupStyle && msIsEmpty))
+        (optSingle (fun _ -> unindent) ao')
+    +> onlyIf (not msIsEmpty) sepNln
     +> sepNlnBetweenTypeAndMembers withKeyword ms
     +> genMemberDefnList ms
 


### PR DESCRIPTION
fixes #2597 