### PR TITLE
Extract Benchmark step to separate pipeline.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,8 @@ jobs:
       run: dotnet fsi build.fsx -p Init
     - name: Build
       run: dotnet fsi build.fsx
-      env:
-        CI: true
-        TABLE_STORAGE_CONNECTION_STRING: ${{ secrets.TABLE_STORAGE_CONNECTION_STRING }}
+    - name: Benchmark
+      run: dotnet fsi build.fsx -p Benchmark
     - name: "trigger fantomas-tools action"
       if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main'
       run: "curl -H 'Accept: application/vnd.github.everest-preview+json' -H 'Authorization: token ${{secrets.FANTOMAS_TOOLS_TOKEN}}' --request POST --data '{\"event_type\": \"fantomas-commit-on-main\"}' https://api.github.com/repos/fsprojects/fantomas-tools/dispatches"


### PR DESCRIPTION
This is useful when you want to publish and to more easily view the result in the GitHub Actions log.