### PR TITLE
Take all let in bindings in a multiline infix expression into account.

### DIFF
--- a/src/Fantomas.Core.Tests/DallasTests.fs
+++ b/src/Fantomas.Core.Tests/DallasTests.fs
@@ -1688,3 +1688,26 @@ type ILModuleReader =
     // ILModuleReader objects only need to be explicitly disposed if memory mapping is used, i.e. reduceMemoryUsage = false
     inherit IDisposable
 """
+
+[<Test>]
+let ``multiline infix operator with three let in bindings`` () =
+    formatSourceString
+        false
+        """
+Ok
+<| let a = 1 in
+   let b = 2 in
+   let c = 3 in
+   ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+Ok
+<| let a = 1 in
+   let b = 2 in
+   let c = 3 in
+   ()
+"""

--- a/src/Fantomas.Core.Tests/OperatorTests.fs
+++ b/src/Fantomas.Core.Tests/OperatorTests.fs
@@ -951,7 +951,6 @@ let isCustomOperationProjectionParameter i (nm: Ident) =
                 | Some argInfos ->
                     i < argInfos.Length
                     && let (_, argInfo) = List.item i argInfos in
-
                        HasFSharpAttribute cenv.g cenv.g.attrib_ProjectionParameterAttribute argInfo.Attribs)
 
         if List.allEqual vs then
@@ -1004,6 +1003,7 @@ let MethInfosEquivByNameAndSig erasureFlag ignoreFinal g amap m minfo minfo2 =
 let MethInfosEquivByNameAndSig erasureFlag ignoreFinal g amap m minfo minfo2 =
     MethInfosEquivByNameAndPartialSig erasureFlag ignoreFinal g amap m minfo minfo2
     && let (CompiledSig(_, retTy, formalMethTypars, _)) = CompiledSigOfMeth g amap m minfo in
+
        let (CompiledSig(_, retTy2, formalMethTypars2, _)) =
            CompiledSigOfMeth g amap m minfo2 in
 


### PR DESCRIPTION
Fixes a regression reported by @jindraivanek on Discord.