### PR TITLE
Ensure extra newlines are not added when formatting `else if`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 * Duplicate newline in else if. [#2752](https://github.com/fsprojects/fantomas/issues/2752)
 
 ## [5.2.2] - 2023-02-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+* Duplicate newline in else if. [#2752](https://github.com/fsprojects/fantomas/issues/2752)
+
 ## [5.2.2] - 2023-02-18
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Core.Tests/IfThenElseTests.fs
@@ -2681,7 +2681,6 @@ if nargTs <> haveArgTs.Length then
     false (* method argument length mismatch *)
 else if
 
-
     // If a known-number-of-arguments-including-object-argument has been given then check that
     (match knownArgCount with
      | ValueNone -> false

--- a/src/Fantomas.Core.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Core.Tests/IfThenElseTests.fs
@@ -2671,7 +2671,8 @@ else
     let res = typesEqual (resT :: argTs) (haveResT :: haveArgTs)
     res
 """
-        config
+        { config with
+            KeepMaxNumberOfBlankLines = 1 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Core.Tests/IfThenElseTests.fs
@@ -2654,22 +2654,42 @@ let ``duplicate newline after shifting trivia between else if, 2752`` () =
     formatSourceString
         false
         """
-if a then
-    b 
+// check for match
+if nargTs <> haveArgTs.Length then
+    false (* method argument length mismatch *)
 else
 
-    if c then d
+// If a known-number-of-arguments-including-object-argument has been given then check that
+if
+    (match knownArgCount with
+        | ValueNone -> false
+        | ValueSome n -> n <> (if methInfo.IsStatic then 0 else 1) + nargTs)
+then
+    false
+else
+
+    let res = typesEqual (resT :: argTs) (haveResT :: haveArgTs)
+    res
 """
         config
     |> prepend newline
     |> should
         equal
         """
-if a then
-    b
+// check for match
+if nargTs <> haveArgTs.Length then
+    false (* method argument length mismatch *)
 else if
 
-    c
+
+    // If a known-number-of-arguments-including-object-argument has been given then check that
+    (match knownArgCount with
+     | ValueNone -> false
+     | ValueSome n -> n <> (if methInfo.IsStatic then 0 else 1) + nargTs)
 then
-    d
+    false
+else
+
+    let res = typesEqual (resT :: argTs) (haveResT :: haveArgTs)
+    res
 """

--- a/src/Fantomas.Core.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Core.Tests/IfThenElseTests.fs
@@ -2648,3 +2648,28 @@ else
 
 printfn "d"
 """
+
+[<Test>]
+let ``duplicate newline after shifting trivia between else if, 2752`` () =
+    formatSourceString
+        false
+        """
+if a then
+    b 
+else
+
+    if c then d
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+if a then
+    b
+else if
+
+    c
+then
+    d
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -73,6 +73,8 @@ let genTrivia (trivia: TriviaNode) (ctx: Context) =
 
     // Some items like #if or Newline should be printed on a newline
     // It is hard to always get this right in CodePrinter, so we detect it based on the current code.
+    // However this may cause duplicate newlines in case of content-after trivia of a node 
+    // for which we emit a Writeline event next.
     let addNewline =
         currentLastLine
         |> Option.map (fun line -> line.Trim().Length > 0)
@@ -96,7 +98,7 @@ let genTrivia (trivia: TriviaNode) (ctx: Context) =
             +> ifElse after sepNlnForTrivia sepNone
         | CommentOnSingleLine s
         | Directive s -> (ifElse addNewline sepNlnForTrivia sepNone) +> !-s +> sepNlnForTrivia
-        | Newline -> (ifElse addNewline (sepNlnForTrivia +> sepNlnForTrivia) sepNlnForTrivia)
+        | Newline -> ifElse addNewline (sepNlnForTrivia +> sepNlnForTrivia) sepNlnForTrivia
 
     gen ctx
 

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -73,8 +73,6 @@ let genTrivia (trivia: TriviaNode) (ctx: Context) =
 
     // Some items like #if or Newline should be printed on a newline
     // It is hard to always get this right in CodePrinter, so we detect it based on the current code.
-    // However this may cause duplicate newlines in case of content-after trivia of a node
-    // for which we emit a Writeline event next.
     let addNewline =
         currentLastLine
         |> Option.map (fun line -> line.Trim().Length > 0)
@@ -98,7 +96,7 @@ let genTrivia (trivia: TriviaNode) (ctx: Context) =
             +> ifElse after sepNlnForTrivia sepNone
         | CommentOnSingleLine s
         | Directive s -> (ifElse addNewline sepNlnForTrivia sepNone) +> !-s +> sepNlnForTrivia
-        | Newline -> ifElse addNewline (sepNlnForTrivia +> sepNlnForTrivia) sepNlnForTrivia
+        | Newline -> (ifElse addNewline (sepNlnForTrivia +> sepNlnForTrivia) sepNlnForTrivia)
 
     gen ctx
 

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -73,7 +73,7 @@ let genTrivia (trivia: TriviaNode) (ctx: Context) =
 
     // Some items like #if or Newline should be printed on a newline
     // It is hard to always get this right in CodePrinter, so we detect it based on the current code.
-    // However this may cause duplicate newlines in case of content-after trivia of a node 
+    // However this may cause duplicate newlines in case of content-after trivia of a node
     // for which we emit a Writeline event next.
     let addNewline =
         currentLastLine

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1348,8 +1348,7 @@ type ElseIfNode(mElse: range, mIf: range, condition: Node, range) as elseIfNode 
 
         member _.AddAfter(triviaNode: TriviaNode) =
             match triviaNode.Content with
-            | TriviaContent.Newline ->
-                condition.AddBefore triviaNode
+            | TriviaContent.Newline -> condition.AddBefore triviaNode
             | TriviaContent.LineCommentAfterSourceCode comment when lastNodeAfterIsLineCommentAfterSource ->
                 // If we already have a line comment after the `else if`, we cannot add another one.
                 // The next best thing would be to add it on the next line as content before of the condition.

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1316,7 +1316,7 @@ type ElseIfNode(mElse: range, mIf: range, condition: Node, range) as elseIfNode 
                 (elseIfNode :> Node).AddBefore triviaNode
 
             member _.AddAfter(triviaNode: TriviaNode) =
-                    (elseIfNode :> Node).AddAfter triviaNode
+                (elseIfNode :> Node).AddAfter triviaNode
 
             member _.Children = Array.empty }
 

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1330,7 +1330,8 @@ type ElseIfNode(mElse: range, mIf: range, condition: Node, range) as elseIfNode 
 
             member _.AddBefore(triviaNode: TriviaNode) =
                 match triviaNode.Content with
-                | CommentOnSingleLine _ -> condition.AddBefore triviaNode
+                | CommentOnSingleLine _
+                | Newline -> condition.AddBefore triviaNode
                 | _ -> (elseIfNode :> Node).AddAfter triviaNode
 
             member _.AddAfter(triviaNode: TriviaNode) =
@@ -1348,7 +1349,6 @@ type ElseIfNode(mElse: range, mIf: range, condition: Node, range) as elseIfNode 
 
         member _.AddAfter(triviaNode: TriviaNode) =
             match triviaNode.Content with
-            | TriviaContent.Newline -> condition.AddBefore triviaNode
             | TriviaContent.LineCommentAfterSourceCode comment when lastNodeAfterIsLineCommentAfterSource ->
                 // If we already have a line comment after the `else if`, we cannot add another one.
                 // The next best thing would be to add it on the next line as content before of the condition.

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1316,7 +1316,7 @@ type ElseIfNode(mElse: range, mIf: range, condition: Node, range) as elseIfNode 
                 (elseIfNode :> Node).AddBefore triviaNode
 
             member _.AddAfter(triviaNode: TriviaNode) =
-                (elseIfNode :> Node).AddAfter triviaNode
+                    (elseIfNode :> Node).AddAfter triviaNode
 
             member _.Children = Array.empty }
 
@@ -1348,6 +1348,8 @@ type ElseIfNode(mElse: range, mIf: range, condition: Node, range) as elseIfNode 
 
         member _.AddAfter(triviaNode: TriviaNode) =
             match triviaNode.Content with
+            | TriviaContent.Newline ->
+                condition.AddBefore triviaNode
             | TriviaContent.LineCommentAfterSourceCode comment when lastNodeAfterIsLineCommentAfterSource ->
                 // If we already have a line comment after the `else if`, we cannot add another one.
                 // The next best thing would be to add it on the next line as content before of the condition.


### PR DESCRIPTION
Fixes #2752.

Duplicate newline was there because we were adding empty line trivia to `else if` node and then adding yet another newline to print the condition expr. 