### PR TITLE
Indent cramped record field body if indent_size is low.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Nested multiline record with indent_size = 2. [#2801](https://github.com/fsprojects/fantomas/issues/2801)
+* Idempotency problem when comment after opening brace in inherit record. [#2803](https://github.com/fsprojects/fantomas/issues/2803)
 
 ## [6.0.0-alpha-007] - 2023-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [6.0.0-alpha-008] - 2023-03-27
 
 ### Fixed
 * Nested multiline record with indent_size = 2. [#2801](https://github.com/fsprojects/fantomas/issues/2801)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Nested multiline record with indent_size = 2. [#2801](https://github.com/fsprojects/fantomas/issues/2801)
+
 ## [6.0.0-alpha-007] - 2023-03-27
 
 ### Changed

--- a/src/Fantomas.Core.Tests/AlignedMultilineBracketStyleTests.fs
+++ b/src/Fantomas.Core.Tests/AlignedMultilineBracketStyleTests.fs
@@ -1593,3 +1593,42 @@ struct // 1
     // 5
     |} // 6
 """
+
+[<Test>]
+let ``multiline field body expression where indent_size = 2`` () =
+    formatSourceString
+        false
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+    let range =
+      { Start =
+          { Line = range.StartLine - 1
+            Character = range.StartColumn }
+        End =
+          { Line = range.EndLine - 1
+            Character = range.EndColumn } }
+
+    [| { Range = range; NewText = formatted } |]
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let handlerFormattedRangeDoc (lines : NamedText, formatted : string, range : FormatSelectionRange) =
+  let range =
+    {
+      Start =
+        {
+          Line = range.StartLine - 1
+          Character = range.StartColumn
+        }
+      End =
+        {
+          Line = range.EndLine - 1
+          Character = range.EndColumn
+        }
+    }
+
+  [| { Range = range ; NewText = formatted } |]
+"""

--- a/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
+++ b/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
@@ -2414,3 +2414,40 @@ let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: Format
 
   [| { Range = range; NewText = formatted } |]
 """
+
+[<Test>]
+let ``trivia after opening brace in inherit expression, 2803`` () =
+    formatSourceString
+        false
+        """
+let range =
+    { // foo
+      // bar
+      inherit // reason
+        Foo()
+      X = y
+      Z =
+        someReallyLongExpressionThatIsLongerThanTheLineLength
+            aLongArgument
+            //
+            anotherLongArgument
+            fooBar }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let range =
+    { // foo
+      // bar
+      inherit // reason
+          Foo()
+      X = y
+      Z =
+        someReallyLongExpressionThatIsLongerThanTheLineLength
+            aLongArgument
+            //
+            anotherLongArgument
+            fooBar }
+"""

--- a/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
+++ b/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
@@ -1742,8 +1742,8 @@ let ``record with comments above field, indent 2`` () =
         equal
         """
 { Foo =
-  // bar
-  someValue }
+    // bar
+    someValue }
 """
 
 [<Test>]
@@ -1799,8 +1799,8 @@ let ``anonymous record with multiline field, indent 2`` () =
         equal
         """
 {| Foo =
-  //  meh
-  someValue |}
+    //  meh
+    someValue |}
 """
 
 [<Test>]
@@ -2279,4 +2279,138 @@ let a =
         Square = 9
     // test2
     |}
+"""
+
+[<Test>]
+let ``multiline field body expression where indent_size = 2, 2801`` () =
+    formatSourceString
+        false
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+    let range =
+      { Start =
+          { Line = range.StartLine - 1
+            Character = range.StartColumn }
+        End =
+          { Line = range.EndLine - 1
+            Character = range.EndColumn } }
+
+    [| { Range = range; NewText = formatted } |]
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+  let range =
+    { Start =
+        { Line = range.StartLine - 1
+          Character = range.StartColumn }
+      End =
+        { Line = range.EndLine - 1
+          Character = range.EndColumn } }
+
+  [| { Range = range; NewText = formatted } |]
+"""
+
+[<Test>]
+let ``multiline field body expression where indent_size = 2, anonymous record`` () =
+    formatSourceString
+        false
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+    let range =
+      {| Start =
+           { Line = range.StartLine - 1
+             Character = range.StartColumn }
+         End =
+           { Line = range.EndLine - 1
+             Character = range.EndColumn } |}
+
+    [| { Range = range; NewText = formatted } |]
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+  let range =
+    {| Start =
+        { Line = range.StartLine - 1
+          Character = range.StartColumn }
+       End =
+        { Line = range.EndLine - 1
+          Character = range.EndColumn } |}
+
+  [| { Range = range; NewText = formatted } |]
+"""
+
+[<Test>]
+let ``multiline field body expression where indent_size = 2, update record`` () =
+    formatSourceString
+        false
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+    let range =
+      { x with 
+        Start =
+          { Line = range.StartLine - 1
+            Character = range.StartColumn }
+        End =
+          { Line = range.EndLine - 1
+            Character = range.EndColumn } }
+
+    [| { Range = range; NewText = formatted } |]
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+  let range =
+    { x with
+        Start =
+          { Line = range.StartLine - 1
+            Character = range.StartColumn }
+        End =
+          { Line = range.EndLine - 1
+            Character = range.EndColumn } }
+
+  [| { Range = range; NewText = formatted } |]
+"""
+
+let ``multiline field body expression where indent_size = 2, inherit record`` () =
+    formatSourceString
+        false
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+  let range =
+    { inherit Foo()
+      Start =
+        { Line = range.StartLine - 1
+          Character = range.StartColumn }
+      End =
+        { Line = range.EndLine - 1
+          Character = range.EndColumn } }
+  [| { Range = range; NewText = formatted } |]
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+  let range =
+    { inherit Foo()
+      Start =
+        { Line = range.StartLine - 1
+          Character = range.StartColumn }
+      End =
+        { Line = range.EndLine - 1
+          Character = range.EndColumn } }
+
+  [| { Range = range; NewText = formatted } |]
 """

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -110,6 +110,7 @@
     <Compile Include="Stroustrup\FunctionApplicationDualListTests.fs" />
     <Compile Include="Stroustrup\SynExprAnonRecdStructTests.fs" />
     <Compile Include="Stroustrup\ExperimentalElmishTests.fs" />
+    <Compile Include="Stroustrup\RecordInstanceTests.fs" />
     <Compile Include="IdentTests.fs" />
     <Compile Include="RecordDeclarationsWithXMLDocTests.fs" />
     <Compile Include="MaxIfThenShortWidthTests.fs" />

--- a/src/Fantomas.Core.Tests/Stroustrup/RecordInstanceTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/RecordInstanceTests.fs
@@ -1,0 +1,46 @@
+﻿module Fantomas.Core.Tests.Stroustrup.RecordInstanceTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelper
+open Fantomas.Core
+
+let config =
+    { config with
+        MultilineBracketStyle = Stroustrup }
+
+[<Test>]
+let ``multiline field body expression where indent_size = 2`` () =
+    formatSourceString
+        false
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+    let range =
+      { Start =
+          { Line = range.StartLine - 1
+            Character = range.StartColumn }
+        End =
+          { Line = range.EndLine - 1
+            Character = range.EndColumn } }
+
+    [| { Range = range; NewText = formatted } |]
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let handlerFormattedRangeDoc (lines: NamedText, formatted: string, range: FormatSelectionRange) =
+  let range = {
+    Start = {
+      Line = range.StartLine - 1
+      Character = range.StartColumn
+    }
+    End = {
+      Line = range.EndLine - 1
+      Character = range.EndColumn
+    }
+  }
+
+  [| { Range = range; NewText = formatted } |]
+"""

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -222,6 +222,7 @@ let mkOpenAndCloseForArrayOrList isArray range =
 
 let mkInheritConstructor (creationAide: CreationAide) (t: SynType) (e: SynExpr) (mInherit: range) (m: range) =
     let inheritNode = stn "inherit" mInherit
+    let m = unionRanges mInherit m
 
     match e with
     | SynExpr.Const(constant = SynConst.Unit; range = StartEndRange 1 (mOpen, unitRange, mClose)) ->
@@ -962,7 +963,7 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
 
         match baseInfo, copyInfo with
         | Some _, Some _ -> failwith "Unexpected that both baseInfo and copyInfo are present in SynExpr.Record"
-        | Some(t, e, mInherit, _, m), None ->
+        | Some(t, e, m, _, mInherit), None ->
             let inheritCtor = mkInheritConstructor creationAide t e mInherit m
 
             ExprInheritRecordNode(stn "{" mOpen, inheritCtor, fieldNodes, stn "}" mClose, exprRange)

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -436,10 +436,10 @@ let genExpr (e: Expr) =
                 +> genSingleTextNode node.ClosingBrace
 
             let genMultilineCramped =
-                genSingleTextNode node.OpeningBrace
-                +> addSpaceIfSpaceAroundDelimiter
+                genSingleTextNodeSuffixDelimiter node.OpeningBrace
                 +> atCurrentColumn (
-                    genInheritInfo
+                    sepNlnWhenWriteBeforeNewlineNotEmpty
+                    +> genInheritInfo
                     +> fieldsExpr genRecordFieldNameAligned
                     +> addSpaceIfSpaceAroundDelimiter
                     +> genSingleTextNode node.ClosingBrace


### PR DESCRIPTION
There most likely is an upstream parser bug involved here.
This fixes #2801 by adding an extra indent when necessary.