### PR TITLE
replacing "vanity alignment" with "whitespace alignment"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,7 +380,7 @@
 
 ### Fixed
 * Comments in SynArgPats.NamePatPairs are lost. [#2541](https://github.com/fsprojects/fantomas/issues/2541)
-* Vanity alignment used inside base ctor call. [#2111](https://github.com/fsprojects/fantomas/issues/2111)
+* Whitespace alignment used inside base ctor call. [#2111](https://github.com/fsprojects/fantomas/issues/2111)
 * Add line break before start of argument list. [#2335](https://github.com/fsprojects/fantomas/issues/2335)
 
 ## [5.1.0-alpha-004] - 2022-10-07

--- a/src/Fantomas.Core.Tests/ClassTests.fs
+++ b/src/Fantomas.Core.Tests/ClassTests.fs
@@ -944,7 +944,7 @@ type MaybeBuilder() =
 """
 
 [<Test>]
-let ``avoid vanity alignment when calling base constructor, 1442`` () =
+let ``avoid whitespace alignment when calling base constructor, 1442`` () =
     formatSourceString
         false
         """

--- a/src/Fantomas.Core.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Core.Tests/PatternMatchingTests.fs
@@ -2014,7 +2014,7 @@ match v with
 """
 
 [<Test>]
-let ``vanity alignment used when splitting line in match block, 1901`` () =
+let ``whitespace alignment used when splitting line in match block, 1901`` () =
     formatSourceString
         false
         """
@@ -2036,7 +2036,7 @@ with
 """
 
 [<Test>]
-let ``vanity alignment used when splitting line in match block, match bang, 1901`` () =
+let ``whitespace alignment used when splitting line in match block, match bang, 1901`` () =
     formatSourceString
         false
         """


### PR DESCRIPTION
This is just replacing the adjective which is unfortunate with something which is neutral, related to : https://github.com/dotnet/docs/pull/36143