### PR TITLE
Ensure closing parenthesis is indented far enough in function application with lambda.

### DIFF
--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -1441,3 +1441,49 @@ let ``lambda with long list of arguments, wrapped in parentheses`` () =
     (a19: int)
     (a20: int) -> ())
 """
+
+[<Test>]
+let ``indent closing parenthesis far enough in lambda application, 1299`` () =
+    formatSourceString
+        false
+        "
+let _ =
+    [] |> List.map (fun _ -> @\"a
+b\"     )
+       |> List.length
+"
+        config
+    |> prepend newline
+    |> should
+        equal
+        "
+let _ =
+    []
+    |> List.map (fun _ ->
+        @\"a
+b\"  )
+    |> List.length
+"
+
+[<Test>]
+let ``indent closing parenthesis far enough in multiline lambda application`` () =
+    formatSourceString
+        false
+        "
+let _ =
+    List.maaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaap (fun _ -> @\"a
+b\"     )
+       |> List.length
+"
+        { config with MaxLineLength = 40 }
+    |> prepend newline
+    |> should
+        equal
+        "
+let _ =
+    List.maaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaap
+        (fun _ ->
+            @\"a
+b\"      )
+    |> List.length
+"

--- a/src/Fantomas.Core/CodePrinter2.fs
+++ b/src/Fantomas.Core/CodePrinter2.fs
@@ -2284,25 +2284,32 @@ let genAppWithLambda sep (node: ExprAppWithLambdaNode) =
                     +> sepSpace
                     +> genSingleTextNode lambdaNode.Arrow
 
-                let singleLine =
-                    genExpr node.FunctionName
-                    +> sep
-                    +> col sepSpace node.Arguments genExpr
-                    +> sep
-                    +> genSingleTextNode node.OpeningParen
-                    +> (genLambdaWithParen lambdaNode |> genNode lambdaNode)
-                    +> sepNlnWhenWriteBeforeNewlineNotEmpty
-                    +> genSingleTextNode node.ClosingParen
+                let singleLine (ctx: Context) =
+                    let startColumn = ctx.WriterModel.Indent
+
+                    (genExpr node.FunctionName
+                     +> sep
+                     +> col sepSpace node.Arguments genExpr
+                     +> sep
+                     +> genSingleTextNode node.OpeningParen
+                     +> (genLambdaWithParen lambdaNode |> genNode lambdaNode)
+                     +> sepNlnWhenWriteBeforeNewlineNotEmpty
+                     +> addFixedSpaces startColumn
+                     +> genSingleTextNode node.ClosingParen)
+                        ctx
 
                 let multiLine =
                     genExpr node.FunctionName
-                    +> indentSepNlnUnindent (
-                        col sepNln node.Arguments genExpr
-                        +> onlyIfNot (List.isEmpty node.Arguments) sepNln
-                        +> genSingleTextNode node.OpeningParen
-                        +> (genLambdaWithParen lambdaNode |> genNode lambdaNode)
-                        +> genSingleTextNode node.ClosingParen
-                    )
+                    +> indentSepNlnUnindent (fun ctx ->
+                        let startColumn = ctx.WriterModel.Indent
+
+                        (col sepNln node.Arguments genExpr
+                         +> onlyIfNot (List.isEmpty node.Arguments) sepNln
+                         +> genSingleTextNode node.OpeningParen
+                         +> (genLambdaWithParen lambdaNode |> genNode lambdaNode)
+                         +> addFixedSpaces startColumn
+                         +> genSingleTextNode node.ClosingParen)
+                            ctx)
 
                 if futureNlnCheck singleLineTestExpr ctx then
                     multiLine ctx


### PR DESCRIPTION
Fixes #1299.