### PR TITLE
Build documentation with strict flag.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -76,7 +76,7 @@ pipeline "Build" {
         whenNot { platformOSX }
         run "dotnet fsi ./docs/.style/style.fsx"
         run
-            $"dotnet fsdocs build --clean --properties Configuration=Release --fscoptions \" -r:{semanticVersioning}\" --eval"
+            $"dotnet fsdocs build --clean --properties Configuration=Release --fscoptions \" -r:{semanticVersioning}\" --eval --strict"
     }
     stage "Push" {
         whenCmdArg "--push"


### PR DESCRIPTION
I believe this will fail the build if the scripts cannot be compiled.
Which is what we want in order to ensure correct documentation.