### PR TITLE
Expose TransformAST api.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+* Add TransformAST to public API.
+
 ## [6.0.1] - 2023-04-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
-### Added
-* Add TransformAST to public API.
-
 ## [6.0.1] - 2023-04-19
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/CodeFormatterTests.fs
+++ b/src/Fantomas.Core.Tests/CodeFormatterTests.fs
@@ -68,3 +68,23 @@ let b = 0
     match oak.ModulesOrNamespaces.[0].Declarations.[0] with
     | ModuleDecl.TopLevelBinding _ -> Assert.Pass()
     | _ -> Assert.Fail()
+
+[<Test>]
+let ``transform parsedInput created with additional defines to Oak`` () =
+    let source =
+        """
+module A
+
+#if DEBUG
+let b = 0
+#endif
+"""
+
+    let ast, _ =
+        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) [ "DEBUG"; "FOO"; "BAR" ]
+
+    let oak = CodeFormatter.TransformAST ast
+
+    match oak.ModulesOrNamespaces.[0].Declarations.[0] with
+    | ModuleDecl.TopLevelBinding _ -> Assert.Pass()
+    | _ -> Assert.Fail()

--- a/src/Fantomas.Core.Tests/CodeFormatterTests.fs
+++ b/src/Fantomas.Core.Tests/CodeFormatterTests.fs
@@ -1,5 +1,6 @@
 module Fantomas.Core.Tests.CodeFormatterTests
 
+open Fantomas.Core.SyntaxOak
 open NUnit.Framework
 open Fantomas.Core
 open Fantomas.Core.Tests.TestHelpers
@@ -39,7 +40,7 @@ let main _ =
     |> ignore
 
 [<Test>]
-let ``trivia is parsed for Oak`` () =
+let ``trivia is transformed to Oak`` () =
     let oak =
         CodeFormatter.ParseOakAsync(false, "let a = 0\n // foo")
         |> Async.RunSynchronously
@@ -47,3 +48,23 @@ let ``trivia is parsed for Oak`` () =
         |> fst
 
     Assert.True(oak.ModulesOrNamespaces.[0].HasContentAfter)
+
+[<Test>]
+let ``transform parsedInput to Oak`` () =
+    let source =
+        """
+module A
+
+#if DEBUG
+let b = 0
+#endif
+"""
+
+    let ast, _ =
+        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) [ "DEBUG" ]
+
+    let oak = CodeFormatter.TransformAST(ast, source)
+
+    match oak.ModulesOrNamespaces.[0].Declarations.[0] with
+    | ModuleDecl.TopLevelBinding _ -> Assert.Pass()
+    | _ -> Assert.Fail()

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -78,6 +78,11 @@ type CodeFormatter =
                     oak, defines.Value)
         }
 
+    static member TransformAST ast = ASTTransformer.mkOak None ast
+
+    static member TransformAST(ast, source) =
+        ASTTransformer.mkOak (Some(SourceText.ofString source)) ast
+
     static member FormatOakAsync(oak: Oak) : Async<string> =
         async {
             let context = Context.Context.Create false FormatConfig.Default

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -67,6 +67,12 @@ type CodeFormatter =
     /// Parse a source string to SyntaxOak
     static member ParseOakAsync: isSignature: bool * source: string -> Async<(Oak * string list) array>
 
+    /// Transform a ParsedInput to an Oak
+    static member TransformAST: ast: ParsedInput -> Oak
+
+    /// Transform a ParsedInput to an Oak
+    static member TransformAST: ast: ParsedInput * source: string -> Oak
+
     /// Format SyntaxOak to string
     static member FormatOakAsync: oak: Oak -> Async<string>
 


### PR DESCRIPTION
I have a use-case in Telplin to transform a ParsedInput (created with a specific set of defines) to an Oak. This would need a `6.1` branch.

@dawedawe you on board with having this?