### PR TITLE
Adjust to optional lhs of SynMeasure.Divide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+* Update FCS to 'Add trivia information to SynConst.Measure', commit 7b5e12842d673b7daa467e0091378bf4acc95e4f
+
+### Fixed
+* Left out lhs in SynMeasure.Divide should not be restored as SynMeasure.One. [#2926](https://github.com/fsprojects/fantomas/issues/2926)
+
 ## 6.1.1 - 2023-06-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 6.1.2 - 2023-07-23
 
 ### Changed
 * Update FCS to 'Add trivia information to SynConst.Measure', commit 7b5e12842d673b7daa467e0091378bf4acc95e4f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 * Left out lhs in SynMeasure.Divide should not be restored as SynMeasure.One. [#2926](https://github.com/fsprojects/fantomas/issues/2926)
+* Block comments in measure are lost or restored twice and in wrong place. [#2927](https://github.com/fsprojects/fantomas/issues/2927)
 
 ## 6.1.1 - 2023-06-29
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,8 @@ Some common use cases include:
     
     <!-- Versions -->
     <PropertyGroup>
-        <FCSCommitHash>9c8b4192966e6554adc5dcc8973f2a23c8fa2722</FCSCommitHash>
+        <FCSRepo>dawedawe/fsharp</FCSRepo>
+        <FCSCommitHash>3da13f3b373b680df1b08ee342ef290a79016438</FCSCommitHash>
         <StreamJsonRpcVersion>2.8.28</StreamJsonRpcVersion>
         <FSharpCoreVersion>6.0.1</FSharpCoreVersion>
     </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,8 +39,7 @@ Some common use cases include:
     
     <!-- Versions -->
     <PropertyGroup>
-        <FCSRepo>dawedawe/fsharp</FCSRepo>
-        <FCSCommitHash>3da13f3b373b680df1b08ee342ef290a79016438</FCSCommitHash>
+        <FCSCommitHash>7b5e12842d673b7daa467e0091378bf4acc95e4f</FCSCommitHash>
         <StreamJsonRpcVersion>2.8.28</StreamJsonRpcVersion>
         <FSharpCoreVersion>6.0.1</FSharpCoreVersion>
     </PropertyGroup>

--- a/build.fsx
+++ b/build.fsx
@@ -193,6 +193,10 @@ let fsharpCompilerHash =
     let xDoc = XElement.Load(__SOURCE_DIRECTORY__ </> "Directory.Build.props")
     xDoc.XPathSelectElements("//FCSCommitHash") |> Seq.head |> (fun xe -> xe.Value)
 
+let fcsRepo =
+    let xDoc = XElement.Load(__SOURCE_DIRECTORY__ </> "Directory.Build.props")
+    xDoc.XPathSelectElements("//FCSRepo") |> Seq.head |> (fun xe -> xe.Value)
+
 let updateFileRaw (file: FileInfo) =
     let lines = File.ReadAllLines file.FullName
     let updatedLines =
@@ -213,8 +217,7 @@ let downloadCompilerFile commitHash relativePath =
             file.Directory.Create()
             let fs = file.Create()
             let fileName = Path.GetFileName(relativePath)
-            let url =
-                $"https://raw.githubusercontent.com/dotnet/fsharp/{commitHash}/{relativePath}"
+            let url = $"https://raw.githubusercontent.com/{fcsRepo}/{commitHash}/{relativePath}"
             let! response =
                 Http.AsyncRequestStream(
                     url,

--- a/build.fsx
+++ b/build.fsx
@@ -193,10 +193,6 @@ let fsharpCompilerHash =
     let xDoc = XElement.Load(__SOURCE_DIRECTORY__ </> "Directory.Build.props")
     xDoc.XPathSelectElements("//FCSCommitHash") |> Seq.head |> (fun xe -> xe.Value)
 
-let fcsRepo =
-    let xDoc = XElement.Load(__SOURCE_DIRECTORY__ </> "Directory.Build.props")
-    xDoc.XPathSelectElements("//FCSRepo") |> Seq.head |> (fun xe -> xe.Value)
-
 let updateFileRaw (file: FileInfo) =
     let lines = File.ReadAllLines file.FullName
     let updatedLines =
@@ -217,7 +213,8 @@ let downloadCompilerFile commitHash relativePath =
             file.Directory.Create()
             let fs = file.Create()
             let fileName = Path.GetFileName(relativePath)
-            let url = $"https://raw.githubusercontent.com/{fcsRepo}/{commitHash}/{relativePath}"
+            let url =
+                $"https://raw.githubusercontent.com/dotnet/fsharp/{commitHash}/{relativePath}"
             let! response =
                 Http.AsyncRequestStream(
                     url,

--- a/src/Fantomas.Core.Tests/SynConstTests.fs
+++ b/src/Fantomas.Core.Tests/SynConstTests.fs
@@ -756,3 +756,18 @@ let ``explicit SynMeasure.One in SynMeasure.Divide should be preserved`` () =
         """
 234<1 / kg>
 """
+
+[<Test>]
+let ``block comments in measure are lost or restored twice and in wrong place, 2927`` () =
+    formatSourceString
+        false
+        """
+234<(* foo *)kg(* bar *)>
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+234< (* foo *) kg (* bar *) >
+"""

--- a/src/Fantomas.Core.Tests/SynConstTests.fs
+++ b/src/Fantomas.Core.Tests/SynConstTests.fs
@@ -728,7 +728,7 @@ let ``single digit constant`` () =
     |> should equal "1"
 
 [<Test>]
-let ``left out lhs in SynMeasure.Divide should not be restored as SynMeasure.One`` () =
+let ``left out lhs in SynMeasure.Divide should not be restored as SynMeasure.One, 2926`` () =
     formatSourceString
         false
         """
@@ -740,4 +740,19 @@ let ``left out lhs in SynMeasure.Divide should not be restored as SynMeasure.One
         equal
         """
 234< / kg>
+"""
+
+[<Test>]
+let ``explicit SynMeasure.One in SynMeasure.Divide should be preserved`` () =
+    formatSourceString
+        false
+        """
+234<1/kg>
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+234<1 / kg>
 """

--- a/src/Fantomas.Core.Tests/SynConstTests.fs
+++ b/src/Fantomas.Core.Tests/SynConstTests.fs
@@ -726,3 +726,18 @@ let ``single digit constant`` () =
         { config with
             InsertFinalNewline = false }
     |> should equal "1"
+
+[<Test>]
+let ``left out lhs in SynMeasure.Divide should not be restored as SynMeasure.One`` () =
+    formatSourceString
+        false
+        """
+234</kg>
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+234< / kg>
+"""

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -169,7 +169,7 @@ let mkMeasure (creationAide: CreationAide) (measure: SynMeasure) : Measure =
         MeasureDivideNode(lhs, stn "/" Range.Zero, mkMeasure creationAide m2, m)
         |> Measure.Divide
     | SynMeasure.Power(ms, rat, m) ->
-        MeasurePowerNode(mkMeasure creationAide ms, stn (mkSynRationalConst rat) Range.Zero, m)
+        MeasurePowerNode(mkMeasure creationAide ms, stn (mkSynRationalConst creationAide rat) Range.Zero, m)
         |> Measure.Power
     | SynMeasure.Named(lid, _) -> mkLongIdent lid |> Measure.Multiple
     | SynMeasure.Paren(measure, StartEndRange 1 (mOpen, m, mClose)) ->
@@ -1993,10 +1993,10 @@ let mkSynValTyparDecls (creationAide: CreationAide) (vt: SynValTyparDecls option
     | None -> None
     | Some(SynValTyparDecls(tds, _)) -> Option.map (mkSynTyparDecls creationAide) tds
 
-let mkSynRationalConst rc =
+let mkSynRationalConst (creationAide: CreationAide) rc =
     let rec visit rc =
         match rc with
-        | SynRationalConst.Integer(value = i) -> string i
+        | SynRationalConst.Integer(i, range) -> creationAide.TextFromSource (fun () -> string i) range
         | SynRationalConst.Rational(numerator = numerator; denominator = denominator) ->
             $"(%i{numerator}/%i{denominator})"
         | SynRationalConst.Negate(rationalConst = innerRc) -> $"-{visit innerRc}"
@@ -2100,7 +2100,7 @@ let mkType (creationAide: CreationAide) (t: SynType) : Type =
         TypeHashConstraintNode(stn "#" mHash, mkType creationAide t, typeRange)
         |> Type.HashConstraint
     | SynType.MeasurePower(t, rc, _) ->
-        TypeMeasurePowerNode(mkType creationAide t, mkSynRationalConst rc, typeRange)
+        TypeMeasurePowerNode(mkType creationAide t, mkSynRationalConst creationAide rc, typeRange)
         |> Type.MeasurePower
     | SynType.StaticConstant(SynConst.String(null, kind, mString), r) ->
         mkConstant creationAide (SynConst.String("null", kind, mString)) r

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -150,8 +150,19 @@ let mkConstant (creationAide: CreationAide) c r : Constant =
             $"\"{content}\"B"
 
         stn (creationAide.TextFromSource fallback r) r |> Constant.FromText
-    | SynConst.Measure(c, numberRange, measure, _) ->
-        ConstantMeasureNode(mkConstant creationAide c numberRange, mkMeasure creationAide measure, r)
+    | SynConst.Measure(c, numberRange, measure, trivia) ->
+        let uOfMRange =
+            mkRange trivia.LessRange.FileName trivia.LessRange.Start trivia.GreaterRange.End
+
+        let unitOfMeasure =
+            UnitOfMeasureNode(
+                stn "<" trivia.LessRange,
+                mkMeasure creationAide measure,
+                stn ">" trivia.GreaterRange,
+                uOfMRange
+            )
+
+        ConstantMeasureNode(mkConstant creationAide c numberRange, unitOfMeasure, r)
         |> Constant.Measure
     | SynConst.SourceIdentifier(c, _, r) -> stn c r |> Constant.FromText
 

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -2659,7 +2659,7 @@ let mkMemberDefn (creationAide: CreationAide) (md: SynMemberDefn) =
         memberDefn = SynBinding(
             attributes = ats
             xmlDoc = px
-            valData = SynValData(Some { MemberKind = SynMemberKind.Constructor }, _, ido)
+            valData = SynValData(Some { MemberKind = SynMemberKind.Constructor }, _, ido, _)
             headPat = SynPat.LongIdent(
                 longDotId = SynLongIdent(id = [ newIdent ])
                 argPats = SynArgPats.Pats [ SynPat.Paren _ as pat ]

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -223,9 +223,7 @@ let genMeasure (measure: Measure) =
         +> genMeasure n.RightHandSide
         |> genNode n
     | Measure.Divide n ->
-        let lhs = n.LeftHandSide |> Option.map genMeasure |> Option.defaultValue id
-
-        lhs
+        optSingle genMeasure n.LeftHandSide
         +> sepSpace
         +> genSingleTextNode n.Operator
         +> sepSpace

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -207,9 +207,9 @@ let genConstant (c: Constant) =
     | Constant.Unit n -> genUnit n
     | Constant.Measure n ->
         (genConstant n.Constant |> genNode (Constant.Node n.Constant))
-        +> !- "<"
-        +> genMeasure n.Measure
-        +> !- ">"
+        +> genSingleTextNode n.Measure.LessThan
+        +> genMeasure n.Measure.Measure
+        +> genSingleTextNode n.Measure.GreaterThan
         |> genNode n
 
 let genMeasure (measure: Measure) =
@@ -230,7 +230,7 @@ let genMeasure (measure: Measure) =
         +> genMeasure n.RightHandSide
         |> genNode n
     | Measure.Power n -> genMeasure n.Measure +> !- "^" +> genSingleTextNode n.Exponent |> genNode n
-    | Measure.Seq n -> col sepSpace n.Measures genMeasure
+    | Measure.Seq n -> col sepSpace n.Measures genMeasure |> genNode n
     | Measure.Multiple n -> genIdentListNode n
     | Measure.Paren n ->
         genSingleTextNode n.OpeningParen

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -222,6 +222,15 @@ let genMeasure (measure: Measure) =
         +> sepSpace
         +> genMeasure n.RightHandSide
         |> genNode n
+    | Measure.Divide n ->
+        let lhs = n.LeftHandSide |> Option.map genMeasure |> Option.defaultValue id
+
+        lhs
+        +> sepSpace
+        +> genSingleTextNode n.Operator
+        +> sepSpace
+        +> genMeasure n.RightHandSide
+        |> genNode n
     | Measure.Power n -> genMeasure n.Measure +> !- "^" +> genSingleTextNode n.Exponent |> genNode n
     | Measure.Seq n -> col sepSpace n.Measures genMeasure
     | Measure.Multiple n -> genIdentListNode n

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -2630,9 +2630,9 @@ type UnitNode(openingParen: SingleTextNode, closingParen: SingleTextNode, range)
     member val OpeningParen = openingParen
     member val ClosingParen = closingParen
 
-type ConstantMeasureNode(constant: Constant, measure: Measure, range) =
+type ConstantMeasureNode(constant: Constant, measure: UnitOfMeasureNode, range) =
     inherit NodeBase(range)
-    override val Children: Node array = [| yield Constant.Node constant; yield Measure.Node measure |]
+    override val Children: Node array = [| yield Constant.Node constant; yield measure |]
     member val Constant = constant
     member val Measure = measure
 
@@ -2744,6 +2744,15 @@ type TypeConstraint =
         | SupportsMember n -> n
         | EnumOrDelegate n -> n
         | WhereSelfConstrained t -> Type.Node t
+
+type UnitOfMeasureNode(lessThan: SingleTextNode, measure: Measure, greaterThan: SingleTextNode, range) =
+    inherit NodeBase(range)
+
+    override val Children: Node array = [| yield lessThan; yield Measure.Node measure; yield greaterThan |]
+
+    member val LessThan = lessThan
+    member val Measure = measure
+    member val GreaterThan = greaterThan
 
 type MeasureOperatorNode(lhs: Measure, operator: SingleTextNode, rhs: Measure, range) =
     inherit NodeBase(range)

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -2754,6 +2754,19 @@ type MeasureOperatorNode(lhs: Measure, operator: SingleTextNode, rhs: Measure, r
     member val Operator = operator
     member val RightHandSide = rhs
 
+type MeasureDivideNode(lhs: Measure option, operator: SingleTextNode, rhs: Measure, range) =
+    inherit NodeBase(range)
+
+    override val Children: Node array =
+        [| if Option.isSome lhs then
+               yield Measure.Node lhs.Value
+           yield operator
+           yield Measure.Node rhs |]
+
+    member val LeftHandSide = lhs
+    member val Operator = operator
+    member val RightHandSide = rhs
+
 type MeasurePowerNode(measure: Measure, exponent: SingleTextNode, range) =
     inherit NodeBase(range)
     override val Children: Node array = [| yield Measure.Node measure; yield exponent |]
@@ -2778,6 +2791,7 @@ type MeasureParenNode(openingParen: SingleTextNode, measure: Measure, closingPar
 type Measure =
     | Single of SingleTextNode
     | Operator of MeasureOperatorNode
+    | Divide of MeasureDivideNode
     | Power of MeasurePowerNode
     | Multiple of IdentListNode
     | Seq of MeasureSequenceNode
@@ -2787,6 +2801,7 @@ type Measure =
         match m with
         | Single n -> n
         | Operator n -> n
+        | Divide n -> n
         | Power n -> n
         | Multiple n -> n
         | Seq n -> n

--- a/src/Fantomas.FCS/Parse.fs
+++ b/src/Fantomas.FCS/Parse.fs
@@ -407,7 +407,7 @@ let EmptyParsedInput (filename, isLastCompiland) =
         )
 
 let createLexbuf langVersion sourceText =
-    UnicodeLexing.SourceTextAsLexbuf(true, LanguageVersion(langVersion), sourceText)
+    UnicodeLexing.SourceTextAsLexbuf(true, LanguageVersion(langVersion), None, sourceText)
 
 let createLexerFunction (defines: string list) lexbuf (errorLogger: CapturingDiagnosticsLogger) =
     let lightStatus = IndentationAwareSyntaxStatus(true, true)


### PR DESCRIPTION
This makes use of the new modeling of `SynMeasure.Divide`.
Now that the `measure1` is optional, we have a chance to see, if the original code had it or not.
fixes #2926 and #2927 