### PR TITLE
Initial chain proof of concept.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [5.2.0-alpha-011] - 2023-01-12
 
 ### Fixes 
 * Stroustrup: Two lists given directly as parameters, break code [#2681](https://github.com/fsprojects/fantomas/issues/2681)
@@ -10,11 +10,9 @@
 * Piped multiline application is indented too far. [#2682](https://github.com/fsprojects/fantomas/issues/2682)
 * Comment not assigned to first parameter in constructor. [#2692](https://github.com/fsprojects/fantomas/issues/2692)
 * Stroustrup: Type alias for anonymous record type. [#2179](https://github.com/fsprojects/fantomas/issues/2179)
-
-## [5.2.0-beta-001] - 2023-01-02
-
-### Changed
-* Consider v5.2 to be stable and production ready.
+* Space before lambda should not occur in chain. [#2685](https://github.com/fsprojects/fantomas/issues/2685)
+* Trivia inside chained lambda is not restored correctly. [#2686](https://github.com/fsprojects/fantomas/issues/2686)
+* SpaceBeforeUppercaseInvocation not respected in TypeApp DotGet. [#2700](https://github.com/fsprojects/fantomas/issues/2700)
 
 ## [5.2.0-alpha-010] - 2022-12-30
 

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -172,7 +172,7 @@ A().B(fun b -> b)
 """
 
 [<Test>]
-let ``2685 `` () =
+let ``space before lambda should not occur in chain, 2685 `` () =
     formatSourceString
         false
         """

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -275,3 +275,40 @@ A.B
     .C(D)
     .E.[0]
 """
+
+[<Test>]
+let ``trivia inside chain, 2686`` () =
+    formatSourceString
+        false
+        """
+builder.
+    FirstThing<X>(fun lambda ->
+        // aaaaaa
+        ()
+    )
+    .SecondThing<Y>(fun next ->
+        // bbbbb
+        next
+    )
+    // ccccc
+    .ThirdThing<Z>().X
+"""
+        { config with
+            MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .FirstThing<X>(fun lambda ->
+        // aaaaaa
+        ()
+    )
+    .SecondThing<Y>(fun next ->
+        // bbbbb
+        next
+    )
+    // ccccc
+    .ThirdThing<Z>()
+    .X
+"""

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -1,0 +1,277 @@
+module Fantomas.Core.Tests.ChainTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelper
+
+[<Test>]
+let ``appUnit dot identifier`` () =
+    formatSourceString
+        false
+        """
+X().Y
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+X().Y
+"""
+
+[<Test>]
+let ``appParen dot identifier`` () =
+    formatSourceString
+        false
+        """
+X(a).Y
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+X(a).Y
+"""
+
+[<Test>]
+let ``appUnit dot appUnit`` () =
+    formatSourceString
+        false
+        """
+X().Y()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+X().Y()
+"""
+
+[<Test>]
+let ``typed appUnit dot identifier`` () =
+    formatSourceString
+        false
+        """
+X<a>().Y
+X<a>().Y<b>()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+X<a>().Y
+X<a>().Y<b>()
+"""
+
+[<Test>]
+let ``appParenLambda dot identifier`` () =
+    formatSourceString
+        false
+        """
+X(fun x -> x).Y
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+X(fun x -> x).Y
+"""
+
+[<Test>]
+let ``identifier dot appUnit dot identifier`` () =
+    formatSourceString
+        false
+        """
+X.Y().Z
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+X.Y().Z
+"""
+
+[<Test>]
+let ``identifier dot indexed expr dot identifier`` () =
+    formatSourceString
+        false
+        """
+A.[0].B
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+A.[0].B
+"""
+
+[<Test>]
+let ``identifier dot indexed expr dot appParenExpr`` () =
+    formatSourceString
+        false
+        """
+A.[0].B(1)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+A.[0].B(1)
+"""
+
+[<Test>]
+let ``identifier dot typed appUnit dot identifier`` () =
+    formatSourceString
+        false
+        """
+X.Y<a>().Z
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+X.Y<a>().Z
+"""
+
+[<Test>]
+let ``identifier dot typed identifier dot identifier`` () =
+    formatSourceString
+        false
+        """
+X.Y<a>.Z
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+X.Y<a>.Z
+"""
+
+[<Test>]
+let ``appUnit dot appParen`` () =
+    formatSourceString
+        false
+        """
+A().B(fun b -> b)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+A().B(fun b -> b)
+"""
+
+[<Test>]
+let ``2685 `` () =
+    formatSourceString
+        false
+        """
+module A =
+    let foo =
+        Foai.SomeLongTextYikes().ConfigureBarry(fun alpha beta gamma ->
+            context.AddSomething ("a string") |> ignore
+        ).MoreContext(fun builder ->
+            // also good stuff
+            ()
+        ).ABC().XYZ
+"""
+        { config with
+            SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+module A =
+    let foo =
+        Foai
+            .SomeLongTextYikes()
+            .ConfigureBarry(fun alpha beta gamma -> context.AddSomething ("a string") |> ignore)
+            .MoreContext(fun builder ->
+                // also good stuff
+                ())
+            .ABC()
+            .XYZ
+"""
+
+[<Test>]
+let ``identifier dot appUnit dot typed appUnit `` () =
+    formatSourceString
+        false
+        """
+A.B().C<'d>()
+"""
+        { config with
+            MaxDotGetExpressionWidth = 0 }
+    |> prepend newline
+    |> should
+        equal
+        """
+A
+    .B()
+    .C<'d>()
+"""
+
+[<Test>]
+let ``identifier dot appUnit dot typed identifier `` () =
+    formatSourceString
+        false
+        """
+A.B().C<'d>
+"""
+        { config with
+            MaxDotGetExpressionWidth = 0 }
+    |> prepend newline
+    |> should
+        equal
+        """
+A
+    .B()
+    .C<'d>
+"""
+
+[<Test>]
+let ``identifier dot identifier dot appExpr dot appUnit dot index expr`` () =
+    formatSourceString
+        false
+        """
+A.B.C(D).E().[0]
+"""
+        { config with
+            MaxDotGetExpressionWidth = 0 }
+    |> prepend newline
+    |> should
+        equal
+        """
+A.B
+    .C(D)
+    .E()
+    .[0]
+"""
+
+[<Test>]
+let ``identifier dot identifier dot appExpr dot identifier dot index expr`` () =
+    formatSourceString
+        false
+        """
+A.B.C(D).E.[0]
+"""
+        { config with
+            MaxDotGetExpressionWidth = 0 }
+    |> prepend newline
+    |> should
+        equal
+        """
+A.B
+    .C(D)
+    .E.[0]
+"""

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -172,38 +172,6 @@ A().B(fun b -> b)
 """
 
 [<Test>]
-let ``space before lambda should not occur in chain, 2685 `` () =
-    formatSourceString
-        false
-        """
-module A =
-    let foo =
-        Foai.SomeLongTextYikes().ConfigureBarry(fun alpha beta gamma ->
-            context.AddSomething ("a string") |> ignore
-        ).MoreContext(fun builder ->
-            // also good stuff
-            ()
-        ).ABC().XYZ
-"""
-        { config with
-            SpaceBeforeUppercaseInvocation = true }
-    |> prepend newline
-    |> should
-        equal
-        """
-module A =
-    let foo =
-        Foai
-            .SomeLongTextYikes()
-            .ConfigureBarry(fun alpha beta gamma -> context.AddSomething ("a string") |> ignore)
-            .MoreContext(fun builder ->
-                // also good stuff
-                ())
-            .ABC()
-            .XYZ
-"""
-
-[<Test>]
 let ``identifier dot appUnit dot typed appUnit `` () =
     formatSourceString
         false

--- a/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
@@ -2287,9 +2287,7 @@ let loader (projectRoot: string) (siteContent: SiteContents) =
         """
 let loadFile n =
     let file =
-        System
-            .IO
-            .Path
+        System.IO.Path
             .Combine(
                 contentDir,
                 (n |> System.IO.Path.GetFileNameWithoutExtension)

--- a/src/Fantomas.Core.Tests/DotGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotGetTests.fs
@@ -18,10 +18,7 @@ Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<option<option<unit>>
     |> should
         equal
         """
-Microsoft
-    .FSharp
-    .Reflection
-    .FSharpType
+Microsoft.FSharp.Reflection.FSharpType
     .GetUnionCases(
         typeof<option<option<unit>>>
             .GetGenericTypeDefinition()
@@ -45,13 +42,9 @@ System.Diagnostics.FileVersionInfo.GetVersionInfo(
     |> should
         equal
         """
-System
-    .Diagnostics
-    .FileVersionInfo
+System.Diagnostics.FileVersionInfo
     .GetVersionInfo(
-        System
-            .Reflection
-            .Assembly
+        System.Reflection.Assembly
             .GetExecutingAssembly()
             .Location
     )
@@ -79,13 +72,9 @@ let ``split chained method call expression, 246`` () =
 root.SetAttribute(
     "driverVersion",
     "AltCover.Recorder "
-    + System
-        .Diagnostics
-        .FileVersionInfo
+    + System.Diagnostics.FileVersionInfo
         .GetVersionInfo(
-            System
-                .Reflection
-                .Assembly
+            System.Reflection.Assembly
                 .GetExecutingAssembly()
                 .Location
         )
@@ -105,16 +94,8 @@ Equinox.EventStore.Resolver<'event, 'state, _>(gateway, codec, fold, initial, ca
     |> should
         equal
         """
-Equinox
-    .EventStore
-    .Resolver<'event, 'state, _>(
-        gateway,
-        codec,
-        fold,
-        initial,
-        cacheStrategy,
-        accessStrategy
-    )
+Equinox.EventStore
+    .Resolver<'event, 'state, _>(gateway, codec, fold, initial, cacheStrategy, accessStrategy)
     .Resolve
 """
 
@@ -163,14 +144,8 @@ module Services =
             ) =
             match storage with
             | Storage.MemoryStore store ->
-                Equinox
-                    .MemoryStore
-                    .Resolver(
-                        store,
-                        FsCodec.Box.Codec.Create(),
-                        fold,
-                        initial
-                    )
+                Equinox.MemoryStore
+                    .Resolver(store, FsCodec.Box.Codec.Create(), fold, initial)
                     .Resolve
             | Storage.EventStore(gateway, cache) ->
                 let accessStrategy = Equinox.EventStore.AccessStrategy.RollingSnapshots snapshot
@@ -178,16 +153,8 @@ module Services =
                 let cacheStrategy =
                     Equinox.EventStore.CachingStrategy.SlidingWindow(cache, TimeSpan.FromMinutes 20.)
 
-                Equinox
-                    .EventStore
-                    .Resolver<'event, 'state, _>(
-                        gateway,
-                        codec,
-                        fold,
-                        initial,
-                        cacheStrategy,
-                        accessStrategy
-                    )
+                Equinox.EventStore
+                    .Resolver<'event, 'state, _>(gateway, codec, fold, initial, cacheStrategy, accessStrategy)
                     .Resolve
 """
 
@@ -312,8 +279,7 @@ let firstName =
         equal
         """
 let firstName =
-    define
-        .Attribute
+    define.Attribute
         .ParsedRes(FirstName.value, FirstName.create)
         .Get(fun u -> u.FirstName)
         .SetRes(userSetter User.setFirstName)
@@ -332,14 +298,8 @@ Equinox.MemoryStore.Resolver(store, FsCodec.Box.Codec.Create(), fold, initial)
     |> should
         equal
         """
-Equinox
-    .MemoryStore
-    .Resolver(
-        store,
-        FsCodec.Box.Codec.Create(),
-        fold,
-        initial
-    )
+Equinox.MemoryStore
+    .Resolver(store, FsCodec.Box.Codec.Create(), fold, initial)
     .Resolve
 """
 
@@ -361,16 +321,8 @@ let ``long ident with dots inside type app inside dotget`` () =
     |> should
         equal
         """
-Equinox
-    .EventStore
-    .Resolver<'event, 'state, _>(
-        gateway,
-        codec,
-        fold,
-        initial,
-        cacheStrategy,
-        accessStrategy
-    )
+Equinox.EventStore
+    .Resolver<'event, 'state, _>(gateway, codec, fold, initial, cacheStrategy, accessStrategy)
     .Resolve
 """
 
@@ -393,8 +345,7 @@ let getColl =
         equal
         """
 let getColl =
-    define
-        .Operation
+    define.Operation
         .ForContext(Context.toAuthenticatedContext)
         .GetCollection(fun _ parser ->
             let x = 2
@@ -678,17 +629,13 @@ type IWebHostBuilderExtensions() =
     [<Extension>]
     static member UseSerilog(webHostBuilder: IWebHostBuilder, index: Index) =
         webHostBuilder.UseSerilog (fun context configuration ->
-            configuration
-                .MinimumLevel
+            configuration.MinimumLevel
                 .Debug()
-                .WriteTo
-                .Logger (fun loggerConfiguration ->
-                    loggerConfiguration
-                        .Enrich
+                .WriteTo.Logger (fun loggerConfiguration ->
+                    loggerConfiguration.Enrich
                         .WithProperty("host", Environment.MachineName)
                         .Enrich.WithProperty("user", Environment.UserName)
-                        .Enrich
-                        .WithProperty (
+                        .Enrich.WithProperty (
                             "application",
                             context.HostingEnvironment.ApplicationName
                         )
@@ -999,8 +946,7 @@ type Foobar =
             FileSystem.SafeExists filename
             && ((tcConfig.GetTargetFrameworkDirectories()
                  |> List.exists (fun clrRoot -> clrRoot = Path.GetDirectoryName filename))
-                || (tcConfig
-                       .FxResolver
+                || (tcConfig.FxResolver
                        .GetSystemAssemblies()
                        .Contains(fileNameWithoutExtension filename))
                 || tcConfig.FxResolver.IsInReferenceAssemblyPackDirectory filename)
@@ -1078,8 +1024,7 @@ module Foo =
 module Foo =
     let bar () =
         let saveDir =
-            fs
-                .DirectoryInfo
+            fs.DirectoryInfo
                 .FromDirectoryName(
                     fs.Path.Combine ((ThingThing.rootRoot fs thingThing).FullName, "tada!")
                 )
@@ -1118,8 +1063,7 @@ module Foo =
 module Foo =
     let bar () =
         let saveDir =
-            fs
-                .DirectoryInfo
+            fs.DirectoryInfo
                 .FromDirectoryName(
                     fs.Path.Combine (
                         (ThingThing.rootRoot fs thingThing).FullName,
@@ -1236,7 +1180,8 @@ let ``dotget function application should add space before argument, long`` () =
         """
 m.Property(fun p -> p.Name).IsRequired().HasColumnName("ModelName").HasMaxLength 64
 """
-        config
+        { config with
+            MaxDotGetExpressionWidth = 70 }
     |> prepend newline
     |> should
         equal
@@ -1245,7 +1190,8 @@ m
     .Property(fun p -> p.Name)
     .IsRequired()
     .HasColumnName("ModelName")
-    .HasMaxLength 64
+    .HasMaxLength
+    64
 """
 
 [<Test>]
@@ -1264,9 +1210,7 @@ m.Property(fun p -> p.Name).IsRequired().HasColumnName("ModelName").HasMaxLength
 m
     .Property(fun p -> p.Name)
     .IsRequired()
-    .HasColumnName(
-        "ModelName"
-    )
+    .HasColumnName("ModelName")
     .HasMaxLength
 """
 
@@ -1289,10 +1233,7 @@ db.Schema.Users.Query
     |> should
         equal
         """
-db
-    .Schema
-    .Users
-    .Query
+db.Schema.Users.Query
     .Where(fun x -> x.Role)
     .Matches(
         function
@@ -1300,10 +1241,7 @@ db
         | _ -> __
     )
     .In(
-        db
-            .Schema
-            .Companies
-            .Query
+        db.Schema.Companies.Query
             .Where(fun x -> x.LicenceId)
             .Equals(licenceId)
             .Select(fun x -> x.Id)
@@ -1356,11 +1294,8 @@ module Program =
         let builder = WebAssemblyHostBuilder.CreateDefault(args)
         builder.RootComponents.Add<Pages.Main.MyApp>("#main")
 
-        builder
-            .Services
-            .AddRemoting(
-                builder.HostEnvironment
-            )
+        builder.Services
+            .AddRemoting(builder.HostEnvironment)
             .Services
 #if (!DEBUG)
             .RemoveAll<Microsoft.Extensions.Http.IHttpMessageHandlerBuilderFilter>()

--- a/src/Fantomas.Core.Tests/DotGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotGetTests.fs
@@ -1338,6 +1338,8 @@ Assembly.GetExecutingAssembly().GetCustomAttribute<MyCustomAttribute>().SomeProp
     |> should
         equal
         """
-Assembly.GetExecutingAssembly().GetCustomAttribute<MyCustomAttribute>()
+Assembly
+    .GetExecutingAssembly()
+    .GetCustomAttribute<MyCustomAttribute>()
     .SomeProperty
 """

--- a/src/Fantomas.Core.Tests/DotIndexedGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotIndexedGetTests.fs
@@ -120,14 +120,14 @@ a.Some.Thing(
     |> should
         equal
         """
-a
-    .Some
+a.Some
     .Thing(
         "aaa",
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
     )
-    .Meh().[0]
+    .Meh()
+    .[0]
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -119,6 +119,7 @@
     <Compile Include="BaseConstructorTests.fs" />
     <Compile Include="DallasTests.fs" />
     <Compile Include="InlineTests.fs" />
+    <Compile Include="ChainTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Core\Fantomas.Core.fsproj" />

--- a/src/Fantomas.Core.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Core.Tests/IfThenElseTests.fs
@@ -2457,12 +2457,8 @@ module Foo =
 module Foo =
     let bar =
         if
-            Regex(
-                "long long long long long long long long long"
-            )
-                .Match(
-                s
-            )
+            Regex("long long long long long long long long long")
+                .Match(s)
                 .Success
         then
             None

--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -319,7 +319,8 @@ CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettin
         if hostedService then
             RoleEnvironment.GetConfigurationSettingValue(configName)
         else
-            ConfigurationManager.ConnectionStrings.[configName]
+            ConfigurationManager
+                .ConnectionStrings.[configName]
                 .ConnectionString
 
     configSettingPublisher.Invoke(connectionString)
@@ -1293,9 +1294,10 @@ type Item() =
 let items = [ Item(); Item(); Item() ]
 
 let firstOrDef =
-    items.FirstOrDefault(fun x ->
-        x.ValidFrom <= DateTime.Now
-        || x.ValidFrom > DateTime.Now)
+    items
+        .FirstOrDefault(fun x ->
+            x.ValidFrom <= DateTime.Now
+            || x.ValidFrom > DateTime.Now)
         .Value
 """
 

--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -1497,3 +1497,29 @@ let _ =
 b\"      )
     |> List.length
 "
+
+[<Test>]
+let ``lambda with generic argument in function identifier, 2699`` () =
+    formatSourceString
+        false
+        """
+MailboxProcessor<string>.Start
+    (fun inbox ->
+        async {
+            while true do
+                let! msg = inbox.Receive()
+                do! sw.WriteLineAsync(msg) |> Async.AwaitTask
+        })
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+MailboxProcessor<string>.Start(fun inbox ->
+    async {
+        while true do
+            let! msg = inbox.Receive()
+            do! sw.WriteLineAsync(msg) |> Async.AwaitTask
+    })
+"""

--- a/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -975,13 +975,10 @@ configuration
     |> should
         equal
         """
-configuration
-    .MinimumLevel
+configuration.MinimumLevel
     .Debug()
-    .WriteTo
-    .Logger(fun loggerConfiguration ->
-        loggerConfiguration
-            .Enrich
+    .WriteTo.Logger(fun loggerConfiguration ->
+        loggerConfiguration.Enrich
             .WithProperty("host", Environment.MachineName)
             .Enrich.WithProperty("user", Environment.UserName)
             .Enrich.WithProperty("application", context.HostingEnvironment.ApplicationName)
@@ -1006,8 +1003,7 @@ configuration
     |> should
         equal
         """
-configuration
-    .MinimumLevel
+configuration.MinimumLevel
     .Debug()
     .WriteTo.Logger(fun x -> x * x)
 """
@@ -1057,23 +1053,21 @@ configuration
     |> should
         equal
         """
-configuration
-    .MinimumLevel
+configuration.MinimumLevel
     .Debug()
-    .WriteTo
-    .Logger(fun
-                (a0: int)
-                (a1: int)
-                (a2: int)
-                (a3: int)
-                (a4: int)
-                (a5: int)
-                (a6: int)
-                (a7: int)
-                (a8: int)
-                (a9: int)
-                (a10: int)
-                (a11: int) ->
+    .WriteTo.Logger(fun
+                        (a0: int)
+                        (a1: int)
+                        (a2: int)
+                        (a3: int)
+                        (a4: int)
+                        (a5: int)
+                        (a6: int)
+                        (a7: int)
+                        (a8: int)
+                        (a9: int)
+                        (a10: int)
+                        (a11: int) ->
         //
         ()
     )

--- a/src/Fantomas.Core.Tests/RecordTests.fs
+++ b/src/Fantomas.Core.Tests/RecordTests.fs
@@ -442,10 +442,11 @@ let ``meaningful space should be preserved, 353`` () =
     |> should
         equal
         """
-to'.WithCommon(fun o' ->
-    { dotnetOptions o' with
-        WorkingDirectory = Path.getFullName "RegressionTesting/issue29"
-        Verbosity = Some DotNet.Verbosity.Minimal })
+to'
+    .WithCommon(fun o' ->
+        { dotnetOptions o' with
+            WorkingDirectory = Path.getFullName "RegressionTesting/issue29"
+            Verbosity = Some DotNet.Verbosity.Minimal })
     .WithParameters
 """
 
@@ -543,8 +544,7 @@ I wanted to know why you created Fable. Did you always plan to use F#? Or were y
 type Database =
 
     static member Default() =
-        Database
-            .Lowdb
+        Database.Lowdb
             .defaults(
                 { Version = CurrentVersion
                   Questions =

--- a/src/Fantomas.Core.Tests/SpaceBeforeUppercaseInvocationTests.fs
+++ b/src/Fantomas.Core.Tests/SpaceBeforeUppercaseInvocationTests.fs
@@ -342,3 +342,18 @@ module A =
             .ABC()
             .XYZ
 """
+
+[<Test>]
+let ``typeApp with dotGet and paren expr, 2700`` () =
+    formatSourceString
+        false
+        """
+let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (mapping)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(mapping)
+"""

--- a/src/Fantomas.Core.Tests/SpaceBeforeUppercaseInvocationTests.fs
+++ b/src/Fantomas.Core.Tests/SpaceBeforeUppercaseInvocationTests.fs
@@ -62,15 +62,7 @@ let x = DateTimeOffset(2017,6,1,10,3,14,TimeSpan(1,30,0)).LocalDateTime
         equal
         """
 let x =
-    DateTimeOffset(
-        2017,
-        6,
-        1,
-        10,
-        3,
-        14,
-        TimeSpan (1, 30, 0)
-    )
+    DateTimeOffset(2017, 6, 1, 10, 3, 14, TimeSpan (1, 30, 0))
         .LocalDateTime
 """
 
@@ -317,4 +309,36 @@ match x with
 | b.C () -> ()
 | D (e = f) -> ()
 | g.H (i = j) -> ()
+"""
+
+[<Test>]
+let ``never add a space before paren lambda in chain, 2685`` () =
+    formatSourceString
+        false
+        """
+module A =
+    let foo =
+        Foai.SomeLongTextYikes().ConfigureBarry(fun alpha beta gamma ->
+            context.AddSomething ("a string") |> ignore
+        ).MoreContext(fun builder ->
+            // also good stuff
+            ()
+        ).ABC().XYZ
+
+"""
+        spaceBeforeConfig
+    |> prepend newline
+    |> should
+        equal
+        """
+module A =
+    let foo =
+        Foai
+            .SomeLongTextYikes()
+            .ConfigureBarry(fun alpha beta gamma -> context.AddSomething ("a string") |> ignore)
+            .MoreContext(fun builder ->
+                // also good stuff
+                ())
+            .ABC()
+            .XYZ
 """

--- a/src/Fantomas.Core.Tests/SpecialConstructsTests.fs
+++ b/src/Fantomas.Core.Tests/SpecialConstructsTests.fs
@@ -22,7 +22,8 @@ let inline private retype<'T, 'U> (x: 'T) : 'U = (# "" x : 'U #)
 let ``don't add whitespace in chained accessors, 566`` () =
     formatSourceString
         false
-        """type F =
+        """
+type F =
   abstract G : int list -> Map<int, int>
 
 let x : F = { new F with member __.G _ = Map.empty }

--- a/src/Fantomas.Core.Tests/TestHelpers.fs
+++ b/src/Fantomas.Core.Tests/TestHelpers.fs
@@ -35,10 +35,10 @@ let formatSourceString isFsiFile (s: string) config =
 
                 CodeFormatter.FormatASTAsync(ast, config = config)
 
-        // let! isValid = CodeFormatter.IsValidFSharpCodeAsync(isFsiFile, formatted)
-        //
-        // if not isValid then
-        //     failwithf $"The formatted result is not valid F# code or contains warnings\n%s{formatted}"
+        let! isValid = CodeFormatter.IsValidFSharpCodeAsync(isFsiFile, formatted)
+
+        if not isValid then
+            failwithf $"The formatted result is not valid F# code or contains warnings\n%s{formatted}"
 
         return formatted.Replace("\r\n", "\n")
     }

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -824,7 +824,8 @@ type BlobHelper(Account: CloudStorageAccount) =
                 if hostedService then
                     RoleEnvironment.GetConfigurationSettingValue(configName)
                 else
-                    ConfigurationManager.ConnectionStrings.[configName]
+                    ConfigurationManager
+                        .ConnectionStrings.[configName]
                         .ConnectionString
 
             configSettingPublisher.Invoke(connectionString)

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -840,6 +840,13 @@ let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list option =
         | other -> continuation [ LinkExpr.Expr other ]
 
     match e with
+    // An identifier only application with a parenthesis lambda expression.
+    // ex: `List.map (fun n -> n)` or `MailboxProcessor<string>.Start (fun n -> n)
+    // Because the identifier is not complex we don't consider it a chain.
+    | SynExpr.App(
+        isInfix = false
+        funcExpr = SynExpr.LongIdent _ | SynExpr.Ident _ | SynExpr.DotGet(expr = SynExpr.TypeApp(expr = SynExpr.Ident _))
+        argExpr = ParenExpr(_, SynExpr.Lambda _, _, _)) -> None
     | SynExpr.App(
         isInfix = false
         funcExpr = SynExpr.DotGet _ | SynExpr.TypeApp(expr = SynExpr.DotGet _)

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -1184,23 +1184,6 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
     | AppSingleParenArg(e, px) ->
         ExprAppSingleParenArgNode(mkExpr creationAide e, mkExpr creationAide px, exprRange)
         |> Expr.AppSingleParenArg
-    | SynExpr.DotGet(
-        expr = SynExpr.App(funcExpr = App(fe, args); argExpr = ParenLambda(lpr, pats, mArrow, body, mLambda, rpr))
-        longDotId = lid) ->
-        let lambdaNode = mkLambda creationAide pats mArrow body mLambda
-
-        let appWithLambdaNode =
-            ExprAppWithLambdaNode(
-                mkExpr creationAide fe,
-                List.map (mkExpr creationAide) args,
-                stn "(" lpr,
-                Choice1Of2 lambdaNode,
-                stn ")" rpr,
-                exprRange
-            )
-
-        ExprDotGetAppWithLambdaNode(appWithLambdaNode, mkSynLongIdent lid, exprRange)
-        |> Expr.DotGetAppWithLambda
 
     | SynExpr.App(funcExpr = App(fe, args); argExpr = ParenLambda(lpr, pats, mArrow, body, mLambda, rpr)) ->
         let lambdaNode = mkLambda creationAide pats mArrow body mLambda

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1200,13 +1200,6 @@ let genExpr (e: Expr) =
         expressionFitsOnRestOfLine short long |> genNode node
 
     // functionName arg1 arg2 (fun x y z -> ...)
-    | Expr.DotGetAppWithLambda node ->
-        leadingExpressionIsMultiline (genAppWithLambda sepNone node.AppWithLambda) (fun isMultiline ->
-            if isMultiline then
-                (indent +> sepNln +> genIdentListNodeWithDotMultiline node.Property +> unindent)
-            else
-                genIdentListNodeWithDot node.Property)
-        |> genNode node
     | Expr.AppWithLambda node ->
         let sepSpaceAfterFunctionName =
             match node.Arguments with

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -240,9 +240,6 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ExprAppSingleParenArgNode as node ->
         let expr = Expr.AppSingleParenArg node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprDotGetAppWithLambdaNode as node ->
-        let expr = Expr.DotGetAppWithLambda node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprAppWithLambdaNode as node ->
         let expr = Expr.AppWithLambda node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -231,20 +231,8 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ExprIndexWithoutDotNode as node ->
         let expr = Expr.IndexWithoutDot node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprAppDotGetTypeAppNode as node ->
-        let expr = Expr.AppDotGetTypeApp node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprDotGetAppDotGetAppParenLambdaNode as node ->
-        let expr = Expr.DotGetAppDotGetAppParenLambda node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprDotGetAppParenNode as node ->
-        let expr = Expr.DotGetAppParen node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprDotGetAppWithParenLambdaNode as node ->
-        let expr = Expr.DotGetAppWithParenLambda node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprDotGetAppNode as node ->
-        let expr = Expr.DotGetApp node
+    | :? ExprChain as node ->
+        let expr = Expr.Chain node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprAppLongIdentAndSingleParenArgNode as node ->
         let expr = Expr.AppLongIdentAndSingleParenArg node
@@ -308,9 +296,6 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprDotNamedIndexedPropertySetNode as node ->
         let expr = Expr.DotNamedIndexedPropertySet node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprDotGetNode as node ->
-        let expr = Expr.DotGet node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprDotSetNode as node ->
         let expr = Expr.DotSet node

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1152,88 +1152,43 @@ type ExprIndexWithoutDotNode(identifierExpr: Expr, indexExpr: Expr, range) =
     member x.Identifier = identifierExpr
     member x.Index = indexExpr
 
-type ExprAppDotGetTypeAppNode(typeApp: ExprTypeAppNode, property: IdentListNode, arguments: Expr list, range) =
+type LinkSingleAppParen(functionName: Expr, parenExpr: ExprParenNode, range) =
     inherit NodeBase(range)
+    override this.Children = [| yield Expr.Node functionName; yield parenExpr |]
+    member x.FunctionName = functionName
+    member x.Paren = parenExpr
 
-    override this.Children =
-        [| yield typeApp; yield property; yield! List.map Expr.Node arguments |]
-
-    member x.TypeApp = typeApp
-    member x.Property = property
-    member x.Arguments = arguments
-
-type ExprDotGetAppDotGetAppParenLambdaNode
-    (
-        identifierExpr: Expr,
-        identifierArgExpr: Expr,
-        appLids: IdentListNode,
-        es: Expr list,
-        property: IdentListNode,
-        range
-    ) =
+type LinkSingleAppUnit(functionName: Expr, unit: UnitNode, range) =
     inherit NodeBase(range)
+    override this.Children = [| yield Expr.Node functionName; yield unit |]
+    member x.FunctionName = functionName
+    member x.Unit = unit
 
-    override this.Children =
-        [| yield Expr.Node identifierExpr
-           yield Expr.Node identifierArgExpr
-           yield appLids
-           yield! List.map Expr.Node es
-           yield property |]
+[<RequireQualifiedAccess>]
+type ChainLink =
+    | Identifier of Expr
+    | Dot of SingleTextNode
+    | Expr of Expr
+    | AppParen of
+        // There should only be one argument
+        LinkSingleAppParen
+    | AppUnit of LinkSingleAppUnit
+    // [ expr ] from DotIndexedGet
+    | IndexExpr of Expr // e.[f]
 
-    member x.Identifier = identifierExpr
-    member x.IdentifierArg = identifierArgExpr
-    member x.AppLids = appLids
-    member x.Args = es
-    member x.Property = property
+    static member Node(link: ChainLink) : Node =
+        match link with
+        | Identifier e -> Expr.Node e
+        | Dot n -> n
+        | Expr e -> Expr.Node e
+        | AppParen n -> n
+        | AppUnit n -> n
+        | IndexExpr e -> Expr.Node e
 
-type ExprDotGetAppParenNode(funcExpr: Expr, parenExpr: Expr, property: IdentListNode, range) =
+type ExprChain(links: ChainLink list, range) =
     inherit NodeBase(range)
-
-    override this.Children =
-        [| yield Expr.Node funcExpr; yield Expr.Node parenExpr; yield property |]
-
-    member x.Function = funcExpr
-    member x.ParenArg = parenExpr
-    member x.Property = property
-
-type DotGetAppPartNode
-    (
-        identifier: IdentListNode,
-        typeParameterInfo: (SingleTextNode * Type list * SingleTextNode) option,
-        expr: Expr,
-        range: range
-    ) =
-    inherit NodeBase(range)
-
-    override this.Children =
-        let typeParameterInfoNodes =
-            match typeParameterInfo with
-            | None -> [||]
-            | Some(lt, ts, gt) -> [| yield (lt :> Node); yield! List.map Type.Node ts; yield gt |]
-
-        [| yield identifier; yield! typeParameterInfoNodes; yield Expr.Node expr |]
-
-    member x.Identifier = identifier
-    member x.TypeParameterInfo = typeParameterInfo
-    member x.Expr = expr
-
-type ExprDotGetAppWithParenLambdaNode
-    (funcExpr: Expr, parenLambda: ExprParenLambdaNode, args: DotGetAppPartNode list, range) =
-    inherit NodeBase(range)
-
-    override this.Children =
-        [| yield Expr.Node funcExpr; yield parenLambda; yield! nodes args |]
-
-    member x.Function = funcExpr
-    member x.ParenLambda = parenLambda
-    member x.Arguments = args
-
-type ExprDotGetAppNode(funcExpr: Expr, args: DotGetAppPartNode list, range) =
-    inherit NodeBase(range)
-
-    override this.Children = [| yield Expr.Node funcExpr; yield! nodes args |]
-    member x.FunctionExpr = funcExpr
-    member x.Arguments = args
+    override this.Children = List.map ChainLink.Node links |> List.toArray
+    member x.Links = links
 
 type ExprAppLongIdentAndSingleParenArgNode(functionName: IdentListNode, argExpr: Expr, range) =
     inherit NodeBase(range)
@@ -1577,12 +1532,6 @@ type ExprDotNamedIndexedPropertySetNode
     member x.Property = propertyExpr
     member x.Set = setExpr
 
-type ExprDotGetNode(expr: Expr, identifier: IdentListNode, range) =
-    inherit NodeBase(range)
-    override this.Children = [| yield Expr.Node expr; yield identifier |]
-    member x.Expr = expr
-    member x.Identifier = identifier
-
 type ExprDotSetNode(identifier: Expr, property: IdentListNode, setExpr: Expr, range) =
     inherit NodeBase(range)
 
@@ -1724,11 +1673,6 @@ type Expr =
     | SameInfixApps of ExprSameInfixAppsNode
     | InfixApp of ExprInfixAppNode
     | IndexWithoutDot of ExprIndexWithoutDotNode
-    | AppDotGetTypeApp of ExprAppDotGetTypeAppNode
-    | DotGetAppDotGetAppParenLambda of ExprDotGetAppDotGetAppParenLambdaNode
-    | DotGetAppParen of ExprDotGetAppParenNode
-    | DotGetAppWithParenLambda of ExprDotGetAppWithParenLambdaNode
-    | DotGetApp of ExprDotGetAppNode
     | AppLongIdentAndSingleParenArg of ExprAppLongIdentAndSingleParenArgNode
     | AppSingleParenArg of ExprAppSingleParenArgNode
     | DotGetAppWithLambda of ExprDotGetAppWithLambdaNode
@@ -1751,7 +1695,6 @@ type Expr =
     | DotIndexedSet of ExprDotIndexedSetNode
     | NamedIndexedPropertySet of ExprNamedIndexedPropertySetNode
     | DotNamedIndexedPropertySet of ExprDotNamedIndexedPropertySetNode
-    | DotGet of ExprDotGetNode
     | DotSet of ExprDotSetNode
     | Set of ExprSetNode
     | LibraryOnlyStaticOptimization of ExprLibraryOnlyStaticOptimizationNode
@@ -1761,6 +1704,7 @@ type Expr =
     | IndexRange of ExprIndexRangeNode
     | IndexFromEnd of ExprIndexFromEndNode
     | Typar of SingleTextNode
+    | Chain of ExprChain
 
     static member Node(x: Expr) : Node =
         match x with
@@ -1797,11 +1741,6 @@ type Expr =
         | SameInfixApps n -> n
         | InfixApp n -> n
         | IndexWithoutDot n -> n
-        | AppDotGetTypeApp n -> n
-        | DotGetAppDotGetAppParenLambda n -> n
-        | DotGetAppParen n -> n
-        | DotGetAppWithParenLambda n -> n
-        | DotGetApp n -> n
         | AppLongIdentAndSingleParenArg n -> n
         | AppSingleParenArg n -> n
         | DotGetAppWithLambda n -> n
@@ -1824,7 +1763,6 @@ type Expr =
         | DotIndexedSet n -> n
         | NamedIndexedPropertySet n -> n
         | DotNamedIndexedPropertySet n -> n
-        | DotGet n -> n
         | DotSet n -> n
         | Set n -> n
         | LibraryOnlyStaticOptimization n -> n
@@ -1834,6 +1772,7 @@ type Expr =
         | IndexRange n -> n
         | IndexFromEnd n -> n
         | Typar n -> n
+        | Chain n -> n
 
     member e.IsStroustrupStyleExpr: bool =
         match e with

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1203,13 +1203,6 @@ type ExprAppSingleParenArgNode(functionExpr: Expr, argExpr: Expr, range) =
     member x.FunctionExpr = functionExpr
     member x.ArgExpr = argExpr
 
-type ExprDotGetAppWithLambdaNode(appWithLambda: ExprAppWithLambdaNode, property: IdentListNode, range) =
-    inherit NodeBase(range)
-
-    override this.Children = [| yield appWithLambda; yield property |]
-    member x.AppWithLambda = appWithLambda
-    member x.Property = property
-
 type ExprAppWithLambdaNode
     (
         functionName: Expr,
@@ -1675,7 +1668,6 @@ type Expr =
     | IndexWithoutDot of ExprIndexWithoutDotNode
     | AppLongIdentAndSingleParenArg of ExprAppLongIdentAndSingleParenArgNode
     | AppSingleParenArg of ExprAppSingleParenArgNode
-    | DotGetAppWithLambda of ExprDotGetAppWithLambdaNode
     | AppWithLambda of ExprAppWithLambdaNode
     | NestedIndexWithoutDot of ExprNestedIndexWithoutDotNode
     | EndsWithDualListApp of ExprEndsWithDualListAppNode
@@ -1743,7 +1735,6 @@ type Expr =
         | IndexWithoutDot n -> n
         | AppLongIdentAndSingleParenArg n -> n
         | AppSingleParenArg n -> n
-        | DotGetAppWithLambda n -> n
         | AppWithLambda n -> n
         | NestedIndexWithoutDot n -> n
         | EndsWithDualListApp n -> n


### PR DESCRIPTION
An attempt to address https://github.com/fsharp/fslang-design/issues/688.
This is merely a suggestion on how to provide guidance. Nothing has been decided so far.

The gist of this PR is that everything that is `SynExpr.DotGet` related is being converted to an `Expr.Chain`. A `ChainNode` consists of links. Each link is either a dot or something between a dot.

Examples:
```fsharp
A.B.C().D
E.F(fun g -> g).H
I<j>().K[0].L(m,n,o).P
``` 

The expression between a dot could be multiple things:
- An identifier such as `A` or `A<b>`
- An application with unit `A()`
- An application with a parenthesis expression `A(b)` (including lambdas `A(fun b -> b)`)
- An index expression `.[A]`

Capturing all these different F# AST shapes into one unified model is already a big win.
A lot of very selective AST combinations can now easily be replaced with this. Regardless of the what the style will end up being.