### PR TITLE
Enable Server gc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.2.0-alpha-005] - 2022-12-16
+
+### Fixes
+* MultiLineLambdaClosingNewline didn't trigger correctly on line which was one character too long. [#2642](https://github.com/fsprojects/fantomas/issues/2642)
+
+### Changed
+* Enable ServerGarbageCollection. [#2655](https://github.com/fsprojects/fantomas/pull/2655)
+
 ## [5.2.0-alpha-004] - 2022-12-07
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,7 @@ Some common use cases include:
         <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
         <!-- https://www.gresearch.co.uk/blog/article/improve-nuget-restores-with-static-graph-evaluation/ -->
         <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+        <ServerGarbageCollection>true</ServerGarbageCollection>
     </PropertyGroup>
     
     <!-- Versions -->


### PR DESCRIPTION
On my local machine:

Before:
```
Benchmark/step-0> | Method |     Mean |   Error |  StdDev | Rank |       Gen0 |      Gen1 |     Gen2 | Allocated |
Benchmark/step-0> |------- |---------:|--------:|--------:|-----:|-----------:|----------:|---------:|----------:|
Benchmark/step-0> | Format | 136.0 ms | 0.55 ms | 0.46 ms |    1 | 13250.0000 | 2500.0000 | 750.0000 | 157.83 MB |
```

After:
```
Benchmark/step-0> | Method |     Mean |    Error |   StdDev | Rank |     Gen0 |     Gen1 | Allocated |
Benchmark/step-0> |------- |---------:|---------:|---------:|-----:|---------:|---------:|----------:|
Benchmark/step-0> | Format | 98.23 ms | 0.772 ms | 0.722 ms |    1 | 600.0000 | 400.0000 | 157.82 MB |
```

I think we should do this for the daemon as well, as this makes sense for the request/response model of an LSP. 
[FsAutoComplete](https://github.com/fsharp/FsAutoComplete/blob/main/src/FsAutoComplete/FsAutoComplete.fsproj#L8) does this as well.