### PR TITLE
Change CodeFormatter.MakePosition return type to pos option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+* Rename public API `CodeFormatter.MakePosition -> CodeFormatter.MakeSomePosition` and change its return type to `pos option`. [#2749](https://github.com/fsprojects/fantomas/pull/2749)
+
 ## [6.0.0-alpha-001] - 2023-01-24
 
 ### Changed

--- a/src/Fantomas.Core.Tests/CursorTests.fs
+++ b/src/Fantomas.Core.Tests/CursorTests.fs
@@ -17,7 +17,7 @@ let a =
 """
 
     let formattedResult =
-        CodeFormatter.FormatDocumentAsync(false, source, cursor = CodeFormatter.MakePosition(3, 8))
+        CodeFormatter.FormatDocumentAsync(false, source, ?cursor = CodeFormatter.MakeSomePosition(3, 8))
         |> Async.RunSynchronously
 
     // After formatting the let binding will be on one line
@@ -35,7 +35,7 @@ let a =
 """
 
     let formattedResult =
-        CodeFormatter.FormatDocumentAsync(false, source, cursor = CodeFormatter.MakePosition(3, 7))
+        CodeFormatter.FormatDocumentAsync(false, source, ?cursor = CodeFormatter.MakeSomePosition(3, 7))
         |> Async.RunSynchronously
 
     match formattedResult.Cursor with

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -32,4 +32,4 @@ type CodeFormatter =
     static member MakeRange(fileName, startLine, startCol, endLine, endCol) =
         Range.mkRange fileName (Position.mkPos startLine startCol) (Position.mkPos endLine endCol)
 
-    static member MakePosition(line, column) = Position.mkPos line column
+    static member MakeSomePosition(line, column) = Position.mkPos line column |> Some

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -36,4 +36,4 @@ type CodeFormatter =
     static member MakeRange: fileName: string * startLine: int * startCol: int * endLine: int * endCol: int -> range
 
     /// Make a pos from line and column
-    static member MakePosition: line: int * column: int -> pos
+    static member MakeSomePosition: line: int * column: int -> pos option

--- a/src/Fantomas/Daemon.fs
+++ b/src/Fantomas/Daemon.fs
@@ -60,7 +60,7 @@ type FantomasDaemon(sender: Stream, reader: Stream) as this =
 
                 let cursor =
                     request.Cursor
-                    |> Option.map (fun cursor -> CodeFormatter.MakePosition(cursor.Line, cursor.Column))
+                    |> Option.bind (fun cursor -> CodeFormatter.MakeSomePosition(cursor.Line, cursor.Column))
 
                 try
                     let! formatResponse =


### PR DESCRIPTION
Since this public method is intended for non-trivial situations, such as use in reflection-based calls

[Rider example](https://github.com/JetBrains/resharper-fsharp/blob/8cb4658df4471c87acb87be998ad6bbbe9e060a3/ReSharper.FSharp/src/FSharp.Fantomas.Host/src/FantomasCodeFormatter.cs#L176-L180)

and reflection calls do not support automatic conversion from `Position` to `FSharpOption<Position>`, it would be more convenient to have `FSharpOptions<Position>` as the return type.