### PR TITLE
Add regression test for cons pattern in let binding (#1996)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 * Missing space before arrow. [#2888](https://github.com/fsprojects/fantomas/issues/2888)
+* Cons pattern in let bindings is converted to invalid code. [#1996](https://github.com/fsprojects/fantomas/issues/1996)
 
 ## [6.0.3] - 2023-05-14
 

--- a/src/Fantomas.Core.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Core.Tests/LetBindingTests.fs
@@ -2165,3 +2165,16 @@ let x
     ) =
     print "hello"
 """
+
+[<Test>]
+let ``cons pattern in let binding, 1996`` () =
+    formatSourceString
+        false
+        """let x::y = []
+"""
+
+    config
+    |> should
+        equal
+        """let x :: y = []
+"""

--- a/src/Fantomas.Core.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Core.Tests/LetBindingTests.fs
@@ -2170,11 +2170,13 @@ let x
 let ``cons pattern in let binding, 1996`` () =
     formatSourceString
         false
-        """let x::y = []
+        """
+let x::y = []
 """
-
-    config
+        config
+    |> prepend newline
     |> should
         equal
-        """let x :: y = []
+        """
+let x :: y = []
 """


### PR DESCRIPTION
I wrote a regression test case for cons pattern in let binding (#1996).
Is it OK?