### PR TITLE
Don't hook up SerilogTraceListener in FantomasDaemon.

### DIFF
--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="Integration\WriteTests.fs" />
     <Compile Include="Integration\DaemonTests.fs" />
     <Compile Include="Integration\ForceTests.fs" />
+    <Compile Include="ToolLocatorTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />

--- a/src/Fantomas.Tests/ToolLocatorTests.fs
+++ b/src/Fantomas.Tests/ToolLocatorTests.fs
@@ -1,0 +1,25 @@
+﻿module Fantomas.CoreGlobalTool.Tests.ToolLocatorTests
+
+open Fantomas.Client
+open Fantomas.Client.LSPFantomasServiceTypes
+open Fantomas.Client.Contracts
+open NUnit.Framework
+
+[<Explicit "This is meant to troubleshoot local problems">]
+[<Test>]
+let ``locate fantomas tool`` () =
+    let pwd = @"C:\Users\nojaf\Projects"
+    let result = FantomasToolLocator.findFantomasTool (Folder pwd)
+
+    match result with
+    | Error error -> Assert.Fail $"Could not locate tool: %A{error}"
+    | Ok(FantomasToolFound(FantomasVersion(version), startInfo)) ->
+        let result = FantomasToolLocator.createFor startInfo
+
+        match result with
+        | Error error -> Assert.Fail $"Could not start tool: %A{error}"
+        | Ok runningFantomasTool ->
+            let version2 =
+                runningFantomasTool.RpcClient.InvokeAsync<string>(Methods.Version).Result
+
+            Assert.AreEqual(version, $"v{version2}")


### PR DESCRIPTION
I found out that the recent Serilog changes broke the daemon functionality.
Long story short when run `dotnet fantomas --daemon`, with the latest alpha, you get:
![image](https://user-images.githubusercontent.com/2621499/220564120-80ffeb30-9f0f-4e16-b9cd-4b291ab6d9cc.png)

That `Listening started.` ruins the whole communication protocol.
I've added an explicit unit test to easier troubleshoot problems like this in the future.
Will release a new alpha if this build is green.