### PR TITLE
Print attributes for MemberDefn.ExplicitCtor.

### DIFF
--- a/src/Fantomas.Core.Tests/DallasTests.fs
+++ b/src/Fantomas.Core.Tests/DallasTests.fs
@@ -1755,3 +1755,35 @@ type TypeDefnUnionNode
     =
     inherit NodeBase(range)
 """
+
+[<Test>]
+let ``attributes in explicit constructor`` () =
+    formatSourceString
+        false
+        """
+open System
+
+type MyClass (a: int, b: int) = 
+    
+    member val PropA = a with get, set
+    member val PropB = b with get, set
+
+    [<Obsolete("Do not use")>]
+    new(x: int) =
+        MyClass(x, x)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+open System
+
+type MyClass(a: int, b: int) =
+
+    member val PropA = a with get, set
+    member val PropB = b with get, set
+
+    [<Obsolete("Do not use")>]
+    new(x: int) = MyClass(x, x)
+"""

--- a/src/Fantomas.Core/CodePrinter2.fs
+++ b/src/Fantomas.Core/CodePrinter2.fs
@@ -3513,6 +3513,7 @@ let genMemberDefn (md: MemberDefn) =
     | MemberDefn.DoExpr node -> genExpr (Expr.Single node)
     | MemberDefn.ExplicitCtor node ->
         genXml node.XmlDoc
+        +> genAttributes node.Attributes
         +> genAccessOpt node.Accessibility
         +> genSingleTextNode node.New
         +> sepSpaceBeforeClassConstructor


### PR DESCRIPTION
@dawedawe I was going to give you a pointer to see if you found your way around the new code.
But the change was so simple I just went ahead with it.
I deliberately didn't add a changelog entry. Having an unreleased section in both `main` and `v5.2` can be annoying when rebasing.

Steps I used to solve the problem:

Check if the `MemberDefnExplicitCtorNode` does have attributes. It does, so this means the type definition is correct. 

Next, verify if the untyped tree was correctly transformed into the Oak in Fangorn.

![image](https://user-images.githubusercontent.com/2621499/205520778-f1e30287-8a00-4af8-b07f-be4d4b738b16.png)

This is the case as you can see in the online tool.

Lastly, check in `CodePrinter2` if we are printing the attributes. It turned out we weren't.
