### PR TITLE
Move isStroustrupStyleExpr and isStroustrupStyleType functions

### DIFF
--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -851,7 +851,7 @@ let genExpr (e: Expr) =
                 onlyIf
                     (isMultiline
                      && ctx.Config.MultiLineLambdaClosingNewline
-                     && not (ctx.Config.ExperimentalStroustrupStyle && node.Lambda.Expr.IsStroustrupStyleExpr))
+                     && not (isStroustrupStyleExpr ctx.Config node.Lambda.Expr))
                     sepNln
                     ctx)
         +> genSingleTextNode node.ClosingParen
@@ -1052,9 +1052,7 @@ let genExpr (e: Expr) =
                         +> onlyIfCtx
                             (fun ctx ->
                                 ctx.Config.MultiLineLambdaClosingNewline
-                                && (not (
-                                    ctx.Config.ExperimentalStroustrupStyle && lambdaNode.Expr.IsStroustrupStyleExpr
-                                )))
+                                && (not (isStroustrupStyleExpr ctx.Config lambdaNode.Expr)))
                             sepNln
                         +> genSingleTextNode appParen.Paren.ClosingParen
                     | _ ->
@@ -1912,7 +1910,7 @@ let genClause (isLastItem: bool) (node: MatchClauseNode) =
                         ctx)
 
     let genPatAndBody ctx =
-        if ctx.Config.ExperimentalStroustrupStyle && node.BodyExpr.IsStroustrupStyleExpr then
+        if isStroustrupStyleExpr ctx.Config node.BodyExpr then
             let startColumn = ctx.Column
             (genPatInClause node.Pattern +> atIndentLevel false startColumn genWhenAndBody) ctx
         else
@@ -2171,9 +2169,7 @@ let genAppWithLambda sep (node: ExprAppWithLambdaNode) =
                     | Choice1Of2 lambdaNode ->
                         genSingleTextNode node.OpeningParen
                         +> (genLambdaWithParen lambdaNode |> genNode lambdaNode)
-                        +> onlyIf
-                            (not (ctx.Config.ExperimentalStroustrupStyle && lambdaNode.Expr.IsStroustrupStyleExpr))
-                            sepNln
+                        +> onlyIf (not (isStroustrupStyleExpr ctx.Config lambdaNode.Expr)) sepNln
                         +> genSingleTextNode node.ClosingParen
                     | Choice2Of2 matchLambdaNode ->
                         genSingleTextNode node.OpeningParen
@@ -2195,11 +2191,7 @@ let genAppWithLambda sep (node: ExprAppWithLambdaNode) =
                                  +> (genLambdaWithParen lambdaNode |> genNode lambdaNode))
                                 (fun isMultiline ->
                                     onlyIf
-                                        (isMultiline
-                                         && not (
-                                             ctx.Config.ExperimentalStroustrupStyle
-                                             && lambdaNode.Expr.IsStroustrupStyleExpr
-                                         ))
+                                        (isMultiline && not (isStroustrupStyleExpr ctx.Config lambdaNode.Expr))
                                         sepNln
                                     +> genSingleTextNode node.ClosingParen)
                         | Choice2Of2 matchLambdaNode ->

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -234,6 +234,8 @@ val sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup:
 val sepSpaceOrIndentAndNlnIfTypeExceedsPageWidthUnlessStroustrup:
     f: (Type -> Context -> Context) -> t: Type -> (Context -> Context)
 
+val isStroustrupStyleExpr: config: FormatConfig -> e: Expr -> bool
+
 val autoParenthesisIfExpressionExceedsPageWidth: expr: (Context -> Context) -> ctx: Context -> Context
 val futureNlnCheck: f: (Context -> Context) -> ctx: Context -> bool
 /// similar to futureNlnCheck but validates whether the expression is going over the max page width

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -382,11 +382,6 @@ type Type =
         | Or n -> n
         | LongIdentApp n -> n
 
-    member e.IsStroustrupStyleType: bool =
-        match e with
-        | AnonRecord _ -> true
-        | _ -> false
-
 /// A pattern composed from a left hand-side pattern, a single text token/operator and a right hand-side pattern.
 type PatLeftMiddleRight(lhs: Pattern, middle: Choice<SingleTextNode, string>, rhs: Pattern, range) =
     inherit NodeBase(range)
@@ -1726,21 +1721,6 @@ type Expr =
         | IndexFromEnd n -> n
         | Typar n -> n
         | Chain n -> n
-
-    member e.IsStroustrupStyleExpr: bool =
-        match e with
-        | Expr.Record node ->
-            match node.Extra with
-            | RecordNodeExtra.Inherit _ -> false
-            | RecordNodeExtra.With _
-            | RecordNodeExtra.None -> true
-        | Expr.AnonRecord _ -> true
-        | Expr.NamedComputation node ->
-            match node.Name with
-            | Expr.Ident _ -> true
-            | _ -> false
-        | Expr.ArrayOrList _ -> true
-        | _ -> false
 
     member e.HasParentheses: bool =
         match e with


### PR DESCRIPTION
Per @nojaf's advice in different PR, I refactored `isStroustrupStyleExpr` and `isStroustrupStyleType` to functions in `Context.fs`.

Those changes felt like a distinct enough change to extract into its own PR.