### PR TITLE
Remove Context.HasSource

### DIFF
--- a/src/Fantomas.Core.Tests/CodeFormatterTests.fs
+++ b/src/Fantomas.Core.Tests/CodeFormatterTests.fs
@@ -47,3 +47,23 @@ let ``trivia is parsed for Oak`` () =
         |> fst
 
     Assert.True(oak.ModulesOrNamespaces.[0].HasContentAfter)
+
+[<Test>]
+let ``parsed oak can be formatted back to source`` () =
+    let source = "$\"gc{i}\""
+
+    let oak =
+        CodeFormatter.ParseOakAsync(false, source)
+        |> Async.RunSynchronously
+        |> Array.head
+        |> fst
+
+    let formatted =
+        CodeFormatter.FormatOakAsync(
+            oak,
+            { FormatConfig.Default with
+                InsertFinalNewline = false }
+        )
+        |> Async.RunSynchronously
+
+    Assert.AreEqual(source, formatted)

--- a/src/Fantomas.Core.Tests/InterpolatedStringTests.fs
+++ b/src/Fantomas.Core.Tests/InterpolatedStringTests.fs
@@ -79,6 +79,21 @@ let s = $"%s{text} bar"
 """
 
 [<Test>]
+let ``interpolation from AST with multiple fillExprs`` () =
+    formatAST
+        false
+        """
+$"%s{text} %i{bar} %f{meh}"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+$"%s{text} %i{bar} %f{meh}"
+"""
+
+[<Test>]
 let ``multiline expression in multiline string`` () =
     formatSourceString
         false

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -80,14 +80,16 @@ type CodeFormatter =
 
     static member FormatOakAsync(oak: Oak) : Async<string> =
         async {
-            let context = Context.Context.Create false FormatConfig.Default
+            // At this point the source is, from a certain point of view, encapsulated in the Oak.
+            let context = Context.Context.Create true FormatConfig.Default
             let result = context |> CodePrinter.genFile oak |> Context.dump false
             return result.Code
         }
 
     static member FormatOakAsync(oak: Oak, config: FormatConfig) : Async<string> =
         async {
-            let context = Context.Context.Create false config
+            // At this point the source is, from a certain point of view, encapsulated in the Oak.
+            let context = Context.Context.Create true config
             let result = context |> CodePrinter.genFile oak |> Context.dump false
             return result.Code
         }

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -80,16 +80,14 @@ type CodeFormatter =
 
     static member FormatOakAsync(oak: Oak) : Async<string> =
         async {
-            // At this point the source is, from a certain point of view, encapsulated in the Oak.
-            let context = Context.Context.Create true FormatConfig.Default
+            let context = Context.Context.Create FormatConfig.Default
             let result = context |> CodePrinter.genFile oak |> Context.dump false
             return result.Code
         }
 
     static member FormatOakAsync(oak: Oak, config: FormatConfig) : Async<string> =
         async {
-            // At this point the source is, from a certain point of view, encapsulated in the Oak.
-            let context = Context.Context.Create true config
+            let context = Context.Context.Create config
             let result = context |> CodePrinter.genFile oak |> Context.dump false
             return result.Code
         }

--- a/src/Fantomas.Core/CodeFormatterImpl.fs
+++ b/src/Fantomas.Core/CodeFormatterImpl.fs
@@ -57,7 +57,7 @@ let formatAST
     (config: FormatConfig)
     (cursor: pos option)
     : FormatResult =
-    let context = Context.Context.Create sourceText.IsSome config
+    let context = Context.Context.Create config
 
     let oak =
         match sourceText with

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1524,8 +1524,7 @@ let genExpr (e: Expr) =
                 |> fun ctx -> { ctx with Config = currentConfig }
             |> atCurrentColumnIndent
 
-        onlyIfCtx (fun ctx -> not ctx.HasSource) (!- "$\"")
-        +> col sepNone node.Parts (fun part ->
+        col sepNone node.Parts (fun part ->
             match part with
             | Choice1Of2 stringNode -> genSingleTextNode stringNode
             | Choice2Of2 fillNode ->
@@ -1534,11 +1533,7 @@ let genExpr (e: Expr) =
                         genInterpolatedFillExpr fillNode.Expr
                         +> optSingle (fun format -> sepColonFixed +> genSingleTextNode format) fillNode.Ident
 
-                    if not ctx.HasSource then
-                        (!- "{" +> genFill +> !- "}") ctx
-                    else
-                        genFill ctx)
-        +> onlyIfCtx (fun ctx -> not ctx.HasSource) (!- "\"")
+                    genFill ctx)
         |> genNode node
     | Expr.IndexRangeWildcard node -> genSingleTextNode node
     | Expr.TripleNumberIndexRange node ->

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -181,7 +181,6 @@ module WriterEvents =
 [<System.Diagnostics.DebuggerDisplay("\"{Dump()}\"")>]
 type Context =
     { Config: FormatConfig
-      HasSource: bool
       WriterModel: WriterModel
       WriterEvents: Queue<WriterEvent>
       FormattedCursor: pos option }
@@ -189,15 +188,12 @@ type Context =
     /// Initialize with a string writer and use space as delimiter
     static member Default =
         { Config = FormatConfig.Default
-          HasSource = false
           WriterModel = WriterModel.init
           WriterEvents = Queue.empty
           FormattedCursor = None }
 
-    static member Create hasSource config : Context =
-        { Context.Default with
-            Config = config
-            HasSource = hasSource }
+    static member Create config : Context =
+        { Context.Default with Config = config }
 
     member x.WithDummy(writerCommands, ?keepPageWidth) =
         let keepPageWidth = keepPageWidth |> Option.defaultValue false

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -53,19 +53,14 @@ type WriterModel =
 
 [<System.Diagnostics.DebuggerDisplay("\"{Dump()}\"")>]
 type Context =
-    {
-        Config: FormatConfig
-        /// Indicates the presence of source code.
-        /// This could be absent in the case we are formatting from AST.
-        HasSource: bool
-        WriterModel: WriterModel
-        WriterEvents: Queue<WriterEvent>
-        FormattedCursor: pos option
-    }
+    { Config: FormatConfig
+      WriterModel: WriterModel
+      WriterEvents: Queue<WriterEvent>
+      FormattedCursor: pos option }
 
     /// Initialize with a string writer and use space as delimiter
     static member Default: Context
-    static member Create: hasSource: bool -> config: FormatConfig -> Context
+    static member Create: config: FormatConfig -> Context
     member WithDummy: writerCommands: Queue<WriterEvent> * ?keepPageWidth: bool -> Context
     member WithShortExpression: maxWidth: int * ?startColumn: int -> Context
     member Column: int

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -404,7 +404,7 @@ let formatSelection
                 MaxLineLength = maxLineLength }
 
         let formattedSelection =
-            let context = Context.Context.Create true selectionConfig
+            let context = Context.Context.Create selectionConfig
 
             match tree with
             | TreeForSelection.Unsupported ->


### PR DESCRIPTION
Quite the edge case, but I'm trying the following:
- Parse a raw string to an Oak.
- Update some nodes in that Oak whilst keeping all the rest exactly the same.
- Format the new (updated) Oak back to a string.

This didn't work for interpolated strings and I moved the workaround to `ASTTransformer` instead of `CodePrinter`.