### PR TITLE
Clean up genBinding

### DIFF
--- a/src/Fantomas.Core/CodePrinter2.fs
+++ b/src/Fantomas.Core/CodePrinter2.fs
@@ -2613,15 +2613,15 @@ let genReturnTypeBinding (node: BindingReturnInfoNode option) =
 
 let genBinding (b: BindingNode) (ctx: Context) : Context =
     let spaceBefore, alternativeSyntax =
-        let (|Keywords|) (mt: MultipleTextsNode) =
-            List.map (fun (st: SingleTextNode) -> st.Text) mt.Content
+        let keywords =
+            List.map (fun (st: SingleTextNode) -> st.Text) b.LeadingKeyword.Content
 
-        match b.LeadingKeyword with
-        | Keywords [ "member" ]
-        | Keywords [ "override" ]
-        | Keywords [ "static"; "member" ]
-        | Keywords [ "abstract"; "member" ]
-        | Keywords [ "default" ] -> ctx.Config.SpaceBeforeMember, ctx.Config.AlternativeLongMemberDefinitions
+        match keywords with
+        | [ "member" ]
+        | [ "override" ]
+        | [ "static"; "member" ]
+        | [ "abstract"; "member" ]
+        | [ "default" ] -> ctx.Config.SpaceBeforeMember, ctx.Config.AlternativeLongMemberDefinitions
         | _ -> ctx.Config.SpaceBeforeParameter, ctx.Config.AlignFunctionSignatureToIndentation
 
     let isRecursiveLetOrUseFunction =

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -79,7 +79,6 @@ module WriterModel =
     let update maxPageWidth cmd m =
         let doNewline m =
             let m = { m with Indent = max m.Indent m.AtColumn }
-
             let nextLine = String.replicate m.Indent " "
             let currentLine = String.Concat(List.head m.Lines, m.WriteBeforeNewline).TrimEnd()
             let otherLines = List.tail m.Lines

--- a/src/Fantomas.Core/Defines.fs
+++ b/src/Fantomas.Core/Defines.fs
@@ -247,11 +247,15 @@ let getDefineExprs (hashDirectives: ConditionalDirectiveTrivia list) =
 
     result
 
+let satSolveMaxStepsMaxSteps = 100
+
 let getOptimizedDefinesSets (hashDirectives: ConditionalDirectiveTrivia list) =
-    let maxSteps = FormatConfig.satSolveMaxStepsMaxSteps
     let defineExprs = getDefineExprs hashDirectives
 
-    match DefineCombinationSolver.mergeBoolExprs maxSteps defineExprs |> List.map snd with
+    match
+        DefineCombinationSolver.mergeBoolExprs satSolveMaxStepsMaxSteps defineExprs
+        |> List.map snd
+    with
     | [] -> [ [] ]
     | xs -> xs
 

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -3,8 +3,6 @@ module Fantomas.Core.FormatConfig
 open System
 open System.ComponentModel
 
-let satSolveMaxStepsMaxSteps = 100
-
 type FormatException(msg: string) =
     inherit Exception(msg)
 


### PR DESCRIPTION
The code for printing a function with or without return type has historically always been very similar.
Because of the different rules in both style guides, it was split up but with minimal changes, we can converge these two functions.