### PR TITLE
Let the icons (green, orange, ...) in the explanation be rendered.

### DIFF
--- a/docs/content/webcomponents.js
+++ b/docs/content/webcomponents.js
@@ -1,7 +1,7 @@
 import {html} from 'https://cdn.skypack.dev/lit';
 import {component} from 'https://cdn.skypack.dev/haunted';
 
-function FantomasSettingIcon(type) {
+function FantomasSettingIconCore(type) {
     let settingType
     switch (type) {
         case 'green':
@@ -54,15 +54,28 @@ function Navigation({next, previous}) {
 function FantomasSetting({name, green, orange, red, gr}) {
     return html`
         <div class="d-flex align-items-center my-2">
-            ${green && FantomasSettingIcon('green')}
-            ${orange && FantomasSettingIcon('orange')}
-            ${red && FantomasSettingIcon('red')}
-            ${gr && FantomasSettingIcon('gr')}
+            ${green && FantomasSettingIconCore('green')}
+            ${orange && FantomasSettingIconCore('orange')}
+            ${red && FantomasSettingIconCore('red')}
+            ${gr && FantomasSettingIconCore('gr')}
             <h4 id="${name}" class="m-0">
                 <a href="#${name}">${name}</a>
             </h4>
         </div>`
 }
+
+function FantomasSettingIcon({green, orange, red, gr}) {
+    return html`
+            ${green && FantomasSettingIconCore('green')}
+            ${orange && FantomasSettingIconCore('orange')}
+            ${red && FantomasSettingIconCore('red')}
+            ${gr && FantomasSettingIconCore('gr')}
+            `
+}
+
+customElements.define('fantomas-setting-icon', component(FantomasSettingIcon, {
+    useShadowDOM: false, observedAttributes: ['green', 'orange', 'red', 'gr']
+}));
 
 customElements.define('fantomas-setting', component(FantomasSetting, {
     useShadowDOM: false, observedAttributes: ['name', 'green', 'orange', 'red', 'gr']

--- a/docs/docs/end-users/Configuration.fsx
+++ b/docs/docs/end-users/Configuration.fsx
@@ -52,10 +52,10 @@ let formatCode input configIndent =
 ## Settings recommendations
 Fantomas ships with a series of settings that you can use freely depending  on your case.  
 However, there are settings that we do not recommend and generally should not be used.
-<p><fantomas-setting-icon type="green"></fantomas-setting-icon><strong>Safe to change:</strong> Settings that aren't attached to any guidelines. Depending on your team or your own preferences, feel free to change these as it's been agreed on the codebase, however, you can always use it's defaults.</p>
-<p><fantomas-setting-icon type="orange"></fantomas-setting-icon><strong>Use with caution:</strong> Settings where it is not recommended to change the default value. They might lead to incomplete results.</p>
-<p><fantomas-setting-icon type="red"></fantomas-setting-icon><strong>Do not use:</strong> Settings that don't follow any guidelines.</p>
-<p><fantomas-setting-icon-gresearch></fantomas-setting-icon-gresearch><strong>G-Research:</strong> G-Research styling guide. If you use one of these, for consistency reasons you should use all of them.</p>
+<p><fantomas-setting-icon green></fantomas-setting-icon><strong>Safe to change:</strong> Settings that aren't attached to any guidelines. Depending on your team or your own preferences, feel free to change these as it's been agreed on the codebase, however, you can always use it's defaults.</p>
+<p><fantomas-setting-icon orange></fantomas-setting-icon><strong>Use with caution:</strong> Settings where it is not recommended to change the default value. They might lead to incomplete results.</p>
+<p><fantomas-setting-icon red></fantomas-setting-icon><strong>Do not use:</strong> Settings that don't follow any guidelines.</p>
+<p><fantomas-setting-icon gr></fantomas-setting-icon><strong>G-Research:</strong> G-Research styling guide. If you use one of these, for consistency reasons you should use all of them.</p>
 *)
 
 (**


### PR DESCRIPTION
Currently the icons left of the explanation text aren't rendered.
I'm not much of a JS dev, so there's most likely a better fix.