### PR TITLE
Add SynExpr.ArrayOrListComputed case to visit() in ChainExpr AP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Conditional defines around selfIdentifier in implicit type constructor. [#2733](https://github.com/fsprojects/fantomas/issues/2733)
+* Insert extra spaces around index between method calling and member variable accessing. [#2760](https://github.com/fsprojects/fantomas/issues/2760)
 
 ### Changed
 * Update FCS to 'Add SynMemberDefnImplicitCtorTrivia', commit 924a64e8e40c840f05fbe7113796f267dd603282

--- a/src/Fantomas.Core.Tests/DotIndexedGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotIndexedGetTests.fs
@@ -168,3 +168,24 @@ module Unix =
                     )).[0]
         }
 """
+
+[<Test>]
+let ``extra spaces around index between method calling and member variable accessing, 2760`` () =
+    formatSourceString
+        false
+        """
+x().y[0].z // spaces inserted around index
+x().y.[0].z // no spaces inserted
+x().y[0] // no spaces inserted
+x.y[0].z // no spaces inserted
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+x().y[0].z // spaces inserted around index
+x().y.[0].z // no spaces inserted
+x().y[0] // no spaces inserted
+x.y[0].z // no spaces inserted
+"""

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -788,6 +788,8 @@ let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list option =
                       yield LinkExpr.Dot dotRange
                       yield LinkExpr.IndexExpr indexArgs ])
 
+        | SynExpr.ArrayOrListComputed(false, synExpr, _) -> continuation [ LinkExpr.IndexExpr synExpr ]
+
         | other -> continuation [ LinkExpr.Expr other ]
 
     match e with


### PR DESCRIPTION
fixes #2760