### PR TITLE
Capture index without dot inside a chain.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [5.2.1] - 2023-02-04
 
 ### Fixed
 * Conditional defines around selfIdentifier in implicit type constructor. [#2733](https://github.com/fsprojects/fantomas/issues/2733)
+* Insert extra spaces around index between method calling and member variable accessing. [#2760](https://github.com/fsprojects/fantomas/issues/2760)
+* Exception caused by long line over 80 characters including method calling and member indexing. [#2761](https://github.com/fsprojects/fantomas/issues/2761)
 
 ### Changed
 * Update FCS to 'Add SynMemberDefnImplicitCtorTrivia', commit 924a64e8e40c840f05fbe7113796f267dd603282

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -387,3 +387,54 @@ Fooooooooooo.Baaaaaaaaaaaaaaaaar
     .Moooooooooooooooo.Booooooooooooooooooooh
     .Yooooooooooooooou.Meeeeeeh.Meh2
 """
+
+[<Test>]
+let ``dot get with index without dot expression , 2761`` () =
+    formatSourceString
+        false
+        """
+x().y[0].zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+x().y[0].zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+"""
+
+[<Test>]
+let ``don't add extra space in index without dot expression, 2760`` () =
+    formatSourceString
+        false
+        """
+x().y[0].z // spaces inserted around index
+x().y.[0].z // no spaces inserted
+x().y[0] // no spaces inserted
+x.y[0].z // no spaces inserted
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+x().y[0].z // spaces inserted around index
+x().y.[0].z // no spaces inserted
+x().y[0] // no spaces inserted
+x.y[0].z // no spaces inserted
+"""
+
+[<Test>]
+let ``multiple idents in dotget with index without dot`` () =
+    formatSourceString
+        false
+        """
+v().w.x.y.z['a'].b
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+v().w.x.y.z['a'].b
+"""

--- a/src/Fantomas.Core/Utils.fs
+++ b/src/Fantomas.Core/Utils.fs
@@ -2,6 +2,7 @@ namespace Fantomas.Core
 
 open System
 open System.Text.RegularExpressions
+open Microsoft.FSharp.Core.CompilerServices
 
 [<RequireQualifiedAccess>]
 module String =
@@ -101,6 +102,20 @@ module List =
             | head :: tail -> visit tail (fun ys -> f head :: ys |> continuation)
 
         visit xs id
+
+    let cutOffLast list =
+        let mutable headList = ListCollector<'a>()
+
+        let rec visit list =
+            match list with
+            | []
+            | [ _ ] -> ()
+            | head :: tail ->
+                headList.Add(head)
+                visit tail
+
+        visit list
+        headList.Close()
 
 module Async =
     let map f computation =

--- a/src/Fantomas.Core/Utils.fsi
+++ b/src/Fantomas.Core/Utils.fsi
@@ -15,6 +15,8 @@ module List =
     val moreThanOne: ('a list -> bool)
     val partitionWhile: f: (int -> 'a -> bool) -> xs: 'a list -> 'a list * 'a list
     val mapWithLast: f: ('a -> 'b) -> g: ('a -> 'b) -> xs: 'a list -> 'b list
+    /// Removes the last element of a list
+    val cutOffLast: 'a list -> 'a list
 
 module Async =
     val map: f: ('a -> 'b) -> computation: Async<'a> -> Async<'b>


### PR DESCRIPTION
@dawedawe this fixes both #2760 and #2761.
I'm on the fence about this. It fixes both stylistic and soundness problem.
We might want to have this on the main branch after all. I don't think we can fix the `soundness` without changing the style. (however minor that change actually fix).


