### PR TITLE
Fix mkSynTypar to account for quotes around type parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Preserves quotes around type parameter names. [#2875](https://github.com/fsprojects/fantomas/issues/2875)
+
 ## [6.0.2] - 2023-05-05
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Core.Tests/FunctionDefinitionTests.fs
@@ -1323,3 +1323,33 @@ let a : int * string * bool = 1, "", false
         """
 let a: int * string * bool = 1, "", false
 """
+
+[<Test>]
+let ``should preserve quotes around type parameters, 2875`` () =
+    formatSourceString
+        false
+        """
+let repro (a: '``QuotedWithIllegalChar<'T>``) = ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let repro (a: '``QuotedWithIllegalChar<'T>``) = ()
+"""
+
+[<Test>]
+let ``should preserve quotes around statically resolved type parameters`` () =
+    formatSourceString
+        false
+        """
+let inline repro (a: ^``QuotedWithIllegalChar<'T>``) = ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let inline repro (a: ^``QuotedWithIllegalChar<'T>``) = ()
+"""

--- a/src/Fantomas.Core.Tests/SignatureTests.fs
+++ b/src/Fantomas.Core.Tests/SignatureTests.fs
@@ -2277,3 +2277,17 @@ type ILMethodDef =
         metadataIndex: int32 ->
             ILMethodDef
 """
+
+let ``should preserve quotes around type parameters, 2875`` () =
+    formatSourceString
+        true
+        """
+val repro: '``QuotedWithIllegalChar<'T>`` -> unit
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+val repro: '``QuotedWithIllegalChar<'T>`` -> unit
+"""

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -1980,9 +1980,17 @@ let mkSynTypar (SynTypar(ident, req, _)) =
             (Position.mkPos ident.idRange.StartLine (ident.idRange.StartColumn - 1))
             ident.idRange.End
 
+    let identText =
+        let width = ident.idRange.EndColumn - ident.idRange.StartColumn
+        // 5 because of ^ or ' and `` on each side
+        if ident.idText.Length + 5 = width then
+            $"``{ident.idText}``"
+        else
+            ident.idText
+
     match req with
-    | TyparStaticReq.None -> stn $"'{ident}" range
-    | TyparStaticReq.HeadType -> stn $"^{ident.idText}" range
+    | TyparStaticReq.None -> stn $"'{identText}" range
+    | TyparStaticReq.HeadType -> stn $"^{identText}" range
 
 let mkSynTypeConstraint (creationAide: CreationAide) (tc: SynTypeConstraint) : TypeConstraint =
     match tc with


### PR DESCRIPTION
Should fix https://github.com/fsprojects/fantomas/issues/2875.

Hopefully I have not forgotten anything.