### PR TITLE
Use exact dotnet version in EndToEndTests.

### DIFF
--- a/src/Fantomas.Client.Tests/EndToEndTests.fs
+++ b/src/Fantomas.Client.Tests/EndToEndTests.fs
@@ -40,7 +40,16 @@ type EndToEndTests() =
 
                 // This sdk version must match the version used in this repository.
                 // It will be the version which the CI/CD pipeline has access to.
-                do! dotnet "new globaljson --sdk-version 7.0.202 --roll-forward latestPatch"
+                let! dotnetVersionResult =
+                    Cli
+                        .Wrap("dotnet")
+                        .WithWorkingDirectory(__SOURCE_DIRECTORY__)
+                        .WithArguments("--version")
+                        .ExecuteBufferedAsync()
+                        .Task
+
+                let dotnetVersion = dotnetVersionResult.StandardOutput.Trim()
+                do! dotnet $"new globaljson --sdk-version %s{dotnetVersion} --roll-forward latestPatch"
                 do! dotnet "new tool-manifest"
 
                 do!


### PR DESCRIPTION
Should fix the Windows builds.