### PR TITLE
add a double indent when the indent_size is lower than the default 4 spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Duplicate newline in else if. [#2752](https://github.com/fsprojects/fantomas/issues/2752)
+* Try-with expression with long when guard - when breaking line, add a double indent when the indent_size is lower than the default 4 spaces. [#2784](https://github.com/fsprojects/fantomas/issues/2784)
 
 ## [5.2.2] - 2023-02-18
 

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -120,6 +120,7 @@
     <Compile Include="DallasTests.fs" />
     <Compile Include="InlineTests.fs" />
     <Compile Include="ChainTests.fs" />
+    <Compile Include="TryWithTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Core\Fantomas.Core.fsproj" />

--- a/src/Fantomas.Core.Tests/TryWithTests.fs
+++ b/src/Fantomas.Core.Tests/TryWithTests.fs
@@ -1,0 +1,31 @@
+module Fantomas.Core.Tests.TryWithTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelper
+
+[<Test>]
+let ``try-with expression with long when guard - when breaking line, add a double indent when the indent_size is lower than the default 4 spaces, 2784``
+    ()
+    =
+    formatSourceString
+        false
+        """
+try
+  c ()
+with
+| :? WebSocketException as e when e.WebSocketErrorCode = WebSocketError.ConnectionClosedPrematurely && sourceParty = Agent ->
+  ()
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+try
+  c ()
+with :? WebSocketException as e when
+    e.WebSocketErrorCode = WebSocketError.ConnectionClosedPrematurely
+    && sourceParty = Agent ->
+  ()
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1346,7 +1346,19 @@ let genExpr (e: Expr) =
                     onlyIfCtx (fun ctx -> linesAfter > linesBefore || hasWriteBeforeNewlineContent ctx) sepBar)
             +> genPatInClause clauseNode.Pattern
             +> optSingle
-                (fun e -> !- " when" +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (genExpr e))
+                (fun e ->
+                    !- " when"
+                    +> expressionFitsOnRestOfLine (sepSpace +> genExpr e) (fun ctx ->
+                        // See https://github.com/fsprojects/fantomas/issues/2784
+                        let doubleIndent = ctx.Config.IndentSize < 4
+
+                        (indent
+                         +> onlyIf doubleIndent indent
+                         +> sepNln
+                         +> genExpr e
+                         +> unindent
+                         +> onlyIf doubleIndent unindent)
+                            ctx))
                 clauseNode.WhenExpr
             +> sepSpace
             +> genSingleTextNodeWithSpaceSuffix sepSpace clauseNode.Arrow


### PR DESCRIPTION
try-with expression with long when guard - when breaking line, add a double indent when the indent_size is lower than the default 4 spaces  - fixes #2784

just pretending I'm smart enough to know how to fix that :trollface: 
while in reality @nojaf fixed it for me 😂 