### PR TITLE
Adjust docs to post-paket era

### DIFF
--- a/docs/docs/contributors/Index.md
+++ b/docs/docs/contributors/Index.md
@@ -25,6 +25,6 @@ Or if something isn't all that clear. Our goal is to make this documentation as 
 
 There is currently [a known issue](https://github.com/fsprojects/fantomas/issues/2447) when loading the `fantomas` solution in Visual Studio that prevents the solution from being able to build properly. This is due to an issue in the `Ionide.KeepAChangelog` build step (tracking the issue [here](https://github.com/ionide/KeepAChangelog/issues/8)).
 
-To workaround this in the meantime, you'll need to comment out the references to `Ionide.KeepAChangelog.Tasks` in `paket.dependencies` and all of the `paket.references` files, and then run `dotnet paket install` again. **Please be careful not to include these changes when submitting a PR!**
+To workaround this in the meantime, you'll need to comment out the references to `Ionide.KeepAChangelog.Tasks` in `Directory.Build.props` and all of the `packages.lock.json` files, and then run `dotnet restore`. **Please be careful not to include these changes when submitting a PR!**
 
 <fantomas-nav next="./FSharp.html"></fantomas-nav>

--- a/docs/docs/contributors/Solution Structure.md
+++ b/docs/docs/contributors/Solution Structure.md
@@ -21,7 +21,7 @@ graph TD
 ## Fantomas.FCS
 
 This is a very custom fork of the F# compiler. We only expose a single parse function to construct the untyped syntax tree.
-We achieve this by taking the files necessary to compile the F# parser from source (via `paket`).
+We achieve this by taking the files necessary to compile the F# parser from source (via custom code in a `Fun.Build` pipeline).
 This limits the dependency footprint that our compiler has, compared to the official [F# compiler NuGet package](https://www.nuget.org/packages/FSharp.Compiler.Service).
 
 Note that the AST returned by `Fantomas.FCS` looks identical to what the official F# compiler returns. 


### PR DESCRIPTION
﻿- Adjust the Ionide.KeepAChangelog Visual Studio issue
﻿- Adjust documentation about our way to get the compiler sources.