### PR TITLE
Return string from FormatASTAsync api.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [6.0.0-alpha-007] - 2023-03-27
+
+### Changed
+
+* `CodeFormatter.FormatASTAsync` returns a string. [#2799](https://github.com/fsprojects/fantomas/pull/2799)
+* Cursor with defines. [#2774](https://github.com/fsprojects/fantomas/pull/2774)
+
+### Removed
+
+* Strict mode. [#2798](https://github.com/fsprojects/fantomas/pull/2798)
+
 ## [6.0.0-alpha-006] - 2023-03-17
 
 ### Fixed

--- a/docs/docs/end-users/GeneratingCode.fsx
+++ b/docs/docs/end-users/GeneratingCode.fsx
@@ -50,7 +50,7 @@ let implementationSyntaxTree =
                     false,
                     None,
                     None,
-                    Choice1Of2(IdentListNode([], Range.Zero)),
+                    Choice1Of2(IdentListNode([ IdentifierOrDot.Ident(SingleTextNode("a", Range.Zero)) ], Range.Zero)),
                     None,
                     [],
                     None,

--- a/src/Fantomas.Core.Tests/FormatAstTests.fs
+++ b/src/Fantomas.Core.Tests/FormatAstTests.fs
@@ -15,7 +15,6 @@ let parseAndFormat sourceCode =
     let formattedCode =
         CodeFormatter.FormatASTAsync(ast, source = sourceCode)
         |> Async.RunSynchronously
-        |> fun formatResult -> formatResult.Code
         |> String.normalizeNewLine
         |> fun s -> s.TrimEnd('\n')
 

--- a/src/Fantomas.Core.Tests/SynLongIdentTests.fs
+++ b/src/Fantomas.Core.Tests/SynLongIdentTests.fs
@@ -404,5 +404,4 @@ let ``backticks can be added from AST only scenarios`` () =
                 InsertFinalNewline = false }
     )
     |> Async.RunSynchronously
-    |> fun result -> result.Code
     |> should equal "``new``"

--- a/src/Fantomas.Core.Tests/TestHelpers.fs
+++ b/src/Fantomas.Core.Tests/TestHelpers.fs
@@ -2,7 +2,6 @@ module Fantomas.Core.Tests.TestHelper
 
 open System
 open Fantomas.Core
-open Fantomas.Core.SyntaxOak
 open NUnit.Framework
 open FsUnit
 
@@ -42,13 +41,13 @@ let formatAST isFsiFile (source: string) config =
         let ast, _ =
             Fantomas.FCS.Parse.parseFile isFsiFile (FSharp.Compiler.Text.SourceText.ofString source) []
 
-        let! formatted = CodeFormatter.FormatASTAsync(ast, config = config)
-        let! isValid = CodeFormatter.IsValidFSharpCodeAsync(isFsiFile, formatted.Code)
+        let! formattedCode = CodeFormatter.FormatASTAsync(ast, config = config)
+        let! isValid = CodeFormatter.IsValidFSharpCodeAsync(isFsiFile, formattedCode)
 
         if not isValid then
-            failwithf $"The formatted result is not valid F# code or contains warnings\n%s{formatted.Code}"
+            failwithf $"The formatted result is not valid F# code or contains warnings\n%s{formattedCode}"
 
-        return formatted.Code.Replace("\r\n", "\n")
+        return formattedCode.Replace("\r\n", "\n")
     }
     |> Async.RunSynchronously
 

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -12,21 +12,31 @@ type CodeFormatter =
             return results |> Array.map (fun (ast, DefineCombination(defines)) -> ast, defines)
         }
 
-    static member FormatASTAsync(ast: ParsedInput) : Async<FormatResult> =
-        CodeFormatterImpl.formatAST ast None FormatConfig.Default None |> async.Return
+    static member FormatASTAsync(ast: ParsedInput) : Async<string> =
+        async {
+            let result = CodeFormatterImpl.formatAST ast None FormatConfig.Default None
+            return result.Code
+        }
 
-    static member FormatASTAsync(ast: ParsedInput, config) : Async<FormatResult> =
-        CodeFormatterImpl.formatAST ast None config None |> async.Return
+    static member FormatASTAsync(ast: ParsedInput, config) : Async<string> =
+        async {
+            let result = CodeFormatterImpl.formatAST ast None config None
+            return result.Code
+        }
 
-    static member FormatASTAsync(ast: ParsedInput, source) : Async<FormatResult> =
-        let sourceText = Some(CodeFormatterImpl.getSourceText source)
-
-        CodeFormatterImpl.formatAST ast sourceText FormatConfig.Default None
-        |> async.Return
+    static member FormatASTAsync(ast: ParsedInput, source) : Async<string> =
+        async {
+            let sourceText = Some(CodeFormatterImpl.getSourceText source)
+            let result = CodeFormatterImpl.formatAST ast sourceText FormatConfig.Default None
+            return result.Code
+        }
 
     static member FormatASTAsync(ast: ParsedInput, source, config) : Async<FormatResult> =
-        let sourceText = Some(CodeFormatterImpl.getSourceText source)
-        CodeFormatterImpl.formatAST ast sourceText config None |> async.Return
+        async {
+            let sourceText = Some(CodeFormatterImpl.getSourceText source)
+            let result = CodeFormatterImpl.formatAST ast sourceText config None
+            return result
+        }
 
     static member FormatDocumentAsync(isSignature, source) =
         CodeFormatterImpl.formatDocument FormatConfig.Default isSignature (CodeFormatterImpl.getSourceText source) None

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -10,13 +10,13 @@ type CodeFormatter =
     static member ParseAsync: isSignature: bool * source: string -> Async<(ParsedInput * string list) array>
 
     /// Format an abstract syntax tree
-    static member FormatASTAsync: ast: ParsedInput -> Async<FormatResult>
+    static member FormatASTAsync: ast: ParsedInput -> Async<string>
 
     /// Format an abstract syntax tree using a given config
-    static member FormatASTAsync: ast: ParsedInput * config: FormatConfig -> Async<FormatResult>
+    static member FormatASTAsync: ast: ParsedInput * config: FormatConfig -> Async<string>
 
     /// Format an abstract syntax tree with the original source for trivia processing
-    static member FormatASTAsync: ast: ParsedInput * source: string -> Async<FormatResult>
+    static member FormatASTAsync: ast: ParsedInput * source: string -> Async<string>
 
     /// <summary>
     /// Format a source string using an optional config.

--- a/src/Fantomas.Core/CodeFormatterImpl.fs
+++ b/src/Fantomas.Core/CodeFormatterImpl.fs
@@ -4,7 +4,6 @@ module internal Fantomas.Core.CodeFormatterImpl
 open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
-open SyntaxOak
 open MultipleDefineCombinations
 
 let getSourceText (source: string) : ISourceText = source.TrimEnd() |> SourceText.ofString

--- a/src/Fantomas.Core/CodeFormatterImpl.fsi
+++ b/src/Fantomas.Core/CodeFormatterImpl.fsi
@@ -3,7 +3,6 @@ module internal Fantomas.Core.CodeFormatterImpl
 
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
-open Fantomas.Core.SyntaxOak
 
 val getSourceText: source: string -> ISourceText
 


### PR DESCRIPTION
I think it makes sense to align the return type of `FormatASTAsync` with `FormatOakAsync`.
As the cursor is never passed into these methods, it would always be empty in the result anyway.