### PR TITLE
Improve TypeDefn

### DIFF
--- a/src/Fantomas.Core.Tests/DallasTests.fs
+++ b/src/Fantomas.Core.Tests/DallasTests.fs
@@ -1711,3 +1711,18 @@ Ok
    let c = 3 in
    ()
 """
+
+[<Test>]
+let ``type alias with trivia`` () =
+    formatSourceString
+        false
+        """
+(* 1 *) type (* 2 *) A (* 3 *) = (* 4 *) int (* 5 *)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(* 1 *) type (* 2 *) A (* 3 *) = (* 4 *) int (* 5 *)
+"""

--- a/src/Fantomas.Core/CodePrinter2.fs
+++ b/src/Fantomas.Core/CodePrinter2.fs
@@ -3121,7 +3121,8 @@ let sepNlnTypeAndMembers (node: ITypeDefn) (ctx: Context) : Context =
             else
                 ctx
 
-let genTypeWithImplicitConstructor (typeName: TypeNameNode) (implicitConstructor: ImplicitConstructorNode option) =
+let genTypeWithImplicitConstructor (typeName: TypeNameNode) =
+    let implicitConstructor = typeName.ImplicitConstructor
     let hasAndKeyword = typeName.LeadingKeyword.Text = "and"
 
     genXml typeName.XmlDoc
@@ -3346,7 +3347,7 @@ let genTypeDefn (td: TypeDefn) =
                 sepNlnUnlessContentBefore (MemberDefn.Node h)
                 +> indentSepNlnUnindent (genMemberDefnList members)
 
-        genTypeWithImplicitConstructor typeName node.ImplicitConstructor
+        genTypeWithImplicitConstructor typeName
         +> indentSepNlnUnindent (
             genSingleTextNode bodyNode.Kind
             +> onlyIfNot bodyNode.Members.IsEmpty (indentSepNlnUnindent (genMemberDefnList bodyNode.Members))
@@ -3372,9 +3373,9 @@ let genTypeDefn (td: TypeDefn) =
         )
         |> genNode node
     | TypeDefn.Regular node ->
-        genTypeWithImplicitConstructor typeName node.ImplicitConstructor
+        genTypeWithImplicitConstructor typeName
         +> indentSepNlnUnindent (genMemberDefnList members)
-        |> genNode (TypeDefn.Node td)
+        |> genNode node
 
 let genTypeList (node: TypeFunsNode) =
     let shortExpr =

--- a/src/Fantomas.Core/Flowering.fs
+++ b/src/Fantomas.Core/Flowering.fs
@@ -27,11 +27,13 @@ let internal collectTriviaFromCodeComments
             let startLine = source.GetLineString(r.StartLine - 1)
             let endLine = source.GetLineString(r.EndLine - 1)
 
+            let contentBeforeComment =
+                startLine.Substring(0, r.StartColumn).TrimStart(' ', ';').Length
+
+            let contentAfterComment = endLine.Substring(r.EndColumn).TrimEnd(' ', ';').Length
+
             let content =
-                if
-                    startLine.TrimStart(' ', ';').StartsWith("(*")
-                    && endLine.TrimEnd(' ', ';').EndsWith("*)")
-                then
+                if contentBeforeComment = 0 && contentAfterComment = 0 then
                     CommentOnSingleLine content
                 else
                     BlockComment(content, false, false)

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -2199,6 +2199,7 @@ type TypeNameNode
         identifier: IdentListNode,
         typeParams: TyparDecls option,
         constraints: TypeConstraint list,
+        implicitConstructor: ImplicitConstructorNode option,
         equalsToken: SingleTextNode option,
         withKeyword: SingleTextNode option,
         range
@@ -2209,10 +2210,11 @@ type TypeNameNode
         [| yield! noa xmlDoc
            yield! noa attributes
            yield leadingKeyword
-           yield! noa (Option.map TyparDecls.Node typeParams)
-           yield! List.map TypeConstraint.Node constraints
            yield! noa ao
            yield identifier
+           yield! noa (Option.map TyparDecls.Node typeParams)
+           yield! List.map TypeConstraint.Node constraints
+           yield! noa implicitConstructor
            yield! noa equalsToken
            yield! noa withKeyword |]
 
@@ -2224,6 +2226,7 @@ type TypeNameNode
     member x.Identifier = identifier
     member x.TypeParameters = typeParams
     member x.Constraints = constraints
+    member x.ImplicitConstructor = implicitConstructor
     member x.EqualsToken = equalsToken
     member x.WithKeyword = withKeyword
 
@@ -2444,13 +2447,11 @@ type TypeDefnDelegateNode(typeNameNode, delegateNode: SingleTextNode, typeList: 
         member x.TypeName = typeNameNode
         member x.Members = List.empty
 
-type TypeDefnRegularNode(typeNameNode, implicitCtor: ImplicitConstructorNode option, members, range) =
+type TypeDefnRegularNode(typeNameNode, members, range) =
     inherit NodeBase(range)
 
     override this.Children =
         [| yield typeNameNode; yield! List.map MemberDefn.Node members |]
-
-    member x.ImplicitConstructor = implicitCtor
 
     interface ITypeDefn with
         member x.TypeName = typeNameNode


### PR DESCRIPTION
- Move `ImplicitConstructorNode` to `TypeNameNode` level
- Improve the range of `TypeNameNode`
- Have a single path to print `TypeNameNode`
- Fix a bug where a block comment was considered to be on one line.