### PR TITLE
Remove unused code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+* Update FCS to 'Remove unused code', commit cb106cf3182ff218f0a0e42780815dba94b60013
+
 ## [5.2.0] - 2023-01-19
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@ Some common use cases include:
     
     <!-- Versions -->
     <PropertyGroup>
-        <FCSCommitHash>e30d14cb46f290050ac8e2bbea5e9b804b97bdde</FCSCommitHash>
+        <FCSCommitHash>cb106cf3182ff218f0a0e42780815dba94b60013</FCSCommitHash>
         <StreamJsonRpcVersion>2.8.28</StreamJsonRpcVersion>
         <FSharpCoreVersion>6.0.1</FSharpCoreVersion>
     </PropertyGroup>

--- a/build.fsx
+++ b/build.fsx
@@ -222,6 +222,8 @@ pipeline "Init" {
             [| "src/Compiler/FSComp.txt"
                "src/Compiler/Interactive/FSIstrings.txt"
                "src/Compiler/FSStrings.resx"
+               "src/Compiler/Utilities/Activity.fsi"
+               "src/Compiler/Utilities/Activity.fs"
                "src/Compiler/Utilities/sformat.fsi"
                "src/Compiler/Utilities/sformat.fs"
                "src/Compiler/Utilities/sr.fsi"

--- a/src/Fantomas.Benchmarks/packages.lock.json
+++ b/src/Fantomas.Benchmarks/packages.lock.json
@@ -198,6 +198,11 @@
         "resolved": "5.0.0",
         "contentHash": "FXkLXiK0sVVewcso0imKQoOxjoPAj42R8HtjjbSjVPAzwDfzoyoznWxgA3c38LDbN9SJux1xXoXYAhz98j7r2g=="
       },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw=="
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -208,8 +213,8 @@
       },
       "System.Memory": {
         "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw=="
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
       },
       "System.Reflection.Emit": {
         "type": "Transitive",
@@ -265,7 +270,8 @@
         "type": "Project",
         "dependencies": {
           "FSharp.Core": "[6.0.1, )",
-          "System.Memory": "[4.5.4, )",
+          "System.Diagnostics.DiagnosticSource": "[7.0.0, )",
+          "System.Memory": "[4.5.5, )",
           "System.Runtime": "[4.3.1, )"
         }
       }

--- a/src/Fantomas.Core.Tests/packages.lock.json
+++ b/src/Fantomas.Core.Tests/packages.lock.json
@@ -186,6 +186,11 @@
           "System.Runtime": "4.1.0"
         }
       },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw=="
+      },
       "System.Diagnostics.Tools": {
         "type": "Transitive",
         "resolved": "4.0.1",
@@ -306,8 +311,8 @@
       },
       "System.Memory": {
         "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw=="
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
       },
       "System.ObjectModel": {
         "type": "Transitive",
@@ -579,7 +584,8 @@
         "type": "Project",
         "dependencies": {
           "FSharp.Core": "[6.0.1, )",
-          "System.Memory": "[4.5.4, )",
+          "System.Diagnostics.DiagnosticSource": "[7.0.0, )",
+          "System.Memory": "[4.5.5, )",
           "System.Runtime": "[4.3.1, )"
         }
       }

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -133,18 +133,6 @@ let genIdentListNodeAux addLeadingDot (iln: IdentListNode) =
 let genIdentListNode iln = genIdentListNodeAux false iln
 let genIdentListNodeWithDot iln = genIdentListNodeAux true iln
 
-let genIdentListNodeWithDotMultiline (iln: IdentListNode) =
-    coli sepNone iln.Content (fun idx iod ->
-        match iod with
-        | IdentifierOrDot.Ident ident ->
-            if idx = 0 then
-                genSingleTextNodeWithLeadingDot ident
-            else
-                genSingleTextNode ident
-        | IdentifierOrDot.KnownDot dot -> sepNln +> genSingleTextNode dot
-        | IdentifierOrDot.UnknownDot _ -> sepNln +> sepDot)
-    |> genNode iln
-
 let genAccessOpt (nodeOpt: SingleTextNode option) =
     match nodeOpt with
     | None -> sepNone
@@ -2078,14 +2066,6 @@ let colGenericTypeParameters typeParameters =
             | _ -> sepNone
 
         leadingSpace +> genType t)
-
-let genGenericTypeParametersAux lessThan typeParameters greaterThan =
-    genSingleTextNode lessThan
-    +> colGenericTypeParameters typeParameters
-    +> genSingleTextNode greaterThan
-
-let genGenericTypeParameters (typeApp: ExprTypeAppNode) =
-    genGenericTypeParametersAux typeApp.LessThan typeApp.TypeParameters typeApp.GreaterThan
 
 let genFunctionNameWithMultilineLids (trailing: Context -> Context) (longIdent: IdentListNode) (parentNode: Node) =
     match longIdent.Content with

--- a/src/Fantomas.Core/packages.lock.json
+++ b/src/Fantomas.Core/packages.lock.json
@@ -96,10 +96,19 @@
         "resolved": "4.5.1",
         "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
       },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Numerics.Vectors": "4.4.0",
@@ -122,14 +131,15 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
           "FSharp.Core": "[6.0.1, )",
-          "System.Memory": "[4.5.4, )",
+          "System.Diagnostics.DiagnosticSource": "[7.0.0, )",
+          "System.Memory": "[4.5.5, )",
           "System.Runtime": "[4.3.1, )"
         }
       }

--- a/src/Fantomas.FCS/Fantomas.FCS.fsproj
+++ b/src/Fantomas.FCS/Fantomas.FCS.fsproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);57</NoWarn> <!-- Experimental -->
+    <NoWarn>$(NoWarn);57;</NoWarn> <!-- Experimental -->
+    <NoWarn>$(NoWarn);1204</NoWarn> <!-- This construct is for use in the FSharp.Core library and should not be used directly -->
     <DefineConstants>$(DefineConstants);COMPILER;FSHARPCORE_USE_PACKAGE</DefineConstants>
     <FsYaccOutputFolder>generated\$(TargetFramework)\</FsYaccOutputFolder>
     <FsLexOutputFolder>generated\$(TargetFramework)\</FsLexOutputFolder>
@@ -25,6 +26,12 @@
       <Link>FSStrings.resx</Link>
       <LogicalName>FSStrings.resources</LogicalName>
     </EmbeddedResource>
+    <Compile Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\Utilities\Activity.fsi">
+      <Link>Utilities\Activity.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\Utilities\Activity.fs">
+      <Link>Utilities\Activity.fs</Link>
+    </Compile>
     <Compile Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\Utilities\sformat.fsi">
       <Link>Utilities\sformat.fsi</Link>
     </Compile>
@@ -304,7 +311,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="FsLexYacc" Version="11.0.1" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Fantomas.FCS/packages.lock.json
+++ b/src/Fantomas.FCS/packages.lock.json
@@ -45,11 +45,21 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Direct",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
       "System.Memory": {
         "type": "Direct",
-        "requested": "[4.5.4, )",
-        "resolved": "4.5.4",
-        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
+        "requested": "[4.5.5, )",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Numerics.Vectors": "4.4.0",
@@ -142,8 +152,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       }
     }
   }

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -430,8 +430,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "5.0.1",
-        "contentHash": "uXQEYqav2V3zP6OwkOKtLv+qIi6z3m1hsGyKwXX7ZA7htT4shoVccGxnJ9kVRFPNAsi1ArZTq2oh7WOto6GbkQ=="
+        "resolved": "7.0.0",
+        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw=="
       },
       "System.Diagnostics.Tracing": {
         "type": "Transitive",
@@ -536,8 +536,8 @@
       },
       "System.Memory": {
         "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw=="
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
       },
       "System.Net.Http": {
         "type": "Transitive",
@@ -947,7 +947,8 @@
         "type": "Project",
         "dependencies": {
           "FSharp.Core": "[6.0.1, )",
-          "System.Memory": "[4.5.4, )",
+          "System.Diagnostics.DiagnosticSource": "[7.0.0, )",
+          "System.Memory": "[4.5.5, )",
           "System.Runtime": "[4.3.1, )"
         }
       }

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -420,8 +420,11 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "5.0.1",
-        "contentHash": "uXQEYqav2V3zP6OwkOKtLv+qIi6z3m1hsGyKwXX7ZA7htT4shoVccGxnJ9kVRFPNAsi1ArZTq2oh7WOto6GbkQ=="
+        "resolved": "7.0.0",
+        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Diagnostics.Tracing": {
         "type": "Transitive",
@@ -521,8 +524,8 @@
       },
       "System.Memory": {
         "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw=="
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
       },
       "System.Net.Http": {
         "type": "Transitive",
@@ -634,8 +637,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "zOHkQmzPCn5zm/BH+cxC1XbUS3P4Yoi3xzW7eRgVpDR2tPGSzyMZ17Ig1iRkfJuY0nhxkQQde8pgePNiA7z7TQ=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",
@@ -902,7 +905,8 @@
         "type": "Project",
         "dependencies": {
           "FSharp.Core": "[6.0.1, )",
-          "System.Memory": "[4.5.4, )",
+          "System.Diagnostics.DiagnosticSource": "[7.0.0, )",
+          "System.Memory": "[4.5.5, )",
           "System.Runtime": "[4.3.1, )"
         }
       }


### PR DESCRIPTION
Removed some unused functions in `CodePrinter`.
Also bumped `FCS` to a commit where a lot of unused code was removed there.
`Fantomas.FCS` would now take a dependency on `System.Diagnostics.DiagnosticSource` but that was bound to happen eventually.