### PR TITLE
Add additional newline when there is trivia after the opening parenthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Invalid code: moved line comment. [#2847](https://github.com/fsprojects/fantomas/issues/2847)
+
 ## [6.0.0] - 2023-04-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [6.0.1] - 2023-04-19
 
 ### Fixed
 * Invalid code: moved line comment. [#2847](https://github.com/fsprojects/fantomas/issues/2847)

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -127,6 +127,7 @@
     <Compile Include="TryWithTests.fs" />
     <Compile Include="CursorTests.fs" />
     <Compile Include="MultipleDefineCombinationsTests.fs" />
+    <Compile Include="ParenthesesTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Core\Fantomas.Core.fsproj" />

--- a/src/Fantomas.Core.Tests/ParenthesesTests.fs
+++ b/src/Fantomas.Core.Tests/ParenthesesTests.fs
@@ -1,0 +1,40 @@
+module Fantomas.Core.Tests.ParenthesesTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelpers
+
+[<Test>]
+let ``trivia after opening parenthesis, 2847`` () =
+    formatSourceString
+        false
+        """
+let canConvertMemorised =
+    Memoized.memoize
+        (fun objectType ->
+            (   // Include F# discriminated unions
+                FSharpType.IsUnion objectType
+                // and exclude the standard FSharp lists (which are implemented as discriminated unions)
+                && not (objectType.GetTypeInfo().IsGenericType && objectType.GetGenericTypeDefinition() = typedefof<_ list>)
+            )
+            // include tuples
+            || tupleAsHeterogeneousArray && FSharpType.IsTuple objectType
+        )
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let canConvertMemorised =
+    Memoized.memoize (fun objectType ->
+        ( // Include F# discriminated unions
+        FSharpType.IsUnion objectType
+        // and exclude the standard FSharp lists (which are implemented as discriminated unions)
+        && not (
+            objectType.GetTypeInfo().IsGenericType
+            && objectType.GetGenericTypeDefinition() = typedefof<_ list>
+        ))
+        // include tuples
+        || tupleAsHeterogeneousArray && FSharpType.IsTuple objectType)
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -712,6 +712,7 @@ let genExpr (e: Expr) =
             +> genSingleTextNode node.ClosingParen
         | _ ->
             genSingleTextNode node.OpeningParen
+            +> sepNlnWhenWriteBeforeNewlineNotEmpty
             +> genExpr node.Expr
             +> genSingleTextNode node.ClosingParen
         |> genNode node


### PR DESCRIPTION
Fixes #2847.

Hey @jindraivanek,

Thanks for the report. I have a fix for this problem, but I'm not sure this will never lead to any other problems.

On a side note, we currently don't immediately print the line comment after the source. This has been the case since the inception of trivia I think. Since trivia has evolved quite a bit, what do you think of changing this mechanism? To always directly write the trivia and insert a new line? Does that sound worth exploring?