### PR TITLE
Consolidate records part two

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@ Some common use cases include:
     
     <!-- Versions -->
     <PropertyGroup>
-        <FCSCommitHash>924a64e8e40c840f05fbe7113796f267dd603282</FCSCommitHash>
+        <FCSCommitHash>ec1f2e206445dacd88e17fbfed42c0688cb6216d</FCSCommitHash>
         <StreamJsonRpcVersion>2.8.28</StreamJsonRpcVersion>
         <FSharpCoreVersion>6.0.1</FSharpCoreVersion>
     </PropertyGroup>

--- a/src/Fantomas.Core.Tests/AlignedMultilineBracketStyleArrayOrListTests.fs
+++ b/src/Fantomas.Core.Tests/AlignedMultilineBracketStyleArrayOrListTests.fs
@@ -1,4 +1,4 @@
-module Fantomas.Core.Tests.MultilineBlockBracketsOnSameColumnArrayOrListTests
+module Fantomas.Core.Tests.AlignedMultilineBracketStyleArrayOrListTests
 
 open NUnit.Framework
 open FsUnit

--- a/src/Fantomas.Core.Tests/AlignedMultilineBracketStyleTests.fs
+++ b/src/Fantomas.Core.Tests/AlignedMultilineBracketStyleTests.fs
@@ -1545,3 +1545,28 @@ let v = {
         Lackeys = [ "Zippy" ; "George" ; "Bungle" ]
 }
 """
+
+[<Test>]
+let ``anonymous struct record with trivia`` () =
+    formatSourceString
+        false
+        """
+struct // 1
+    {| // 2
+        // 3
+        X = 4
+    // 5       
+    |} // 6 
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+struct // 1
+    {| // 2
+        // 3
+        X = 4
+    // 5
+    |} // 6
+"""

--- a/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
+++ b/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
@@ -1721,8 +1721,8 @@ let ``record with comments above field, indent 2`` () =
         equal
         """
 { Foo =
-    // bar
-    someValue }
+  // bar
+  someValue }
 """
 
 [<Test>]
@@ -1778,8 +1778,8 @@ let ``anonymous record with multiline field, indent 2`` () =
         equal
         """
 {| Foo =
-    //  meh
-    someValue |}
+  //  meh
+  someValue |}
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -59,7 +59,7 @@
     <Compile Include="SpaceBeforeClassConstructorTests.fs" />
     <Compile Include="SpaceBeforeMemberTests.fs" />
     <Compile Include="AlignedMultilineBracketStyleTests.fs" />
-    <Compile Include="MultilineBlockBracketsOnSameColumnArrayOrListTests.fs" />
+    <Compile Include="AlignedMultilineBracketStyleArrayOrListTests.fs" />
     <Compile Include="NewlineBetweenTypeDefinitionAndMembersTests.fs" />
     <Compile Include="MaxValueBindingWidthTests.fs" />
     <Compile Include="MaxFunctionBindingWidthTests.fs" />
@@ -108,6 +108,7 @@
     <Compile Include="Stroustrup\ElmishTests.fs" />
     <Compile Include="Stroustrup\FunctionApplicationSingleListTests.fs" />
     <Compile Include="Stroustrup\FunctionApplicationDualListTests.fs" />
+    <Compile Include="Stroustrup\SynExprAnonRecdStructTests.fs" />
     <Compile Include="IdentTests.fs" />
     <Compile Include="RecordDeclarationsWithXMLDocTests.fs" />
     <Compile Include="MaxIfThenShortWidthTests.fs" />

--- a/src/Fantomas.Core.Tests/NumberOfItemsRecordTests.fs
+++ b/src/Fantomas.Core.Tests/NumberOfItemsRecordTests.fs
@@ -697,8 +697,8 @@ let ``indent update anonymous record fields far enough`` () =
         """
 let expected =
   {| ThisIsAThing.Empty with
-       TheNewValue = 1
-       ThatValue = 2 |}
+      TheNewValue = 1
+      ThatValue = 2 |}
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynExprAnonRecdStructTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynExprAnonRecdStructTests.fs
@@ -1,0 +1,35 @@
+﻿module Fantomas.Core.Tests.Stroustrup.SynExprAnonRecdStructTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelper
+open Fantomas.Core
+
+let config =
+    { config with
+        MultilineBracketStyle = Stroustrup }
+
+[<Test>]
+let ``anonymous struct record with trivia`` () =
+    formatSourceString
+        false
+        """
+struct // 1
+    {| // 2
+        // 3
+        X = 4
+    // 5       
+    |} // 6 
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+struct // 1
+    {| // 2
+        // 3
+        X = 4
+    // 5
+    |} // 6
+"""

--- a/src/Fantomas.Core.Tests/StructTests.fs
+++ b/src/Fantomas.Core.Tests/StructTests.fs
@@ -164,3 +164,28 @@ type NameStruct() =
     struct
     end
 """
+
+[<Test>]
+let ``anonymous struct record with trivia`` () =
+    formatSourceString
+        false
+        """
+struct // 1
+    {| // 2
+        // 3
+        X = 4
+    // 5       
+    |} // 6 
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+struct // 1
+    {| // 2
+       // 3
+       X = 4
+    // 5
+    |} // 6
+"""

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -975,7 +975,11 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
         | None, None ->
             ExprRecordNode(stn "{" mOpen, None, fieldNodes, stn "}" mClose, exprRange)
             |> Expr.Record
-    | SynExpr.AnonRecd(isStruct, copyInfo, recordFields, StartEndRange 2 (mOpen, _, mClose)) ->
+    | SynExpr.AnonRecd(true,
+                       copyInfo,
+                       recordFields,
+                       (StartRange 6 (mStruct, _) & EndRange 2 (mClose, _)),
+                       { OpeningBraceRange = mOpen }) ->
         let fields =
             recordFields
             |> List.choose (function
@@ -988,19 +992,36 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
                     Some(RecordFieldNode(longIdent, stn "=" mEq, mkExpr creationAide e, m))
                 | _ -> None)
 
-        let recordNode =
-            ExprRecordNode(
-                stn "{|" mOpen,
-                Option.map (fst >> mkExpr creationAide) copyInfo,
-                fields,
-                stn "|}" mClose,
-                exprRange
-            )
+        ExprAnonStructRecordNode(
+            stn "struct" mStruct,
+            stn "{|" mOpen,
+            Option.map (fst >> mkExpr creationAide) copyInfo,
+            fields,
+            stn "|}" mClose,
+            exprRange
+        )
+        |> Expr.AnonStructRecord
+    | SynExpr.AnonRecd(false, copyInfo, recordFields, EndRange 2 (mClose, _), { OpeningBraceRange = mOpen }) ->
+        let fields =
+            recordFields
+            |> List.choose (function
+                | ident, Some mEq, e ->
+                    let m = unionRanges ident.idRange e.Range
 
-        if isStruct then
-            Expr.AnonStructRecord recordNode
-        else
-            Expr.Record recordNode
+                    let longIdent =
+                        IdentListNode([ IdentifierOrDot.Ident(mkIdent ident) ], ident.idRange)
+
+                    Some(RecordFieldNode(longIdent, stn "=" mEq, mkExpr creationAide e, m))
+                | _ -> None)
+
+        ExprRecordNode(
+            stn "{|" mOpen,
+            Option.map (fst >> mkExpr creationAide) copyInfo,
+            fields,
+            stn "|}" mClose,
+            exprRange
+        )
+        |> Expr.Record
     | SynExpr.ObjExpr(t, eio, withKeyword, bd, members, ims, StartRange 3 (mNew, _), StartEndRange 1 (mOpen, _, mClose)) ->
         let interfaceNodes =
             ims

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -988,15 +988,19 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
                     Some(RecordFieldNode(longIdent, stn "=" mEq, mkExpr creationAide e, m))
                 | _ -> None)
 
-        ExprAnonRecordNode(
-            isStruct,
-            stn "{|" mOpen,
-            Option.map (fst >> mkExpr creationAide) copyInfo,
-            fields,
-            stn "|}" mClose,
-            exprRange
-        )
-        |> Expr.AnonRecord
+        let recordNode =
+            ExprRecordNode(
+                stn "{|" mOpen,
+                Option.map (fst >> mkExpr creationAide) copyInfo,
+                fields,
+                stn "|}" mClose,
+                exprRange
+            )
+
+        if isStruct then
+            Expr.AnonStructRecord recordNode
+        else
+            Expr.Record recordNode
     | SynExpr.ObjExpr(t, eio, withKeyword, bd, members, ims, StartRange 3 (mNew, _), StartEndRange 1 (mOpen, _, mClose)) ->
         let interfaceNodes =
             ims

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -464,8 +464,8 @@ let genExpr (e: Expr) =
         let smallRecordExpr = genSmallRecordNode node
         let multilineRecordExpr = genMultilineRecord node
         genRecord smallRecordExpr multilineRecordExpr node
-    | Expr.AnonRecord node ->
-        let genStructPrefix = onlyIf node.IsStruct !- "struct "
+    | Expr.AnonStructRecord node ->
+        let genStructPrefix = !- "struct "
         let smallRecordExpr = genStructPrefix +> genSmallRecordNode node
         let multilineRecordExpr = genStructPrefix +> genMultilineRecord node
         genRecord smallRecordExpr multilineRecordExpr node
@@ -826,7 +826,7 @@ let genExpr (e: Expr) =
             let genExpr e =
                 match e with
                 | Expr.Record _
-                | Expr.AnonRecord _ -> atCurrentColumnIndent (genExpr e)
+                | Expr.AnonStructRecord _ -> atCurrentColumnIndent (genExpr e)
                 | _ -> genExpr e
 
             genExpr node.LeftHandSide

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -462,59 +462,12 @@ let genExpr (e: Expr) =
             |> genNode node
     | Expr.Record node ->
         let smallRecordExpr = genSmallRecordNode node
-
-        let genCrampedFields targetColumn =
-            match node.CopyInfo with
-            | Some we -> genMultilineRecordCopyExpr (genMultilineRecordFieldsExpr node) we
-            | None ->
-                fun (ctx: Context) ->
-                    col
-                        sepNln
-                        node.Fields
-                        (fun e ->
-                            // Add spaces to ensure the record field (incl trivia) starts at the right column.
-                            addFixedSpaces targetColumn
-                            // Lock the start of the record field, however keep potential indentations in relation to the opening curly brace
-                            +> atCurrentColumn (genRecordFieldName e))
-                        ctx
-
-        let multilineRecordExpr = genMultilineRecord genCrampedFields node
+        let multilineRecordExpr = genMultilineRecord node
         genRecord smallRecordExpr multilineRecordExpr node
     | Expr.AnonRecord node ->
         let genStructPrefix = onlyIf node.IsStruct !- "struct "
         let smallRecordExpr = genStructPrefix +> genSmallRecordNode node
-
-        let genMultilineAnonCrampedFields targetColumn =
-            match node.CopyInfo with
-            | Some we ->
-                atCurrentColumn (
-                    genExpr we
-                    +> (!- " with" +> indentSepNlnUnindent (genMultilineRecordFieldsExpr node))
-                )
-            | None ->
-                fun (ctx: Context) ->
-                    col
-                        sepNln
-                        node.Fields
-                        (fun fieldNode ->
-                            let genNode =
-                                if ctx.Config.IndentSize < 3 then
-                                    sepSpaceOrDoubleIndentAndNlnIfExpressionExceedsPageWidth
-                                else
-                                    sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth
-
-                            // Add spaces to ensure the record field (incl trivia) starts at the right column.
-                            addFixedSpaces targetColumn
-                            +> atCurrentColumn (enterNode fieldNode +> genIdentListNode fieldNode.FieldName)
-                            +> sepSpace
-                            +> genSingleTextNode fieldNode.Equals
-                            +> genNode (genExpr fieldNode.Expr)
-                            +> leaveNode fieldNode)
-                        ctx
-
-        let multilineRecordExpr =
-            genStructPrefix +> genMultilineRecord genMultilineAnonCrampedFields node
-
+        let multilineRecordExpr = genStructPrefix +> genMultilineRecord node
         genRecord smallRecordExpr multilineRecordExpr node
     | Expr.InheritRecord node ->
         let genSmallInheritRecordExpr =
@@ -1618,24 +1571,28 @@ let genQuoteExpr (node: ExprQuoteNode) =
 /// Prints the inside of an update record expression.
 /// This function does not print the opening and closing braces.
 /// </summary>
+/// <param name="addAdditionalIndent">Should there be an additional indent after the `with` keyword.</param>
 /// <param name="fieldsExpr">Record fields.</param>
 /// <param name="copyExpr">Expression before the `with` keyword.</param>
-let genMultilineRecordCopyExpr fieldsExpr copyExpr =
+let genMultilineRecordCopyExpr (addAdditionalIndent: bool) fieldsExpr copyExpr =
     atCurrentColumnIndent (genExpr copyExpr)
     +> !- " with"
     +> indent
-    +> whenShortIndent indent
+    +> onlyIf addAdditionalIndent indent
     +> sepNln
     +> fieldsExpr
-    +> whenShortIndent unindent
+    +> onlyIf addAdditionalIndent unindent
     +> unindent
 
 let genRecordFieldName (node: RecordFieldNode) =
-    genIdentListNode node.FieldName
-    +> sepSpace
-    +> genSingleTextNode node.Equals
+    atCurrentColumn (
+        enterNode node
+        +> genIdentListNode node.FieldName
+        +> sepSpace
+        +> genSingleTextNode node.Equals
+    )
     +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup genExpr node.Expr
-    |> genNode node
+    +> leaveNode node
 
 let genMultilineRecordFieldsExpr (node: ExprRecordBaseNode) =
     col sepNln node.Fields genRecordFieldName
@@ -1668,23 +1625,13 @@ let genSmallRecordNode (node: ExprRecordNode) =
 /// This is too avoid offset errors when using a smaller `indent_size`.
 /// </para>
 /// </summary>
-/// <param name="genCrampedFields">
-///<para>
-/// Takes a targetColumn that indicates the column
-/// after the opening brace `{ ` with respect to the `SpaceAroundDelimiter` setting.
-/// </para>
-/// <para>
-/// In `Cramped` style we try to ensure that all record fields are starting at that column.
-/// </para>
-/// </param>
 /// <param name="node">The ExprRecordNode</param>
 /// <param name="ctx">Context</param>
-let genMultilineRecord genCrampedFields (node: ExprRecordNode) (ctx: Context) =
+let genMultilineRecord (node: ExprRecordNode) (ctx: Context) =
     let expressionStartColumn = ctx.Column
+    let openBraceLength = node.OpeningBrace.Text.Length
 
     let targetColumn =
-        let openBraceLength = node.OpeningBrace.Text.Length
-
         expressionStartColumn
         + (if ctx.Config.SpaceAroundDelimiter then
                openBraceLength + 1
@@ -1696,12 +1643,14 @@ let genMultilineRecord genCrampedFields (node: ExprRecordNode) (ctx: Context) =
 
         match node.CopyInfo with
         | Some ci ->
+            let additionalIndent = ctx.Config.IndentSize < 3
+
             genSingleTextNodeSuffixDelimiter node.OpeningBrace
             +> ifElseCtx
                 (fun ctx -> ctx.Config.IsStroustrupStyle)
                 (indent +> sepNln)
                 sepNlnWhenWriteBeforeNewlineNotEmpty // comment after curly brace
-            +> genMultilineRecordCopyExpr fieldsExpr ci
+            +> genMultilineRecordCopyExpr additionalIndent fieldsExpr ci
             +> onlyIfCtx (fun ctx -> ctx.Config.IsStroustrupStyle) unindent
             +> sepNln
             +> genSingleTextNode node.ClosingBrace
@@ -1712,18 +1661,40 @@ let genMultilineRecord genCrampedFields (node: ExprRecordNode) (ctx: Context) =
             +> genSingleTextNode node.ClosingBrace
 
     let genMultilineCramped =
+        let genFields =
+            match node.CopyInfo with
+            | Some we ->
+                let additionalIndent =
+                    // Anonymous record
+                    (openBraceLength = 2 && ctx.Config.IndentSize <= 3)
+                    // Regular record
+                    || ctx.Config.IndentSize < 3
+
+                genMultilineRecordCopyExpr additionalIndent (genMultilineRecordFieldsExpr node) we
+            | None ->
+                fun (ctx: Context) ->
+                    col
+                        sepNln
+                        node.Fields
+                        (fun e ->
+                            // Add spaces to ensure the record field (incl trivia) starts at the right column.
+                            addFixedSpaces targetColumn
+                            // Potential indentations will be in relation to the opening curly brace.
+                            +> genRecordFieldName e)
+                        ctx
+
         match node.CopyInfo with
         | Some _ ->
             genSingleTextNode node.OpeningBrace
             +> sepNlnWhenWriteBeforeNewlineNotEmptyOr addSpaceIfSpaceAroundDelimiter // comment after curly brace
-            +> genCrampedFields targetColumn
+            +> genFields
             +> addSpaceIfSpaceAroundDelimiter
             +> genSingleTextNode node.ClosingBrace
         | None ->
             atCurrentColumn (
                 genSingleTextNodeSuffixDelimiter node.OpeningBrace
                 +> sepNlnWhenWriteBeforeNewlineNotEmpty // comment after curly brace
-                +> genCrampedFields targetColumn
+                +> genFields
                 +> sepNlnWhenWriteBeforeNewlineNotEmpty
                 +> (fun ctx ->
                     // Edge case scenario to make sure that the closing brace is not before the opening one

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -465,9 +465,15 @@ let genExpr (e: Expr) =
         let multilineRecordExpr = genMultilineRecord node
         genRecord smallRecordExpr multilineRecordExpr node
     | Expr.AnonStructRecord node ->
-        let genStructPrefix = !- "struct "
+        let genStructPrefix = genSingleTextNodeWithSpaceSuffix sepSpace node.Struct
         let smallRecordExpr = genStructPrefix +> genSmallRecordNode node
-        let multilineRecordExpr = genStructPrefix +> genMultilineRecord node
+
+        let multilineRecordExpr =
+            if node.Struct.HasContentAfter then
+                genStructPrefix +> indentSepNlnUnindent (genMultilineRecord node)
+            else
+                genStructPrefix +> genMultilineRecord node
+
         genRecord smallRecordExpr multilineRecordExpr node
     | Expr.InheritRecord node ->
         let genSmallInheritRecordExpr =

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -757,7 +757,7 @@ let isStroustrupStyleExpr (config: FormatConfig) (e: Expr) =
 
     match e with
     | Expr.Record _
-    | Expr.AnonRecord _
+    | Expr.AnonStructRecord _
     | Expr.ArrayOrList _ -> isStroustrupEnabled
     | Expr.NamedComputation _ -> not config.NewlineBeforeMultilineComputationExpression
     | _ -> false

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -166,6 +166,9 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ExprInheritRecordNode as node ->
         let expr = Expr.InheritRecord node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
+    | :? ExprAnonStructRecordNode as node ->
+        let expr = Expr.AnonStructRecord node
+        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprRecordNode as node ->
         let expr = Expr.Record node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -163,9 +163,6 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ExprArrayOrListNode as node ->
         let expr = Expr.ArrayOrList node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprAnonRecordNode as node ->
-        let expr = Expr.AnonRecord node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprInheritRecordNode as node ->
         let expr = Expr.InheritRecord node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -759,6 +759,9 @@ type ExprRecordBaseNode(openingBrace: SingleTextNode, fields: RecordFieldNode li
     member val ClosingBrace = closingBrace
     member x.HasFields = List.isNotEmpty x.Fields
 
+/// <summary>
+/// Represents a record instance in, parsed from both `SynExpr.Record` and `SynExpr.AnonRecd`.
+/// </summary>
 type ExprRecordNode
     (
         openingBrace: SingleTextNode,
@@ -796,18 +799,6 @@ type ExprInheritRecordNode
            yield InheritConstructor.Node inheritConstructor
            yield! nodes fields
            yield closingBrace |]
-
-type ExprAnonRecordNode
-    (
-        isStruct: bool,
-        openingBrace: SingleTextNode,
-        copyInfo: Expr option,
-        fields: RecordFieldNode list,
-        closingBrace: SingleTextNode,
-        range
-    ) =
-    inherit ExprRecordNode(openingBrace, copyInfo, fields, closingBrace, range)
-    member val IsStruct = isStruct
 
 type InterfaceImplNode
     (
@@ -1604,7 +1595,7 @@ type Expr =
     | ArrayOrList of ExprArrayOrListNode
     | Record of ExprRecordNode
     | InheritRecord of ExprInheritRecordNode
-    | AnonRecord of ExprAnonRecordNode
+    | AnonStructRecord of ExprRecordNode
     | ObjExpr of ExprObjExprNode
     | While of ExprWhileNode
     | For of ExprForNode
@@ -1669,7 +1660,7 @@ type Expr =
         | ArrayOrList n -> n
         | Record n -> n
         | InheritRecord n -> n
-        | AnonRecord n -> n
+        | AnonStructRecord n -> n
         | ObjExpr n -> n
         | While n -> n
         | For n -> n

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -760,7 +760,7 @@ type ExprRecordBaseNode(openingBrace: SingleTextNode, fields: RecordFieldNode li
     member x.HasFields = List.isNotEmpty x.Fields
 
 /// <summary>
-/// Represents a record instance in, parsed from both `SynExpr.Record` and `SynExpr.AnonRecd`.
+/// Represents a record instance, parsed from both `SynExpr.Record` and `SynExpr.AnonRecd`.
 /// </summary>
 type ExprRecordNode
     (
@@ -781,6 +781,25 @@ type ExprRecordNode
            yield closingBrace |]
 
     member x.HasFields = List.isNotEmpty x.Fields
+
+type ExprAnonStructRecordNode
+    (
+        structNode: SingleTextNode,
+        openingBrace: SingleTextNode,
+        copyInfo: Expr option,
+        fields: RecordFieldNode list,
+        closingBrace: SingleTextNode,
+        range
+    ) =
+    inherit ExprRecordNode(openingBrace, copyInfo, fields, closingBrace, range)
+    member val Struct = structNode
+
+    override val Children: Node array =
+        [| yield structNode
+           yield openingBrace
+           yield! copyInfo |> Option.map Expr.Node |> noa
+           yield! nodes fields
+           yield closingBrace |]
 
 type ExprInheritRecordNode
     (
@@ -1595,7 +1614,7 @@ type Expr =
     | ArrayOrList of ExprArrayOrListNode
     | Record of ExprRecordNode
     | InheritRecord of ExprInheritRecordNode
-    | AnonStructRecord of ExprRecordNode
+    | AnonStructRecord of ExprAnonStructRecordNode
     | ObjExpr of ExprObjExprNode
     | While of ExprWhileNode
     | For of ExprForNode


### PR DESCRIPTION
This is a follow-up on https://github.com/fsprojects/fantomas/pull/2750.
I changed some of the tests as I believe the outcome is correct.
Indentation should take place from the opening brace position, I remember Don saying that fondly at some point.

At some point, I will correct the range of `SynExpr.AnonRecd` to start from the `struct` keyword.
Then we can bring back `ExprAnonRecordNode` and properly insert `SingleTextNode` for `struct`.

