### PR TITLE
Refactor ExprEndsWithDualListAppNode and ExprEndsWithSingleListAppNode

### DIFF
--- a/src/Fantomas.Core.Tests/ASTTransformerTests.fs
+++ b/src/Fantomas.Core.Tests/ASTTransformerTests.fs
@@ -59,5 +59,5 @@ let ``avoid stack-overflow in long array/list, 2485`` () =
             )
         )
 
-    let _rootNode = ASTTransformer.mkOak FormatConfig.Default None ast
+    let _rootNode = ASTTransformer.mkOak None ast
     Assert.Pass()

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -7,15 +7,13 @@ open FSharp.Compiler.Text.Range
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTrivia
 open FSharp.Compiler.Xml
-open Fantomas.Core.FormatConfig
 open Fantomas.Core.ISourceTextExtensions
 open Fantomas.Core.RangePatterns
 open Fantomas.Core.SyntaxOak
 open Microsoft.FSharp.Core
 
 type CreationAide =
-    { SourceText: ISourceText option
-      Config: FormatConfig }
+    { SourceText: ISourceText option }
 
     member x.TextFromSource fallback range =
         match x.SourceText with
@@ -213,51 +211,6 @@ let (|Sequentials|_|) e =
         let xs = visit e2 id
         Some(e1 :: xs)
     | _ -> None
-
-let (|EndsWithSingleListAppExpr|_|) (isStroustrup: bool) (e: SynExpr) =
-    if not isStroustrup then
-        None
-    else
-        match e with
-        | SynExpr.App(ExprAtomicFlag.NonAtomic,
-                      false,
-                      (SynExpr.App _ as funcExpr),
-                      (SynExpr.ArrayOrList _ | SynExpr.ArrayOrListComputed _ as lastArg),
-                      _) ->
-            let rec collectApplicationArgument (e: SynExpr) (continuation: SynExpr seq -> SynExpr seq) =
-                match e with
-                | SynExpr.App(ExprAtomicFlag.NonAtomic, false, (SynExpr.App _ as funcExpr), argExpr, _) ->
-                    collectApplicationArgument funcExpr (fun es ->
-                        seq {
-                            yield! es
-                            yield argExpr
-                        }
-                        |> continuation)
-                | SynExpr.App(ExprAtomicFlag.NonAtomic, false, funcNameExpr, ae, _) ->
-                    let args = Seq.toList (continuation (Seq.singleton ae))
-
-                    Some(funcNameExpr, args, lastArg)
-                | _ -> None
-
-            collectApplicationArgument funcExpr id
-        | SynExpr.App(ExprAtomicFlag.NonAtomic,
-                      false,
-                      funcExpr,
-                      (SynExpr.ArrayOrList _ | SynExpr.ArrayOrListComputed _ as lastArg),
-                      _) -> Some(funcExpr, [], lastArg)
-        | _ -> None
-
-let (|EndsWithDualListAppExpr|_|) (isStroustrup: bool) (e: SynExpr) =
-    if not isStroustrup then
-        None
-    else
-        match e with
-        | SynExpr.App(ExprAtomicFlag.NonAtomic,
-                      false,
-                      EndsWithSingleListAppExpr isStroustrup (e, es, lastButOneArg),
-                      (SynExpr.ArrayOrList _ | SynExpr.ArrayOrListComputed _ as lastArg),
-                      _) -> Some(e, es, lastButOneArg, lastArg)
-        | _ -> None
 
 let mkOpenAndCloseForArrayOrList isArray range =
     if isArray then
@@ -1261,25 +1214,6 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
         )
         |> Expr.NestedIndexWithoutDot
 
-    | EndsWithDualListAppExpr creationAide.Config.ExperimentalStroustrupStyle (e, es, firstList, lastList) ->
-        ExprEndsWithDualListAppNode(
-            mkExpr creationAide e,
-            List.map (mkExpr creationAide) es,
-            mkExpr creationAide firstList,
-            mkExpr creationAide lastList,
-            exprRange
-        )
-        |> Expr.EndsWithDualListApp
-    | EndsWithSingleListAppExpr creationAide.Config.ExperimentalStroustrupStyle (e, es, aol) ->
-        ExprEndsWithSingleListAppNode(
-            mkExpr creationAide e,
-            List.map (mkExpr creationAide) es,
-            mkExpr creationAide aol,
-            exprRange
-        )
-        |> Expr.EndsWithSingleListApp
-
-    // | Expr.App _ -> failwith "Not Implemented"
     | App(fe, args) ->
         ExprAppNode(mkExpr creationAide fe, List.map (mkExpr creationAide) args, exprRange)
         |> Expr.App
@@ -3354,10 +3288,8 @@ let mkFullTreeRange ast =
         let astRange = unionRanges startPos endPos
         includeTrivia astRange trivia.CodeComments trivia.ConditionalDirectives
 
-let mkOak (config: FormatConfig) (sourceText: ISourceText option) (ast: ParsedInput) =
-    let creationAide =
-        { SourceText = sourceText
-          Config = config }
+let mkOak (sourceText: ISourceText option) (ast: ParsedInput) =
+    let creationAide = { SourceText = sourceText }
 
     let fullRange = mkFullTreeRange ast
 

--- a/src/Fantomas.Core/ASTTransformer.fsi
+++ b/src/Fantomas.Core/ASTTransformer.fsi
@@ -2,7 +2,6 @@ module internal Fantomas.Core.ASTTransformer
 
 open FSharp.Compiler.Text
 open FSharp.Compiler.Syntax
-open Fantomas.Core.FormatConfig
 open Fantomas.Core.SyntaxOak
 
-val mkOak: config: FormatConfig -> sourceText: ISourceText option -> ast: ParsedInput -> Oak
+val mkOak: sourceText: ISourceText option -> ast: ParsedInput -> Oak

--- a/src/Fantomas.Core/CodeFormatterImpl.fs
+++ b/src/Fantomas.Core/CodeFormatterImpl.fs
@@ -59,9 +59,9 @@ let formatAST (ast: ParsedInput) (sourceText: ISourceText option) (config: Forma
 
         let fileNode =
             match sourceText with
-            | None -> ASTTransformer.mkOak config None ast
+            | None -> ASTTransformer.mkOak None ast
             | Some sourceText ->
-                ASTTransformer.mkOak config (Some sourceText) ast
+                ASTTransformer.mkOak (Some sourceText) ast
                 |> Trivia.enrichTree config sourceText ast
 
         context |> CodePrinter.genFile fileNode |> Context.dump false

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -4,6 +4,7 @@ open System
 open Fantomas.Core.Context
 open Fantomas.Core.SyntaxOak
 open Fantomas.Core.FormatConfig
+open Microsoft.FSharp.Core.CompilerServices
 
 let noBreakInfixOps = set [| "="; ">"; "<"; "%" |]
 let newLineInfixOps = set [ "|>"; "||>"; "|||>"; ">>"; ">>=" ]
@@ -1243,100 +1244,100 @@ let genExpr (e: Expr) =
         +> sepCloseLFixed
         +> genExpr node.Argument
         |> genNode node
-    | Expr.EndsWithDualListApp node ->
+
+    | Expr.App node ->
         fun ctx ->
-            // check if everything else beside the last array/list fits on one line
-            let singleLineTestExpr =
-                genExpr node.FunctionExpr
-                +> sepSpace
-                +> col sepSpace node.SequentialExpr genExpr
-                +> sepSpace
-                +> genExpr node.FirstArrayOrList
-
-            let short =
-                genExpr node.FunctionExpr
-                +> sepSpace
-                +> col sepSpace node.SequentialExpr genExpr
-                +> onlyIfNot node.SequentialExpr.IsEmpty sepSpace
-                +> genExpr node.FirstArrayOrList
-                +> sepSpace
-                +> genExpr node.LastArrayOrList
-
-            let long =
-                // check if everything besides both lists fits on one line
+            match node with
+            | EndsWithDualListApp ctx.Config (sequentialArgs: Expr list, firstList, lastList) ->
+                // check if everything else beside the last array/list fits on one line
                 let singleLineTestExpr =
                     genExpr node.FunctionExpr
                     +> sepSpace
-                    +> col sepSpace node.SequentialExpr genExpr
+                    +> col sepSpace sequentialArgs genExpr
+                    +> sepSpace
+                    +> genExpr firstList
+
+                let short =
+                    genExpr node.FunctionExpr
+                    +> sepSpace
+                    +> col sepSpace sequentialArgs genExpr
+                    +> onlyIfNot sequentialArgs.IsEmpty sepSpace
+                    +> genExpr firstList
+                    +> sepSpace
+                    +> genExpr lastList
+
+                let long =
+                    // check if everything besides both lists fits on one line
+                    let singleLineTestExpr =
+                        genExpr node.FunctionExpr +> sepSpace +> col sepSpace sequentialArgs genExpr
+
+                    if futureNlnCheck singleLineTestExpr ctx then
+                        genExpr node.FunctionExpr
+                        +> indent
+                        +> sepNln
+                        +> col sepNln sequentialArgs genExpr
+                        +> sepSpace
+                        +> genExpr firstList
+                        +> sepSpace
+                        +> genExpr lastList
+                        +> unindent
+                    else
+                        genExpr node.FunctionExpr
+                        +> sepSpace
+                        +> col sepSpace sequentialArgs genExpr
+                        +> onlyIfNot sequentialArgs.IsEmpty sepSpace
+                        +> genExpr firstList
+                        +> sepSpace
+                        +> genExpr lastList
 
                 if futureNlnCheck singleLineTestExpr ctx then
+                    long ctx
+                else
+                    short ctx
+
+            | EndsWithSingleListApp ctx.Config (sequentialArgs: Expr list, arrayOrList) ->
+                // check if everything else beside the last array/list fits on one line
+                let singleLineTestExpr =
+                    genExpr node.FunctionExpr +> sepSpace +> col sepSpace sequentialArgs genExpr
+
+                let short =
+                    genExpr node.FunctionExpr
+                    +> sepSpace
+                    +> col sepSpace sequentialArgs genExpr
+                    +> onlyIfNot sequentialArgs.IsEmpty sepSpace
+                    +> genExpr arrayOrList
+
+                let long =
                     genExpr node.FunctionExpr
                     +> indent
                     +> sepNln
-                    +> col sepNln node.SequentialExpr genExpr
-                    +> sepSpace
-                    +> genExpr node.FirstArrayOrList
-                    +> sepSpace
-                    +> genExpr node.LastArrayOrList
+                    +> col sepNln sequentialArgs genExpr
+                    +> onlyIfNot sequentialArgs.IsEmpty sepNln
+                    +> genExpr arrayOrList
                     +> unindent
+
+                if futureNlnCheck singleLineTestExpr ctx then
+                    long ctx
                 else
+                    short ctx
+
+            | _ ->
+                let shortExpression =
+                    let sep ctx =
+                        match node.Arguments with
+                        | [] -> ctx
+                        | [ singleArg ] -> sepSpaceBeforeParenInFuncInvocation node.FunctionExpr singleArg ctx
+                        | _ -> sepSpace ctx
+
+                    genExpr node.FunctionExpr +> sep +> col sepSpace node.Arguments genExpr
+
+                let longExpression =
                     genExpr node.FunctionExpr
-                    +> sepSpace
-                    +> col sepSpace node.SequentialExpr genExpr
-                    +> onlyIfNot node.SequentialExpr.IsEmpty sepSpace
-                    +> genExpr node.FirstArrayOrList
-                    +> sepSpace
-                    +> genExpr node.LastArrayOrList
+                    +> indentSepNlnUnindent (col sepNln node.Arguments genExpr)
 
-            if futureNlnCheck singleLineTestExpr ctx then
-                long ctx
-            else
-                short ctx
+                expressionFitsOnRestOfLine shortExpression longExpression ctx
+
         |> genNode node
-    | Expr.EndsWithSingleListApp node ->
-        fun ctx ->
-            // check if everything else beside the last array/list fits on one line
-            let singleLineTestExpr =
-                genExpr node.FunctionExpr
-                +> sepSpace
-                +> col sepSpace node.SequentialExpr genExpr
-
-            let short =
-                genExpr node.FunctionExpr
-                +> sepSpace
-                +> col sepSpace node.SequentialExpr genExpr
-                +> onlyIfNot node.SequentialExpr.IsEmpty sepSpace
-                +> genExpr node.ArrayOrList
-
-            let long =
-                genExpr node.FunctionExpr
-                +> indent
-                +> sepNln
-                +> col sepNln node.SequentialExpr genExpr
-                +> onlyIfNot node.SequentialExpr.IsEmpty sepNln
-                +> genExpr node.ArrayOrList
-                +> unindent
-
-            if futureNlnCheck singleLineTestExpr ctx then
-                long ctx
-            else
-                short ctx
-        |> genNode node
-    | Expr.App node ->
-        let shortExpression =
-            let sep ctx =
-                match node.Arguments with
-                | [] -> ctx
-                | [ singleArg ] -> sepSpaceBeforeParenInFuncInvocation node.FunctionExpr singleArg ctx
-                | _ -> sepSpace ctx
-
-            genExpr node.FunctionExpr +> sep +> col sepSpace node.Arguments genExpr
-
-        let longExpression =
-            genExpr node.FunctionExpr
-            +> indentSepNlnUnindent (col sepNln node.Arguments genExpr)
-
-        expressionFitsOnRestOfLine shortExpression longExpression |> genNode node
     | Expr.TypeApp node ->
         fun ctx ->
             let startColum = ctx.Column
@@ -2126,6 +2127,39 @@ let genFunctionNameWithMultilineLids (trailing: Context -> Context) (longIdent: 
         )
     | _ -> sepNone
     |> genNode parentNode
+
+let (|EndsWithDualListApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
+    if not config.ExperimentalStroustrupStyle then
+        None
+    else
+        let mutable otherArgs = ListCollector<Expr>()
+
+        let rec visit (args: Expr list) =
+            match args with
+            | [] -> None
+            | [ Expr.ArrayOrList _ as firstList; Expr.ArrayOrList _ as lastList ] ->
+                Some(otherArgs.Close(), firstList, lastList)
+            | arg :: args ->
+                otherArgs.Add(arg)
+                visit args
+
+        visit appNode.Arguments
+
+let (|EndsWithSingleListApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
+    if not config.ExperimentalStroustrupStyle then
+        None
+    else
+        let mutable otherArgs = ListCollector<Expr>()
+
+        let rec visit (args: Expr list) =
+            match args with
+            | [] -> None
+            | [ Expr.ArrayOrList _ as singleList ] -> Some(otherArgs.Close(), singleList)
+            | arg :: args ->
+                otherArgs.Add(arg)
+                visit args
+
+        visit appNode.Arguments
 
 let genAppWithLambda sep (node: ExprAppWithLambdaNode) =
     let short =

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -246,12 +246,6 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ExprNestedIndexWithoutDotNode as node ->
         let expr = Expr.NestedIndexWithoutDot node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprEndsWithDualListAppNode as node ->
-        let expr = Expr.EndsWithDualListApp node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprEndsWithSingleListAppNode as node ->
-        let expr = Expr.EndsWithSingleListApp node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprAppNode as node ->
         let expr = Expr.App node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
@@ -385,7 +379,7 @@ let formatSelection
         if not isValid then
             raise (FormatException $"Parsing failed with errors: %A{baseDiagnostics}")
 
-        let rootNode = ASTTransformer.mkOak config (Some sourceText) baseUntypedTree
+        let rootNode = ASTTransformer.mkOak (Some sourceText) baseUntypedTree
 
 #if DEBUG
         printTriviaNode rootNode
@@ -426,7 +420,7 @@ let formatSelection
                 let formattedCode = CodePrinter.genFile enrichedTree context |> Context.dump true
                 let source = SourceText.ofString formattedCode
                 let formattedAST, _ = Fantomas.FCS.Parse.parseFile isSignature source []
-                let formattedTree = ASTTransformer.mkOak selectionConfig (Some source) formattedAST
+                let formattedTree = ASTTransformer.mkOak (Some source) formattedAST
                 let rangeOfSelection = findRangeOf t formattedTree
 
                 match rangeOfSelection with

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1244,33 +1244,6 @@ type ExprNestedIndexWithoutDotNode(identifierExpr: Expr, indexExpr: Expr, argume
     member x.Index = indexExpr
     member x.Argument = argumentExpr
 
-type ExprEndsWithDualListAppNode
-    (functionExpr: Expr, sequentialExprs: Expr list, firstArrayOrList: Expr, lastArrayOrList: Expr, range) =
-    inherit NodeBase(range)
-
-    override this.Children =
-        [| yield Expr.Node functionExpr
-           yield! List.map Expr.Node sequentialExprs
-           yield Expr.Node firstArrayOrList
-           yield Expr.Node lastArrayOrList |]
-
-    member x.FunctionExpr = functionExpr
-    member x.SequentialExpr = sequentialExprs
-    member x.FirstArrayOrList = firstArrayOrList
-    member x.LastArrayOrList = lastArrayOrList
-
-type ExprEndsWithSingleListAppNode(functionExpr: Expr, sequentialExprs: Expr list, arrayOrList: Expr, range) =
-    inherit NodeBase(range)
-
-    override this.Children =
-        [| yield Expr.Node functionExpr
-           yield! List.map Expr.Node sequentialExprs
-           yield Expr.Node arrayOrList |]
-
-    member x.FunctionExpr = functionExpr
-    member x.SequentialExpr = sequentialExprs
-    member x.ArrayOrList = arrayOrList
-
 type ExprAppNode(functionExpr: Expr, arguments: Expr list, range) =
     inherit NodeBase(range)
 
@@ -1670,8 +1643,6 @@ type Expr =
     | AppSingleParenArg of ExprAppSingleParenArgNode
     | AppWithLambda of ExprAppWithLambdaNode
     | NestedIndexWithoutDot of ExprNestedIndexWithoutDotNode
-    | EndsWithDualListApp of ExprEndsWithDualListAppNode
-    | EndsWithSingleListApp of ExprEndsWithSingleListAppNode
     | App of ExprAppNode
     | TypeApp of ExprTypeAppNode
     | TryWithSingleClause of ExprTryWithSingleClauseNode
@@ -1737,8 +1708,6 @@ type Expr =
         | AppSingleParenArg n -> n
         | AppWithLambda n -> n
         | NestedIndexWithoutDot n -> n
-        | EndsWithDualListApp n -> n
-        | EndsWithSingleListApp n -> n
         | App n -> n
         | TypeApp n -> n
         | TryWithSingleClause n -> n


### PR DESCRIPTION
I don't think the Oak should be affected by any stylistic settings.
So in that regard, `ExprEndsWithDualListAppNode` and `ExprEndsWithSingleListAppNode` were a bit unfortunate choices. Both cases are special groupings of ExprAppNode if experimental Stroustrup is active.

It feels more correct to move this to `CodePrinter` instead of `ASTTransformer`.

If we in the future want to have a grouping of applications that ends with a record, we can more easily facilitate this without the need of having an extra special `Node`.