### PR TITLE
Keep Subsequent identifier links on the same line.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 * Trivia before open statement is not preserved. [#2704](https://github.com/fsprojects/fantomas/issues/2704)
 * Type app identifier is considered as an expression. [#2705](https://github.com/fsprojects/fantomas/issues/2705)
+* Subsequent identifier links in chain should be on the same line. [#2712](https://github.com/fsprojects/fantomas/issues/2712)
 
 ## [5.2.0-alpha-011] - 2023-01-12
 

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -340,11 +340,34 @@ let ``very long chain with a some index expressions`` () =
 Universe.Galaxy.SolarSystem.Planet.[3].Countries.[9].People.Count
 """
         { config with
-            MaxDotGetExpressionWidth = 0 }
+            MaxDotGetExpressionWidth = 0
+            MaxLineLength = 50 }
     |> prepend newline
     |> should
         equal
         """
-Universe
-    .Galaxy.SolarSystem.Planet.[3].Countries.[9].People.Count
+Universe.Galaxy.SolarSystem.Planet.[3].Countries
+    .[9].People.Count
+"""
+
+[<Test>]
+let ``Even longer chain with only simple links`` () =
+    formatSourceString
+        false
+        """
+Fooooooooooo.Baaaaaaaaaaaaaaaaar.Foooooooooooooooooo.Baaaaaaaar.Basssss.Baazzzzzzzzzzzzzzzzzz.[0].Meeeeeeeeeeeeeeeeeh
+    .Moooooooooooooooo.Booooooooooooooooooooh.Yooooooooooooooou.Meeeeeeh.Meh2
+"""
+        { config with
+            MaxDotGetExpressionWidth = 0
+            MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+Fooooooooooo.Baaaaaaaaaaaaaaaaar
+    .Foooooooooooooooooo.Baaaaaaaar.Basssss
+    .Baazzzzzzzzzzzzzzzzzz.[0].Meeeeeeeeeeeeeeeeeh
+    .Moooooooooooooooo.Booooooooooooooooooooh
+    .Yooooooooooooooou.Meeeeeeh.Meh2
 """

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -299,3 +299,52 @@ Map
 Map.empty<_, obj>
     .Add("headerAction", modifyHeader.Action.ArmValue)
 """
+
+[<Test>]
+let ``all simple links should be on the same line, 2712`` () =
+    formatSourceString
+        false
+        """
+type Duck() =
+    member this.Duck  = Duck ()
+    member this.Goose() = Duck()
+    
+let d = Duck()
+
+d.Duck.Duck.Duck.Goose().Duck.Goose().Duck.Duck.Goose().Duck.Duck.Duck.Goose().Duck.Duck.Duck.Duck.Goose()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Duck() =
+    member this.Duck = Duck()
+    member this.Goose() = Duck()
+
+let d = Duck()
+
+d.Duck.Duck.Duck
+    .Goose()
+    .Duck.Goose()
+    .Duck.Duck.Goose()
+    .Duck.Duck.Duck.Goose()
+    .Duck.Duck.Duck.Duck.Goose()
+"""
+
+[<Test>]
+let ``very long chain with a some index expressions`` () =
+    formatSourceString
+        false
+        """
+Universe.Galaxy.SolarSystem.Planet.[3].Countries.[9].People.Count
+"""
+        { config with
+            MaxDotGetExpressionWidth = 0 }
+    |> prepend newline
+    |> should
+        equal
+        """
+Universe
+    .Galaxy.SolarSystem.Planet.[3].Countries.[9].People.Count
+"""

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -351,7 +351,7 @@ Universe.Galaxy.SolarSystem.Planet.[3].Countries
 """
 
 [<Test>]
-let ``Even longer chain with only simple links`` () =
+let ``even longer chain with only simple links`` () =
     formatSourceString
         false
         """

--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -320,8 +320,7 @@ CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettin
             RoleEnvironment.GetConfigurationSettingValue(configName)
         else
             ConfigurationManager
-                .ConnectionStrings.[configName]
-                .ConnectionString
+                .ConnectionStrings.[configName].ConnectionString
 
     configSettingPublisher.Invoke(connectionString)
     |> ignore)

--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -319,8 +319,7 @@ CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettin
         if hostedService then
             RoleEnvironment.GetConfigurationSettingValue(configName)
         else
-            ConfigurationManager
-                .ConnectionStrings.[configName].ConnectionString
+            ConfigurationManager.ConnectionStrings.[configName].ConnectionString
 
     configSettingPublisher.Invoke(connectionString)
     |> ignore)

--- a/src/Fantomas.Core.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Core.Tests/LetBindingTests.fs
@@ -1078,9 +1078,7 @@ let ``don't add additional newline before SynExpr.New, 1049`` () =
         """
 let getVersion () =
     let version =
-        let assembly =
-            typeof<FSharp.Compiler.SourceCodeServices.FSharpChecker>
-                .Assembly
+        let assembly = typeof<FSharp.Compiler.SourceCodeServices.FSharpChecker>.Assembly
 
         let version = assembly.GetName().Version
         sprintf "%i.%i.%i" version.Major version.Minor version.Revision
@@ -1252,8 +1250,7 @@ let x =
            if tcref.IsILTycon then
                tcref.ILTyconRawMetadata.CustomAttrs.AsArray
                |> Array.exists (fun attr ->
-                   attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>
-                       .FullName)
+                   attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>.FullName)
            else
                false
 """
@@ -1315,8 +1312,7 @@ let x =
            if tcref.IsILTycon then
                tcref.ILTyconRawMetadata.CustomAttrs.AsArray
                |> Array.exists (fun attr ->
-                   attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>
-                       .FullName)
+                   attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>.FullName)
            else
                false
 """

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -824,8 +824,7 @@ type BlobHelper(Account: CloudStorageAccount) =
                 if hostedService then
                     RoleEnvironment.GetConfigurationSettingValue(configName)
                 else
-                    ConfigurationManager
-                        .ConnectionStrings.[configName].ConnectionString
+                    ConfigurationManager.ConnectionStrings.[configName].ConnectionString
 
             configSettingPublisher.Invoke(connectionString)
             |> ignore)

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -825,8 +825,7 @@ type BlobHelper(Account: CloudStorageAccount) =
                     RoleEnvironment.GetConfigurationSettingValue(configName)
                 else
                     ConfigurationManager
-                        .ConnectionStrings.[configName]
-                        .ConnectionString
+                        .ConnectionStrings.[configName].ConnectionString
 
             configSettingPublisher.Invoke(connectionString)
             |> ignore)

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1093,22 +1093,26 @@ let genExpr (e: Expr) =
                     let isLast = List.isEmpty rest
                     let genDotAndLink = genSingleTextNode dot +> genLink isLast link
                     let currentIsSimple = ((|SimpleChain|_|) >> Option.isSome) link
+                    let currentLinkFitsOnRestOfLine = not (futureNlnCheck genDotAndLink ctx)
 
-                    if lastLinkWasSimple && not (futureNlnCheck genDotAndLink ctx) then
+                    if lastLinkWasSimple && currentLinkFitsOnRestOfLine then
                         // The last link was an identifier and the current link fits on the remainder of the current line.
                         genIndentedLinks currentIsSimple rest (genDotAndLink ctx)
                     else
-                        let ctx' = onlyIfNot lastLinkWasSimple sepNlnUnlessLastEventIsNewline ctx
+                        let ctx' =
+                            onlyIf
+                                (not // Last link was `.Foo()`
+                                    lastLinkWasSimple
+                                 // `.Foo.Bar` but `Bar` crossed the max_line_length
+                                 || (lastLinkWasSimple && currentIsSimple && not currentLinkFitsOnRestOfLine))
+                                sepNlnUnlessLastEventIsNewline
+                                ctx
 
                         genIndentedLinks
                             currentIsSimple
                             rest
                             // Print the current link
-                            ((genDotAndLink
-                              // Don't suffix with a newline if we are at the end of the chain,
-                              // or if the current link is an identifier.
-                              +> onlyIfNot (isLast || currentIsSimple) sepNln)
-                                ctx')
+                            (genDotAndLink ctx')
                 | _ -> failwith "Expected dot in chain at this point"
 
             let genFirstLinkAndIndentOther (firstLink: ChainLink) (others: ChainLink list) =
@@ -1125,7 +1129,7 @@ let genExpr (e: Expr) =
                             short
                             (match leadingChain with
                              | [] -> sepNone
-                             | head :: links -> genFirstLinkAndIndentOther head links)
+                             | head :: links -> genLink false head +> indent +> genIndentedLinks true links +> unindent)
                             ctx
                 | _ ->
                     expressionFitsOnRestOfLine

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1096,8 +1096,10 @@ let genExpr (e: Expr) =
 
                     if lastLinkWasSimple && not (futureNlnCheck genDotAndLink ctx) then
                         // The last link was an identifier and the current link fits on the remainder of the current line.
-                        genIndentedLinks currentIsSimple rest ((genDotAndLink +> onlyIfNot isLast sepNln) ctx)
+                        genIndentedLinks currentIsSimple rest (genDotAndLink ctx)
                     else
+                        let ctx' = onlyIfNot lastLinkWasSimple sepNlnUnlessLastEventIsNewline ctx
+
                         genIndentedLinks
                             currentIsSimple
                             rest
@@ -1106,7 +1108,7 @@ let genExpr (e: Expr) =
                               // Don't suffix with a newline if we are at the end of the chain,
                               // or if the current link is an identifier.
                               +> onlyIfNot (isLast || currentIsSimple) sepNln)
-                                ctx)
+                                ctx')
                 | _ -> failwith "Expected dot in chain at this point"
 
             let genFirstLinkAndIndentOther (firstLink: ChainLink) (others: ChainLink list) =


### PR DESCRIPTION
Fixes #2712.