### PR TITLE
Move atCurrentColumn calls from multiline application expression to specific locations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Stroustrup: Two lists given directly as parameters, break code [#2681](https://github.com/fsprojects/fantomas/issues/2681)
 * fsharp_experimental_stroustrup_style=true breaks on types with nested anonymous records. [#2413](https://github.com/fsprojects/fantomas/issues/2413)
 * Stroustrup style breaks on nested records. [#2587](https://github.com/fsprojects/fantomas/issues/2587)
+* Piped multiline application is indented too far. [#2682](https://github.com/fsprojects/fantomas/issues/2682)
 
 ## [5.2.0-beta-001] - 2023-01-02
 

--- a/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -1144,3 +1144,50 @@ module Foo =
         )
         |> Seq.length
 """
+
+[<Test>]
+let ``double pipe with application with two lambdas, 2682`` () =
+    formatSourceString
+        false
+        """
+(someLongItemOne, someLongItemTwo)
+||> Prefix.fnName
+    (fun delta echo -> delta, echo)
+    (fun (k: One * Two * Three) ->
+        // multiline
+        ()
+    )
+    lastArgument
+
+(someLongItemOne, someLongItemTwo)
+|> Prefix.fnName
+    (fun delta echo -> delta, echo)
+    (fun (k: One * Two * Three) ->
+        // multiline
+        ()
+    )
+    lastArgument
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(someLongItemOne, someLongItemTwo)
+||> Prefix.fnName
+    (fun delta echo -> delta, echo)
+    (fun (k: One * Two * Three) ->
+        // multiline
+        ()
+    )
+    lastArgument
+
+(someLongItemOne, someLongItemTwo)
+|> Prefix.fnName
+    (fun delta echo -> delta, echo)
+    (fun (k: One * Two * Three) ->
+        // multiline
+        ()
+    )
+    lastArgument
+"""

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -581,22 +581,6 @@ let wordOf = sepSpace +> !- "of "
 
 let indentSepNlnUnindent f = indent +> sepNln +> f +> unindent
 
-// we need to make sure each expression in the function application has offset at least greater than
-// indentation of the function expression itself
-// we replace sepSpace in such case
-// remarks: https://github.com/fsprojects/fantomas/issues/1611
-let indentIfNeeded f (ctx: Context) =
-    let savedColumn = ctx.WriterModel.AtColumn
-
-    if savedColumn >= ctx.Column then
-        // missingSpaces needs to be at least one more than the column
-        // of function expression being applied upon, otherwise (as known up to F# 4.7)
-        // this would lead to a compile error for the function application
-        let missingSpaces = (savedColumn - ctx.FinalizeModel.Column) + ctx.Config.IndentSize
-        atIndentLevel true savedColumn (!-(String.replicate missingSpaces " ")) ctx
-    else
-        f ctx
-
 let shortExpressionWithFallback
     (shortExpression: Context -> Context)
     fallbackExpression

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -188,7 +188,6 @@ val wordAnd: (Context -> Context)
 val wordAndFixed: (Context -> Context)
 val wordOf: (Context -> Context)
 val indentSepNlnUnindent: f: (Context -> Context) -> (Context -> Context)
-val indentIfNeeded: f: (Context -> Context) -> ctx: Context -> Context
 
 val isShortExpression:
     maxWidth: int ->


### PR DESCRIPTION
Fixes #2682.

The gist of this fix is moving `atCurrentColumn` calls to the very specific location they are required to ensure valid code.
`
The usage in `ExprApp` was too general and I moved it to `Expr.JoinIn` and removed the need for it in `Expr.TypeApp`.

`atCurrentColumn` break the natural indentation flow and we should avoid it as much as possible.