### PR TITLE
Correct the range for recursive types

### DIFF
--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -3368,3 +3368,44 @@ module Primitives =
 #endif
         BlockHeightOffset16 = BlockHeightOffset16 of uint16
 """
+
+[<Test>]
+let ``xml doc before recursive type, 2360`` () =
+    formatSourceString
+        false
+        """
+module Primitives =
+    type BlockHeight =
+        | BlockHeight of uint32 
+
+    /// **Description**
+    ///
+    /// 16bit relative block height used for `OP_CSV` locks,
+    /// Since OP_CSV allow only block number of 0 ~ 65535, it is safe
+    /// to restrict into the range smaller than BlockHeight
+    and
+#if !NoDUsAsStructs
+        [<Struct>]
+#endif
+        BlockHeightOffset16 =
+            | BlockHeightOffset16 of uint16
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Primitives =
+    type BlockHeight = BlockHeight of uint32
+
+    /// **Description**
+    ///
+    /// 16bit relative block height used for `OP_CSV` locks,
+    /// Since OP_CSV allow only block number of 0 ~ 65535, it is safe
+    /// to restrict into the range smaller than BlockHeight
+    and
+#if !NoDUsAsStructs
+        [<Struct>]
+#endif
+        BlockHeightOffset16 = BlockHeightOffset16 of uint16
+"""

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -3336,3 +3336,35 @@ type MyType
     ) =
     let x = 5
 """
+
+[<Test>]
+let ``trivia before attributes in recursive type, 2361 `` () =
+    formatSourceString
+        false
+        """
+module Primitives =
+    type BlockHeight =
+        | BlockHeight of uint32 
+
+    and
+#if !NoDUsAsStructs
+        [<Struct>]
+#endif
+        BlockHeightOffset16 =
+            | BlockHeightOffset16 of uint16
+
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Primitives =
+    type BlockHeight = BlockHeight of uint32
+
+    and
+#if !NoDUsAsStructs
+        [<Struct>]
+#endif
+        BlockHeightOffset16 = BlockHeightOffset16 of uint16
+"""

--- a/src/Fantomas.Core/CodePrinter2.fs
+++ b/src/Fantomas.Core/CodePrinter2.fs
@@ -3156,9 +3156,9 @@ let genTypeDefn (td: TypeDefn) =
         genXml typeName.XmlDoc
         +> onlyIfNot hasAndKeyword (genAttributes typeName.Attributes)
         +> genSingleTextNode typeName.LeadingKeyword
+        +> onlyIf hasTriviaAfterLeadingKeyword indent
         +> onlyIf hasAndKeyword (sepSpace +> genOnelinerAttributes typeName.Attributes)
         +> sepSpace
-        +> onlyIf hasTriviaAfterLeadingKeyword indent
         +> genAccessOpt typeName.Accessibility
         +> genTypeAndParam (genIdentListNode typeName.Identifier) typeName.TypeParameters
         +> onlyIfNot typeName.Constraints.IsEmpty (sepSpace +> genTypeConstraints typeName.Constraints)

--- a/src/Fantomas.Core/Fangorn.fs
+++ b/src/Fantomas.Core/Fangorn.fs
@@ -2048,6 +2048,8 @@ let mkTypeDefn
                 let startRange =
                     if not px.IsEmpty then
                         px.Range
+                    elif leadingKeyword.Text = "and" then
+                        (leadingKeyword :> Node).Range
                     else
                         match ats with
                         | [] -> (leadingKeyword :> Node).Range


### PR DESCRIPTION
Correct the range for recursive types.
Indent everything after the leading keyword.

Fixes https://github.com/fsprojects/fantomas/issues/2360
Fixes https://github.com/fsprojects/fantomas/issues/2361