### PR TITLE
remove call to genNode in genFunctionNameWithMultilineLids to avoid duplicated trivia printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 * If then expression inside object instantiation breaks when formatted. [#2819](https://github.com/fsprojects/fantomas/pull/2819)
 * fsharp_space_before_colon not honored for return type info of explicit get, set. [#2825](https://github.com/fsprojects/fantomas/pull/2825)
+* Fantomas is trying to format the input multiple times due to the detection of multiple defines. [#2822](https://github.com/fsprojects/fantomas/pull/2822)
 
 ### Changed
 * Update FCS to 'Add parser recovery for incomplete named pat pair', commit ba6647ebf5b94823c4d6fafd1e7d5f806d915ee0

--- a/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
@@ -3020,7 +3020,52 @@ type internal CompilerStateCache(readAllBytes: string -> byte[], projectOptions:
 """
 
 [<Test>]
-let ``duplicated trivia printing in ExprAppLongIdentAndSingleParenArgNode with both defines, 2822`` () =
+let ``duplicated trivia printing in ExprAppLongIdentAndSingleParenArgNode, 2822`` () =
+    formatSourceString
+        false
+        """
+fun config ->
+#if LOGGING_DEBUG || LOGGING_LOCAL
+            let template =
+                "[{Timestamp:HH:mm:ss.fff} {Level:u3} {SourceContext:l}] {Message:lj} | {Properties}{NewLine}{Exception}"
+#endif
+
+            config
+#if LOGGING_DEBUG
+                .WriteTo
+                .Debug(outputTemplate = template)
+#endif
+#if LOGGING_LOCAL
+                .WriteTo
+                .AnsiConsoleLog(
+                    outputTemplate = template
+                )
+#endif
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+fun config ->
+#if LOGGING_DEBUG || LOGGING_LOCAL
+    let template =
+        "[{Timestamp:HH:mm:ss.fff} {Level:u3} {SourceContext:l}] {Message:lj} | {Properties}{NewLine}{Exception}"
+#endif
+
+    config
+#if LOGGING_DEBUG
+        .WriteTo
+        .Debug(outputTemplate = template)
+#endif
+#if LOGGING_LOCAL
+        .WriteTo
+        .AnsiConsoleLog(outputTemplate = template)
+#endif
+"""
+
+[<Test>]
+let ``duplicated trivia printing in ExprAppLongIdentAndSingleParenArgNode, LOGGING_DEBUG LOGGING_LOCAL`` () =
     formatSourceStringWithDefines
         [ "LOGGING_DEBUG"; "LOGGING_LOCAL" ]
         """
@@ -3064,7 +3109,7 @@ fun config ->
 """
 
 [<Test>]
-let ``duplicated trivia printing in ExprAppLongIdentAndSingleParenArgNode with define 1, 2822`` () =
+let ``duplicated trivia printing in ExprAppLongIdentAndSingleParenArgNode, LOGGING_DEBUG`` () =
     formatSourceStringWithDefines
         [ "LOGGING_DEBUG" ]
         """
@@ -3099,7 +3144,7 @@ fun config ->
 """
 
 [<Test>]
-let ``duplicated trivia printing in ExprAppLongIdentAndSingleParenArgNode with define 2, 2822`` () =
+let ``duplicated trivia printing in ExprAppLongIdentAndSingleParenArgNode, LOGGING_LOCAL`` () =
     formatSourceStringWithDefines
         [ "LOGGING_LOCAL" ]
         """
@@ -3132,7 +3177,7 @@ fun config ->
 """
 
 [<Test>]
-let ``duplicated trivia printing in ExprAppLongIdentAndSingleParenArgNode with no define, 2822`` () =
+let ``duplicated trivia printing in ExprAppLongIdentAndSingleParenArgNode, no defines`` () =
     formatSourceStringWithDefines
         []
         """

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -986,7 +986,7 @@ let genExpr (e: Expr) =
 
             ifElseCtx
                 (futureNlnCheck shortLids)
-                (genFunctionNameWithMultilineLids args node.FunctionName node)
+                (genFunctionNameWithMultilineLids args node.FunctionName)
                 (shortLids +> args)
 
         expressionFitsOnRestOfLine short long |> genNode node
@@ -2182,7 +2182,7 @@ let colGenericTypeParameters typeParameters =
 
         leadingSpace +> genType t)
 
-let genFunctionNameWithMultilineLids (trailing: Context -> Context) (longIdent: IdentListNode) (parentNode: Node) =
+let genFunctionNameWithMultilineLids (trailing: Context -> Context) (longIdent: IdentListNode) =
     match longIdent.Content with
     | IdentifierOrDot.Ident identNode :: t ->
         genSingleTextNode identNode
@@ -2200,7 +2200,6 @@ let genFunctionNameWithMultilineLids (trailing: Context -> Context) (longIdent: 
             +> trailing
         )
     | _ -> sepNone
-    |> genNode parentNode
 
 let (|EndsWithDualListApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
     if not (config.ExperimentalElmish || config.IsStroustrupStyle) then


### PR DESCRIPTION
fixes #2822 