### PR TITLE
Process `else if` using ElseIfNode.

### DIFF
--- a/src/Fantomas.Core.Tests/CommentTests.fs
+++ b/src/Fantomas.Core.Tests/CommentTests.fs
@@ -494,9 +494,8 @@ else
         """
 if a then
     ()
-else
-// Comment 1
-if
+else if
+    // Comment 1
     b
 then
     ()

--- a/src/Fantomas.Core.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Core.Tests/IfThenElseTests.fs
@@ -456,8 +456,7 @@ let ``comment after else keyword before if keyword`` () =
         """
 if a then
     b
-else // meh
-if
+else if // meh
     c
 then
     d
@@ -704,8 +703,8 @@ if // bar
         """
 if a then
     b
-else // foo
-if // bar
+else if // foo
+    // bar
     c
 then
     d
@@ -824,7 +823,7 @@ else     e
         equal
         """
 if a then b
-else (* meh *) if c then d
+else if (* meh *) c then d
 else e
 """
 
@@ -930,8 +929,8 @@ if // c1
     a // c2
 then // c3
     b // c4
-else // c5
-if // c6
+else if // c5
+    // c6
     c // c7
 then // c8
     d // c9
@@ -2591,4 +2590,38 @@ then
     error (Error(FSComp.SR.tcKindOfTypeSpecifiedDoesNotMatchDefinition (), m))
 
 k
+"""
+
+[<Test>]
+let ``trivia after else in else if in multiline condition, 2449 `` () =
+    formatSourceString
+        false
+        """
+if true then
+    printfn "a"
+else // this is a comment
+    if
+        false
+    then
+        printfn "b"
+    else
+        printfn "c"
+
+printfn "d"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+if true then
+    printfn "a"
+else if // this is a comment
+    false
+then
+    printfn "b"
+else
+    printfn "c"
+
+printfn "d"
 """

--- a/src/Fantomas.Core/CodePrinter2.fs
+++ b/src/Fantomas.Core/CodePrinter2.fs
@@ -2008,29 +2008,27 @@ let genClause (isLastItem: bool) (node: MatchClauseNode) =
     genBar +> genPatAndBody |> genNode node
 
 let genControlExpressionStartCore
-    (startKeyword: Choice<SingleTextNode, MultipleTextsNode>)
+    (startKeyword: Choice<SingleTextNode, IfKeywordNode>)
     (innerExpr: Expr)
     (endKeyword: SingleTextNode)
     =
     let enterStart =
         match startKeyword with
         | Choice1Of2 n -> enterNode (n :> Node)
-        | Choice2Of2 n -> enterNode (n :> Node) +> optSingle enterNode (List.tryHead n.Content)
+        | Choice2Of2 n -> enterNode n.Node
 
     let genStart =
         match startKeyword with
         | Choice1Of2 node -> !-node.Text
-        | Choice2Of2 mtn ->
-            coli sepSpace mtn.Content (fun idx node ->
-                onlyIf (idx <> 0) (enterNode node)
-                +> !-node.Text
-                +> leaveNode node
-                +> sepNlnWhenWriteBeforeNewlineNotEmpty)
+        | Choice2Of2 ifKw ->
+            match ifKw with
+            | IfKeywordNode.SingleWord node -> !-node.Text
+            | IfKeywordNode.ElseIf _ -> !- "else if"
 
     let leaveStart =
         match startKeyword with
         | Choice1Of2 n -> leaveNode (n :> Node)
-        | Choice2Of2 n -> leaveNode (n :> Node)
+        | Choice2Of2 n -> leaveNode n.Node
 
     let shortIfExpr =
         genStart

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1469,9 +1469,9 @@ type ElseIfNode(mElse: range, mIf: range, condition: Node, range) as elseIfNode 
     let elseNode =
         { new Node with
             member _.ContentBefore: TriviaNode seq = Seq.empty
-            member x.HasContentBefore: bool = false
+            member _.HasContentBefore: bool = false
             member _.ContentAfter: TriviaNode seq = Seq.empty
-            member x.HasContentAfter: bool = false
+            member _.HasContentAfter: bool = false
             member _.Range = mElse
 
             member _.AddBefore(triviaNode: TriviaNode) =
@@ -1485,9 +1485,9 @@ type ElseIfNode(mElse: range, mIf: range, condition: Node, range) as elseIfNode 
     let ifNode =
         { new Node with
             member _.ContentBefore: TriviaNode seq = Seq.empty
-            member x.HasContentBefore: bool = false
+            member _.HasContentBefore: bool = false
             member _.ContentAfter: TriviaNode seq = Seq.empty
-            member x.HasContentAfter: bool = false
+            member _.HasContentAfter: bool = false
             member _.Range = mIf
 
             member _.AddBefore(triviaNode: TriviaNode) =

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1461,11 +1461,89 @@ type ExprTryFinallyNode(tryNode: SingleTextNode, tryExpr: Expr, finallyNode: Sin
     member x.Finally = finallyNode
     member x.FinallyExpr = finallyExpr
 
-type ExprIfThenNode(ifNode: MultipleTextsNode, ifExpr: Expr, thenNode: SingleTextNode, thenExpr: Expr, range) =
+type ElseIfNode(mElse: range, mIf: range, condition: Node, range) as elseIfNode =
+    let nodesBefore = Queue<TriviaNode>(0)
+    let nodesAfter = Queue<TriviaNode>(0)
+    let mutable lastNodeAfterIsLineCommentAfterSource = false
+
+    let elseNode =
+        { new Node with
+            member _.ContentBefore: TriviaNode seq = Seq.empty
+            member x.HasContentBefore: bool = false
+            member _.ContentAfter: TriviaNode seq = Seq.empty
+            member x.HasContentAfter: bool = false
+            member _.Range = mElse
+
+            member _.AddBefore(triviaNode: TriviaNode) =
+                (elseIfNode :> Node).AddBefore triviaNode
+
+            member _.AddAfter(triviaNode: TriviaNode) =
+                (elseIfNode :> Node).AddAfter triviaNode
+
+            member _.Children = Array.empty }
+
+    let ifNode =
+        { new Node with
+            member _.ContentBefore: TriviaNode seq = Seq.empty
+            member x.HasContentBefore: bool = false
+            member _.ContentAfter: TriviaNode seq = Seq.empty
+            member x.HasContentAfter: bool = false
+            member _.Range = mIf
+
+            member _.AddBefore(triviaNode: TriviaNode) =
+                match triviaNode.Content with
+                | CommentOnSingleLine _ -> condition.AddBefore triviaNode
+                | _ -> (elseIfNode :> Node).AddAfter triviaNode
+
+            member _.AddAfter(triviaNode: TriviaNode) =
+                (elseIfNode :> Node).AddAfter triviaNode
+
+            member _.Children = Array.empty }
+
+    interface Node with
+        member _.ContentBefore: TriviaNode seq = nodesBefore
+        member x.HasContentBefore: bool = not (Seq.isEmpty nodesBefore)
+        member _.ContentAfter: TriviaNode seq = nodesAfter
+        member x.HasContentAfter: bool = not (Seq.isEmpty nodesAfter)
+        member _.Range = range
+        member _.AddBefore(triviaNode: TriviaNode) = nodesBefore.Enqueue triviaNode
+
+        member _.AddAfter(triviaNode: TriviaNode) =
+            match triviaNode.Content with
+            | TriviaContent.LineCommentAfterSourceCode comment when lastNodeAfterIsLineCommentAfterSource ->
+                // If we already have a line comment after the `else if`, we cannot add another one.
+                // The next best thing would be to add it on the next line as content before of the condition.
+                let triviaNode =
+                    TriviaNode(TriviaContent.CommentOnSingleLine comment, triviaNode.Range)
+
+                condition.AddBefore triviaNode
+            | _ ->
+                lastNodeAfterIsLineCommentAfterSource <-
+                    match triviaNode.Content with
+                    | LineCommentAfterSourceCode _ -> true
+                    | _ -> false
+
+                nodesAfter.Enqueue triviaNode
+
+        member this.Children = [| elseNode; ifNode |]
+
+[<RequireQualifiedAccess>]
+type IfKeywordNode =
+    | SingleWord of SingleTextNode
+    | ElseIf of ElseIfNode
+
+    member x.Node =
+        match x with
+        | SingleWord n -> n :> Node
+        | ElseIf n -> n :> Node
+
+    member x.Range = x.Node.Range
+
+type ExprIfThenNode(ifNode: IfKeywordNode, ifExpr: Expr, thenNode: SingleTextNode, thenExpr: Expr, range) =
     inherit NodeBase(range)
 
     override this.Children =
-        [| yield ifNode
+        [| yield ifNode.Node
            yield Expr.Node ifExpr
            yield thenNode
            yield Expr.Node thenExpr |]
@@ -1477,7 +1555,7 @@ type ExprIfThenNode(ifNode: MultipleTextsNode, ifExpr: Expr, thenNode: SingleTex
 
 type ExprIfThenElseNode
     (
-        ifNode: MultipleTextsNode,
+        ifNode: IfKeywordNode,
         ifExpr: Expr,
         thenNode: SingleTextNode,
         thenExpr: Expr,
@@ -1488,7 +1566,7 @@ type ExprIfThenElseNode
     inherit NodeBase(range)
 
     override this.Children =
-        [| yield ifNode
+        [| yield ifNode.Node
            yield Expr.Node ifExpr
            yield thenNode
            yield Expr.Node thenExpr


### PR DESCRIPTION
Related to https://github.com/fsprojects/fantomas/issues/2449.
@dawedawe this might seem a bit complex and it definitely is a very creative way to approach the problem space.

In essence, I wrote a special type that deals with the trivia assignment of `else if`.
If a trivia would be assigned to either `else` or `if`, the best possible node is selected so that we can write `else if` in one piece without trivia interference.

This isn't without drawbacks but given the delicate nature this might do the trick.
