### PR TITLE
V6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.1.0-alpha-006 - 2023-06-20
+
+Contains fixes of 6.0.8
+
 ## 6.1.0-alpha-005 - 2023-06-20
 
 Contains fixes of 6.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.1.0 - 2023-06-27
+
+Stable release
+
 ## 6.1.0-alpha-006 - 2023-06-20
 
 Contains fixes of 6.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.0-alpha-002 - 2023-05-02
+
+### Changed
+* Enrich transformed Oak. [#2869](https://github.com/fsprojects/fantomas/pull/2869)
+
 ## 6.1.0-alpha-001 - 2023-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.0-alpha-001 - 2023-05-02
+
+### Added
+* TransformAST in CodeFormatter. [#2868](https://github.com/fsprojects/fantomas/pull/2868)
+
 ## [6.0.8] - 2023-06-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.1.0-alpha-004 - 2023-06-19
+
+Contains fixes of 6.0.6
+
 ## 6.1.0-alpha-003 - 2023-06-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.0-alpha-003 - 2023-06-02
+
+### Changed
+* Rename `namespace FSharp.Compiler` to `namespace Fantomas.FCS` for `Fantomas.FCS`. [#2894](https://github.com/fsprojects/fantomas/pull/2894)
+
 ## 6.1.0-alpha-002 - 2023-05-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.1.0-alpha-005 - 2023-06-20
+
+Contains fixes of 6.0.7
+
 ## 6.1.0-alpha-004 - 2023-06-19
 
 Contains fixes of 6.0.6

--- a/build.fsx
+++ b/build.fsx
@@ -193,6 +193,17 @@ let fsharpCompilerHash =
     let xDoc = XElement.Load(__SOURCE_DIRECTORY__ </> "Directory.Build.props")
     xDoc.XPathSelectElements("//FCSCommitHash") |> Seq.head |> (fun xe -> xe.Value)
 
+let updateFileRaw (file: FileInfo) =
+    let lines = File.ReadAllLines file.FullName
+    let updatedLines =
+        lines
+        |> Array.map (fun line ->
+            if line.Contains("FSharp.Compiler") then
+                line.Replace("FSharp.Compiler", "Fantomas.FCS")
+            else
+                line)
+    File.WriteAllLines(file.FullName, updatedLines)
+
 let downloadCompilerFile commitHash relativePath =
     async {
         let file = FileInfo(deps </> commitHash </> relativePath)
@@ -213,6 +224,8 @@ let downloadCompilerFile commitHash relativePath =
                 printfn $"Could not download %s{relativePath}"
             do! Async.AwaitTask(response.ResponseStream.CopyToAsync(fs))
             fs.Close()
+
+            updateFileRaw file
     }
 
 pipeline "Init" {

--- a/docs/docs/end-users/GeneratingCode.fsx
+++ b/docs/docs/end-users/GeneratingCode.fsx
@@ -33,9 +33,9 @@ To illustrate the API, lets generate a simple value binding: `let a = 0`.
 *)
 
 #r "../../../src/Fantomas/bin/Release/net6.0/Fantomas.FCS.dll"
-#r "../../../src/Fantomas/bin/Release/net6.0/Fantomas.Core.dll" // In production use #r "nuget: Fantomas.Core, 6.0-alpha-*"
+#r "../../../src/Fantomas/bin/Release/net6.0/Fantomas.Core.dll" // In production use #r "nuget: Fantomas.Core, 6.*"
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 
 let implementationSyntaxTree =
@@ -88,11 +88,8 @@ The more you interact with AST/Oak, the easier you pick up which node represents
 
 ### Fantomas.FCS
 
-When looking at the example, we notice that we've opened `FSharp.Compiler.Text`.   
-Don't be fooled by this, `Fantomas.Core` and `Fantomas.FCS` **do not reference [FSharp.Compiler.Service](https://www.nuget.org/packages/FSharp.Compiler.Service)**!  
-Instead, `Fantomas.FCS` is a custom version of the F# compiler (built from source) that only exposes the F# parser and the syntax tree.
-
-`Fantomas.FCS` exposes the exact same namespaces because it builds from the exact same F# compiler source code.   
+When looking at the example, we notice that we've opened `Fantomas.FCS.Text`.    
+`Fantomas.FCS` is a custom version of the F# compiler (built from source) that only exposes the F# parser and the syntax tree.  
 The key difference is that `Fantomas.FCS` will most likely contain a more recent version of the F# parser.  
 You can read the [CHANGELOG](https://github.com/fsprojects/fantomas/blob/main/CHANGELOG.md) to see what git commit was used to build `Fantomas.FCS`.
 

--- a/src/Fantomas.Core.Tests/ASTTransformerTests.fs
+++ b/src/Fantomas.Core.Tests/ASTTransformerTests.fs
@@ -1,10 +1,10 @@
 module Fantomas.Core.Tests.ASTTransformerTests
 
 open NUnit.Framework
-open FSharp.Compiler.Text
-open FSharp.Compiler.Xml
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
+open Fantomas.FCS.Text
+open Fantomas.FCS.Xml
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.SyntaxTrivia
 open Fantomas.Core
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/CodeFormatterTests.fs
+++ b/src/Fantomas.Core.Tests/CodeFormatterTests.fs
@@ -108,3 +108,22 @@ let b = 0
     match oak.ModulesOrNamespaces.[0].Declarations.[0] with
     | ModuleDecl.TopLevelBinding _ -> Assert.Pass()
     | _ -> Assert.Fail()
+
+[<Test>]
+let ``transform parsedInput contains trivia in Oak`` () =
+    let source =
+        """
+module A
+
+// foo
+let b = 0
+"""
+
+    let ast, _ =
+        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) []
+
+    let oak = CodeFormatter.TransformAST(ast, source)
+
+    match oak.ModulesOrNamespaces.[0].Declarations.[0] with
+    | ModuleDecl.TopLevelBinding node -> Assert.True node.HasContentBefore
+    | _ -> Assert.Fail()

--- a/src/Fantomas.Core.Tests/CodeFormatterTests.fs
+++ b/src/Fantomas.Core.Tests/CodeFormatterTests.fs
@@ -1,5 +1,6 @@
 module Fantomas.Core.Tests.CodeFormatterTests
 
+open Fantomas.Core.SyntaxOak
 open NUnit.Framework
 open Fantomas.Core
 open Fantomas.Core.Tests.TestHelpers
@@ -39,7 +40,7 @@ let main _ =
     |> ignore
 
 [<Test>]
-let ``trivia is parsed for Oak`` () =
+let ``trivia is transformed to Oak`` () =
     let oak =
         CodeFormatter.ParseOakAsync(false, "let a = 0\n // foo")
         |> Async.RunSynchronously
@@ -67,3 +68,43 @@ let ``parsed oak can be formatted back to source`` () =
         |> Async.RunSynchronously
 
     Assert.AreEqual(source, formatted)
+
+[<Test>]
+let ``transform parsedInput to Oak`` () =
+    let source =
+        """
+module A
+
+#if DEBUG
+let b = 0
+#endif
+"""
+
+    let ast, _ =
+        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) [ "DEBUG" ]
+
+    let oak = CodeFormatter.TransformAST(ast, source)
+
+    match oak.ModulesOrNamespaces.[0].Declarations.[0] with
+    | ModuleDecl.TopLevelBinding _ -> Assert.Pass()
+    | _ -> Assert.Fail()
+
+[<Test>]
+let ``transform parsedInput created with additional defines to Oak`` () =
+    let source =
+        """
+module A
+
+#if DEBUG
+let b = 0
+#endif
+"""
+
+    let ast, _ =
+        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) [ "DEBUG"; "FOO"; "BAR" ]
+
+    let oak = CodeFormatter.TransformAST ast
+
+    match oak.ModulesOrNamespaces.[0].Declarations.[0] with
+    | ModuleDecl.TopLevelBinding _ -> Assert.Pass()
+    | _ -> Assert.Fail()

--- a/src/Fantomas.Core.Tests/CodeFormatterTests.fs
+++ b/src/Fantomas.Core.Tests/CodeFormatterTests.fs
@@ -1,8 +1,9 @@
 module Fantomas.Core.Tests.CodeFormatterTests
 
-open Fantomas.Core.SyntaxOak
 open NUnit.Framework
+open Fantomas.FCS.Text
 open Fantomas.Core
+open Fantomas.Core.SyntaxOak
 open Fantomas.Core.Tests.TestHelpers
 
 [<Test>]
@@ -81,7 +82,7 @@ let b = 0
 """
 
     let ast, _ =
-        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) [ "DEBUG" ]
+        Fantomas.FCS.Parse.parseFile false (SourceText.ofString source) [ "DEBUG" ]
 
     let oak = CodeFormatter.TransformAST(ast, source)
 
@@ -101,7 +102,7 @@ let b = 0
 """
 
     let ast, _ =
-        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) [ "DEBUG"; "FOO"; "BAR" ]
+        Fantomas.FCS.Parse.parseFile false (SourceText.ofString source) [ "DEBUG"; "FOO"; "BAR" ]
 
     let oak = CodeFormatter.TransformAST ast
 
@@ -119,8 +120,7 @@ module A
 let b = 0
 """
 
-    let ast, _ =
-        Fantomas.FCS.Parse.parseFile false (FSharp.Compiler.Text.SourceText.ofString source) []
+    let ast, _ = Fantomas.FCS.Parse.parseFile false (SourceText.ofString source) []
 
     let oak = CodeFormatter.TransformAST(ast, source)
 

--- a/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
+++ b/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
@@ -209,7 +209,7 @@ let a =
 
     // Let's create a dummy Oak
     // In practise, a FCS Syntax tree will be transformed to an Oak
-    let zeroRange = FSharp.Compiler.Text.Range.Zero
+    let zeroRange = Fantomas.FCS.Text.Range.Zero
     let stn text = SingleTextNode(text, zeroRange)
 
     let tree =
@@ -321,7 +321,7 @@ let b = 2
 """
 
     // Imagine that we always want to print a new line between let bindings.
-    let zeroRange = FSharp.Compiler.Text.Range.Zero
+    let zeroRange = Fantomas.FCS.Text.Range.Zero
     let stn text = SingleTextNode(text, zeroRange)
 
     let mkBinding name body =

--- a/src/Fantomas.Core.Tests/CursorTests.fs
+++ b/src/Fantomas.Core.Tests/CursorTests.fs
@@ -1,6 +1,6 @@
 ﻿module Fantomas.Core.Tests.CursorTests
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core

--- a/src/Fantomas.Core.Tests/DefinesTests.fs
+++ b/src/Fantomas.Core.Tests/DefinesTests.fs
@@ -2,7 +2,7 @@ module Fantomas.Core.Tests.TokenParserTests
 
 open NUnit.Framework
 open FsUnit
-open FSharp.Compiler.Syntax
+open Fantomas.FCS.Syntax
 open Fantomas.Core
 open Fantomas.Core.Defines
 open Fantomas.Core.Tests.TestHelpers

--- a/src/Fantomas.Core.Tests/FormattingSelectionOnlyTests.fs
+++ b/src/Fantomas.Core.Tests/FormattingSelectionOnlyTests.fs
@@ -1,6 +1,6 @@
 module Fantomas.Core.Tests.FormattingSelectionOnlyTests
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Core
 open NUnit.Framework
 open FsUnit

--- a/src/Fantomas.Core.Tests/SynLongIdentTests.fs
+++ b/src/Fantomas.Core.Tests/SynLongIdentTests.fs
@@ -1,9 +1,9 @@
 module Fantomas.Core.Tests.SynLongIdentTests
 
-open FSharp.Compiler.Text
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
-open FSharp.Compiler.Xml
+open Fantomas.FCS.Text
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.SyntaxTrivia
+open Fantomas.FCS.Xml
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core

--- a/src/Fantomas.Core.Tests/TestHelpers.fs
+++ b/src/Fantomas.Core.Tests/TestHelpers.fs
@@ -40,7 +40,7 @@ let formatSourceString isFsiFile (s: string) config =
 let formatAST isFsiFile (source: string) config =
     async {
         let ast, _ =
-            Fantomas.FCS.Parse.parseFile isFsiFile (FSharp.Compiler.Text.SourceText.ofString source) []
+            Fantomas.FCS.Parse.parseFile isFsiFile (Fantomas.FCS.Text.SourceText.ofString source) []
 
         let! formattedCode = CodeFormatter.FormatASTAsync(ast, config = config)
         let! isValid = CodeFormatter.IsValidFSharpCodeAsync(isFsiFile, formattedCode)

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -2,11 +2,11 @@
 
 open System.Collections.Generic
 open System.Text.RegularExpressions
-open FSharp.Compiler.Text
-open FSharp.Compiler.Text.Range
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
-open FSharp.Compiler.Xml
+open Fantomas.FCS.Text
+open Fantomas.FCS.Text.Range
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.SyntaxTrivia
+open Fantomas.FCS.Xml
 open Fantomas.Core.ISourceTextExtensions
 open Fantomas.Core.RangePatterns
 open Fantomas.Core.SyntaxOak

--- a/src/Fantomas.Core/ASTTransformer.fsi
+++ b/src/Fantomas.Core/ASTTransformer.fsi
@@ -1,7 +1,7 @@
 module internal Fantomas.Core.ASTTransformer
 
-open FSharp.Compiler.Text
-open FSharp.Compiler.Syntax
+open Fantomas.FCS.Text
+open Fantomas.FCS.Syntax
 open Fantomas.Core.SyntaxOak
 
 val mkOak: sourceText: ISourceText option -> ast: ParsedInput -> Oak

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -81,7 +81,9 @@ type CodeFormatter =
     static member TransformAST ast = ASTTransformer.mkOak None ast
 
     static member TransformAST(ast, source) =
-        ASTTransformer.mkOak (Some(SourceText.ofString source)) ast
+        let sourceText = SourceText.ofString source
+        let oak = ASTTransformer.mkOak (Some sourceText) ast
+        Trivia.enrichTree FormatConfig.Default sourceText ast oak
 
     static member FormatOakAsync(oak: Oak) : Async<string> =
         async {

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -78,6 +78,11 @@ type CodeFormatter =
                     oak, defines.Value)
         }
 
+    static member TransformAST ast = ASTTransformer.mkOak None ast
+
+    static member TransformAST(ast, source) =
+        ASTTransformer.mkOak (Some(SourceText.ofString source)) ast
+
     static member FormatOakAsync(oak: Oak) : Async<string> =
         async {
             let context = Context.Context.Create FormatConfig.Default

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -1,7 +1,7 @@
 namespace Fantomas.Core
 
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.Text
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 
 [<Sealed>]

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -67,6 +67,12 @@ type CodeFormatter =
     /// Parse a source string to SyntaxOak
     static member ParseOakAsync: isSignature: bool * source: string -> Async<(Oak * string list) array>
 
+    /// Transform a ParsedInput to an Oak
+    static member TransformAST: ast: ParsedInput -> Oak
+
+    /// Transform a ParsedInput to an Oak
+    static member TransformAST: ast: ParsedInput * source: string -> Oak
+
     /// Format SyntaxOak to string
     static member FormatOakAsync: oak: Oak -> Async<string>
 

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -1,7 +1,7 @@
 namespace Fantomas.Core
 
-open FSharp.Compiler.Text
-open FSharp.Compiler.Syntax
+open Fantomas.FCS.Text
+open Fantomas.FCS.Syntax
 open Fantomas.Core.SyntaxOak
 
 [<Sealed>]

--- a/src/Fantomas.Core/CodeFormatterImpl.fs
+++ b/src/Fantomas.Core/CodeFormatterImpl.fs
@@ -1,9 +1,9 @@
 [<RequireQualifiedAccess>]
 module internal Fantomas.Core.CodeFormatterImpl
 
-open FSharp.Compiler.Diagnostics
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.Text
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text
 open MultipleDefineCombinations
 
 let getSourceText (source: string) : ISourceText = source.TrimEnd() |> SourceText.ofString

--- a/src/Fantomas.Core/CodeFormatterImpl.fsi
+++ b/src/Fantomas.Core/CodeFormatterImpl.fsi
@@ -1,8 +1,8 @@
 ﻿[<RequireQualifiedAccess>]
 module internal Fantomas.Core.CodeFormatterImpl
 
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.Text
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text
 
 val getSourceText: source: string -> ISourceText
 

--- a/src/Fantomas.Core/CodeFormatterTypes.fs
+++ b/src/Fantomas.Core/CodeFormatterTypes.fs
@@ -1,6 +1,6 @@
 ﻿namespace Fantomas.Core
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 type FormatResult =
     {

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -102,7 +102,7 @@ let genTrivia (node: Node) (trivia: TriviaNode) (ctx: Context) =
                 let originalColumnOffset = trivia.Range.EndColumn - node.Range.EndColumn
 
                 let formattedCursor =
-                    FSharp.Compiler.Text.Position.mkPos ctx.WriterModel.Lines.Length (ctx.Column + originalColumnOffset)
+                    Fantomas.FCS.Text.Position.mkPos ctx.WriterModel.Lines.Length (ctx.Column + originalColumnOffset)
 
                 { ctx with
                     FormattedCursor = Some formattedCursor }
@@ -122,7 +122,7 @@ let recordCursorNode f (node: Node) (ctx: Context) =
 
         let formattedCursor =
             let columnOffsetInSource = cursor.Column - node.Range.StartColumn
-            FSharp.Compiler.Text.Position.mkPos currentStartLine (currentStartColumn + columnOffsetInSource)
+            Fantomas.FCS.Text.Position.mkPos currentStartLine (currentStartColumn + columnOffsetInSource)
 
         { ctxAfter with
             FormattedCursor = Some formattedCursor }
@@ -766,7 +766,7 @@ let genExpr (e: Expr) =
             | [] -> genExpr node.LeadingExpr
             | (operator, e2) :: es ->
                 let m =
-                    FSharp.Compiler.Text.Range.unionRanges (Expr.Node node.LeadingExpr).Range (Expr.Node e2).Range
+                    Fantomas.FCS.Text.Range.unionRanges (Expr.Node node.LeadingExpr).Range (Expr.Node e2).Range
 
                 genMultilineInfixExpr (ExprInfixAppNode(node.LeadingExpr, operator, e2, m))
                 +> sepNln
@@ -1045,9 +1045,9 @@ let genExpr (e: Expr) =
                 let parenExpr =
                     mkExprParenNode
                         node.OpeningParen
-                        (Expr.Null(SingleTextNode("", FSharp.Compiler.Text.Range.Zero)))
+                        (Expr.Null(SingleTextNode("", Fantomas.FCS.Text.Range.Zero)))
                         node.ClosingParen
-                        FSharp.Compiler.Text.Range.Zero
+                        Fantomas.FCS.Text.Range.Zero
 
                 sepSpaceBeforeParenInFuncInvocation node.FunctionName parenExpr
             | _ -> sepSpace
@@ -1839,16 +1839,16 @@ let genTupleExpr (node: ExprTupleNode) =
             | IsLambdaOrIfThenElse e ->
                 let parenNode =
                     mkExprParenNode
-                        (SingleTextNode("(", FSharp.Compiler.Text.Range.Zero))
+                        (SingleTextNode("(", Fantomas.FCS.Text.Range.Zero))
                         e
-                        (SingleTextNode(")", FSharp.Compiler.Text.Range.Zero))
-                        FSharp.Compiler.Text.Range.Zero
+                        (SingleTextNode(")", Fantomas.FCS.Text.Range.Zero))
+                        Fantomas.FCS.Text.Range.Zero
 
                 ExprInfixAppNode(
                     exprInfixAppNode.LeftHandSide,
                     exprInfixAppNode.Operator,
                     parenNode,
-                    FSharp.Compiler.Text.range.Zero
+                    Fantomas.FCS.Text.range.Zero
                 )
                 |> Expr.InfixApp
             | _ -> expr

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -1,7 +1,7 @@
 module internal Fantomas.Core.Context
 
 open System
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Core
 open Fantomas.Core.SyntaxOak
 
@@ -375,7 +375,7 @@ let newlineBetweenLastWriteEvent ctx =
 let lastWriteEventOnLastLine ctx =
     writeEventsOnLastLine ctx |> Seq.tryHead
 
-// A few utility functions from https://github.com/fsharp/powerpack/blob/master/src/FSharp.Compiler.CodeDom/generator.fs
+// A few utility functions from https://github.com/fsharp/powerpack/blob/master/src/Fantomas.FCS.CodeDom/generator.fs
 
 /// Indent one more level based on configuration
 let indent (ctx: Context) =

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -1,6 +1,6 @@
 module internal Fantomas.Core.Context
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 
 type WriterEvent =

--- a/src/Fantomas.Core/Defines.fs
+++ b/src/Fantomas.Core/Defines.fs
@@ -1,6 +1,6 @@
 namespace Fantomas.Core
 
-open FSharp.Compiler.SyntaxTrivia
+open Fantomas.FCS.SyntaxTrivia
 open Fantomas.Core
 
 type internal DefineCombination =

--- a/src/Fantomas.Core/Defines.fsi
+++ b/src/Fantomas.Core/Defines.fsi
@@ -8,6 +8,6 @@ type internal DefineCombination =
     static member Empty: DefineCombination
 
 module internal Defines =
-    open FSharp.Compiler.SyntaxTrivia
+    open Fantomas.FCS.SyntaxTrivia
 
     val getDefineCombination: hashDirectives: ConditionalDirectiveTrivia list -> DefineCombination list

--- a/src/Fantomas.Core/ISourceTextExtensions.fs
+++ b/src/Fantomas.Core/ISourceTextExtensions.fs
@@ -1,7 +1,7 @@
 ﻿module Fantomas.Core.ISourceTextExtensions
 
 open System.Text
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 type ISourceText with
 

--- a/src/Fantomas.Core/ISourceTextExtensions.fsi
+++ b/src/Fantomas.Core/ISourceTextExtensions.fsi
@@ -1,6 +1,6 @@
 module Fantomas.Core.ISourceTextExtensions
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 type ISourceText with
 

--- a/src/Fantomas.Core/MultipleDefineCombinations.fs
+++ b/src/Fantomas.Core/MultipleDefineCombinations.fs
@@ -5,7 +5,7 @@ open System.Linq
 open System.Text
 open System.Text.RegularExpressions
 open Microsoft.FSharp.Core.CompilerServices
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 /// A CodeFragment represents a chunk of code that is either
 ///     a single conditional hash directive line,

--- a/src/Fantomas.Core/RangeHelpers.fs
+++ b/src/Fantomas.Core/RangeHelpers.fs
@@ -1,6 +1,6 @@
 namespace Fantomas.Core
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 [<RequireQualifiedAccess>]
 module RangeHelpers =

--- a/src/Fantomas.Core/RangeHelpers.fsi
+++ b/src/Fantomas.Core/RangeHelpers.fsi
@@ -1,6 +1,6 @@
 namespace Fantomas.Core
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 [<RequireQualifiedAccess>]
 module RangeHelpers =

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -1,6 +1,6 @@
 ﻿module internal Fantomas.Core.Selection
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 open Fantomas.Core.ISourceTextExtensions
 

--- a/src/Fantomas.Core/Selection.fsi
+++ b/src/Fantomas.Core/Selection.fsi
@@ -1,6 +1,6 @@
 module internal Fantomas.Core.Selection
 
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 val formatSelection:
     config: FormatConfig -> isSignature: bool -> selection: range -> sourceText: ISourceText -> Async<string * range>

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1,7 +1,7 @@
 module rec Fantomas.Core.SyntaxOak
 
 open System.Collections.Generic
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 
 type TriviaContent =
     | CommentOnSingleLine of string

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -1,8 +1,8 @@
 ﻿module internal Fantomas.Core.Trivia
 
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
-open FSharp.Compiler.Text
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.SyntaxTrivia
+open Fantomas.FCS.Text
 open Fantomas.Core.ISourceTextExtensions
 open Fantomas.Core.SyntaxOak
 

--- a/src/Fantomas.Core/Trivia.fsi
+++ b/src/Fantomas.Core/Trivia.fsi
@@ -1,7 +1,7 @@
 module internal Fantomas.Core.Trivia
 
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.Text
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 
 val findNodeWhereRangeFitsIn: root: Node -> range: range -> Node option

--- a/src/Fantomas.Core/Validation.fs
+++ b/src/Fantomas.Core/Validation.fs
@@ -1,8 +1,8 @@
 ﻿module internal Fantomas.Core.Validation
 
-open FSharp.Compiler.Diagnostics
-open FSharp.Compiler.Text
-open FSharp.Compiler.Syntax
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.Text
+open Fantomas.FCS.Syntax
 open Fantomas.FCS.Parse
 
 let private safeToIgnoreWarnings =
@@ -10,7 +10,7 @@ let private safeToIgnoreWarnings =
         [ "This construct is deprecated: it is only for use in the F# library"
           "Identifiers containing '@' are reserved for use in F# code generation" ]
 
-// Exception of type 'FSharp.Compiler.DiagnosticsLogger+LibraryUseOnly' was thrown.
+// Exception of type 'Fantomas.FCS.DiagnosticsLogger+LibraryUseOnly' was thrown.
 
 let noWarningOrErrorDiagnostics diagnostics =
     let errors =

--- a/src/Fantomas.FCS/Fantomas.FCS.fsproj
+++ b/src/Fantomas.FCS/Fantomas.FCS.fsproj
@@ -174,14 +174,14 @@
       <Link>Facilities\prim-parsing.fs</Link>
     </Compile>
     <FsLex Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\AbstractIL\illex.fsl">
-      <OtherFlags>--module FSharp.Compiler.AbstractIL.AsciiLexer --internal --open Internal.Utilities.Text.Lexing --open FSharp.Compiler.AbstractIL.AsciiParser --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+      <OtherFlags>--module Fantomas.FCS.AbstractIL.AsciiLexer --internal --open Internal.Utilities.Text.Lexing --open Fantomas.FCS.AbstractIL.AsciiParser --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
       <Link>AbstractIL\illex.fsl</Link>
     </FsLex>
     <None Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\AbstractIL\illex.fsl">
       <Link>AbstractIL\illex.fsl</Link>
     </None>
     <FsYacc Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\AbstractIL\ilpars.fsy">
-      <OtherFlags>--module FSharp.Compiler.AbstractIL.AsciiParser --open FSharp.Compiler.AbstractIL --open FSharp.Compiler.AbstractIL.AsciiConstants --open FSharp.Compiler.AbstractIL.IL --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
+      <OtherFlags>--module Fantomas.FCS.AbstractIL.AsciiParser --open Fantomas.FCS.AbstractIL --open Fantomas.FCS.AbstractIL.AsciiConstants --open Fantomas.FCS.AbstractIL.IL --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
       <Link>AbstractIL\ilpars.fsy</Link>
     </FsYacc>
     <None Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\AbstractIL\ilpars.fsy">
@@ -224,19 +224,19 @@
       <Link>SyntaxTree\PrettyNaming.fs</Link>
     </Compile>
     <FsLex Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\pplex.fsl">
-      <OtherFlags>--module FSharp.Compiler.PPLexer --internal --open FSharp.Compiler.Lexhelp --open Internal.Utilities.Text.Lexing --open FSharp.Compiler.PPParser --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+      <OtherFlags>--module Fantomas.FCS.PPLexer --internal --open Fantomas.FCS.Lexhelp --open Internal.Utilities.Text.Lexing --open Fantomas.FCS.PPParser --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
       <Link>SyntaxTree\pplex.fsl</Link>
     </FsLex>
     <FsYacc Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\pppars.fsy">
-      <OtherFlags>--module FSharp.Compiler.PPParser --open FSharp.Compiler --open FSharp.Compiler.Syntax --open FSharp.Compiler.ParseHelpers --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
+      <OtherFlags>--module Fantomas.FCS.PPParser --open Fantomas.FCS --open Fantomas.FCS.Syntax --open Fantomas.FCS.ParseHelpers --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
       <Link>SyntaxTree\pppars.fsy</Link>
     </FsYacc>
     <FsLex Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\lex.fsl">
-      <OtherFlags>--module FSharp.Compiler.Lexer --open FSharp.Compiler.Lexhelp --open Internal.Utilities.Text.Lexing --open FSharp.Compiler.Parser --open FSharp.Compiler.Text --open FSharp.Compiler.ParseHelpers --internal --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+      <OtherFlags>--module Fantomas.FCS.Lexer --open Fantomas.FCS.Lexhelp --open Internal.Utilities.Text.Lexing --open Fantomas.FCS.Parser --open Fantomas.FCS.Text --open Fantomas.FCS.ParseHelpers --internal --unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
       <Link>SyntaxTree\lex.fsl</Link>
     </FsLex>
     <FsYacc Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\pars.fsy">
-      <OtherFlags>-v --module FSharp.Compiler.Parser --open FSharp.Compiler --open FSharp.Compiler.Syntax --open FSharp.Compiler.Text --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
+      <OtherFlags>-v --module Fantomas.FCS.Parser --open Fantomas.FCS --open Fantomas.FCS.Syntax --open Fantomas.FCS.Text --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
       <Link>SyntaxTree\pars.fsy</Link>
     </FsYacc>
     <None Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\pplex.fsl">

--- a/src/Fantomas.FCS/Parse.fs
+++ b/src/Fantomas.FCS/Parse.fs
@@ -3,25 +3,25 @@ module Fantomas.FCS.Parse
 open System
 open System.Text
 open System.Diagnostics
-open FSharp.Compiler.Diagnostics
-open FSharp.Compiler.DiagnosticMessage
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.DiagnosticMessage
 open Internal.Utilities
 open Internal.Utilities.Library
-open FSharp.Compiler
-open FSharp.Compiler.AbstractIL.IL
-open FSharp.Compiler.DiagnosticsLogger
-open FSharp.Compiler.Features
-open FSharp.Compiler.Lexhelp
-open FSharp.Compiler.Text
-open FSharp.Compiler.Text.Position
-open FSharp.Compiler.Text.Range
-open FSharp.Compiler.Xml
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
-open FSharp.Compiler.Syntax.PrettyNaming
-open FSharp.Compiler.SyntaxTreeOps
-open FSharp.Compiler.IO
-open FSharp.Compiler.ParseHelpers
+open Fantomas.FCS
+open Fantomas.FCS.AbstractIL.IL
+open Fantomas.FCS.DiagnosticsLogger
+open Fantomas.FCS.Features
+open Fantomas.FCS.Lexhelp
+open Fantomas.FCS.Text
+open Fantomas.FCS.Text.Position
+open Fantomas.FCS.Text.Range
+open Fantomas.FCS.Xml
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.SyntaxTrivia
+open Fantomas.FCS.Syntax.PrettyNaming
+open Fantomas.FCS.SyntaxTreeOps
+open Fantomas.FCS.IO
+open Fantomas.FCS.ParseHelpers
 
 let FSharpSigFileSuffixes = [ ".mli"; ".fsi" ]
 

--- a/src/Fantomas.FCS/Parse.fsi
+++ b/src/Fantomas.FCS/Parse.fsi
@@ -1,8 +1,8 @@
 module Fantomas.FCS.Parse
 
-open FSharp.Compiler.Diagnostics
-open FSharp.Compiler.Syntax
-open FSharp.Compiler.Text
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.Syntax
+open Fantomas.FCS.Text
 
 type FSharpParserDiagnostic =
     { Severity: FSharpDiagnosticSeverity

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -73,8 +73,8 @@
       },
       "editorconfig": {
         "type": "Transitive",
-        "resolved": "0.13.0",
-        "contentHash": "1IAdbakbxaKyVv/gr3VTHkbFMFgfOSpP4VRSvOg50Ee9qAfXDr4F8FvOtwq7Pi6fcoxxXYfOYceT1U3oODdpFg=="
+        "resolved": "0.14.0",
+        "contentHash": "emt1KlBtTsTSHWeLnlD1grQYN991wlzIh8t0/HF8ambYTLE8v25sPU9q2eu3sNj/Za7Ij6a0MW00lDGTsphEhQ=="
       },
       "Fable.Core": {
         "type": "Transitive",
@@ -922,7 +922,7 @@
           "StreamJsonRpc": "[2.8.28, )",
           "System.IO.Abstractions": "[17.2.3, )",
           "Thoth.Json.Net": "[8.0.0, )",
-          "editorconfig": "[0.13.0, )"
+          "editorconfig": "[0.14.0, )"
         }
       },
       "fantomas.client": {

--- a/src/Fantomas/Daemon.fs
+++ b/src/Fantomas/Daemon.fs
@@ -8,7 +8,7 @@ open System.Threading
 open System.Threading.Tasks
 open StreamJsonRpc
 open Thoth.Json.Net
-open FSharp.Compiler.Text
+open Fantomas.FCS.Text
 open Fantomas.Client.Contracts
 open Fantomas.Client.LSPFantomasServiceTypes
 open Fantomas.Core

--- a/src/Fantomas/EditorConfig.fs
+++ b/src/Fantomas/EditorConfig.fs
@@ -2,6 +2,7 @@ module Fantomas.EditorConfig
 
 open System.Collections.Generic
 open System.ComponentModel
+open EditorConfig.Core
 open Fantomas.Core
 
 module Reflection =
@@ -15,7 +16,7 @@ module Reflection =
           DisplayName: string option
           Description: string option }
 
-    let inline private getCustomAttribute<'t, 'v when 't :> Attribute and 't: null>
+    let inline getCustomAttribute<'t, 'v when 't :> Attribute and 't: null>
         (projection: 't -> 'v)
         (property: PropertyInfo)
         : 'v option =
@@ -40,7 +41,7 @@ let toEditorConfigName value =
     value
     |> Seq.map (fun c ->
         if System.Char.IsUpper(c) then
-            sprintf "_%s" (c.ToString().ToLower())
+            $"_%s{c.ToString().ToLower()}"
         else
             c.ToString())
     |> String.concat ""
@@ -49,28 +50,28 @@ let toEditorConfigName value =
         if List.contains name supportedProperties then
             name
         else
-            sprintf "fsharp_%s" name
+            $"fsharp_%s{name}"
 
-let private getFantomasFields (fallbackConfig: FormatConfig) =
+let getFantomasFields (fallbackConfig: FormatConfig) =
     Reflection.getRecordFields fallbackConfig
     |> Array.map (fun (recordField, defaultValue) ->
         let editorConfigName = toEditorConfigName recordField.PropertyName
 
         (editorConfigName, defaultValue))
 
-let private (|Number|_|) (d: string) =
+let (|Number|_|) (d: string) =
     match System.Int32.TryParse(d) with
     | true, d -> Some(box d)
     | _ -> None
 
-let private (|MultilineFormatterType|_|) mft =
+let (|MultilineFormatterType|_|) mft =
     MultilineFormatterType.OfConfigString mft
 
-let private (|BracketStyle|_|) bs = MultilineBracketStyle.OfConfigString bs
+let (|BracketStyle|_|) bs = MultilineBracketStyle.OfConfigString bs
 
-let private (|EndOfLineStyle|_|) eol = EndOfLineStyle.OfConfigString eol
+let (|EndOfLineStyle|_|) eol = EndOfLineStyle.OfConfigString eol
 
-let private (|Boolean|_|) b =
+let (|Boolean|_|) b =
     if b = "true" then Some(box true)
     elif b = "false" then Some(box false)
     else None
@@ -102,18 +103,18 @@ let configToEditorConfig (config: FormatConfig) : string =
             |> Some
         | :? System.Int32 as i -> $"%s{toEditorConfigName recordField.PropertyName}=%d{i}" |> Some
         | :? MultilineFormatterType as mft ->
-            sprintf "%s=%s" (toEditorConfigName recordField.PropertyName) (MultilineFormatterType.ToConfigString mft)
+            $"%s{toEditorConfigName recordField.PropertyName}=%s{MultilineFormatterType.ToConfigString mft}"
             |> Some
         | :? EndOfLineStyle as eols ->
-            sprintf "%s=%s" (toEditorConfigName recordField.PropertyName) (EndOfLineStyle.ToConfigString eols)
+            $"%s{toEditorConfigName recordField.PropertyName}=%s{EndOfLineStyle.ToConfigString eols}"
             |> Some
         | _ -> None)
     |> String.concat "\n"
 
-let private editorConfigParser = EditorConfig.Core.EditorConfigParser()
+let editorConfigParser = EditorConfigParser(EditorConfigFileCache.GetOrCreate)
 
 let tryReadConfiguration (fsharpFile: string) : FormatConfig option =
-    let editorConfigSettings: EditorConfig.Core.FileConfiguration =
+    let editorConfigSettings: FileConfiguration =
         editorConfigParser.Parse(fileName = fsharpFile)
 
     if editorConfigSettings.Properties.Count = 0 then

--- a/src/Fantomas/EditorConfig.fsi
+++ b/src/Fantomas/EditorConfig.fsi
@@ -12,8 +12,6 @@ module Reflection =
 
     val inline getRecordFields: x: 'a -> (FSharpRecordField * obj)[]
 
-val supportedProperties: string list
-
 val toEditorConfigName: value: seq<char> -> string
 
 val parseOptionsFromEditorConfig:

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Thoth.Json.Net" Version="8.0.0" />
     <PackageReference Include="SerilogTraceListener" Version="3.2.1-dev-00011" />
-    <PackageReference Include="editorconfig" Version="0.13.0" />
+    <PackageReference Include="editorconfig" Version="0.14.0" />
     <PackageReference Include="Ignore" Version="0.1.46" />
     <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
     <PackageReference Include="Spectre.Console" Version="0.46.1-preview.0.6" />

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -26,9 +26,9 @@
       },
       "editorconfig": {
         "type": "Direct",
-        "requested": "[0.13.0, )",
-        "resolved": "0.13.0",
-        "contentHash": "1IAdbakbxaKyVv/gr3VTHkbFMFgfOSpP4VRSvOg50Ee9qAfXDr4F8FvOtwq7Pi6fcoxxXYfOYceT1U3oODdpFg=="
+        "requested": "[0.14.0, )",
+        "resolved": "0.14.0",
+        "contentHash": "emt1KlBtTsTSHWeLnlD1grQYN991wlzIh8t0/HF8ambYTLE8v25sPU9q2eu3sNj/Za7Ij6a0MW00lDGTsphEhQ=="
       },
       "FSharp.Core": {
         "type": "Direct",


### PR DESCRIPTION
### Changed
* Rename `namespace FSharp.Compiler` to `namespace Fantomas.FCS` for `Fantomas.FCS`. [#2894](https://github.com/fsprojects/fantomas/pull/2894)
* Enrich transformed Oak. [#2869](https://github.com/fsprojects/fantomas/pull/2869)

### Added
* TransformAST in CodeFormatter. [#2868](https://github.com/fsprojects/fantomas/pull/2868)