### PR TITLE
Consider TypeApp as Identifier in mkLinksFromFunctionName.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Type app identifier is considered as an expression. [#2705](https://github.com/fsprojects/fantomas/issues/2705)
+
 ## [5.2.0-alpha-011] - 2023-01-12
 
 ### Fixed 

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -280,3 +280,22 @@ builder
     .ThirdThing<Z>()
     .X
 """
+
+[<Test>]
+let ``leading type app with two identifiers, 2705`` () =
+    formatSourceString
+        false
+        """
+Map
+    .empty<_, obj>
+    .Add("headerAction", modifyHeader.Action.ArmValue)
+"""
+        { config with
+            MaxDotGetExpressionWidth = 0 }
+    |> prepend newline
+    |> should
+        equal
+        """
+Map.empty<_, obj>
+    .Add("headerAction", modifyHeader.Action.ArmValue)
+"""

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -824,7 +824,7 @@ let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list option =
                 let leftLinks = List.take (leftLinks.Length - 1) leftLinks
                 continuation [ yield! leftLinks; yield! app ])
 
-        | SynExpr.TypeApp _ as typeApp -> mkLinksFromFunctionName LinkExpr.Expr typeApp |> continuation
+        | SynExpr.TypeApp _ as typeApp -> mkLinksFromFunctionName LinkExpr.Identifier typeApp |> continuation
 
         | SynExpr.LongIdent(longDotId = sli) -> continuation (mkLinksFromSynLongIdent sli)
 


### PR DESCRIPTION
Fixes #2705