### PR TITLE
Drop `Experimental` prefix from `ExperimentalStroustrup`.

### DIFF
--- a/docs/docs/end-users/Configuration.fsx
+++ b/docs/docs/end-users/Configuration.fsx
@@ -28,7 +28,7 @@ fsharp_bar_before_discriminated_union_declaration = true
 
 #\ Apply specific settings for a targeted subfolder
 [src/Elmish/View.fs]
-fsharp_multiline_bracket_style = experimental_stroustrup
+fsharp_multiline_bracket_style = stroustrup
 ```
 *)
 
@@ -39,9 +39,9 @@ You can quickly try your settings via the <a href="https://fsprojects.github.io/
 <img src="{{root}}/online_tool_usage.gif" alt="drawing" width="100%"/>
 *)
 
-#r "nuget: Fantomas.Core, 5.2.0-alpha-012"
+#r "../../../src/Fantomas.Core/bin/Release/netstandard2.0/Fantomas.FCS.dll"
+#r "../../../src/Fantomas.Core/bin/Release/netstandard2.0/Fantomas.Core.dll"
 
-open Fantomas.Core.FormatConfig
 open Fantomas.Core
 
 let formatCode input configIndent =
@@ -63,7 +63,7 @@ However, there are settings that we do not recommend and generally should not be
 
 <fantomas-setting name="indent_size" orange></fantomas-setting>
 
-` indent_size` has to be between 1 and 10.
+`indent_size` has to be between 1 and 10.
 
 This preference sets the indentation
 The common values are 2 and 4.  
@@ -576,7 +576,7 @@ formatCode
 
 `Cramped` The default way in F# to format brackets.  
 `Aligned` Alternative way of formatting records, arrays and lists. This will align the braces at the same column level.  
-`ExperimentalStroustrup` Please contribute to [fsprojects/fantomas#1408](https://github.com/fsprojects/fantomas/issues/1408) and engage in [fsharp/fslang-design#706](https://github.com/fsharp/fslang-design/issues/706).
+`Stroustrup` Please contribute to [fsprojects/fantomas#1408](https://github.com/fsprojects/fantomas/issues/1408) and engage in [fsharp/fslang-design#706](https://github.com/fsharp/fslang-design/issues/706).
 
 Default = Cramped.
 *)
@@ -632,7 +632,7 @@ formatCode
            (19, 20, 21) |]
     """
     { FormatConfig.Default with
-        MultilineBracketStyle = ExperimentalStroustrup }
+        MultilineBracketStyle = Stroustrup }
 (*** include-it ***)
 
 (**

--- a/docs/docs/end-users/Configuration.fsx
+++ b/docs/docs/end-users/Configuration.fsx
@@ -15,6 +15,12 @@ Your IDE should respect your settings, however the implementation of that is edi
 UI might be available depending on the IDE.
 *)
 
+#r "../../../src/Fantomas/bin/Release/net6.0/Fantomas.FCS.dll"
+#r "../../../src/Fantomas/bin/Release/net6.0/Fantomas.Core.dll"
+
+printf $"version: {Fantomas.Core.CodeFormatter.GetVersion()}"
+(*** include-output  ***)
+
 (**
 ## Usage
 Inside .editorconfig you can specify the file extension and code location to be use per config:
@@ -39,13 +45,13 @@ You can quickly try your settings via the <a href="https://fsprojects.github.io/
 <img src="{{root}}/online_tool_usage.gif" alt="drawing" width="100%"/>
 *)
 
-#r "../../../src/Fantomas.Core/bin/Release/netstandard2.0/Fantomas.FCS.dll"
-#r "../../../src/Fantomas.Core/bin/Release/netstandard2.0/Fantomas.Core.dll"
-
 open Fantomas.Core
 
 let formatCode input configIndent =
-    CodeFormatter.FormatDocumentAsync(false, input, configIndent)
+    async {
+        let! result = CodeFormatter.FormatDocumentAsync(false, input, configIndent)
+        printf $"%s{result.Code}"
+    }
     |> Async.RunSynchronously
 
 (**
@@ -87,7 +93,7 @@ formatCode
     """
     { FormatConfig.Default with
         IndentSize = 2 }
-(*** include-it ***)
+(*** include-output ***)
 (**
 <fantomas-setting name="max_line_length" green></fantomas-setting>
 
@@ -105,7 +111,7 @@ formatCode
     """
     { FormatConfig.Default with
         MaxLineLength = 60 }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="end_of_line" green></fantomas-setting>
@@ -130,7 +136,7 @@ formatCode
     """
     { FormatConfig.Default with
         InsertFinalNewline = false }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_space_before_parameter" orange></fantomas-setting>
@@ -148,7 +154,7 @@ formatCode
     """
     { FormatConfig.Default with
         SpaceBeforeParameter = false }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_space_before_lowercase_invocation" orange></fantomas-setting>
@@ -169,7 +175,7 @@ match x with
     """
     { FormatConfig.Default with
         SpaceBeforeLowercaseInvocation = false }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_space_before_uppercase_invocation" green gr></fantomas-setting>
@@ -190,7 +196,7 @@ match x with
     """
     { FormatConfig.Default with
         SpaceBeforeUppercaseInvocation = true }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_space_before_class_constructor" orange></fantomas-setting>
@@ -209,7 +215,7 @@ formatCode
     { FormatConfig.Default with
         SpaceBeforeClassConstructor = true }
 
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_space_before_member" green gr></fantomas-setting>
@@ -229,7 +235,7 @@ formatCode
     """
     { FormatConfig.Default with
         SpaceBeforeMember = true }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_space_before_colon" green></fantomas-setting>
@@ -247,7 +253,7 @@ formatCode
     """
     { FormatConfig.Default with
         SpaceBeforeColon = true }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_space_after_comma" orange></fantomas-setting>
@@ -264,7 +270,7 @@ formatCode
     """
     { FormatConfig.Default with
         SpaceAfterComma = false }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_space_before_semicolon" green gr></fantomas-setting>
@@ -282,7 +288,7 @@ formatCode
     """
     { FormatConfig.Default with
         SpaceBeforeSemicolon = true }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_space_after_semicolon" orange></fantomas-setting>
@@ -300,7 +306,7 @@ formatCode
     """
     { FormatConfig.Default with
         SpaceAfterSemicolon = false }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_space_around_delimiter" orange></fantomas-setting>
@@ -317,7 +323,7 @@ formatCode
     """
     { FormatConfig.Default with
         SpaceAroundDelimiter = false }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 ## Maximum width constraints
@@ -341,7 +347,7 @@ formatCode
     """
     { FormatConfig.Default with
         MaxIfThenShortWidth = 15 }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_max_if_then_else_short_width" green></fantomas-setting>
@@ -358,7 +364,7 @@ formatCode
     """
     { FormatConfig.Default with
         MaxIfThenElseShortWidth = 10 }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_max_infix_operator_expression" green></fantomas-setting>
@@ -374,7 +380,7 @@ formatCode
     """
     { FormatConfig.Default with
         MaxInfixOperatorExpression = 20 }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_max_record_width" green></fantomas-setting>
@@ -393,7 +399,7 @@ formatCode
     """
     { FormatConfig.Default with
         MaxRecordWidth = 20 }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_max_record_number_of_items" green></fantomas-setting>
@@ -425,7 +431,7 @@ formatCode
     { FormatConfig.Default with
         MaxRecordNumberOfItems = 2
         RecordMultilineFormatter = MultilineFormatterType.NumberOfItems }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_record_multiline_formatter" green></fantomas-setting>
@@ -453,7 +459,7 @@ formatCode
     """
     { FormatConfig.Default with
         RecordMultilineFormatter = MultilineFormatterType.NumberOfItems }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_max_array_or_list_width" green></fantomas-setting>
@@ -471,7 +477,7 @@ formatCode
     """
     { FormatConfig.Default with
         MaxArrayOrListWidth = 20 }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_max_array_or_list_number_of_items" green></fantomas-setting>
@@ -491,7 +497,7 @@ formatCode
     { FormatConfig.Default with
         MaxArrayOrListNumberOfItems = 2
         ArrayOrListMultilineFormatter = MultilineFormatterType.NumberOfItems }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_array_or_list_multiline_formatter" green></fantomas-setting>
@@ -511,7 +517,7 @@ formatCode
     """
     { FormatConfig.Default with
         ArrayOrListMultilineFormatter = MultilineFormatterType.NumberOfItems }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_max_value_binding_width" green></fantomas-setting>
@@ -530,7 +536,7 @@ formatCode
     """
     { FormatConfig.Default with
         MaxValueBindingWidth = 10 }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_max_function_binding_width" green></fantomas-setting>
@@ -549,7 +555,7 @@ formatCode
     """
     { FormatConfig.Default with
         MaxFunctionBindingWidth = 10 }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_max_dot_get_expression_width" green></fantomas-setting>
@@ -569,14 +575,14 @@ formatCode
     """
     { FormatConfig.Default with
         MaxDotGetExpressionWidth = 100 }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_multiline_bracket_style" green gr></fantomas-setting>
 
 `Cramped` The default way in F# to format brackets.  
 `Aligned` Alternative way of formatting records, arrays and lists. This will align the braces at the same column level.  
-`Stroustrup` Please contribute to [fsprojects/fantomas#1408](https://github.com/fsprojects/fantomas/issues/1408) and engage in [fsharp/fslang-design#706](https://github.com/fsharp/fslang-design/issues/706).
+`Stroustrup` Allow for easier reordering of members and keeping the code succinct. 
 
 Default = Cramped.
 *)
@@ -606,7 +612,7 @@ formatCode
     """
     { FormatConfig.Default with
         MultilineBracketStyle = Aligned }
-(*** include-it ***)
+(*** include-output ***)
 
 formatCode
     """ 
@@ -633,7 +639,7 @@ formatCode
     """
     { FormatConfig.Default with
         MultilineBracketStyle = Stroustrup }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 ## G-Research style
@@ -657,7 +663,7 @@ type Range =
     """
     { FormatConfig.Default with
         NewlineBetweenTypeDefinitionAndMembers = true }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_align_function_signature_to_indentation" green gr></fantomas-setting>
@@ -679,7 +685,7 @@ let run
     """
     { FormatConfig.Default with
         AlignFunctionSignatureToIndentation = true }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_alternative_long_member_definitions" green gr></fantomas-setting>
@@ -712,7 +718,7 @@ type D() =
     """
     { FormatConfig.Default with
         AlternativeLongMemberDefinitions = true }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_multi_line_lambda_closing_newline" green gr></fantomas-setting>
@@ -740,7 +746,7 @@ let printListWithOffset a list1 =
     """
     { FormatConfig.Default with
         MultiLineLambdaClosingNewline = true }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_experimental_keep_indent_in_branch" orange gr></fantomas-setting>
@@ -770,7 +776,7 @@ let main argv =
     """
     { FormatConfig.Default with
         ExperimentalKeepIndentInBranch = true }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_bar_before_discriminated_union_declaration" green gr></fantomas-setting>
@@ -788,7 +794,7 @@ formatCode
     { FormatConfig.Default with
         BarBeforeDiscriminatedUnionDeclaration = true }
 
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 ## Other
@@ -822,7 +828,7 @@ formatCode
     """
     { FormatConfig.Default with
         BlankLinesAroundNestedMultilineExpressions = false }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_keep_max_number_of_blank_lines" green></fantomas-setting>
@@ -840,7 +846,7 @@ formatCode
     """
     { FormatConfig.Default with
         KeepMaxNumberOfBlankLines = 1 }
-(*** include-it ***)
+(*** include-output ***)
 
 (**
 <fantomas-setting name="fsharp_strict_mode" red></fantomas-setting>
@@ -867,7 +873,7 @@ formatCode
     """
     { FormatConfig.Default with
         StrictMode = true }
-(*** include-it ***)
+(*** include-output ***)
 (**
 <fantomas-nav previous="./StyleGuide.html" next="./IgnoreFiles.html"></fantomas-nav>
 

--- a/fantomas.sln
+++ b/fantomas.sln
@@ -16,6 +16,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{29F22904-C9E0-40AA-B971-9AE377C17F59}"
 	ProjectSection(SolutionItems) = preProject
 		docs\index.html = docs\index.html
+		docs\docs\end-users\Configuration.fsx = docs\docs\end-users\Configuration.fsx
 	EndProjectSection
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fantomas.Client", "src\Fantomas.Client\Fantomas.Client.fsproj", "{AA895F94-CCF2-4FCF-A9BB-E16987B57535}"

--- a/src/Fantomas.Core.Tests/AlignedMultilineBracketStyleTests.fs
+++ b/src/Fantomas.Core.Tests/AlignedMultilineBracketStyleTests.fs
@@ -1526,7 +1526,7 @@ let ``update record in stroustrup style`` () =
 let v = { rainbow with Boss = "Jeffrey" ; Lackeys = [ "Zippy"; "George"; "Bungle" ] }
 """
         { config with
-            MultilineBracketStyle = ExperimentalStroustrup }
+            MultilineBracketStyle = Stroustrup }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/DallasTests.fs
+++ b/src/Fantomas.Core.Tests/DallasTests.fs
@@ -1857,7 +1857,7 @@ let someTest input1 input2 =
     }
 """
         { config with
-            MultilineBracketStyle = ExperimentalStroustrup }
+            MultilineBracketStyle = Stroustrup }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/NumberOfItemsListOrArrayTests.fs
+++ b/src/Fantomas.Core.Tests/NumberOfItemsListOrArrayTests.fs
@@ -88,7 +88,7 @@ h [ longValueThatIsALotOfCharactersSoooooLong; longValueThatIsALotOfCharactersSo
     """
         { config with
             ArrayOrListMultilineFormatter = NumberOfItems
-            MultilineBracketStyle = ExperimentalStroustrup }
+            MultilineBracketStyle = Stroustrup }
     |> prepend newline
     |> should
         equal
@@ -206,7 +206,7 @@ h [ longValueThatIsALotOfCharactersSoooooLong; longValueThatIsALotOfCharactersSo
     """
         { config with
             ArrayOrListMultilineFormatter = NumberOfItems
-            MultilineBracketStyle = ExperimentalStroustrup }
+            MultilineBracketStyle = Stroustrup }
     |> prepend newline
     |> should
         equal
@@ -240,7 +240,7 @@ h [ longValueThatIsALotOfCharactersSoooooLong; longValueThatIsALotOfCharactersSo
     """
         { config with
             ArrayOrListMultilineFormatter = NumberOfItems
-            MultilineBracketStyle = ExperimentalStroustrup }
+            MultilineBracketStyle = Stroustrup }
     |> prepend newline
     |> should
         equal
@@ -272,7 +272,7 @@ h [ longValueThatIsALotOfCharactersSoooooLong; longValueThatIsALotOfCharactersSo
     """
         { config with
             ArrayOrListMultilineFormatter = NumberOfItems
-            MultilineBracketStyle = ExperimentalStroustrup }
+            MultilineBracketStyle = Stroustrup }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/Stroustrup/DotIndexedSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/DotIndexedSetExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/DotSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/DotSetExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/ElmishTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/ElmishTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup }
+        MultilineBracketStyle = Stroustrup }
 
 [<Test>]
 let ``long named arguments should go on newline`` () =

--- a/src/Fantomas.Core.Tests/Stroustrup/FunctionApplicationDualListTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/FunctionApplicationDualListTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup }
+        MultilineBracketStyle = Stroustrup }
 
 [<Test>]
 let ``two short lists`` () =

--- a/src/Fantomas.Core.Tests/Stroustrup/FunctionApplicationSingleListTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/FunctionApplicationSingleListTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup }
+        MultilineBracketStyle = Stroustrup }
 
 [<Test>]
 let ``short function application`` () =

--- a/src/Fantomas.Core.Tests/Stroustrup/KeepIndentInBranchExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/KeepIndentInBranchExpressionTests.fs
@@ -10,7 +10,7 @@ open Fantomas.Core
 let config =
     { config with
         ExperimentalKeepIndentInBranch = true
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 // There currently is no conflict with this setting, but I'm guessing the case was never brought up.

--- a/src/Fantomas.Core.Tests/Stroustrup/LambdaExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/LambdaExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/LetOrUseBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/LetOrUseBangExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/LongIdentSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/LongIdentSetExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/MultiLineLambdaClosingNewlineExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/MultiLineLambdaClosingNewlineExpressionTests.fs
@@ -8,7 +8,7 @@ open Fantomas.Core
 let config =
     { config with
         MultiLineLambdaClosingNewline = true
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/NamedArgumentExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/NamedArgumentExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SetExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionLongPatternExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionLongPatternExpressionTests.fs
@@ -8,7 +8,7 @@ open Fantomas.Core.Tests.TestHelper
 let config =
     { config with
         MaxLineLength = 80
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 // TODO: conclude on what should happen here

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionWithReturnTypeExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionWithReturnTypeExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynExprAndBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynExprAndBangExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynMatchClauseExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynMatchClauseExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSigReprSimpleTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSigReprSimpleTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup }
+        MultilineBracketStyle = Stroustrup }
 
 [<Test>]
 let ``record type definition`` () =

--- a/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynTypeDefnSimpleReprRecordTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup }
+        MultilineBracketStyle = Stroustrup }
 
 [<Test>]
 let ``record type definition`` () =

--- a/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnBangExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnExpressionTests.fs
@@ -7,7 +7,7 @@ open Fantomas.Core.Tests.TestHelper
 
 let config =
     { config with
-        MultilineBracketStyle = ExperimentalStroustrup
+        MultilineBracketStyle = Stroustrup
         MaxArrayOrListWidth = 40 }
 
 [<Test>]

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -753,11 +753,7 @@ let sepSpaceOrDoubleIndentAndNlnIfExpressionExceedsPageWidth expr (ctx: Context)
         ctx
 
 let sepSpaceOrIndentAndNlnIfExceedsPageWidthUnlessStroustrup isStroustrup f (node: Node) (ctx: Context) =
-    if
-        ctx.Config.ExperimentalStroustrupStyle
-        && isStroustrup
-        && Seq.isEmpty node.ContentBefore
-    then
+    if ctx.Config.IsStroustrupStyle && isStroustrup && Seq.isEmpty node.ContentBefore then
         (sepSpace +> f) ctx
     else
         sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth f ctx
@@ -866,7 +862,7 @@ let ifAlignOrStroustrupBrackets f g =
         (fun ctx ->
             match ctx.Config.MultilineBracketStyle with
             | Aligned
-            | ExperimentalStroustrup -> true
+            | Stroustrup -> true
             | Cramped -> false)
         f
         g
@@ -907,7 +903,7 @@ let addParenIfAutoNln expr f =
 
 let autoIndentAndNlnExpressUnlessStroustrup (f: Expr -> Context -> Context) (e: Expr) (ctx: Context) =
     let shouldUseStroustrup =
-        ctx.Config.ExperimentalStroustrupStyle
+        ctx.Config.IsStroustrupStyle
         && e.IsStroustrupStyleExpr
         && let node = Expr.Node e in
            Seq.isEmpty node.ContentBefore
@@ -919,7 +915,7 @@ let autoIndentAndNlnExpressUnlessStroustrup (f: Expr -> Context -> Context) (e: 
 
 let autoIndentAndNlnTypeUnlessStroustrup (f: Type -> Context -> Context) (t: Type) (ctx: Context) =
     let shouldUseStroustrup =
-        ctx.Config.ExperimentalStroustrupStyle
+        ctx.Config.IsStroustrupStyle
         && t.IsStroustrupStyleType
         && let node = Type.Node t in
            Seq.isEmpty node.ContentBefore
@@ -935,7 +931,7 @@ let autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup
     (ctx: Context)
     =
     let isStroustrup =
-        ctx.Config.ExperimentalStroustrupStyle
+        ctx.Config.IsStroustrupStyle
         && e.IsStroustrupStyleExpr
         && Seq.isEmpty (Expr.Node e).ContentBefore
 

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -38,7 +38,6 @@ type MultilineBracketStyle =
         match cfgString with
         | "cramped" -> Some Cramped
         | "aligned" -> Some Aligned
-        | "experimental_stroustrup" -> Some Stroustrup // TODO: Should we keep this working or just drop this altogether
         | "stroustrup" -> Some Stroustrup
         | _ -> None
 

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -26,19 +26,20 @@ type MultilineFormatterType =
 type MultilineBracketStyle =
     | Cramped
     | Aligned
-    | ExperimentalStroustrup
+    | Stroustrup
 
     static member ToConfigString(cfg: MultilineBracketStyle) =
         match cfg with
         | Cramped -> "cramped"
         | Aligned -> "aligned"
-        | ExperimentalStroustrup -> "experimental_stroustrup"
+        | Stroustrup -> "stroustrup"
 
     static member OfConfigString(cfgString: string) =
         match cfgString with
         | "cramped" -> Some Cramped
         | "aligned" -> Some Aligned
-        | "experimental_stroustrup" -> Some ExperimentalStroustrup
+        | "experimental_stroustrup" -> Some Stroustrup // TODO: Should we keep this working or just drop this altogether
+        | "stroustrup" -> Some Stroustrup
         | _ -> None
 
 [<RequireQualifiedAccess>]
@@ -210,8 +211,8 @@ type FormatConfig =
       BarBeforeDiscriminatedUnionDeclaration: bool
 
       [<Category("Convention")>]
-      [<DisplayName("How to format brackets")>]
-      [<Description("Possible options include cramped (default), aligned, and experimental_stroustrup")>]
+      [<DisplayName("How to format bracket expressions (arrays, objects, etc.) that span multiple lines")>]
+      [<Description("Possible options include cramped (default), aligned, and stroustrup")>]
       MultilineBracketStyle: MultilineBracketStyle
 
       [<Category("Convention")>]
@@ -223,7 +224,7 @@ type FormatConfig =
       [<Description("Pretty printing based on ASTs only.\nPlease do not use this setting for formatting hand written code!")>]
       StrictMode: bool }
 
-    member x.ExperimentalStroustrupStyle = x.MultilineBracketStyle = ExperimentalStroustrup
+    member x.IsStroustrupStyle = x.MultilineBracketStyle = Stroustrup
 
     static member Default =
         { IndentSize = 4

--- a/src/Fantomas.Tests/EditorConfigurationTests.fs
+++ b/src/Fantomas.Tests/EditorConfigurationTests.fs
@@ -464,7 +464,7 @@ fsharp_multiline_bracket_style = experimental_stroustrup
 
     let config = EditorConfig.readConfiguration fsharpFile.FSharpFile
 
-    Assert.AreEqual(ExperimentalStroustrup, config.MultilineBracketStyle)
+    Assert.AreEqual(Stroustrup, config.MultilineBracketStyle)
 
 [<Test>]
 let ``fsharp_multiline_bracket_style = aligned`` () =

--- a/src/Fantomas.Tests/EditorConfigurationTests.fs
+++ b/src/Fantomas.Tests/EditorConfigurationTests.fs
@@ -448,13 +448,13 @@ insert_final_newline = false
     Assert.IsFalse config.InsertFinalNewline
 
 [<Test>]
-let ``fsharp_multiline_bracket_style = experimental_stroustrup`` () =
+let ``fsharp_multiline_bracket_style = stroustrup`` () =
     let rootDir = tempName ()
 
     let editorConfig =
         """
 [*.fs]
-fsharp_multiline_bracket_style = experimental_stroustrup
+fsharp_multiline_bracket_style = stroustrup
 """
 
     use configFixture =


### PR DESCRIPTION
﻿Drop `Experimental` prefix from `ExperimentalStroustrup`.

I also updated the configuration docs script to reference the local version to stay in sync.