### PR TITLE
Call ignoreFile.IsIgnored with absolute path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.1.5] - 2022-12-22
+
+### Fixed
+* Call ignoreFile.IsIgnored with absolute path. [#2656](https://github.com/fsprojects/fantomas/pull/2656)
+
 ## [5.1.4] - 2022-11-30
 
 ### Fixed

--- a/src/Fantomas/IgnoreFile.fs
+++ b/src/Fantomas/IgnoreFile.fs
@@ -77,16 +77,7 @@ module IgnoreFile =
             let fullPath = fs.Path.GetFullPath(file)
 
             try
-                let path =
-                    if fullPath.StartsWith ignoreFile.Location.Directory.FullName then
-                        fullPath.[ignoreFile.Location.Directory.FullName.Length + 1 ..]
-                    else
-                        // This scenario is a bit unexpected - it suggests that we are
-                        // trying to ask an ignorefile whether a file that is outside
-                        // its dependency tree is ignored.
-                        fullPath
-
-                ignoreFile.IsIgnored path
+                ignoreFile.IsIgnored fullPath
             with ex ->
                 printfn "%A" ex
                 false

--- a/src/Fantomas/IgnoreFile.fsi
+++ b/src/Fantomas/IgnoreFile.fsi
@@ -2,9 +2,16 @@ namespace Fantomas
 
 open System.IO.Abstractions
 
+type AbsoluteFilePath =
+    private
+    | AbsoluteFilePath of string
+
+    member Path: string
+    static member Create: fs: IFileSystem -> filePath: string -> AbsoluteFilePath
+
 /// The string argument is taken relative to the location
 /// of the ignore-file.
-type IsPathIgnored = string -> bool
+type IsPathIgnored = AbsoluteFilePath -> bool
 
 type IgnoreFile =
     { Location: IFileInfo
@@ -19,14 +26,14 @@ module IgnoreFile =
     /// Note that this is intended for use only in the daemon; the command-line tool
     /// does not support `.fantomasignore` files anywhere other than the current
     /// working directory.
-    val find: fs: IFileSystem -> loadIgnoreList: (string -> string -> bool) -> filePath: string -> IgnoreFile option
+    val find: fs: IFileSystem -> loadIgnoreList: (string -> IsPathIgnored) -> filePath: string -> IgnoreFile option
 
     val loadIgnoreList: fs: IFileSystem -> ignoreFilePath: string -> IsPathIgnored
 
     val internal current':
         fs: IFileSystem ->
         currentDirectory: string ->
-        loadIgnoreList: (string -> string -> bool) ->
+        loadIgnoreList: (string -> IsPathIgnored) ->
             Lazy<IgnoreFile option>
 
     /// When executed from the command line, Fantomas will not dynamically locate


### PR DESCRIPTION
I discovered that ignored files can potentially be formatted by `Fantomas.Client`.
Steps to reproduce:
- Clone https://github.com/dotnet/fsharp
- Run the following script:

```fsharp
#r "nuget: Fantomas.Client"

open System
open System.IO
open Fantomas.Client.Contracts
open Fantomas.Client.LSPFantomasService

let service = new LSPFantomasService() :> FantomasService

let file = @"C:\Users\nojaf\Projects\fsharp\src\Compiler\Checking\NicePrint.fs"
let content = File.ReadAllText file

let formatReq : FormatDocumentRequest = {
    SourceCode = content
    FilePath = file
    Config = None
}

service.FormatDocumentAsync(formatReq).Result.Code
```
The code will read `1` which means `Formatted`, you should receive `4` (`Ignored`) instead.

I believe I found a fix for this problem but I would like a review from @Smaug123 to be sure.