### PR TITLE
Extend logging and verbosity options

### DIFF
--- a/src/Fantomas.Tests/Integration/ConfigTests.fs
+++ b/src/Fantomas.Tests/Integration/ConfigTests.fs
@@ -6,7 +6,10 @@ open FsUnit
 open Fantomas.Tests.TestHelpers
 
 [<Literal>]
-let Verbosity = "--verbosity d"
+let DetailedVerbosity = "--verbosity d"
+
+[<Literal>]
+let NormalVerbosity = "--verbosity n"
 
 [<Test>]
 let ``config file in working directory should not require relative prefix, 821`` () =
@@ -24,7 +27,7 @@ indent_size=2
 """
         )
 
-    let args = sprintf "%s %s" Verbosity fileFixture.Filename
+    let args = sprintf "%s %s" DetailedVerbosity fileFixture.Filename
     let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 0
     output |> should contain (sprintf "Processing %s" fileFixture.Filename)
@@ -49,7 +52,7 @@ end_of_line=cr
 """
         )
 
-    let args = sprintf "%s %s" Verbosity fileFixture.Filename
+    let args = sprintf "%s %s" NormalVerbosity fileFixture.Filename
     let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 1
     StringAssert.Contains("Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'", output)

--- a/src/Fantomas.Tests/Integration/ConfigTests.fs
+++ b/src/Fantomas.Tests/Integration/ConfigTests.fs
@@ -27,7 +27,7 @@ indent_size=2
     let args = sprintf "%s %s" Verbosity fileFixture.Filename
     let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 0
-    output |> should startWith (sprintf "Processing %s" fileFixture.Filename)
+    output |> should contain (sprintf "Processing %s" fileFixture.Filename)
     let result = System.IO.File.ReadAllText(fileFixture.Filename)
 
     result

--- a/src/Fantomas.Tests/Integration/ConfigTests.fs
+++ b/src/Fantomas.Tests/Integration/ConfigTests.fs
@@ -5,6 +5,9 @@ open NUnit.Framework
 open FsUnit
 open Fantomas.Tests.TestHelpers
 
+[<Literal>]
+let Verbosity = "--verbosity d"
+
 [<Test>]
 let ``config file in working directory should not require relative prefix, 821`` () =
     use fileFixture =
@@ -21,7 +24,8 @@ indent_size=2
 """
         )
 
-    let { ExitCode = exitCode; Output = output } = runFantomasTool fileFixture.Filename
+    let args = sprintf "%s %s" Verbosity fileFixture.Filename
+    let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 0
     output |> should startWith (sprintf "Processing %s" fileFixture.Filename)
     let result = System.IO.File.ReadAllText(fileFixture.Filename)
@@ -45,7 +49,8 @@ end_of_line=cr
 """
         )
 
-    let { ExitCode = exitCode; Output = output } = runFantomasTool fileFixture.Filename
+    let args = sprintf "%s %s" Verbosity fileFixture.Filename
+    let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 1
     StringAssert.Contains("Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'", output)
 

--- a/src/Fantomas.Tests/Integration/ForceTests.fs
+++ b/src/Fantomas.Tests/Integration/ForceTests.fs
@@ -5,6 +5,9 @@ open NUnit.Framework
 open FsUnit
 open Fantomas.Tests.TestHelpers
 
+[<Literal>]
+let Verbosity = "--verbosity d"
+
 // The day this test fails because Fantomas can format the file, is the day you can remove this file.
 
 [<Test>]
@@ -17,7 +20,7 @@ let ``code that was invalid should be still be written`` () =
     use outputFixture = new OutputFile()
 
     let { ExitCode = exitCode; Output = output } =
-        runFantomasTool $"--force --out {outputFixture.Filename} {sourceFile}"
+        runFantomasTool $"{Verbosity} --force --out {outputFixture.Filename} {sourceFile}"
 
     exitCode |> should equal 0
     output |> should contain "was not valid after formatting"

--- a/src/Fantomas.Tests/Integration/IgnoreFilesTests.fs
+++ b/src/Fantomas.Tests/Integration/IgnoreFilesTests.fs
@@ -84,11 +84,13 @@ let ``ignore file in folder`` () =
 
     use ignoreFixture = new FantomasIgnoreFile("A.fs")
 
-    let { ExitCode = exitCode } =
-        runFantomasTool (sprintf ".%c%s" Path.DirectorySeparatorChar subFolder)
+    let { ExitCode = exitCode; Output = output } =
+        runFantomasTool (sprintf "%s .%c%s" Verbosity Path.DirectorySeparatorChar subFolder)
 
     exitCode |> should equal 0
     File.ReadAllText inputFixture.Filename |> should equal Source
+
+    output |> should contain "Processed files: 0"
 
 [<Test>]
 let ``ignore file while checking`` () =
@@ -135,3 +137,4 @@ let ``honor ignore file when processing a folder`` () =
         runFantomasTool (sprintf "%s .%c%s" Verbosity Path.DirectorySeparatorChar subFolder)
 
     output |> should not' (contain "ignored")
+    output |> should contain "Processed files: 1"

--- a/src/Fantomas.Tests/Integration/IgnoreFilesTests.fs
+++ b/src/Fantomas.Tests/Integration/IgnoreFilesTests.fs
@@ -8,6 +8,9 @@ open Fantomas.Tests.TestHelpers
 [<Literal>]
 let Source = "let  foo =   47"
 
+[<Literal>]
+let Verbosity = "--verbosity d"
+
 [<Test>]
 let ``ignore all fs files`` () =
     let fileName = "ToBeIgnored"
@@ -31,8 +34,8 @@ let ``ignore specific file`` () =
     use inputFixture = new TemporaryFileCodeSample(Source, fileName = fileName)
 
     use ignoreFixture = new FantomasIgnoreFile("A.fs")
-
-    let { ExitCode = exitCode; Output = output } = runFantomasTool inputFixture.Filename
+    let args = sprintf "%s %s" Verbosity inputFixture.Filename
+    let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 0
 
     printfn "%s" output
@@ -63,8 +66,8 @@ let ``don't ignore other files`` () =
     use inputFixture = new TemporaryFileCodeSample(Source, fileName = fileName)
 
     use ignoreFixture = new FantomasIgnoreFile("A.fs")
-
-    let { ExitCode = exitCode; Output = output } = runFantomasTool inputFixture.Filename
+    let args = sprintf "%s %s" Verbosity inputFixture.Filename
+    let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 0
 
     output |> should contain "Processing"
@@ -96,7 +99,7 @@ let ``ignore file while checking`` () =
     use ignoreFixture = new FantomasIgnoreFile("A.fs")
 
     let { ExitCode = exitCode; Output = output } =
-        sprintf "%s --check" inputFixture.Filename |> runFantomasTool
+        sprintf "%s %s --check" Verbosity inputFixture.Filename |> runFantomasTool
 
     exitCode |> should equal 0
 
@@ -129,6 +132,6 @@ let ``honor ignore file when processing a folder`` () =
     use inputFixture = new FantomasIgnoreFile("*.fsx")
 
     let { Output = output } =
-        runFantomasTool (sprintf ".%c%s" Path.DirectorySeparatorChar subFolder)
+        runFantomasTool (sprintf "%s .%c%s" Verbosity Path.DirectorySeparatorChar subFolder)
 
     output |> should not' (contain "ignored")

--- a/src/Fantomas.Tests/Integration/MultiplePathsTests.fs
+++ b/src/Fantomas.Tests/Integration/MultiplePathsTests.fs
@@ -11,6 +11,9 @@ let UserCode = "let a  =   9"
 [<Literal>]
 let FormattedCode = "let a = 9\n"
 
+[<Literal>]
+let Verbosity = "--verbosity d"
+
 let private fileContentMatches (expectedContent: string) (actualPath: string) : unit =
     if File.Exists(actualPath) then
         let actualContent = File.ReadAllText(actualPath)
@@ -45,7 +48,7 @@ let ``format multiple paths with recursive flag`` () =
     use fileFixtureThree = new TemporaryFileCodeSample(UserCode, subFolder = "sub")
 
     let arguments =
-        sprintf "\"%s\" \"%s\" \"sub\" -r" fileFixtureOne.Filename fileFixtureTwo.Filename
+        sprintf "%s \"%s\" \"%s\" \"sub\" -r" Verbosity fileFixtureOne.Filename fileFixtureTwo.Filename
 
     let { ExitCode = exitCode; Output = output } = runFantomasTool arguments
 

--- a/src/Fantomas.Tests/Integration/WriteTests.fs
+++ b/src/Fantomas.Tests/Integration/WriteTests.fs
@@ -12,13 +12,16 @@ let FormattedCode =
 [<Literal>]
 let UnformattedCode = "let a =   9"
 
+[<Literal>]
+let Verbosity = "--verbosity d"
+
 [<Test>]
 let ``correctly formatted file should not be written, 1984`` () =
     let fileName = "A"
 
     use inputFixture = new TemporaryFileCodeSample(FormattedCode, fileName = fileName)
-
-    let { ExitCode = exitCode; Output = output } = runFantomasTool inputFixture.Filename
+    let args = sprintf "%s %s" Verbosity inputFixture.Filename
+    let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 0
 
     output |> should contain "was unchanged"
@@ -28,8 +31,8 @@ let ``incorrectly formatted file should be written`` () =
     let fileName = "A"
 
     use inputFixture = new TemporaryFileCodeSample(UnformattedCode, fileName = fileName)
-
-    let { ExitCode = exitCode; Output = output } = runFantomasTool inputFixture.Filename
+    let args = sprintf "%s %s" Verbosity inputFixture.Filename
+    let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 0
 
     output |> should contain "has been written"

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -330,10 +330,15 @@
       },
       "Serilog": {
         "type": "Transitive",
-        "resolved": "2.8.0",
-        "contentHash": "zjuKXW5IQws43IHX7VY9nURsaCiBYh2kyJCWLJRSWrTsx/syBKHV8MibWe2A+QH3Er0AiwA+OJmO3DhFJDY1+A==",
+        "resolved": "2.12.0",
+        "contentHash": "xaiJLIdu6rYMKfQMYUZgTy8YK7SMZjB4Yk50C/u//Z4OsvxkUfSPJy4nknfvwAC34yr13q7kcyh4grbwhSxyZg=="
+      },
+      "Serilog.Sinks.Console": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "K6N5q+5fetjnJPvCmkWOpJ/V8IEIoMIB1s86OzBrbxwTyHxdx3pmz4H+8+O/Dc/ftUX12DM1aynx/dDowkwzqg==",
         "dependencies": {
-          "System.Collections.NonGeneric": "4.3.0"
+          "Serilog": "2.10.0"
         }
       },
       "SerilogTraceListener": {
@@ -396,19 +401,6 @@
         "type": "Transitive",
         "resolved": "5.0.0",
         "contentHash": "FXkLXiK0sVVewcso0imKQoOxjoPAj42R8HtjjbSjVPAzwDfzoyoznWxgA3c38LDbN9SJux1xXoXYAhz98j7r2g=="
-      },
-      "System.Collections.NonGeneric": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "prtjIEMhGUnQq6RnPEYLpFt8AtLbp9yq2zxOSrY7KJJZrw25Fi97IzBqY7iqssbM61Ek5b8f3MG/sG1N2sN5KA==",
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
       },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
@@ -921,6 +913,8 @@
           "Fantomas.Client": "[1.0.0, )",
           "Fantomas.Core": "[1.0.0, )",
           "Ignore": "[0.1.46, )",
+          "Serilog": "[2.12.0, )",
+          "Serilog.Sinks.Console": "[4.1.0, )",
           "SerilogTraceListener": "[3.2.1-dev-00011, )",
           "StreamJsonRpc": "[2.8.28, )",
           "System.IO.Abstractions": "[17.2.3, )",

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fsi" />
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Logging.fs" />
     <Compile Include="IgnoreFile.fsi" />
     <Compile Include="IgnoreFile.fs" />
     <Compile Include="EditorConfig.fsi" />

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -34,6 +34,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Thoth.Json.Net" Version="8.0.0" />

--- a/src/Fantomas/IgnoreFile.fs
+++ b/src/Fantomas/IgnoreFile.fs
@@ -2,6 +2,7 @@ namespace Fantomas
 
 open System.IO.Abstractions
 open Ignore
+open Fantomas.Logging
 
 type AbsoluteFilePath =
     private
@@ -90,5 +91,5 @@ module IgnoreFile =
             try
                 ignoreFile.IsIgnored fullPath
             with ex ->
-                printfn "%A" ex
+                stdlog "%A" ex
                 false

--- a/src/Fantomas/IgnoreFile.fs
+++ b/src/Fantomas/IgnoreFile.fs
@@ -91,5 +91,5 @@ module IgnoreFile =
             try
                 ignoreFile.IsIgnored fullPath
             with ex ->
-                stdlog "%A" ex
+                sprintf "%A" ex |> stdlog
                 false

--- a/src/Fantomas/IgnoreFile.fs
+++ b/src/Fantomas/IgnoreFile.fs
@@ -91,5 +91,5 @@ module IgnoreFile =
             try
                 ignoreFile.IsIgnored fullPath
             with ex ->
-                sprintf "%A" ex |> stdlog
+                elog $"%A{ex}"
                 false

--- a/src/Fantomas/Logging.fs
+++ b/src/Fantomas/Logging.fs
@@ -1,28 +1,27 @@
 module Fantomas.Logging
 
+open Serilog
+
 [<RequireQualifiedAccess>]
 type VerbosityLevel =
     | Normal
     | Detailed
 
-/// log a message
-let stdlog (s: Printf.TextWriterFormat<_>) = printfn s
+let private logger =
+    Log.Logger <- LoggerConfiguration().WriteTo.Console().CreateLogger()
+    Log.Logger
 
-/// log a message to stderr
-let elog (s: Printf.TextWriterFormat<_>) = eprintfn s
+/// log a message
+let stdlog (s: string) = logger.Information(s)
+
+/// log an error
+let elog (s: string) = logger.Error(s)
 
 /// log a message if the verbosity level is >= Detailed
 let logGrEqDetailed verbosity s =
     if verbosity = VerbosityLevel.Detailed then
-        printfn "%s" s
+        logger.Information(s)
     else
         ()
 
-// Todo - this doesn't work yet
-// let logGrEqDetailedF (verbosity: VerbosityLevel) (s: Printf.TextWriterFormat<_>) =
-//     if verbosity = VerbosityLevel.Detailed then
-//         printfn s |> ignore
-//     else
-//         ()
-
-// logGrEqDetailedF VerbosityLevel.Detailed "foo %d" 32
+let closeAndFlushLog () = Log.CloseAndFlush()

--- a/src/Fantomas/Logging.fs
+++ b/src/Fantomas/Logging.fs
@@ -1,0 +1,28 @@
+module Fantomas.Logging
+
+[<RequireQualifiedAccess>]
+type VerbosityLevel =
+    | Normal
+    | Detailed
+
+/// log a message
+let stdlog (s: Printf.TextWriterFormat<_>) = printfn s
+
+/// log a message to stderr
+let elog (s: Printf.TextWriterFormat<_>) = eprintfn s
+
+/// log a message if the verbosity level is >= Detailed
+let logGrEqDetailed verbosity s =
+    if verbosity = VerbosityLevel.Detailed then
+        printfn "%s" s
+    else
+        ()
+
+// Todo - this doesn't work yet
+// let logGrEqDetailedF (verbosity: VerbosityLevel) (s: Printf.TextWriterFormat<_>) =
+//     if verbosity = VerbosityLevel.Detailed then
+//         printfn s |> ignore
+//     else
+//         ()
+
+// logGrEqDetailedF VerbosityLevel.Detailed "foo %d" 32

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -48,6 +48,21 @@
         "resolved": "0.1.8",
         "contentHash": "hHUZIVz9BlF++B5w183c5HwbqSIXUtJU+lxhKz3ebQ5X8INBIWV7dS/FK8uSqSMUTYavuKkRRTZvJlbYXPUykg=="
       },
+      "Serilog": {
+        "type": "Direct",
+        "requested": "[2.12.0, )",
+        "resolved": "2.12.0",
+        "contentHash": "xaiJLIdu6rYMKfQMYUZgTy8YK7SMZjB4Yk50C/u//Z4OsvxkUfSPJy4nknfvwAC34yr13q7kcyh4grbwhSxyZg=="
+      },
+      "Serilog.Sinks.Console": {
+        "type": "Direct",
+        "requested": "[4.1.0, )",
+        "resolved": "4.1.0",
+        "contentHash": "K6N5q+5fetjnJPvCmkWOpJ/V8IEIoMIB1s86OzBrbxwTyHxdx3pmz4H+8+O/Dc/ftUX12DM1aynx/dDowkwzqg==",
+        "dependencies": {
+          "Serilog": "2.10.0"
+        }
+      },
       "SerilogTraceListener": {
         "type": "Direct",
         "requested": "[3.2.1-dev-00011, )",
@@ -347,14 +362,6 @@
         "resolved": "2.0.2",
         "contentHash": "4EQgYdNZ92SyaO7YFk6olVnebF5V+jrHyMUjvPq89tLeMo8NSfgDF+6Zwq/lgh9j/0yfQp9Lkm0ZA0rUATCZFA=="
       },
-      "Serilog": {
-        "type": "Transitive",
-        "resolved": "2.8.0",
-        "contentHash": "zjuKXW5IQws43IHX7VY9nURsaCiBYh2kyJCWLJRSWrTsx/syBKHV8MibWe2A+QH3Er0AiwA+OJmO3DhFJDY1+A==",
-        "dependencies": {
-          "System.Collections.NonGeneric": "4.3.0"
-        }
-      },
       "System.Collections": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -386,19 +393,6 @@
         "type": "Transitive",
         "resolved": "5.0.0",
         "contentHash": "FXkLXiK0sVVewcso0imKQoOxjoPAj42R8HtjjbSjVPAzwDfzoyoznWxgA3c38LDbN9SJux1xXoXYAhz98j7r2g=="
-      },
-      "System.Collections.NonGeneric": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "prtjIEMhGUnQq6RnPEYLpFt8AtLbp9yq2zxOSrY7KJJZrw25Fi97IzBqY7iqssbM61Ek5b8f3MG/sG1N2sN5KA==",
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
       },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",


### PR DESCRIPTION
To show the general direction and maybe get some feedback, here's an early draft for the logging feature:
`--verbosity d` should be the same as in the past with the addition of the count of processed files in the end
`--verbosity n` should be pretty quiet


Fixes #2627 

