### PR TITLE
remove AsParallel() when mapping over the results in mergeMultipleFormatResults()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [6.0.0-alpha-010] - 2023-04-03
+
+### Fixed
+* Fix a performance regression. [#2820](https://github.com/fsprojects/fantomas/pull/2820)
+
 ## [6.0.0-alpha-009] - 2023-03-31
 
 ### Fixed

--- a/src/Fantomas.Core/MultipleDefineCombinations.fs
+++ b/src/Fantomas.Core/MultipleDefineCombinations.fs
@@ -188,14 +188,12 @@ let splitWhenHash (defines: DefineCombination) (newline: string) (source: string
 let mergeMultipleFormatResults config (results: (DefineCombination * FormatResult) list) : FormatResult =
     let allInFragments: FormatResultForDefines list =
         results
-            .AsParallel()
-            .Select(fun (dc, result) ->
-                let fragments = splitWhenHash dc config.EndOfLine.NewLineString result.Code
+        |> List.map (fun (dc, result) ->
+            let fragments = splitWhenHash dc config.EndOfLine.NewLineString result.Code
 
-                { Result = result
-                  Defines = dc
-                  Fragments = fragments })
-        |> Seq.toList
+            { Result = result
+              Defines = dc
+              Fragments = fragments })
 
     let allHaveSameFragmentCount =
         let allWithCount = List.map (fun { Fragments = f } -> f.Length) allInFragments


### PR DESCRIPTION
fixes a performance regression