### PR TITLE
Process `as` keyword in SynMemberDefn.ImplicitCtor trivia.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+* Conditional defines around selfIdentifier in implicit type constructor. [#2733](https://github.com/fsprojects/fantomas/issues/2733)
+
 ### Changed
-* Update FCS to 'Remove unused code', commit cb106cf3182ff218f0a0e42780815dba94b60013
+* Update FCS to 'Add SynMemberDefnImplicitCtorTrivia', commit 924a64e8e40c840f05fbe7113796f267dd603282
 
 ## [5.2.0] - 2023-01-19
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@ Some common use cases include:
     
     <!-- Versions -->
     <PropertyGroup>
-        <FCSCommitHash>cb106cf3182ff218f0a0e42780815dba94b60013</FCSCommitHash>
+        <FCSCommitHash>924a64e8e40c840f05fbe7113796f267dd603282</FCSCommitHash>
         <StreamJsonRpcVersion>2.8.28</StreamJsonRpcVersion>
         <FSharpCoreVersion>6.0.1</FSharpCoreVersion>
     </PropertyGroup>

--- a/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
@@ -2990,3 +2990,31 @@ let ``dead code in active block`` () =
 b
 #endif
 """
+
+[<Test>]
+let ``defines around selfIdentifier in implicit type constructor, 2733`` () =
+    formatSourceString
+        false
+        """
+type internal CompilerStateCache(readAllBytes: string -> byte[], projectOptions: FSharpProjectOptions)
+#if !NO_TYPEPROVIDERS
+    as this =
+#else
+    =
+#endif
+    class end
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type internal CompilerStateCache(readAllBytes: string -> byte[], projectOptions: FSharpProjectOptions)
+#if !NO_TYPEPROVIDERS
+    as this =
+#else
+    =
+#endif
+    class
+    end
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3048,7 +3048,15 @@ let genImplicitConstructor (node: ImplicitConstructorNode) =
         )
 
     expressionFitsOnRestOfLine short long
-    +> optSingle (fun self -> sepSpace +> !- "as " +> genSingleTextNode self +> sepSpace) node.Self
+    +> optSingle
+        (fun (selfNode: AsSelfIdentifierNode) ->
+            sepSpace
+            +> onlyIf selfNode.HasContentBefore indent
+            +> (genSingleTextNode selfNode.As +> sepSpace +> genSingleTextNode selfNode.Self
+                |> genNode selfNode)
+            +> onlyIf selfNode.HasContentBefore unindent
+            +> sepSpace)
+        node.Self
 
 let genTypeDefn (td: TypeDefn) =
     let typeDefnNode = TypeDefn.TypeDefnNode td
@@ -3107,7 +3115,7 @@ let genTypeDefn (td: TypeDefn) =
             +> genSingleTextNode node.Identifier
             +> sepSpace
             +> genSingleTextNode node.Equals
-            +> autoIndentAndNlnWhenWriteBeforeNewlineNotEmpty (sepSpace +> genConstant node.Constant)
+            +> autoIndentAndNlnWhenWriteBeforeNewlineNotEmpty (sepSpace +> genExpr node.Constant)
             |> genNode node
 
         header

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -2108,7 +2108,7 @@ type EnumCaseNode
         attributes: MultipleAttributeListNode option,
         identifier: SingleTextNode,
         equals: SingleTextNode,
-        constant: Constant,
+        constant: Expr,
         range
     ) =
     inherit NodeBase(range)
@@ -2118,7 +2118,7 @@ type EnumCaseNode
            yield! noa bar
            yield identifier
            yield equals
-           yield Constant.Node constant |]
+           yield Expr.Node constant |]
 
     member val XmlDoc = xmlDoc
     member val Bar = bar
@@ -2217,6 +2217,12 @@ type SimplePatNode
     member val Identifier = identifier
     member val Type = t
 
+type AsSelfIdentifierNode(asNode: SingleTextNode, self: SingleTextNode, range) =
+    inherit NodeBase(range)
+    override val Children = [| yield (asNode :> Node); yield self |]
+    member val As = asNode
+    member val Self = self
+
 type ImplicitConstructorNode
     (
         xmlDoc: XmlDocNode option,
@@ -2225,7 +2231,7 @@ type ImplicitConstructorNode
         openingParen: SingleTextNode,
         parameters: SimplePatNode list,
         closingParen: SingleTextNode,
-        self: SingleTextNode option,
+        self: AsSelfIdentifierNode option,
         range
     ) =
     inherit NodeBase(range)


### PR DESCRIPTION
Fixes #2733.