### PR TITLE
Consolidate and share logic for Records and AnonymousRecords

### DIFF
--- a/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
+++ b/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
@@ -657,6 +657,41 @@ let person =
 "
 
 [<Test>]
+let ``multiline string before closing brace with anonymous record`` () =
+    formatSourceString
+        false
+        "
+let person =
+    let y =
+        let x =
+            {| Story = \"\"\"
+            foo
+            bar
+\"\"\"
+            |}
+        ()
+    ()
+"
+        config
+    |> prepend newline
+    |> should
+        equal
+        "
+let person =
+    let y =
+        let x =
+            {| Story =
+                \"\"\"
+            foo
+            bar
+\"\"\"         |}
+
+        ()
+
+    ()
+"
+
+[<Test>]
 let ``issue 457`` () =
     formatSourceString
         false

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -970,10 +970,10 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
         | None, Some(copyExpr, _) ->
             let copyExpr = mkExpr creationAide copyExpr
 
-            ExprCopyableRecordNode(stn "{" mOpen, Some copyExpr, fieldNodes, stn "}" mClose, exprRange)
+            ExprRecordNode(stn "{" mOpen, Some copyExpr, fieldNodes, stn "}" mClose, exprRange)
             |> Expr.Record
         | None, None ->
-            ExprCopyableRecordNode(stn "{" mOpen, None, fieldNodes, stn "}" mClose, exprRange)
+            ExprRecordNode(stn "{" mOpen, None, fieldNodes, stn "}" mClose, exprRange)
             |> Expr.Record
     | SynExpr.AnonRecd(isStruct, copyInfo, recordFields, StartEndRange 2 (mOpen, _, mClose)) ->
         let fields =

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -952,14 +952,6 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
         ExprArrayOrListNode(o, [ mkExpr creationAide singleExpr ], c, exprRange)
         |> Expr.ArrayOrList
     | SynExpr.Record(baseInfo, copyInfo, recordFields, StartEndRange 1 (mOpen, _, mClose)) ->
-        let extra =
-            match baseInfo, copyInfo with
-            | Some _, Some _ -> failwith "Unexpected that both baseInfo and copyInfo are present in SynExpr.Record"
-            | Some(t, e, mInherit, _, m), None ->
-                mkInheritConstructor creationAide t e mInherit m |> RecordNodeExtra.Inherit
-            | None, Some(copyExpr, _) -> mkExpr creationAide copyExpr |> RecordNodeExtra.With
-            | None, None -> RecordNodeExtra.None
-
         let fieldNodes =
             recordFields
             |> List.choose (function
@@ -968,8 +960,21 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
                     Some(RecordFieldNode(mkSynLongIdent fieldName, stn "=" mEq, mkExpr creationAide expr, m))
                 | _ -> None)
 
-        ExprRecordNode(stn "{" mOpen, extra, fieldNodes, stn "}" mClose, exprRange)
-        |> Expr.Record
+        match baseInfo, copyInfo with
+        | Some _, Some _ -> failwith "Unexpected that both baseInfo and copyInfo are present in SynExpr.Record"
+        | Some(t, e, mInherit, _, m), None ->
+            let inheritCtor = mkInheritConstructor creationAide t e mInherit m
+
+            ExprInheritRecordNode(stn "{" mOpen, inheritCtor, fieldNodes, stn "}" mClose, exprRange)
+            |> Expr.InheritRecord
+        | None, Some(copyExpr, _) ->
+            let copyExpr = mkExpr creationAide copyExpr
+
+            ExprRecordNode(stn "{" mOpen, Some copyExpr, fieldNodes, stn "}" mClose, exprRange)
+            |> Expr.Record
+        | None, None ->
+            ExprRecordNode(stn "{" mOpen, None, fieldNodes, stn "}" mClose, exprRange)
+            |> Expr.Record
     | SynExpr.AnonRecd(isStruct, copyInfo, recordFields, StartEndRange 2 (mOpen, _, mClose)) ->
         let fields =
             recordFields

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -970,10 +970,10 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
         | None, Some(copyExpr, _) ->
             let copyExpr = mkExpr creationAide copyExpr
 
-            ExprRecordNode(stn "{" mOpen, Some copyExpr, fieldNodes, stn "}" mClose, exprRange)
+            ExprCopyableRecordNode(stn "{" mOpen, Some copyExpr, fieldNodes, stn "}" mClose, exprRange)
             |> Expr.Record
         | None, None ->
-            ExprRecordNode(stn "{" mOpen, None, fieldNodes, stn "}" mClose, exprRange)
+            ExprCopyableRecordNode(stn "{" mOpen, None, fieldNodes, stn "}" mClose, exprRange)
             |> Expr.Record
     | SynExpr.AnonRecd(isStruct, copyInfo, recordFields, StartEndRange 2 (mOpen, _, mClose)) ->
         let fields =

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -976,7 +976,11 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
             |> List.choose (function
                 | ident, Some mEq, e ->
                     let m = unionRanges ident.idRange e.Range
-                    Some(AnonRecordFieldNode(mkIdent ident, stn "=" mEq, mkExpr creationAide e, m))
+
+                    let longIdent =
+                        IdentListNode([ IdentifierOrDot.Ident(mkIdent ident) ], ident.idRange)
+
+                    Some(RecordFieldNode(longIdent, stn "=" mEq, mkExpr creationAide e, m))
                 | _ -> None)
 
         ExprAnonRecordNode(

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1649,7 +1649,6 @@ let genSmallRecordNode (node: ExprRecordNode) =
          | None -> sepNone)
         node
 
-
 let genMultilineRecord genCrampedFields (node: ExprRecordNode) (ctx: Context) =
     let expressionStartColumn = ctx.Column
 

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -461,7 +461,7 @@ let genExpr (e: Expr) =
                     isSmallExpression size smallExpression multilineExpression ctx
             |> genNode node
     | Expr.Record node ->
-        let smallRecordExpr = genSmallMaybeCopyRecordExpr node
+        let smallRecordExpr = genSmallCopyableRecordNode node
         let genCrampedFields = genMultilineStandardRecordExprCrampedFields node
 
         let multilineRecordExpr =
@@ -473,7 +473,7 @@ let genExpr (e: Expr) =
     | Expr.AnonRecord node ->
         let genStructPrefix = onlyIf node.IsStruct !- "struct "
 
-        let smallRecordExpr = genStructPrefix +> genSmallMaybeCopyRecordExpr node
+        let smallRecordExpr = genStructPrefix +> genSmallCopyableRecordNode node
 
         let genCrampedFields = genMultilineAnonRecordCrampedFields node
 
@@ -1579,7 +1579,7 @@ let private genSmallRecordExpr genExtra (node: ExprRecordNode) =
     +> addSpaceIfSpaceAroundDelimiter
     +> genSingleTextNode node.ClosingBrace
 
-let genSmallMaybeCopyRecordExpr (node: ExprRecordNode) =
+let genSmallCopyableRecordNode (node: ExprCopyableRecordNode) =
     genSmallRecordExpr
         (match node.CopyInfo with
          | Some we -> genExpr we +> !- " with "
@@ -1622,7 +1622,7 @@ let genMultilineInheritRecordInstance (node: ExprInheritRecordNode) =
 
     ifAlignOrStroustrupBrackets genMultilineAlignBrackets genMultilineCramped
 
-let genMultilineRecordAlignBrackets (node: ExprRecordNode) =
+let genMultilineRecordAlignBrackets (node: ExprCopyableRecordNode) =
     let fieldsExpr = genFieldsExpr node
 
     match node.CopyInfo with
@@ -1671,7 +1671,7 @@ let genMultilineAnonRecordCrampedFields (node: ExprAnonRecordNode) targetColumn 
                     +> leaveNode fieldNode)
                 ctx
 
-let genMultilineStandardRecordExprCrampedFields (node: ExprRecordNode) targetColumn =
+let genMultilineStandardRecordExprCrampedFields (node: ExprCopyableRecordNode) targetColumn =
     match node.CopyInfo with
     | Some we -> genCopyExpr (genFieldsExpr node) we
     | None ->
@@ -1686,7 +1686,7 @@ let genMultilineStandardRecordExprCrampedFields (node: ExprRecordNode) targetCol
                     +> atCurrentColumn (genRecordFieldName e))
                 ctx
 
-let genMultilineRecordCramped genFields (node: ExprRecordNode) (ctx: Context) =
+let genMultilineRecordCramped genFields (node: ExprCopyableRecordNode) (ctx: Context) =
     let expressionStartColumn = ctx.Column
 
     let targetColumn =

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1555,10 +1555,10 @@ let genQuoteExpr (node: ExprQuoteNode) =
     +> genSingleTextNode node.CloseToken
     |> genNode node
 
-let genFieldsExpr (node: ExprRecordNode) =
+let genFieldsExpr (node: ExprRecordBaseNode) =
     col sepNln node.Fields genRecordFieldName
 
-let private genSmallRecordExpr genExtra (node: ExprRecordNode) =
+let private genSmallRecordExpr genExtra (node: ExprRecordBaseNode) =
     genSingleTextNode node.OpeningBrace
     +> addSpaceIfSpaceAroundDelimiter
     +> genExtra
@@ -1566,7 +1566,7 @@ let private genSmallRecordExpr genExtra (node: ExprRecordNode) =
     +> addSpaceIfSpaceAroundDelimiter
     +> genSingleTextNode node.ClosingBrace
 
-let genSmallCopyableRecordNode (node: ExprCopyableRecordNode) =
+let genSmallCopyableRecordNode (node: ExprRecordNode) =
     genSmallRecordExpr
         (match node.CopyInfo with
          | Some we -> genExpr we +> !- " with "
@@ -1609,7 +1609,7 @@ let genMultilineInheritRecordInstance (node: ExprInheritRecordNode) =
 
     ifAlignOrStroustrupBrackets genMultilineAlignBrackets genMultilineCramped
 
-let genMultilineRecordAlignBrackets (node: ExprCopyableRecordNode) =
+let genMultilineRecordAlignBrackets (node: ExprRecordNode) =
     let fieldsExpr = genFieldsExpr node
 
     match node.CopyInfo with
@@ -1658,7 +1658,7 @@ let genMultilineAnonRecordCrampedFields (node: ExprAnonRecordNode) targetColumn 
                     +> leaveNode fieldNode)
                 ctx
 
-let genMultilineStandardRecordExprCrampedFields (node: ExprCopyableRecordNode) targetColumn =
+let genMultilineStandardRecordExprCrampedFields (node: ExprRecordNode) targetColumn =
     match node.CopyInfo with
     | Some we -> genCopyExpr (genFieldsExpr node) we
     | None ->
@@ -1673,7 +1673,7 @@ let genMultilineStandardRecordExprCrampedFields (node: ExprCopyableRecordNode) t
                     +> atCurrentColumn (genRecordFieldName e))
                 ctx
 
-let genMultilineRecord genCrampedFields (node: ExprCopyableRecordNode) (ctx: Context) =
+let genMultilineRecord genCrampedFields (node: ExprRecordNode) (ctx: Context) =
     let expressionStartColumn = ctx.Column
 
     let targetColumn =
@@ -1710,7 +1710,7 @@ let genMultilineRecord genCrampedFields (node: ExprCopyableRecordNode) (ctx: Con
 
     ifAlignOrStroustrupBrackets (genMultilineRecordAlignBrackets node) genMultilineCramped ctx
 
-let genRecord smallRecordExpr multilineRecordExpr (node: ExprRecordNode) =
+let genRecord smallRecordExpr multilineRecordExpr (node: ExprRecordBaseNode) =
     fun ctx ->
         let size = getRecordSize ctx node.Fields
         genNode node (isSmallExpression size smallRecordExpr multilineRecordExpr) ctx

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -756,11 +756,7 @@ let isStroustrupStyleExpr (config: FormatConfig) (e: Expr) =
     let isStroustrupEnabled = config.MultilineBracketStyle = Stroustrup
 
     match e with
-    | Expr.Record node ->
-        match node.Extra with
-        | RecordNodeExtra.Inherit _ -> false
-        | RecordNodeExtra.With _
-        | RecordNodeExtra.None -> isStroustrupEnabled
+    | Expr.Record _
     | Expr.AnonRecord _
     | Expr.ArrayOrList _ -> isStroustrupEnabled
     | Expr.NamedComputation _ -> not config.NewlineBeforeMultilineComputationExpression

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -169,7 +169,7 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ExprInheritRecordNode as node ->
         let expr = Expr.InheritRecord node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprCopyableRecordNode as node ->
+    | :? ExprRecordNode as node ->
         let expr = Expr.Record node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprObjExprNode as node ->

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -163,11 +163,14 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ExprArrayOrListNode as node ->
         let expr = Expr.ArrayOrList node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprRecordNode as node ->
-        let expr = Expr.Record node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprAnonRecordNode as node ->
         let expr = Expr.AnonRecord node
+        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
+    | :? ExprInheritRecordNode as node ->
+        let expr = Expr.InheritRecord node
+        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
+    | :? ExprCopyableRecordNode as node ->
+        let expr = Expr.Record node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprObjExprNode as node ->
         let expr = Expr.ObjExpr node

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -782,20 +782,12 @@ type ExprRecordNode
     member val Fields = fields
     member val ClosingBrace = closingBrace
 
-type AnonRecordFieldNode(ident: SingleTextNode, equals: SingleTextNode, rhs: Expr, range) =
-    inherit NodeBase(range)
-
-    override val Children: Node array = [| yield ident; yield equals; yield Expr.Node rhs |]
-    member val Ident = ident
-    member val Equals = equals
-    member val Expr = rhs
-
 type ExprAnonRecordNode
     (
         isStruct: bool,
         openingBrace: SingleTextNode,
         copyInfo: Expr option,
-        fields: AnonRecordFieldNode list,
+        fields: RecordFieldNode list,
         closingBrace: SingleTextNode,
         range
     ) =

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -741,18 +741,6 @@ type InheritConstructor =
         | Paren n -> n.InheritKeyword
         | Other n -> n.InheritKeyword
 
-[<RequireQualifiedAccess; NoComparison>]
-type RecordNodeExtra =
-    | Inherit of inheritConstructor: InheritConstructor
-    | With of expr: Expr
-    | None
-
-    static member Node(extra: RecordNodeExtra) : Node option =
-        match extra with
-        | Inherit n -> Some(InheritConstructor.Node n)
-        | With e -> Some(Expr.Node e)
-        | None -> Option.None
-
 type RecordFieldNode(fieldName: IdentListNode, equals: SingleTextNode, expr: Expr, range) =
     inherit NodeBase(range)
 
@@ -762,7 +750,8 @@ type RecordFieldNode(fieldName: IdentListNode, equals: SingleTextNode, expr: Exp
     member val Expr = expr
 
 [<AbstractClass>]
-type ExprRecordNode(openingBrace: SingleTextNode, fields: RecordFieldNode list, closingBrace: SingleTextNode, range) =
+type ExprRecordBaseNode(openingBrace: SingleTextNode, fields: RecordFieldNode list, closingBrace: SingleTextNode, range)
+    =
     inherit NodeBase(range)
 
     member val OpeningBrace = openingBrace
@@ -770,7 +759,7 @@ type ExprRecordNode(openingBrace: SingleTextNode, fields: RecordFieldNode list, 
     member val ClosingBrace = closingBrace
     member x.HasFields = List.isNotEmpty x.Fields
 
-type ExprCopyableRecordNode
+type ExprRecordNode
     (
         openingBrace: SingleTextNode,
         copyInfo: Expr option,
@@ -778,7 +767,7 @@ type ExprCopyableRecordNode
         closingBrace: SingleTextNode,
         range
     ) =
-    inherit ExprRecordNode(openingBrace, fields, closingBrace, range)
+    inherit ExprRecordBaseNode(openingBrace, fields, closingBrace, range)
 
     member val CopyInfo = copyInfo
 
@@ -798,7 +787,7 @@ type ExprInheritRecordNode
         closingBrace: SingleTextNode,
         range
     ) =
-    inherit ExprRecordNode(openingBrace, fields, closingBrace, range)
+    inherit ExprRecordBaseNode(openingBrace, fields, closingBrace, range)
 
     member val InheritConstructor = inheritConstructor
 
@@ -817,7 +806,7 @@ type ExprAnonRecordNode
         closingBrace: SingleTextNode,
         range
     ) =
-    inherit ExprCopyableRecordNode(openingBrace, copyInfo, fields, closingBrace, range)
+    inherit ExprRecordNode(openingBrace, copyInfo, fields, closingBrace, range)
     member val IsStruct = isStruct
 
 type InterfaceImplNode
@@ -1613,7 +1602,7 @@ type Expr =
     | Tuple of ExprTupleNode
     | StructTuple of ExprStructTupleNode
     | ArrayOrList of ExprArrayOrListNode
-    | Record of ExprCopyableRecordNode
+    | Record of ExprRecordNode
     | InheritRecord of ExprInheritRecordNode
     | AnonRecord of ExprAnonRecordNode
     | ObjExpr of ExprObjExprNode


### PR DESCRIPTION
It's happened several times that something that gets fixed with records that didn't get fixed for anonymous records. Since they share so much in the style guide, I wanted to see if I could refactor `genExpr` to handle them both at the same time so they could share as much logic as possible. I refactored both nodes to use the same field node type, and added an active pattern to join them together and then only handle differences explicitly as needed. It seems to work perfectly to me and I actually found an existing bug that was fixed for records but not anonymous records in the process 🙃.