### PR TITLE
Fix handling of AppExpr with a single stroustrup record

### DIFF
--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -654,6 +654,88 @@ let newState =
 """
 
 [<Test>]
+let ``uppercase app node with single record arg with explicit setting`` () =
+    formatSourceString
+        false
+        """
+let newState =
+    someFunc
+        {
+            F1 = 0
+            F2 = ""
+        }
+
+let newState =
+    Some
+        {
+            F1 = 0
+            F2 = ""
+        }
+"""
+        { config with
+            MultilineBracketStyle = Aligned
+            StroustrupForMultilineRecordAsUppercaseInvocationFinalArg = true
+            RecordMultilineFormatter = NumberOfItems }
+    |> prepend newline
+    |> should
+        equal
+        """
+let newState =
+    someFunc
+        {
+            F1 = 0
+            F2 = ""
+        }
+
+let newState =
+    Some {
+        F1 = 0
+        F2 = ""
+    }
+"""
+
+[<Test>]
+let ``lowercase app node with single record arg with explicit setting`` () =
+    formatSourceString
+        false
+        """
+let newState =
+    someFunc
+        {
+            F1 = 0
+            F2 = ""
+        }
+
+let newState =
+    Some
+        {
+            F1 = 0
+            F2 = ""
+        }
+"""
+        { config with
+            MultilineBracketStyle = Aligned
+            StroustrupForMultilineRecordAsLowercaseInvocationFinalArg = true
+            RecordMultilineFormatter = NumberOfItems }
+    |> prepend newline
+    |> should
+        equal
+        """
+let newState =
+    someFunc {
+        F1 = 0
+        F2 = ""
+    }
+
+let newState =
+    Some
+        {
+            F1 = 0
+            F2 = ""
+        }
+"""
+
+[<Test>]
 let ``lowercase app node with single record arg`` () =
     formatSourceString
         false

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -598,3 +598,82 @@ let newState = {
         }
 }
 """
+
+[<Test>]
+let ``app node with single anonymous record member`` () =
+    formatSourceString
+        false
+        """
+let newState = {|
+    Foo =
+        Some
+            {|
+                F1 = 0
+                F2 = ""
+            |}
+|}
+"""
+        { config with
+            RecordMultilineFormatter = NumberOfItems }
+    |> prepend newline
+    |> should
+        equal
+        """
+let newState = {|
+    Foo =
+        Some {|
+            F1 = 0
+            F2 = ""
+        |}
+|}
+"""
+
+[<Test>]
+let ``app node with single record arg`` () =
+    formatSourceString
+        false
+        """
+let newState = 
+    Some
+        {
+            F1 = 0
+            F2 = ""
+        }
+"""
+        { config with
+            RecordMultilineFormatter = NumberOfItems }
+    |> prepend newline
+    |> should
+        equal
+        """
+let newState =
+    Some {
+        F1 = 0
+        F2 = ""
+    }
+"""
+
+[<Test>]
+let ``lowercase app node with single record arg`` () =
+    formatSourceString
+        false
+        """
+let newState = 
+    someFunc
+        {
+            F1 = 0
+            F2 = ""
+        }
+"""
+        { config with
+            RecordMultilineFormatter = NumberOfItems }
+    |> prepend newline
+    |> should
+        equal
+        """
+let newState =
+    someFunc {
+        F1 = 0
+        F2 = ""
+    }
+"""

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -677,3 +677,45 @@ let newState =
         F2 = ""
     }
 """
+
+[<Test>]
+let ``lowercase app node with multiple args ending in a single record arg`` () =
+    formatSourceString
+        false
+        """
+let newState = 
+    myFn a b c { D = d; E = e }
+"""
+        { config with
+            RecordMultilineFormatter = NumberOfItems }
+    |> prepend newline
+    |> should
+        equal
+        """
+let newState =
+    myFn a b c {
+        D = d
+        E = e
+    }
+"""
+
+[<Test>]
+let ``lowercase app node with multiple args ending in a single anonymous record arg`` () =
+    formatSourceString
+        false
+        """
+let newState = 
+    myFn a b c {| D = d; E = e |}
+"""
+        { config with
+            RecordMultilineFormatter = NumberOfItems }
+    |> prepend newline
+    |> should
+        equal
+        """
+let newState =
+    myFn a b c {|
+        D = d
+        E = e
+    |}
+"""

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -1,4 +1,4 @@
-﻿module Fantomas.Core.Tests.Stroustrup.SynBindingValueExpressionTests
+module Fantomas.Core.Tests.Stroustrup.SynBindingValueExpressionTests
 
 open NUnit.Framework
 open FsUnit
@@ -567,5 +567,34 @@ let myRecord = {
         Value2 = 30
         Value3 = 40
     }
+}
+"""
+
+[<Test>]
+let ``app node with single record member`` () =
+    formatSourceString
+        false
+        """
+let newState = {
+    Foo =
+        Some
+            {
+                F1 = 0
+                F2 = ""
+            }
+}
+"""
+        { config with
+            RecordMultilineFormatter = NumberOfItems }
+    |> prepend newline
+    |> should
+        equal
+        """
+let newState = {
+    Foo =
+        Some {
+            F1 = 0
+            F2 = ""
+        }
 }
 """

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -1,4 +1,4 @@
-module Fantomas.Core.Tests.Stroustrup.SynBindingValueExpressionTests
+﻿module Fantomas.Core.Tests.Stroustrup.SynBindingValueExpressionTests
 
 open NUnit.Framework
 open FsUnit
@@ -651,88 +651,6 @@ let newState =
         F1 = 0
         F2 = ""
     }
-"""
-
-[<Test>]
-let ``uppercase app node with single record arg with explicit setting`` () =
-    formatSourceString
-        false
-        """
-let newState =
-    someFunc
-        {
-            F1 = 0
-            F2 = ""
-        }
-
-let newState =
-    Some
-        {
-            F1 = 0
-            F2 = ""
-        }
-"""
-        { config with
-            MultilineBracketStyle = Aligned
-            StroustrupForMultilineRecordAsUppercaseInvocationFinalArg = true
-            RecordMultilineFormatter = NumberOfItems }
-    |> prepend newline
-    |> should
-        equal
-        """
-let newState =
-    someFunc
-        {
-            F1 = 0
-            F2 = ""
-        }
-
-let newState =
-    Some {
-        F1 = 0
-        F2 = ""
-    }
-"""
-
-[<Test>]
-let ``lowercase app node with single record arg with explicit setting`` () =
-    formatSourceString
-        false
-        """
-let newState =
-    someFunc
-        {
-            F1 = 0
-            F2 = ""
-        }
-
-let newState =
-    Some
-        {
-            F1 = 0
-            F2 = ""
-        }
-"""
-        { config with
-            MultilineBracketStyle = Aligned
-            StroustrupForMultilineRecordAsLowercaseInvocationFinalArg = true
-            RecordMultilineFormatter = NumberOfItems }
-    |> prepend newline
-    |> should
-        equal
-        """
-let newState =
-    someFunc {
-        F1 = 0
-        F2 = ""
-    }
-
-let newState =
-    Some
-        {
-            F1 = 0
-            F2 = ""
-        }
 """
 
 [<Test>]

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2178,7 +2178,7 @@ let (|EndsWithSingleRecordApp|_|) (config: FormatConfig) (appNode: ExprAppNode) 
             otherArgs.Add(arg)
             visit args
 
-    if config.ExperimentalStroustrupStyle then
+    if config.IsStroustrupStyle then
         visit appNode.Arguments
     else
         match appNode.FunctionExpr with

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1178,6 +1178,31 @@ let genExpr (e: Expr) =
                 else
                     short ctx
 
+            | EndsWithSingleRecordApp ctx.Config (sequentialArgs: Expr list, recordOrAnonRecord) ->
+                // check if everything else beside the last array/list fits on one line
+                let singleLineTestExpr =
+                    genExpr node.FunctionExpr +> sepSpace +> col sepSpace sequentialArgs genExpr
+
+                let short =
+                    genExpr node.FunctionExpr
+                    +> sepSpace
+                    +> col sepSpace sequentialArgs genExpr
+                    +> onlyIfNot sequentialArgs.IsEmpty sepSpace
+                    +> genExpr recordOrAnonRecord
+
+                let long =
+                    genExpr node.FunctionExpr
+                    +> indent
+                    +> sepNln
+                    +> col sepNln sequentialArgs genExpr
+                    +> onlyIfNot sequentialArgs.IsEmpty sepNln
+                    +> genExpr recordOrAnonRecord
+                    +> unindent
+
+                if futureNlnCheck singleLineTestExpr ctx then
+                    long ctx
+                else
+                    short ctx
             | _ ->
                 let shortExpression =
                     let sep ctx =
@@ -1190,9 +1215,7 @@ let genExpr (e: Expr) =
 
                 let longExpression =
                     genExpr node.FunctionExpr
-                    +> match node.Arguments with
-                       | [ singleArg ] -> sepSpace +> indentSepNlnUnindentUnlessStroustrup genExpr singleArg
-                       | multiple -> indentSepNlnUnindent (col sepNln multiple genExpr)
+                    +> indentSepNlnUnindent (col sepNln node.Arguments genExpr)
 
                 expressionFitsOnRestOfLine shortExpression longExpression ctx
 
@@ -2138,6 +2161,22 @@ let (|EndsWithSingleListApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
             match args with
             | [] -> None
             | [ Expr.ArrayOrList _ as singleList ] -> Some(otherArgs.Close(), singleList)
+            | arg :: args ->
+                otherArgs.Add(arg)
+                visit args
+
+        visit appNode.Arguments
+
+let (|EndsWithSingleRecordApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
+    if not config.ExperimentalStroustrupStyle then
+        None
+    else
+        let mutable otherArgs = ListCollector<Expr>()
+
+        let rec visit (args: Expr list) =
+            match args with
+            | [] -> None
+            | [ Expr.Record _ | Expr.AnonRecord _ as singleList ] -> Some(otherArgs.Close(), singleList)
             | arg :: args ->
                 otherArgs.Add(arg)
                 visit args

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2168,20 +2168,20 @@ let (|EndsWithSingleListApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
         visit appNode.Arguments
 
 let (|EndsWithSingleRecordApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
-    let mutable otherArgs = ListCollector<Expr>()
-
-    let rec visit (args: Expr list) =
-        match args with
-        | [] -> None
-        | [ Expr.Record _ | Expr.AnonRecord _ as singleRecord ] -> Some(otherArgs.Close(), singleRecord)
-        | arg :: args ->
-            otherArgs.Add(arg)
-            visit args
-
-    if config.IsStroustrupStyle then
-        visit appNode.Arguments
-    else
+    if not config.IsStroustrupStyle then
         None
+    else
+        let mutable otherArgs = ListCollector<Expr>()
+
+        let rec visit (args: Expr list) =
+            match args with
+            | [] -> None
+            | [ Expr.Record _ | Expr.AnonStructRecord _ as singleRecord ] -> Some(otherArgs.Close(), singleRecord)
+            | arg :: args ->
+                otherArgs.Add(arg)
+                visit args
+
+        visit appNode.Arguments
 
 let genAppWithLambda sep (node: ExprAppWithLambdaNode) =
     let short =

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1190,7 +1190,9 @@ let genExpr (e: Expr) =
 
                 let longExpression =
                     genExpr node.FunctionExpr
-                    +> indentSepNlnUnindent (col sepNln node.Arguments genExpr)
+                    +> match node.Arguments with
+                       | [ singleArg ] -> sepSpace +> indentSepNlnUnindentUnlessStroustrup genExpr singleArg
+                       | multiple -> indentSepNlnUnindent (col sepNln multiple genExpr)
 
                 expressionFitsOnRestOfLine shortExpression longExpression ctx
 
@@ -1224,7 +1226,7 @@ let genExpr (e: Expr) =
                 clauseNode.WhenExpr
             +> sepSpace
             +> genSingleTextNodeWithSpaceSuffix sepSpace clauseNode.Arrow
-            +> indentSepNlnUnindentExprUnlessStroustrup genExpr clauseNode.BodyExpr
+            +> indentSepNlnUnindentUnlessStroustrup genExpr clauseNode.BodyExpr
             +> leaveNode clauseNode
 
         atCurrentColumn (
@@ -1810,7 +1812,7 @@ let genNamedArgumentExpr (node: ExprInfixAppNode) =
         genExpr node.LeftHandSide
         +> sepSpace
         +> genSingleTextNode node.Operator
-        +> indentSepNlnUnindentExprUnlessStroustrup (fun e -> sepSpace +> genExpr e) node.RightHandSide
+        +> indentSepNlnUnindentUnlessStroustrup (fun e -> sepSpace +> genExpr e) node.RightHandSide
 
     expressionFitsOnRestOfLine short long |> genNode node
 
@@ -2671,7 +2673,7 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
                     let short = sepSpace +> body
 
                     let long =
-                        indentSepNlnUnindentExprUnlessStroustrup (fun e -> sepSpace +> genExpr e) b.Expr
+                        indentSepNlnUnindentUnlessStroustrup (fun e -> sepSpace +> genExpr e) b.Expr
 
                     isShortExpression ctx.Config.MaxFunctionBindingWidth short long
 
@@ -2760,9 +2762,7 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
             +> (fun ctx ->
                 let prefix = afterLetKeyword +> sepSpace +> genValueName +> genReturnType
                 let short = prefix +> genExpr b.Expr
-
-                let long = prefix +> indentSepNlnUnindentExprUnlessStroustrup genExpr b.Expr
-
+                let long = prefix +> indentSepNlnUnindentUnlessStroustrup genExpr b.Expr
                 isShortExpression ctx.Config.MaxValueBindingWidth short long ctx)
 
     genNode b binding ctx

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2181,12 +2181,7 @@ let (|EndsWithSingleRecordApp|_|) (config: FormatConfig) (appNode: ExprAppNode) 
     if config.IsStroustrupStyle then
         visit appNode.Arguments
     else
-        match appNode.FunctionExpr with
-        | Expr.Constant _ -> None
-        | ParenExpr _ -> None
-        | UppercaseExpr when config.StroustrupForMultilineRecordAsUppercaseInvocationFinalArg -> visit appNode.Arguments
-        | LowercaseExpr when config.StroustrupForMultilineRecordAsLowercaseInvocationFinalArg -> visit appNode.Arguments
-        | _ -> None
+        None
 
 let genAppWithLambda sep (node: ExprAppWithLambdaNode) =
     let short =

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -928,7 +928,7 @@ let addParenIfAutoNln expr f =
     let expr = f expr
     expressionFitsOnRestOfLine expr (ifElse hasParenthesis (sepOpenT +> expr +> sepCloseT) expr)
 
-let indentSepNlnUnindentExprUnlessStroustrup f (e: Expr) (ctx: Context) =
+let indentSepNlnUnindentUnlessStroustrup f (e: Expr) (ctx: Context) =
     let shouldUseStroustrup =
         isStroustrupStyleExpr ctx.Config e && canSafelyUseStroustrup (Expr.Node e)
 

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -257,7 +257,7 @@ val sepSpaceUnlessWriteBeforeNewlineNotEmpty: ctx: Context -> Context
 val autoIndentAndNlnWhenWriteBeforeNewlineNotEmpty: f: (Context -> Context) -> ctx: Context -> Context
 val addParenIfAutoNln: expr: Expr -> f: (Expr -> Context -> Context) -> (Context -> Context)
 
-val indentSepNlnUnindentExprUnlessStroustrup: f: (Expr -> Context -> Context) -> e: Expr -> ctx: Context -> Context
+val indentSepNlnUnindentUnlessStroustrup: f: (Expr -> Context -> Context) -> e: Expr -> ctx: Context -> Context
 
 val autoIndentAndNlnTypeUnlessStroustrup: f: (Type -> Context -> Context) -> t: Type -> ctx: Context -> Context
 

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -221,14 +221,6 @@ type FormatConfig =
       [<DisplayName("Maximum number of consecutive blank lines to keep")>]
       KeepMaxNumberOfBlankLines: Num
 
-      [<Category("Boundaries")>]
-      [<DisplayName("Use stroustrup style for multiline record that is the last arg of an uppercase invocation")>]
-      StroustrupForMultilineRecordAsUppercaseInvocationFinalArg: bool
-
-      [<Category("Boundaries")>]
-      [<DisplayName("Use stroustrup style for multiline record that is the last arg of an lowercase invocation")>]
-      StroustrupForMultilineRecordAsLowercaseInvocationFinalArg: bool
-
       [<Category("Convention")>]
       [<DisplayName("Insert a newline before a computation expression that spans multiple lines")>]
       NewlineBeforeMultilineComputationExpression: bool
@@ -277,6 +269,4 @@ type FormatConfig =
           MultilineBracketStyle = Cramped
           KeepMaxNumberOfBlankLines = 100
           NewlineBeforeMultilineComputationExpression = true
-          StroustrupForMultilineRecordAsUppercaseInvocationFinalArg = false
-          StroustrupForMultilineRecordAsLowercaseInvocationFinalArg = false
           StrictMode = false }

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -221,6 +221,14 @@ type FormatConfig =
       [<DisplayName("Maximum number of consecutive blank lines to keep")>]
       KeepMaxNumberOfBlankLines: Num
 
+      [<Category("Boundaries")>]
+      [<DisplayName("Use stroustrup style for multiline record that is the last arg of an uppercase invocation")>]
+      StroustrupForMultilineRecordAsUppercaseInvocationFinalArg: bool
+
+      [<Category("Boundaries")>]
+      [<DisplayName("Use stroustrup style for multiline record that is the last arg of an lowercase invocation")>]
+      StroustrupForMultilineRecordAsLowercaseInvocationFinalArg: bool
+
       [<Category("Convention")>]
       [<DisplayName("Insert a newline before a computation expression that spans multiple lines")>]
       NewlineBeforeMultilineComputationExpression: bool
@@ -269,4 +277,6 @@ type FormatConfig =
           MultilineBracketStyle = Cramped
           KeepMaxNumberOfBlankLines = 100
           NewlineBeforeMultilineComputationExpression = true
+          StroustrupForMultilineRecordAsUppercaseInvocationFinalArg = false
+          StroustrupForMultilineRecordAsLowercaseInvocationFinalArg = false
           StrictMode = false }


### PR DESCRIPTION
I'm going through the code in https://github.com/dotnet/docs/pull/33171 to try and get fantomas to match the ideal styles there.

This changes the output of the following code from this:

```fsharp
let newState = {
    Foo =
        Some
            {
                F1 = 0
                F2 = ""
            }
}
```
to this

```fsharp
let newState = {
    Foo =
        Some {
            F1 = 0
            F2 = ""
        }
}
```
Which lets fantomas format code to better match some of the examples there.

But this also brings up a point we've discussed before:

For lowercase function applications with a single record node, with Stroustrup enabled, is there a problem with allowing this style? Because this will also format code like this

```fsharp
let newState =
    notAComputationExpr {
        F1 = 0
        F2 = ""
    }
```

I argue that it's fine, and it's is my personal preference, but @nojaf has expressed valid concerns with it, and I thought we'd came to this agreement but I wanted to confirm before doing too much with it that this was one of the settings we wanted to add for Stroustrup: E.g. `fsharp_disallow_stroustrup_for_lowercase_invocations` (because I think we agree its fine for uppercase applications e.g. discriminated unions like above) or something better named? I'd argue that this output makes sense as a default with Stroustrup enabled, but I definitely see the value of allowing people to opt out.

If we do agree that we want to have a separate setting for this, I'm happy to add that change to this PR.