### PR TITLE
Support directives around attributes on "and" type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Indenting problem with `match` workaround for single-line stroustrup expressions [#2586](https://github.com/fsprojects/fantomas/issues/2586)
+* System.Exception: Fantomas is trying to format the input multiple times due to the detect of multiple defines. [#628](https://github.com/fsprojects/fantomas/issues/628).
 
 ## [5.1.3] - 2022-11-14
 

--- a/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
@@ -3025,7 +3025,7 @@ internal T2 = T2
 """
 
 [<Test>]
-let ``attributes in "and" type`` () =
+let ``attributes with directives in "and" type, 628`` () =
     formatSourceString
         false
         """

--- a/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
@@ -2983,3 +2983,85 @@ let ``dead code in active block`` () =
 b
 #endif
 """
+
+[<Test>]
+let ``dont delete #if attr in "and" type, 628`` () =
+    formatSourceStringWithDefines
+        [ "NET2" ]
+        """
+#if NET2
+[<Attr1>]
+#else
+[<Attr2>]
+#endif
+[<NoComparison>]
+type internal T1 = T1
+and [<NoComparison>]
+#if NET2
+[<Attr1>]
+#else
+[<Attr2>]
+#endif
+    internal T2 = T2
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#if NET2
+[<Attr1>]
+#else
+#endif
+[<NoComparison>]
+type internal T1 = T1
+
+and [<NoComparison>]
+#if NET2
+[<Attr1>]
+#else
+#endif
+internal T2 = T2
+"""
+
+[<Test>]
+let ``attributes in "and" type`` () =
+    formatSourceString
+        false
+        """
+#if NET2
+[<Attr1>]
+#else
+[<Attr2>]
+#endif
+[<NoComparison>]
+type internal T1 = T1
+and [<NoComparison>]
+#if NET2
+[<Attr1>]
+#else
+[<Attr2>]
+#endif
+    internal T2 = T2
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+#if NET2
+[<Attr1>]
+#else
+[<Attr2>]
+#endif
+[<NoComparison>]
+type internal T1 = T1
+
+and [<NoComparison>]
+#if NET2
+[<Attr1>]
+#else
+[<Attr2>]
+#endif
+internal T2 = T2
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2916,7 +2916,7 @@ and genTypeDefn (TypeDef(ats, px, leadingKeyword, ao, tds, tcs, equalsRange, tdr
     let genLeadingKeyword =
         match leadingKeyword with
         | SynTypeDefnLeadingKeyword.Type mType -> genAttributes ats +> genTriviaFor SynTypeDefn_Type mType !- "type "
-        | SynTypeDefnLeadingKeyword.And mAnd -> genTriviaFor SynTypeDefn_And mAnd !- "and " +> genOnelinerAttributes ats
+        | SynTypeDefnLeadingKeyword.And mAnd -> genTriviaFor SynTypeDefn_And mAnd !- "and " +> genAttributes ats
         | SynTypeDefnLeadingKeyword.StaticType _
         | SynTypeDefnLeadingKeyword.Synthetic -> sepNone
 

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -1045,7 +1045,7 @@ let sepSemi (ctx: Context) =
 let ifAlignBrackets f g =
     ifElseCtx (fun ctx -> ctx.Config.MultilineBlockBracketsOnSameColumn) f g
 
-let printTriviaContent (c: TriviaContent) (ctx: Context) =
+let printTriviaContent (c: TriviaContent) addBefore (ctx: Context) =
     let currentLastLine = ctx.WriterModel.Lines |> List.tryHead
 
     // Some items like #if or Newline should be printed on a newline
@@ -1073,11 +1073,18 @@ let printTriviaContent (c: TriviaContent) (ctx: Context) =
         +> ifElse after sepNlnForTrivia sepNone
     | Newline -> (ifElse addNewline (sepNlnForTrivia +> sepNlnForTrivia) sepNlnForTrivia)
     | Directive s
-    | Comment(CommentOnSingleLine s) -> (ifElse addNewline sepNlnForTrivia sepNone) +> !-s +> sepNlnForTrivia
+    | Comment(CommentOnSingleLine s) ->
+        (ifElse addNewline sepNlnForTrivia sepNone)
+        +> !-s
+        +> (ifElse addBefore sepNlnForTrivia sepNone)
     <| ctx
 
 let printTriviaInstructions (triviaInstructions: TriviaInstruction list) =
-    col sepNone triviaInstructions (fun { Trivia = trivia } -> printTriviaContent trivia.Item)
+    col
+        sepNone
+        triviaInstructions
+        (fun { Trivia = trivia
+               AddBefore = addBefore } -> printTriviaContent trivia.Item addBefore)
 
 let enterNodeFor (mainNodeName: FsAstType) (range: Range) (ctx: Context) =
     match Map.tryFind mainNodeName ctx.TriviaBefore with


### PR DESCRIPTION
Fixes #628

Minimized repro:
```
#if NET2
[<Attr1>]
#else
[<Attr2>]
#endif
[<NoComparison>]
type internal T1 = T1
and [<NoComparison>]
#if NET2
[<Attr1>]
#else
[<Attr2>]
#endif
    internal T2 = T2
```

Main problem here was that directives after `and` keyword get linked to `=` as *ContentBefore*, and not priinted out. 

This fix link directive trivia after `and` type + attribute combination to attribute node as *ContentAfter*. 

Also changing the way how attributes are printed for `and` type, so trivias are actually printed out, and handling some newline issues in this case.

And fixing some related bugs, surfaced because this is probably first time when Directive is used as *ContentAfter*.


### TODO
- [ ] fix also for .fsi