### PR TITLE
Keep backticks in optional SynType.SignatureParameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Fixed
 * Optional constructor arguments are lost. [#2718](https://github.com/fsprojects/fantomas/issues/2718)
-* Empty nested module. [#2721](https://github.com/fsprojects/fantomas/issues/2721~~~~)
+* Bad format result with SynExpr.DotSet. [#2000](https://github.com/fsprojects/fantomas/issues/2000)
+* Empty nested module. [#2721](https://github.com/fsprojects/fantomas/issues/2721)
+* Optional parameter lost backticks. [#2731](https://github.com/fsprojects/fantomas/issues/2731)
 
 ## [5.2.0-alpha-012] - 2023-01-14
 

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -3567,3 +3567,23 @@ type CsvFile
             defaultArg skipRows 0
         )
 """
+
+[<Test>]
+let ``optional parameter with ticks, 2731`` () =
+    formatSourceString
+        false
+        """
+type [<AllowNullLiteral>] ArrayBuffer =
+    abstract byteLength: int
+    abstract slice: ``begin``: int * ?``end``: int -> ArrayBuffer
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<AllowNullLiteral>]
+type ArrayBuffer =
+    abstract byteLength: int
+    abstract slice: ``begin``: int * ?``end``: int -> ArrayBuffer
+"""

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -2053,10 +2053,12 @@ let mkType (creationAide: CreationAide) (t: SynType) : Type =
         let identNode =
             identOpt
             |> Option.map (fun ident ->
-                if isOptional then
-                    stn $"?{ident.idText}" ident.idRange
+                let identNode = mkIdent ident
+
+                if not isOptional then
+                    identNode
                 else
-                    mkIdent ident)
+                    SingleTextNode($"?{identNode.Text}", ident.idRange))
 
         TypeSignatureParameterNode(mkAttributes creationAide attrs, identNode, mkType creationAide t, typeRange)
         |> Type.SignatureParameter


### PR DESCRIPTION
Fixes #2731 