### PR TITLE
Fix multiline implicit constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 * Regression around `let ...  in` in multiline infix application. [#2633](https://github.com/fsprojects/fantomas/pull/2633)
 * Improve TypeDefn. [#2636](https://github.com/fsprojects/fantomas/pull/2636)
+* Trivia before equals in multiline implicit type constructor. [#2637](https://github.com/fsprojects/fantomas/pull/2637)
 
 ## [5.2.0-alpha-001] - 2022-11-30
 

--- a/src/Fantomas.Core.Tests/DallasTests.fs
+++ b/src/Fantomas.Core.Tests/DallasTests.fs
@@ -1726,3 +1726,32 @@ let ``type alias with trivia`` () =
         """
 (* 1 *) type (* 2 *) A (* 3 *) = (* 4 *) int (* 5 *)
 """
+
+[<Test>]
+let ``trivia before equals in multiline implicit constructor`` () =
+    formatSourceString
+        false
+        """
+type TypeDefnUnionNode
+    (
+        typeNameNode,
+        accessibility: SingleTextNode option,
+        unionCases: UnionCaseNode list,
+        members: MemberDefn list,
+        range
+    )
+
+ =
+    inherit NodeBase(range)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type TypeDefnUnionNode
+    (typeNameNode, accessibility: SingleTextNode option, unionCases: UnionCaseNode list, members: MemberDefn list, range)
+
+    =
+    inherit NodeBase(range)
+"""

--- a/src/Fantomas.Core.Tests/SignatureTests.fs
+++ b/src/Fantomas.Core.Tests/SignatureTests.fs
@@ -1779,7 +1779,7 @@ type Meh =
         * timeout: int ->
         obj
 """
-        { config with MaxLineLength = 5 }
+        { config with MaxLineLength = 12 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core/CodePrinter2.fs
+++ b/src/Fantomas.Core/CodePrinter2.fs
@@ -3189,7 +3189,10 @@ let genTypeDefn (td: TypeDefn) =
                 if isMulti && ctx.Config.AlternativeLongMemberDefinitions then
                     (optSingle genSingleTextNode typeName.EqualsToken) ctx
                 else
-                    (sepSpace +> optSingle genSingleTextNode typeName.EqualsToken) ctx)
+                    (sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (
+                        optSingle genSingleTextNode typeName.EqualsToken
+                    ))
+                        ctx)
         |> genNode typeName
 
     let members = typeDefnNode.Members

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -2281,9 +2281,7 @@ type TypeDefnUnionNode
         unionCases: UnionCaseNode list,
         members: MemberDefn list,
         range
-    )
-
- =
+    ) =
     inherit NodeBase(range)
 
     override this.Children =


### PR DESCRIPTION
Fixes problem with trivia before an equals sign found in the current codebase.