### PR TITLE
Update editorconfig package

### DIFF
--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "editorconfig": {
         "type": "Transitive",
-        "resolved": "0.13.0",
-        "contentHash": "1IAdbakbxaKyVv/gr3VTHkbFMFgfOSpP4VRSvOg50Ee9qAfXDr4F8FvOtwq7Pi6fcoxxXYfOYceT1U3oODdpFg=="
+        "resolved": "0.14.0",
+        "contentHash": "emt1KlBtTsTSHWeLnlD1grQYN991wlzIh8t0/HF8ambYTLE8v25sPU9q2eu3sNj/Za7Ij6a0MW00lDGTsphEhQ=="
       },
       "Fable.Core": {
         "type": "Transitive",
@@ -922,7 +922,7 @@
           "StreamJsonRpc": "[2.8.28, )",
           "System.IO.Abstractions": "[17.2.3, )",
           "Thoth.Json.Net": "[8.0.0, )",
-          "editorconfig": "[0.13.0, )"
+          "editorconfig": "[0.14.0, )"
         }
       },
       "fantomas.client": {

--- a/src/Fantomas/EditorConfig.fs
+++ b/src/Fantomas/EditorConfig.fs
@@ -16,7 +16,7 @@ module Reflection =
           DisplayName: string option
           Description: string option }
 
-    let inline private getCustomAttribute<'t, 'v when 't :> Attribute and 't: null>
+    let inline getCustomAttribute<'t, 'v when 't :> Attribute and 't: null>
         (projection: 't -> 'v)
         (property: PropertyInfo)
         : 'v option =
@@ -52,26 +52,26 @@ let toEditorConfigName value =
         else
             $"fsharp_%s{name}"
 
-let private getFantomasFields (fallbackConfig: FormatConfig) =
+let getFantomasFields (fallbackConfig: FormatConfig) =
     Reflection.getRecordFields fallbackConfig
     |> Array.map (fun (recordField, defaultValue) ->
         let editorConfigName = toEditorConfigName recordField.PropertyName
 
         (editorConfigName, defaultValue))
 
-let private (|Number|_|) (d: string) =
+let (|Number|_|) (d: string) =
     match System.Int32.TryParse(d) with
     | true, d -> Some(box d)
     | _ -> None
 
-let private (|MultilineFormatterType|_|) mft =
+let (|MultilineFormatterType|_|) mft =
     MultilineFormatterType.OfConfigString mft
 
-let private (|BracketStyle|_|) bs = MultilineBracketStyle.OfConfigString bs
+let (|BracketStyle|_|) bs = MultilineBracketStyle.OfConfigString bs
 
-let private (|EndOfLineStyle|_|) eol = EndOfLineStyle.OfConfigString eol
+let (|EndOfLineStyle|_|) eol = EndOfLineStyle.OfConfigString eol
 
-let private (|Boolean|_|) b =
+let (|Boolean|_|) b =
     if b = "true" then Some(box true)
     elif b = "false" then Some(box false)
     else None
@@ -111,8 +111,7 @@ let configToEditorConfig (config: FormatConfig) : string =
         | _ -> None)
     |> String.concat "\n"
 
-let private editorConfigParser =
-    EditorConfigParser(EditorConfigFileCache.GetOrCreate)
+let editorConfigParser = EditorConfigParser(EditorConfigFileCache.GetOrCreate)
 
 let tryReadConfiguration (fsharpFile: string) : FormatConfig option =
     let editorConfigSettings: FileConfiguration =

--- a/src/Fantomas/EditorConfig.fsi
+++ b/src/Fantomas/EditorConfig.fsi
@@ -12,8 +12,6 @@ module Reflection =
 
     val inline getRecordFields: x: 'a -> (FSharpRecordField * obj)[]
 
-val supportedProperties: string list
-
 val toEditorConfigName: value: seq<char> -> string
 
 val parseOptionsFromEditorConfig:

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Thoth.Json.Net" Version="8.0.0" />
     <PackageReference Include="SerilogTraceListener" Version="3.2.1-dev-00011" />
-    <PackageReference Include="editorconfig" Version="0.13.0" />
+    <PackageReference Include="editorconfig" Version="0.14.0" />
     <PackageReference Include="Ignore" Version="0.1.46" />
     <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
     <PackageReference Include="Spectre.Console" Version="0.46.1-preview.0.6" />

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -26,9 +26,9 @@
       },
       "editorconfig": {
         "type": "Direct",
-        "requested": "[0.13.0, )",
-        "resolved": "0.13.0",
-        "contentHash": "1IAdbakbxaKyVv/gr3VTHkbFMFgfOSpP4VRSvOg50Ee9qAfXDr4F8FvOtwq7Pi6fcoxxXYfOYceT1U3oODdpFg=="
+        "requested": "[0.14.0, )",
+        "resolved": "0.14.0",
+        "contentHash": "emt1KlBtTsTSHWeLnlD1grQYN991wlzIh8t0/HF8ambYTLE8v25sPU9q2eu3sNj/Za7Ij6a0MW00lDGTsphEhQ=="
       },
       "FSharp.Core": {
         "type": "Direct",


### PR DESCRIPTION
This uses a cache for parsing editor config files.
See https://github.com/editorconfig/editorconfig-core-net/pull/23.
I tested this for Fantomas itself (200 files) and could see a slight improvement (50ms faster give or take). This would have more effect when with larger editor configs and nested scenarios. 
Nonetheless worth having I think.
 