### PR TITLE
Move FormatConfig into Fantomas.Core namespace.

### DIFF
--- a/src/Fantomas.Benchmarks/Runners.fs
+++ b/src/Fantomas.Benchmarks/Runners.fs
@@ -4,7 +4,7 @@ open System.IO
 open BenchmarkDotNet.Attributes
 open Fantomas.Core
 
-let config = FormatConfig.FormatConfig.Default
+let config = FormatConfig.Default
 
 [<MemoryDiagnoser>]
 [<RankColumn>]

--- a/src/Fantomas.Core.Tests/ASTTransformerTests.fs
+++ b/src/Fantomas.Core.Tests/ASTTransformerTests.fs
@@ -6,7 +6,6 @@ open FSharp.Compiler.Xml
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTrivia
 open Fantomas.Core
-open Fantomas.Core
 
 [<Test>]
 let ``avoid stack-overflow in long array/list, 2485`` () =

--- a/src/Fantomas.Core.Tests/ASTTransformerTests.fs
+++ b/src/Fantomas.Core.Tests/ASTTransformerTests.fs
@@ -6,7 +6,7 @@ open FSharp.Compiler.Xml
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTrivia
 open Fantomas.Core
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``avoid stack-overflow in long array/list, 2485`` () =

--- a/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
+++ b/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.CodePrinterHelperFunctionsTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Context
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 open Fantomas.Core
 open Fantomas.Core.SyntaxOak
 

--- a/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
+++ b/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
@@ -4,7 +4,6 @@ open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Context
 open Fantomas.Core
-open Fantomas.Core
 open Fantomas.Core.SyntaxOak
 
 // This test suite is created to illustrate the various helper functions that are being used in `CodePrinter`.

--- a/src/Fantomas.Core.Tests/ColMultilineItemTests.fs
+++ b/src/Fantomas.Core.Tests/ColMultilineItemTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.ColMultilineItemTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``two short let binding should not have extra newline`` () =

--- a/src/Fantomas.Core.Tests/CommentTests.fs
+++ b/src/Fantomas.Core.Tests/CommentTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.CommentTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``should keep sticky-to-the-left comments after nowarn directives`` () =

--- a/src/Fantomas.Core.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/ComputationExpressionTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.ComputationExpressionTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``async workflows`` () =

--- a/src/Fantomas.Core.Tests/ContextTests.fs
+++ b/src/Fantomas.Core.Tests/ContextTests.fs
@@ -4,7 +4,7 @@ open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Context
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 open Fantomas.Core
 
 let private dump = dump false

--- a/src/Fantomas.Core.Tests/ContextTests.fs
+++ b/src/Fantomas.Core.Tests/ContextTests.fs
@@ -5,7 +5,6 @@ open FsUnit
 open Fantomas.Core.Context
 open Fantomas.Core.Tests.TestHelper
 open Fantomas.Core
-open Fantomas.Core
 
 let private dump = dump false
 

--- a/src/Fantomas.Core.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Core.Tests/ControlStructureTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.ControlStructureTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``if/then/else block`` () =

--- a/src/Fantomas.Core.Tests/DallasTests.fs
+++ b/src/Fantomas.Core.Tests/DallasTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``proof of concept`` () =

--- a/src/Fantomas.Core.Tests/DotGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotGetTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.DotGetTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``a TypeApp inside a DotGet should stay on the same line, 994`` () =

--- a/src/Fantomas.Core.Tests/DotIndexedGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotIndexedGetTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.DotIndexedGetTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``multiline function application inside DotIndexedGet`` () =

--- a/src/Fantomas.Core.Tests/FormattingSelectionOnlyTests.fs
+++ b/src/Fantomas.Core.Tests/FormattingSelectionOnlyTests.fs
@@ -6,7 +6,7 @@ open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
 
-let private config = FormatConfig.FormatConfig.Default
+let private config = FormatConfig.Default
 
 let private formatSelectionOnly isFsiFile selection (source: string) config =
     let formattedSelection, _ =

--- a/src/Fantomas.Core.Tests/InterpolatedStringTests.fs
+++ b/src/Fantomas.Core.Tests/InterpolatedStringTests.fs
@@ -1,6 +1,5 @@
 module Fantomas.Core.Tests.InterpolatedStringTests
 
-open FSharp.Compiler.Text
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper

--- a/src/Fantomas.Core.Tests/KeepIndentInBranchTests.fs
+++ b/src/Fantomas.Core.Tests/KeepIndentInBranchTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/KeepMaxEmptyLinesTests.fs
+++ b/src/Fantomas.Core.Tests/KeepMaxEmptyLinesTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let checkFormat config source expected =
     formatSourceString false source config

--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.LambdaTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``keep comment after arrow`` () =

--- a/src/Fantomas.Core.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Core.Tests/LetBindingTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.LetBindingTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``let in should be preserved`` () =

--- a/src/Fantomas.Core.Tests/ListTests.fs
+++ b/src/Fantomas.Core.Tests/ListTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.ListTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``array indices`` () =

--- a/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.MultiLineLambdaClosingNewlineTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let defaultConfig = config
 

--- a/src/Fantomas.Core.Tests/MultilineBlockBracketsOnSameColumnArrayOrListTests.fs
+++ b/src/Fantomas.Core.Tests/MultilineBlockBracketsOnSameColumnArrayOrListTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.MultilineBlockBracketsOnSameColumnArrayOrListTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
+++ b/src/Fantomas.Core.Tests/MultilineBlockBracketsOnSameColumnRecordTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.MultilineBlockBracketsOnSameColumnRecordTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/NumberOfItemsListOrArrayTests.fs
+++ b/src/Fantomas.Core.Tests/NumberOfItemsListOrArrayTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.NumberOfItemsListOrArrayTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``number of items sized lists are formatted properly`` () =

--- a/src/Fantomas.Core.Tests/NumberOfItemsRecordTests.fs
+++ b/src/Fantomas.Core.Tests/NumberOfItemsRecordTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.NumberOfItemsRecordTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/OpenTypeTests.fs
+++ b/src/Fantomas.Core.Tests/OpenTypeTests.fs
@@ -1,6 +1,5 @@
 module Fantomas.Core.Tests.OpenTypeTests
 
-open Fantomas
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper

--- a/src/Fantomas.Core.Tests/OperatorTests.fs
+++ b/src/Fantomas.Core.Tests/OperatorTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.OperatorTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``should format prefix operators`` () =

--- a/src/Fantomas.Core.Tests/RecordTests.fs
+++ b/src/Fantomas.Core.Tests/RecordTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.RecordTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``record declaration`` () =

--- a/src/Fantomas.Core.Tests/SignatureTests.fs
+++ b/src/Fantomas.Core.Tests/SignatureTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.SignatureTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 // the current behavior results in a compile error since "(string * string) list" is converted to "string * string list"
 [<Test>]

--- a/src/Fantomas.Core.Tests/SpaceBeforeClassConstructorTests.fs
+++ b/src/Fantomas.Core.Tests/SpaceBeforeClassConstructorTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.SpaceBeforeClassConstructorTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let spaceBeforeConfig =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/DotIndexedSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/DotIndexedSetExpressionTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/DotSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/DotSetExpressionTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/ElmishTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/ElmishTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.ElmishTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with
@@ -1355,7 +1355,7 @@ let Dashboard () =
     ]
 """
         { config with
-            RecordMultilineFormatter = Fantomas.Core.FormatConfig.MultilineFormatterType.NumberOfItems
+            RecordMultilineFormatter = MultilineFormatterType.NumberOfItems
             MaxArrayOrListWidth = 20
             // MaxElmishWidth = 10
             MultiLineLambdaClosingNewline = true }

--- a/src/Fantomas.Core.Tests/Stroustrup/FunctionApplicationDualListTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/FunctionApplicationDualListTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/FunctionApplicationSingleListTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/FunctionApplicationSingleListTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/KeepIndentInBranchExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/KeepIndentInBranchExpressionTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 // ExperimentalKeepIndentInBranch has precedence over ExperimentalStroustrupStyle
 

--- a/src/Fantomas.Core.Tests/Stroustrup/LambdaExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/LambdaExpressionTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/LetOrUseBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/LetOrUseBangExpressionTests.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 open FsUnit
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 open Fantomas.Core.Tests.TestHelper
 
 let config =

--- a/src/Fantomas.Core.Tests/Stroustrup/LongIdentSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/LongIdentSetExpressionTests.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 open FsUnit
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 open Fantomas.Core.Tests.TestHelper
 
 let config =

--- a/src/Fantomas.Core.Tests/Stroustrup/MultiLineLambdaClosingNewlineExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/MultiLineLambdaClosingNewlineExpressionTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/NamedArgumentExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/NamedArgumentExpressionTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/SetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SetExpressionTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionExpressionTests.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 open FsUnit
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 open Fantomas.Core.Tests.TestHelper
 
 let config =

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionLongPatternExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionLongPatternExpressionTests.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 open FsUnit
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 open Fantomas.Core.Tests.TestHelper
 
 let config =

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionWithReturnTypeExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionWithReturnTypeExpressionTests.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 open FsUnit
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 open Fantomas.Core.Tests.TestHelper
 
 let config =

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/SynExprAndBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynExprAndBangExpressionTests.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 open FsUnit
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 open Fantomas.Core.Tests.TestHelper
 
 let config =

--- a/src/Fantomas.Core.Tests/Stroustrup/SynMatchClauseExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynMatchClauseExpressionTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSigReprSimpleTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSigReprSimpleTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
@@ -3,7 +3,7 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 let config =
     { config with

--- a/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnBangExpressionTests.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 open FsUnit
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 open Fantomas.Core.Tests.TestHelper
 
 let config =

--- a/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnExpressionTests.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 open FsUnit
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 open Fantomas.Core.Tests.TestHelper
 
 let config =

--- a/src/Fantomas.Core.Tests/TestHelpers.fs
+++ b/src/Fantomas.Core.Tests/TestHelpers.fs
@@ -1,11 +1,10 @@
 module Fantomas.Core.Tests.TestHelper
 
 open System
+open Fantomas.Core
 open Fantomas.Core.SyntaxOak
 open NUnit.Framework
 open FsUnit
-open Fantomas.Core.FormatConfig
-open Fantomas.Core
 
 [<assembly: Parallelizable(ParallelScope.All)>]
 do ()

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.TypeDeclarationTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``exception declarations`` () =

--- a/src/Fantomas.Core.Tests/TypeProviderTests.fs
+++ b/src/Fantomas.Core.Tests/TypeProviderTests.fs
@@ -49,7 +49,7 @@ type Graphml = XmlProvider<Schema= @"http://graphml.graphdrawing.org/xmlns/1.0/g
 
 [<Test>]
 let ``should throw FormatException on unparsed input`` () =
-    Assert.Throws<Fantomas.Core.FormatConfig.FormatException>(fun () ->
+    Assert.Throws<Fantomas.Core.FormatException>(fun () ->
         formatSourceString
             false
             """

--- a/src/Fantomas.Core.Tests/UnionTests.fs
+++ b/src/Fantomas.Core.Tests/UnionTests.fs
@@ -3,7 +3,7 @@ module Fantomas.Core.Tests.UnionsTests
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelper
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 [<Test>]
 let ``enums declaration`` () =

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -10,18 +10,18 @@ type CodeFormatter =
 
     static member FormatASTAsync(ast: ParsedInput, ?source, ?config) : Async<string> =
         let sourceText = Option.map CodeFormatterImpl.getSourceText source
-        let config = Option.defaultValue FormatConfig.FormatConfig.Default config
+        let config = Option.defaultValue FormatConfig.Default config
 
         CodeFormatterImpl.formatAST ast sourceText config |> async.Return
 
     static member FormatDocumentAsync(isSignature, source, config) =
-        let config = Option.defaultValue FormatConfig.FormatConfig.Default config
+        let config = Option.defaultValue FormatConfig.Default config
 
         CodeFormatterImpl.getSourceText source
         |> CodeFormatterImpl.formatDocument config isSignature
 
     static member FormatSelectionAsync(isSignature, source, selection, config) =
-        let config = Option.defaultValue FormatConfig.FormatConfig.Default config
+        let config = Option.defaultValue FormatConfig.Default config
 
         CodeFormatterImpl.getSourceText source
         |> Selection.formatSelection config isSignature selection

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -1,6 +1,5 @@
 namespace Fantomas.Core
 
-open Fantomas.Core.FormatConfig
 open FSharp.Compiler.Text
 open FSharp.Compiler.Syntax
 

--- a/src/Fantomas.Core/CodeFormatterImpl.fs
+++ b/src/Fantomas.Core/CodeFormatterImpl.fs
@@ -4,8 +4,6 @@ module internal Fantomas.Core.CodeFormatterImpl
 open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
-open Fantomas.Core
-open Fantomas.Core.FormatConfig
 open Fantomas.Core.SyntaxOak
 
 let getSourceText (source: string) : ISourceText = source.TrimEnd() |> SourceText.ofString

--- a/src/Fantomas.Core/CodeFormatterImpl.fsi
+++ b/src/Fantomas.Core/CodeFormatterImpl.fsi
@@ -3,7 +3,6 @@ module internal Fantomas.Core.CodeFormatterImpl
 
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
-open Fantomas.Core.FormatConfig
 open Fantomas.Core.SyntaxOak
 
 val getSourceText: source: string -> ISourceText

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3,7 +3,6 @@ module internal rec Fantomas.Core.CodePrinter
 open System
 open Fantomas.Core.Context
 open Fantomas.Core.SyntaxOak
-open Fantomas.Core.FormatConfig
 open Microsoft.FSharp.Core.CompilerServices
 
 let noBreakInfixOps = set [| "="; ">"; "<"; "%" |]

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -2,7 +2,6 @@ module internal Fantomas.Core.Context
 
 open System
 open Fantomas.Core
-open Fantomas.Core.FormatConfig
 open Fantomas.Core.SyntaxOak
 
 type WriterEvent =

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -1,7 +1,5 @@
 module internal Fantomas.Core.Context
 
-open Fantomas.Core
-open Fantomas.Core.FormatConfig
 open Fantomas.Core.SyntaxOak
 
 type WriterEvent =

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -1,4 +1,4 @@
-module Fantomas.Core.FormatConfig
+namespace Fantomas.Core
 
 open System
 open System.ComponentModel

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -1,8 +1,6 @@
 ﻿module internal Fantomas.Core.Selection
 
 open FSharp.Compiler.Text
-open Fantomas.Core
-open Fantomas.Core.FormatConfig
 open Fantomas.Core.SyntaxOak
 open Fantomas.Core.ISourceTextExtensions
 

--- a/src/Fantomas.Core/Selection.fsi
+++ b/src/Fantomas.Core/Selection.fsi
@@ -1,7 +1,6 @@
 module internal Fantomas.Core.Selection
 
 open FSharp.Compiler.Text
-open Fantomas.Core.FormatConfig
 
 val formatSelection:
     config: FormatConfig -> isSignature: bool -> selection: range -> sourceText: ISourceText -> Async<string * range>

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -3,7 +3,6 @@
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTrivia
 open FSharp.Compiler.Text
-open Fantomas.Core.FormatConfig
 open Fantomas.Core.ISourceTextExtensions
 open Fantomas.Core.SyntaxOak
 

--- a/src/Fantomas.Core/Trivia.fsi
+++ b/src/Fantomas.Core/Trivia.fsi
@@ -2,7 +2,6 @@ module internal Fantomas.Core.Trivia
 
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
-open Fantomas.Core.FormatConfig
 open Fantomas.Core.SyntaxOak
 
 val findNodeWhereRangeFitsIn: root: Node -> range: range -> Node option

--- a/src/Fantomas.Tests/EditorConfigurationTests.fs
+++ b/src/Fantomas.Tests/EditorConfigurationTests.fs
@@ -2,7 +2,6 @@ module Fantomas.Tests.EditorConfigurationTests
 
 open System
 open Fantomas.Core
-open Fantomas.Core.FormatConfig
 open Fantomas
 open NUnit.Framework
 open System.IO
@@ -14,7 +13,7 @@ let tempName () = Guid.NewGuid().ToString("N")
 type ConfigurationFile
     internal
     (
-        config: FormatConfig.FormatConfig,
+        config: FormatConfig,
         rootFolderName: string,
         ?editorConfigHeader: string,
         ?subFolder: string,

--- a/src/Fantomas.Tests/Integration/ConfigTests.fs
+++ b/src/Fantomas.Tests/Integration/ConfigTests.fs
@@ -61,8 +61,7 @@ let valid_eol_settings = [ "lf"; "crlf" ]
 
 [<TestCaseSource("valid_eol_settings")>]
 let ``uses end_of_line setting to write user newlines`` setting =
-    let newline =
-        (FormatConfig.EndOfLineStyle.OfConfigString setting).Value.NewLineString
+    let newline = (EndOfLineStyle.OfConfigString setting).Value.NewLineString
 
     let sampleCode nln =
         sprintf "let a = 9%s%slet b = 7%s" nln nln nln
@@ -95,8 +94,7 @@ let ``end_of_line should be respected for ifdef`` () =
 
     use configFixture =
         new ConfigurationFile(
-            sprintf
-                """
+            """
 [*.fs]
 end_of_line = lf
 """

--- a/src/Fantomas.Tests/Integration/DaemonTests.fs
+++ b/src/Fantomas.Tests/Integration/DaemonTests.fs
@@ -42,7 +42,7 @@ let ``config request`` () =
         async {
             let! config = client.InvokeAsync<string>(Methods.Configuration) |> Async.AwaitTask
 
-            FormatConfig.FormatConfig.Default
+            FormatConfig.Default
             |> Fantomas.EditorConfig.configToEditorConfig
             |> fun s -> s.Split('\n')
             |> Seq.map (fun line -> line.Split('=').[0])

--- a/src/Fantomas/Daemon.fs
+++ b/src/Fantomas/Daemon.fs
@@ -12,7 +12,6 @@ open FSharp.Compiler.Text
 open Fantomas.Client.Contracts
 open Fantomas.Client.LSPFantomasServiceTypes
 open Fantomas.Core
-open Fantomas.Core.FormatConfig
 open Fantomas.EditorConfig
 
 type FantomasDaemon(sender: Stream, reader: Stream) as this =
@@ -109,7 +108,7 @@ type FantomasDaemon(sender: Stream, reader: Stream) as this =
     [<JsonRpcMethod(Methods.Configuration)>]
     member _.Configuration() : string =
         let settings =
-            Reflection.getRecordFields FormatConfig.FormatConfig.Default
+            Reflection.getRecordFields FormatConfig.Default
             |> Array.toList
             |> List.choose (fun (recordField, defaultValue) ->
                 let optionalField key value =

--- a/src/Fantomas/EditorConfig.fs
+++ b/src/Fantomas/EditorConfig.fs
@@ -2,7 +2,7 @@ module Fantomas.EditorConfig
 
 open System.Collections.Generic
 open System.ComponentModel
-open Fantomas.Core.FormatConfig
+open Fantomas.Core
 
 module Reflection =
     open System

--- a/src/Fantomas/EditorConfig.fsi
+++ b/src/Fantomas/EditorConfig.fsi
@@ -1,5 +1,7 @@
 module Fantomas.EditorConfig
 
+open Fantomas.Core
+
 module Reflection =
 
     type FSharpRecordField =
@@ -15,12 +17,12 @@ val supportedProperties: string list
 val toEditorConfigName: value: seq<char> -> string
 
 val parseOptionsFromEditorConfig:
-    fallbackConfig: Core.FormatConfig.FormatConfig ->
+    fallbackConfig: FormatConfig ->
     editorConfigProperties: System.Collections.Generic.IReadOnlyDictionary<string, string> ->
-        Core.FormatConfig.FormatConfig
+        FormatConfig
 
-val configToEditorConfig: config: Core.FormatConfig.FormatConfig -> string
+val configToEditorConfig: config: FormatConfig -> string
 
-val tryReadConfiguration: fsharpFile: string -> Core.FormatConfig.FormatConfig option
+val tryReadConfiguration: fsharpFile: string -> FormatConfig option
 
-val readConfiguration: fsharpFile: string -> Core.FormatConfig.FormatConfig
+val readConfiguration: fsharpFile: string -> FormatConfig

--- a/src/Fantomas/Format.fs
+++ b/src/Fantomas/Format.fs
@@ -3,7 +3,6 @@ module Fantomas.Format
 open System
 open System.IO
 open Fantomas.Core
-open Fantomas.Core.FormatConfig
 
 exception CodeFormatException of (string * Option<Exception>) array with
     override x.ToString() =

--- a/src/Fantomas/Format.fsi
+++ b/src/Fantomas/Format.fsi
@@ -1,6 +1,7 @@
 module Fantomas.Format
 
 open System
+open Fantomas.Core
 
 exception CodeFormatException of (string * Option<Exception>) array
 
@@ -11,7 +12,7 @@ type FormatResult =
     | Error of filename: string * formattingError: Exception
     | IgnoredFile of filename: string
 
-val formatContentAsync: (Core.FormatConfig.FormatConfig -> string -> string -> Async<FormatResult>)
+val formatContentAsync: (FormatConfig -> string -> string -> Async<FormatResult>)
 
 val formatFileAsync: (string -> Async<FormatResult>)
 


### PR DESCRIPTION
As mentioned on Discord, currently when using `Fantomas.Core` you need to open two namespaces for the basic 

```fsharp
#r "nuget: Fantomas.Core, 5.2.0-alpha-012"

open Fantomas.Core
open Fantomas.Core.FormatConfig

let config =
    { FormatConfig.Default with
        MaxLineLength = 90 }

CodeFormatter.FormatDocumentAsync(
    false,
    """
let a =  0
    """,
    config
)
|> Async.RunSynchronously
```