### PR TITLE
Rename FSharp.Compiler to Fantomas.FCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.0-alpha-003 - 2023-06-02
+
+### Changed
+* Rename `namespace FSharp.Compiler` to `namespace Fantomas.FCS` for `Fantomas.FCS`. [#2894](https://github.com/fsprojects/fantomas/pull/2894)
+
 ## 6.1.0-alpha-002 - 2023-05-02
 
 ### Changed

--- a/build.fsx
+++ b/build.fsx
@@ -193,6 +193,17 @@ let fsharpCompilerHash =
     let xDoc = XElement.Load(__SOURCE_DIRECTORY__ </> "Directory.Build.props")
     xDoc.XPathSelectElements("//FCSCommitHash") |> Seq.head |> (fun xe -> xe.Value)
 
+let updateFileRaw (file: FileInfo) =
+    let lines = File.ReadAllLines file.FullName
+    let updatedLines =
+        lines
+        |> Array.map (fun line ->
+            if line.Contains("FSharp.Compiler") then
+                line.Replace("FSharp.Compiler", "Fantomas.FCS")
+            else
+                line)
+    File.WriteAllLines(file.FullName, updatedLines)
+
 let downloadCompilerFile commitHash relativePath =
     async {
         let file = FileInfo(deps </> commitHash </> relativePath)
@@ -213,6 +224,8 @@ let downloadCompilerFile commitHash relativePath =
                 printfn $"Could not download %s{relativePath}"
             do! Async.AwaitTask(response.ResponseStream.CopyToAsync(fs))
             fs.Close()
+
+            updateFileRaw file
     }
 
 pipeline "Init" {

--- a/docs/docs/end-users/GeneratingCode.fsx
+++ b/docs/docs/end-users/GeneratingCode.fsx
@@ -33,9 +33,9 @@ To illustrate the API, lets generate a simple value binding: `let a = 0`.
 *)
 
 #r "../../../src/Fantomas/bin/Release/net6.0/Fantomas.FCS.dll"
-#r "../../../src/Fantomas/bin/Release/net6.0/Fantomas.Core.dll" // In production use #r "nuget: Fantomas.Core, 6.0-alpha-*"
+#r "../../../src/Fantomas/bin/Release/net6.0/Fantomas.Core.dll" // In production use #r "nuget: Fantomas.Core, 6.*"
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 
 let implementationSyntaxTree =
@@ -88,11 +88,8 @@ The more you interact with AST/Oak, the easier you pick up which node represents
 
 ### Fantomas.FCS
 
-When looking at the example, we notice that we've opened `FSharp.Compiler.Text`.   
-Don't be fooled by this, `Fantomas.Core` and `Fantomas.FCS` **do not reference [FSharp.Compiler.Service](https://www.nuget.org/packages/FSharp.Compiler.Service)**!  
-Instead, `Fantomas.FCS` is a custom version of the F# compiler (built from source) that only exposes the F# parser and the syntax tree.
-
-`Fantomas.FCS` exposes the exact same namespaces because it builds from the exact same F# compiler source code.   
+When looking at the example, we notice that we've opened `Fantomas.FCS.Text`.    
+`Fantomas.FCS` is a custom version of the F# compiler (built from source) that only exposes the F# parser and the syntax tree.  
 The key difference is that `Fantomas.FCS` will most likely contain a more recent version of the F# parser.  
 You can read the [CHANGELOG](https://github.com/fsprojects/fantomas/blob/main/CHANGELOG.md) to see what git commit was used to build `Fantomas.FCS`.
 

--- a/src/Fantomas.Core.Tests/ASTTransformerTests.fs
+++ b/src/Fantomas.Core.Tests/ASTTransformerTests.fs
@@ -1,10 +1,10 @@
 module Fantomas.Core.Tests.ASTTransformerTests
 
 open NUnit.Framework
-open FSharp.Compiler.Text
-open FSharp.Compiler.Xml
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
+open Fantomas.FCS.Text
+open Fantomas.FCS.Xml
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.SyntaxTrivia
 open Fantomas.Core
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/CodeFormatterTests.fs
+++ b/src/Fantomas.Core.Tests/CodeFormatterTests.fs
@@ -1,8 +1,9 @@
 module Fantomas.Core.Tests.CodeFormatterTests
 
-open Fantomas.Core.SyntaxOak
 open NUnit.Framework
+open Fantomas.FCS.Text
 open Fantomas.Core
+open Fantomas.Core.SyntaxOak
 open Fantomas.Core.Tests.TestHelpers
 
 [<Test>]
@@ -81,7 +82,7 @@ let b = 0
 """
 
     let ast, _ =
-        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) [ "DEBUG" ]
+        Fantomas.FCS.Parse.parseFile false (SourceText.ofString source) [ "DEBUG" ]
 
     let oak = CodeFormatter.TransformAST(ast, source)
 
@@ -101,7 +102,7 @@ let b = 0
 """
 
     let ast, _ =
-        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) [ "DEBUG"; "FOO"; "BAR" ]
+        Fantomas.FCS.Parse.parseFile false (SourceText.ofString source) [ "DEBUG"; "FOO"; "BAR" ]
 
     let oak = CodeFormatter.TransformAST ast
 
@@ -119,8 +120,7 @@ module A
 let b = 0
 """
 
-    let ast, _ =
-        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) []
+    let ast, _ = Fantomas.FCS.Parse.parseFile false (SourceText.ofString source) []
 
     let oak = CodeFormatter.TransformAST(ast, source)
 

--- a/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
+++ b/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
@@ -209,7 +209,7 @@ let a =
 
     // Let's create a dummy Oak
     // In practise, a FCS Syntax tree will be transformed to an Oak
-    let zeroRange = FSharp.Compiler.Text.Range.Zero
+    let zeroRange = Fantomas.FCS.Text.Range.Zero
     let stn text = SingleTextNode(text, zeroRange)
 
     let tree =
@@ -321,7 +321,7 @@ let b = 2
 """
 
     // Imagine that we always want to print a new line between let bindings.
-    let zeroRange = FSharp.Compiler.Text.Range.Zero
+    let zeroRange = Fantomas.FCS.Text.Range.Zero
     let stn text = SingleTextNode(text, zeroRange)
 
     let mkBinding name body =

--- a/src/Fantomas.Core.Tests/CursorTests.fs
+++ b/src/Fantomas.Core.Tests/CursorTests.fs
@@ -1,6 +1,6 @@
 ﻿module Fantomas.Core.Tests.CursorTests
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core

--- a/src/Fantomas.Core.Tests/DefinesTests.fs
+++ b/src/Fantomas.Core.Tests/DefinesTests.fs
@@ -2,7 +2,7 @@ module Fantomas.Core.Tests.TokenParserTests
 
 open NUnit.Framework
 open FsUnit
-open FSharp.Compiler.Syntax
+open Fantomas.FCS.Syntax
 open Fantomas.Core
 open Fantomas.Core.Defines
 open Fantomas.Core.Tests.TestHelpers

--- a/src/Fantomas.Core.Tests/FormattingSelectionOnlyTests.fs
+++ b/src/Fantomas.Core.Tests/FormattingSelectionOnlyTests.fs
@@ -1,6 +1,6 @@
 module Fantomas.Core.Tests.FormattingSelectionOnlyTests
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Core
 open NUnit.Framework
 open FsUnit

--- a/src/Fantomas.Core.Tests/SynLongIdentTests.fs
+++ b/src/Fantomas.Core.Tests/SynLongIdentTests.fs
@@ -1,9 +1,9 @@
 module Fantomas.Core.Tests.SynLongIdentTests
 
-open FSharp.Compiler.Text
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
-open FSharp.Compiler.Xml
+open Fantomas.FCS.Text
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.SyntaxTrivia
+open Fantomas.FCS.Xml
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core

--- a/src/Fantomas.Core.Tests/TestHelpers.fs
+++ b/src/Fantomas.Core.Tests/TestHelpers.fs
@@ -33,7 +33,7 @@ let formatSourceString isFsiFile (s: string) config =
 let formatAST isFsiFile (source: string) config =
     async {
         let ast, _ =
-            Fantomas.FCS.Parse.parseFile isFsiFile (FSharp.Compiler.Text.SourceText.ofString source) []
+            Fantomas.FCS.Parse.parseFile isFsiFile (Fantomas.FCS.Text.SourceText.ofString source) []
 
         let! formattedCode = CodeFormatter.FormatASTAsync(ast, config = config)
         let! isValid = CodeFormatter.IsValidFSharpCodeAsync(isFsiFile, formattedCode)

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -2,11 +2,11 @@
 
 open System.Collections.Generic
 open System.Text.RegularExpressions
-open FSharp.Compiler.Text
-open FSharp.Compiler.Text.Range
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
-open FSharp.Compiler.Xml
+open Fantomas.FCS.Text
+open Fantomas.FCS.Text.Range
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.SyntaxTrivia
+open Fantomas.FCS.Xml
 open Fantomas.Core.ISourceTextExtensions
 open Fantomas.Core.RangePatterns
 open Fantomas.Core.SyntaxOak

--- a/src/Fantomas.Core/ASTTransformer.fsi
+++ b/src/Fantomas.Core/ASTTransformer.fsi
@@ -1,7 +1,7 @@
 module internal Fantomas.Core.ASTTransformer
 
-open FSharp.Compiler.Text
-open FSharp.Compiler.Syntax
+open Fantomas.FCS.Text
+open Fantomas.FCS.Syntax
 open Fantomas.Core.SyntaxOak
 
 val mkOak: sourceText: ISourceText option -> ast: ParsedInput -> Oak

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -1,7 +1,7 @@
 namespace Fantomas.Core
 
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.Text
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 
 [<Sealed>]

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -1,7 +1,7 @@
 namespace Fantomas.Core
 
-open FSharp.Compiler.Text
-open FSharp.Compiler.Syntax
+open Fantomas.FCS.Text
+open Fantomas.FCS.Syntax
 open Fantomas.Core.SyntaxOak
 
 [<Sealed>]

--- a/src/Fantomas.Core/CodeFormatterImpl.fs
+++ b/src/Fantomas.Core/CodeFormatterImpl.fs
@@ -1,9 +1,9 @@
 [<RequireQualifiedAccess>]
 module internal Fantomas.Core.CodeFormatterImpl
 
-open FSharp.Compiler.Diagnostics
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.Text
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text
 open MultipleDefineCombinations
 
 let getSourceText (source: string) : ISourceText = source.TrimEnd() |> SourceText.ofString

--- a/src/Fantomas.Core/CodeFormatterImpl.fsi
+++ b/src/Fantomas.Core/CodeFormatterImpl.fsi
@@ -1,8 +1,8 @@
 ﻿[<RequireQualifiedAccess>]
 module internal Fantomas.Core.CodeFormatterImpl
 
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.Text
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text
 
 val getSourceText: source: string -> ISourceText
 

--- a/src/Fantomas.Core/CodeFormatterTypes.fs
+++ b/src/Fantomas.Core/CodeFormatterTypes.fs
@@ -1,6 +1,6 @@
 ﻿namespace Fantomas.Core
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 type FormatResult =
     {

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -102,7 +102,7 @@ let genTrivia (node: Node) (trivia: TriviaNode) (ctx: Context) =
                 let originalColumnOffset = trivia.Range.EndColumn - node.Range.EndColumn
 
                 let formattedCursor =
-                    FSharp.Compiler.Text.Position.mkPos ctx.WriterModel.Lines.Length (ctx.Column + originalColumnOffset)
+                    Fantomas.FCS.Text.Position.mkPos ctx.WriterModel.Lines.Length (ctx.Column + originalColumnOffset)
 
                 { ctx with
                     FormattedCursor = Some formattedCursor }
@@ -122,7 +122,7 @@ let recordCursorNode f (node: Node) (ctx: Context) =
 
         let formattedCursor =
             let columnOffsetInSource = cursor.Column - node.Range.StartColumn
-            FSharp.Compiler.Text.Position.mkPos currentStartLine (currentStartColumn + columnOffsetInSource)
+            Fantomas.FCS.Text.Position.mkPos currentStartLine (currentStartColumn + columnOffsetInSource)
 
         { ctxAfter with
             FormattedCursor = Some formattedCursor }
@@ -766,7 +766,7 @@ let genExpr (e: Expr) =
             | [] -> genExpr node.LeadingExpr
             | (operator, e2) :: es ->
                 let m =
-                    FSharp.Compiler.Text.Range.unionRanges (Expr.Node node.LeadingExpr).Range (Expr.Node e2).Range
+                    Fantomas.FCS.Text.Range.unionRanges (Expr.Node node.LeadingExpr).Range (Expr.Node e2).Range
 
                 genMultilineInfixExpr (ExprInfixAppNode(node.LeadingExpr, operator, e2, m))
                 +> sepNln
@@ -1045,9 +1045,9 @@ let genExpr (e: Expr) =
                 let parenExpr =
                     mkExprParenNode
                         node.OpeningParen
-                        (Expr.Null(SingleTextNode("", FSharp.Compiler.Text.Range.Zero)))
+                        (Expr.Null(SingleTextNode("", Fantomas.FCS.Text.Range.Zero)))
                         node.ClosingParen
-                        FSharp.Compiler.Text.Range.Zero
+                        Fantomas.FCS.Text.Range.Zero
 
                 sepSpaceBeforeParenInFuncInvocation node.FunctionName parenExpr
             | _ -> sepSpace
@@ -1839,16 +1839,16 @@ let genTupleExpr (node: ExprTupleNode) =
             | IsLambdaOrIfThenElse e ->
                 let parenNode =
                     mkExprParenNode
-                        (SingleTextNode("(", FSharp.Compiler.Text.Range.Zero))
+                        (SingleTextNode("(", Fantomas.FCS.Text.Range.Zero))
                         e
-                        (SingleTextNode(")", FSharp.Compiler.Text.Range.Zero))
-                        FSharp.Compiler.Text.Range.Zero
+                        (SingleTextNode(")", Fantomas.FCS.Text.Range.Zero))
+                        Fantomas.FCS.Text.Range.Zero
 
                 ExprInfixAppNode(
                     exprInfixAppNode.LeftHandSide,
                     exprInfixAppNode.Operator,
                     parenNode,
-                    FSharp.Compiler.Text.range.Zero
+                    Fantomas.FCS.Text.range.Zero
                 )
                 |> Expr.InfixApp
             | _ -> expr

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -1,7 +1,7 @@
 module internal Fantomas.Core.Context
 
 open System
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Core
 open Fantomas.Core.SyntaxOak
 
@@ -375,7 +375,7 @@ let newlineBetweenLastWriteEvent ctx =
 let lastWriteEventOnLastLine ctx =
     writeEventsOnLastLine ctx |> Seq.tryHead
 
-// A few utility functions from https://github.com/fsharp/powerpack/blob/master/src/FSharp.Compiler.CodeDom/generator.fs
+// A few utility functions from https://github.com/fsharp/powerpack/blob/master/src/Fantomas.FCS.CodeDom/generator.fs
 
 /// Indent one more level based on configuration
 let indent (ctx: Context) =

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -1,6 +1,6 @@
 module internal Fantomas.Core.Context
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 
 type WriterEvent =

--- a/src/Fantomas.Core/Defines.fs
+++ b/src/Fantomas.Core/Defines.fs
@@ -1,6 +1,6 @@
 namespace Fantomas.Core
 
-open FSharp.Compiler.SyntaxTrivia
+open Fantomas.FCS.SyntaxTrivia
 open Fantomas.Core
 
 type internal DefineCombination =

--- a/src/Fantomas.Core/Defines.fsi
+++ b/src/Fantomas.Core/Defines.fsi
@@ -8,6 +8,6 @@ type internal DefineCombination =
     static member Empty: DefineCombination
 
 module internal Defines =
-    open FSharp.Compiler.SyntaxTrivia
+    open Fantomas.FCS.SyntaxTrivia
 
     val getDefineCombination: hashDirectives: ConditionalDirectiveTrivia list -> DefineCombination list

--- a/src/Fantomas.Core/ISourceTextExtensions.fs
+++ b/src/Fantomas.Core/ISourceTextExtensions.fs
@@ -1,7 +1,7 @@
 ﻿module Fantomas.Core.ISourceTextExtensions
 
 open System.Text
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 type ISourceText with
 

--- a/src/Fantomas.Core/ISourceTextExtensions.fsi
+++ b/src/Fantomas.Core/ISourceTextExtensions.fsi
@@ -1,6 +1,6 @@
 module Fantomas.Core.ISourceTextExtensions
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 type ISourceText with
 

--- a/src/Fantomas.Core/MultipleDefineCombinations.fs
+++ b/src/Fantomas.Core/MultipleDefineCombinations.fs
@@ -5,7 +5,7 @@ open System.Linq
 open System.Text
 open System.Text.RegularExpressions
 open Microsoft.FSharp.Core.CompilerServices
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 /// A CodeFragment represents a chunk of code that is either
 ///     a single conditional hash directive line,

--- a/src/Fantomas.Core/RangeHelpers.fs
+++ b/src/Fantomas.Core/RangeHelpers.fs
@@ -1,6 +1,6 @@
 namespace Fantomas.Core
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 [<RequireQualifiedAccess>]
 module RangeHelpers =

--- a/src/Fantomas.Core/RangeHelpers.fsi
+++ b/src/Fantomas.Core/RangeHelpers.fsi
@@ -1,6 +1,6 @@
 namespace Fantomas.Core
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 [<RequireQualifiedAccess>]
 module RangeHelpers =

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -1,6 +1,6 @@
 ﻿module internal Fantomas.Core.Selection
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 open Fantomas.Core.ISourceTextExtensions
 

--- a/src/Fantomas.Core/Selection.fsi
+++ b/src/Fantomas.Core/Selection.fsi
@@ -1,6 +1,6 @@
 module internal Fantomas.Core.Selection
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 val formatSelection:
     config: FormatConfig -> isSignature: bool -> selection: range -> sourceText: ISourceText -> Async<string * range>

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1,7 +1,7 @@
 module rec Fantomas.Core.SyntaxOak
 
 open System.Collections.Generic
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 type TriviaContent =
     | CommentOnSingleLine of string

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -1,8 +1,8 @@
 ﻿module internal Fantomas.Core.Trivia
 
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
-open FSharp.Compiler.Text
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.SyntaxTrivia
+open Fantomas.FCS.Text
 open Fantomas.Core.ISourceTextExtensions
 open Fantomas.Core.SyntaxOak
 

--- a/src/Fantomas.Core/Trivia.fsi
+++ b/src/Fantomas.Core/Trivia.fsi
@@ -1,7 +1,7 @@
 module internal Fantomas.Core.Trivia
 
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.Text
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 
 val findNodeWhereRangeFitsIn: root: Node -> range: range -> Node option

--- a/src/Fantomas.Core/Validation.fs
+++ b/src/Fantomas.Core/Validation.fs
@@ -1,8 +1,8 @@
 ﻿module internal Fantomas.Core.Validation
 
-open FSharp.Compiler.Diagnostics
-open FSharp.Compiler.Text
-open FSharp.Compiler.Syntax
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.Text
+open Fantomas.FCS.Syntax
 open Fantomas.FCS.Parse
 
 let private safeToIgnoreWarnings =
@@ -10,7 +10,7 @@ let private safeToIgnoreWarnings =
         [ "This construct is deprecated: it is only for use in the F# library"
           "Identifiers containing '@' are reserved for use in F# code generation" ]
 
-// Exception of type 'FSharp.Compiler.DiagnosticsLogger+LibraryUseOnly' was thrown.
+// Exception of type 'Fantomas.FCS.DiagnosticsLogger+LibraryUseOnly' was thrown.
 
 let noWarningOrErrorDiagnostics diagnostics =
     let errors =

--- a/src/Fantomas.FCS/Fantomas.FCS.fsproj
+++ b/src/Fantomas.FCS/Fantomas.FCS.fsproj
@@ -174,14 +174,14 @@
       <Link>Facilities\prim-parsing.fs</Link>
     </Compile>
     <FsLex Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\AbstractIL\illex.fsl">
-      <OtherFlags>--module FSharp.Compiler.AbstractIL.AsciiLexer --internal --open Internal.Utilities.Text.Lexing --open FSharp.Compiler.AbstractIL.AsciiParser --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+      <OtherFlags>--module Fantomas.FCS.AbstractIL.AsciiLexer --internal --open Internal.Utilities.Text.Lexing --open Fantomas.FCS.AbstractIL.AsciiParser --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
       <Link>AbstractIL\illex.fsl</Link>
     </FsLex>
     <None Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\AbstractIL\illex.fsl">
       <Link>AbstractIL\illex.fsl</Link>
     </None>
     <FsYacc Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\AbstractIL\ilpars.fsy">
-      <OtherFlags>--module FSharp.Compiler.AbstractIL.AsciiParser --open FSharp.Compiler.AbstractIL --open FSharp.Compiler.AbstractIL.AsciiConstants --open FSharp.Compiler.AbstractIL.IL --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
+      <OtherFlags>--module Fantomas.FCS.AbstractIL.AsciiParser --open Fantomas.FCS.AbstractIL --open Fantomas.FCS.AbstractIL.AsciiConstants --open Fantomas.FCS.AbstractIL.IL --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
       <Link>AbstractIL\ilpars.fsy</Link>
     </FsYacc>
     <None Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\AbstractIL\ilpars.fsy">
@@ -224,19 +224,19 @@
       <Link>SyntaxTree\PrettyNaming.fs</Link>
     </Compile>
     <FsLex Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\pplex.fsl">
-      <OtherFlags>--module FSharp.Compiler.PPLexer --internal --open FSharp.Compiler.Lexhelp --open Internal.Utilities.Text.Lexing --open FSharp.Compiler.PPParser --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+      <OtherFlags>--module Fantomas.FCS.PPLexer --internal --open Fantomas.FCS.Lexhelp --open Internal.Utilities.Text.Lexing --open Fantomas.FCS.PPParser --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
       <Link>SyntaxTree\pplex.fsl</Link>
     </FsLex>
     <FsYacc Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\pppars.fsy">
-      <OtherFlags>--module FSharp.Compiler.PPParser --open FSharp.Compiler --open FSharp.Compiler.Syntax --open FSharp.Compiler.ParseHelpers --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
+      <OtherFlags>--module Fantomas.FCS.PPParser --open Fantomas.FCS --open Fantomas.FCS.Syntax --open Fantomas.FCS.ParseHelpers --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
       <Link>SyntaxTree\pppars.fsy</Link>
     </FsYacc>
     <FsLex Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\lex.fsl">
-      <OtherFlags>--module FSharp.Compiler.Lexer --open FSharp.Compiler.Lexhelp --open Internal.Utilities.Text.Lexing --open FSharp.Compiler.Parser --open FSharp.Compiler.Text --open FSharp.Compiler.ParseHelpers --internal --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+      <OtherFlags>--module Fantomas.FCS.Lexer --open Fantomas.FCS.Lexhelp --open Internal.Utilities.Text.Lexing --open Fantomas.FCS.Parser --open Fantomas.FCS.Text --open Fantomas.FCS.ParseHelpers --internal --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
       <Link>SyntaxTree\lex.fsl</Link>
     </FsLex>
     <FsYacc Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\pars.fsy">
-      <OtherFlags>-v --module FSharp.Compiler.Parser --open FSharp.Compiler --open FSharp.Compiler.Syntax --open FSharp.Compiler.Text --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
+      <OtherFlags>-v --module Fantomas.FCS.Parser --open Fantomas.FCS --open Fantomas.FCS.Syntax --open Fantomas.FCS.Text --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
       <Link>SyntaxTree\pars.fsy</Link>
     </FsYacc>
     <None Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\pplex.fsl">

--- a/src/Fantomas.FCS/Parse.fs
+++ b/src/Fantomas.FCS/Parse.fs
@@ -3,25 +3,25 @@ module Fantomas.FCS.Parse
 open System
 open System.Text
 open System.Diagnostics
-open FSharp.Compiler.Diagnostics
-open FSharp.Compiler.DiagnosticMessage
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.DiagnosticMessage
 open Internal.Utilities
 open Internal.Utilities.Library
-open FSharp.Compiler
-open FSharp.Compiler.AbstractIL.IL
-open FSharp.Compiler.DiagnosticsLogger
-open FSharp.Compiler.Features
-open FSharp.Compiler.Lexhelp
-open FSharp.Compiler.Text
-open FSharp.Compiler.Text.Position
-open FSharp.Compiler.Text.Range
-open FSharp.Compiler.Xml
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
-open FSharp.Compiler.Syntax.PrettyNaming
-open FSharp.Compiler.SyntaxTreeOps
-open FSharp.Compiler.IO
-open FSharp.Compiler.ParseHelpers
+open Fantomas.FCS
+open Fantomas.FCS.AbstractIL.IL
+open Fantomas.FCS.DiagnosticsLogger
+open Fantomas.FCS.Features
+open Fantomas.FCS.Lexhelp
+open Fantomas.FCS.Text
+open Fantomas.FCS.Text.Position
+open Fantomas.FCS.Text.Range
+open Fantomas.FCS.Xml
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.SyntaxTrivia
+open Fantomas.FCS.Syntax.PrettyNaming
+open Fantomas.FCS.SyntaxTreeOps
+open Fantomas.FCS.IO
+open Fantomas.FCS.ParseHelpers
 
 let FSharpSigFileSuffixes = [ ".mli"; ".fsi" ]
 

--- a/src/Fantomas.FCS/Parse.fsi
+++ b/src/Fantomas.FCS/Parse.fsi
@@ -1,8 +1,8 @@
 module Fantomas.FCS.Parse
 
-open FSharp.Compiler.Diagnostics
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.Text
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text
 
 type FSharpParserDiagnostic =
     { Severity: FSharpDiagnosticSeverity

--- a/src/Fantomas/Daemon.fs
+++ b/src/Fantomas/Daemon.fs
@@ -8,7 +8,7 @@ open System.Threading
 open System.Threading.Tasks
 open StreamJsonRpc
 open Thoth.Json.Net
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Client.Contracts
 open Fantomas.Client.LSPFantomasServiceTypes
 open Fantomas.Core


### PR DESCRIPTION
Renames all `FSharp.Compiler` to `Fantomas.FCS` namespaces.