### PR TITLE
Ensure the arguments in a multiline application are always indented further than the function expr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 6.1.3 - 2023-08-25
 
 ### Changed
 * Update FCS to 'Add some more ranges to SynMeasure for tooling support', commit 6ed38fcb360a0015828973b1f32cd2ea6b58c6ad
@@ -11,6 +11,7 @@
 * Block comment between measure1 and / is moved between / and measure2 in SynMeasure.Divide. [#2934](https://github.com/fsprojects/fantomas/issues/2934)
 * Block comment between measure1 and * is moved between * and measure2 in SynMeasure.Product. [#2935](https://github.com/fsprojects/fantomas/issues/2935)
 * Block comment between ^ and exponent in SynMeasure.Power is lost. [#2936](https://github.com/fsprojects/fantomas/issues/2936)
+* Opening parens make unstable/incorrect indentation for an Enum wrapping a record. [#2943](https://github.com/fsprojects/fantomas/issues/2943)
 
 ## 6.1.2 - 2023-07-23
 

--- a/src/Fantomas.Core.Tests/AppTests.fs
+++ b/src/Fantomas.Core.Tests/AppTests.fs
@@ -1202,3 +1202,23 @@ foo {
                    c))))
 }
 """
+
+[<Test>]
+let ``don't indent function application arguments when function name is further indented`` () =
+    formatSourceString
+        false
+        """
+((((((((((((((((((((((
+    f a b c
+))))))))))))))))))))))
+"""
+        { config with MaxLineLength = 0 }
+    |> prepend newline
+    |> should
+        equal
+        """
+((((((((((((((((((((((f
+    a
+    b
+    c))))))))))))))))))))))
+"""

--- a/src/Fantomas.Core.Tests/AppTests.fs
+++ b/src/Fantomas.Core.Tests/AppTests.fs
@@ -1145,3 +1145,60 @@ let ``function invocation wrapped in parentheses, 2382`` () =
     42
 )
 """
+
+[<Test>]
+let ``extra indent in multiline application`` () =
+    formatSourceString
+        false
+        """
+((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa b c))
+"""
+        { config with
+            IndentSize = 2
+            MaxLineLength = 0 }
+    |> prepend newline
+    |> should
+        equal
+        """
+((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    b
+    c))
+"""
+
+[<Test>]
+let ``multiline application wrapped in parentheses that equal the indent_size, 2943`` () =
+    formatSourceString
+        false
+        """
+((Combo { e1 = "Making this long so it goes on a new line new line new line new line making it long so it goes on a new line new line" }))
+"""
+        { config with IndentSize = 2 }
+    |> prepend newline
+    |> should
+        equal
+        """
+((Combo
+    { e1 =
+        "Making this long so it goes on a new line new line new line new line making it long so it goes on a new line new line" }))
+"""
+
+[<Test>]
+let ``atCurrentColumn multiline application does not need addition indent`` () =
+    formatSourceString
+        false
+        """
+foo {
+    bar in ((((aaaaaaaaaaaa b c))))
+}
+"""
+        { config with MaxLineLength = 0 }
+    |> prepend newline
+    |> should
+        equal
+        """
+foo {
+    bar in ((((aaaaaaaaaaaa
+                   b
+                   c))))
+}
+"""

--- a/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -1123,12 +1123,12 @@ let ``double pipe with application with two lambdas, 2682`` () =
         """
 (someLongItemOne, someLongItemTwo)
 ||> Prefix.fnName
-    (fun delta echo -> delta, echo)
-    (fun (k: One * Two * Three) ->
-        // multiline
-        ()
-    )
-    lastArgument
+        (fun delta echo -> delta, echo)
+        (fun (k: One * Two * Three) ->
+            // multiline
+            ()
+        )
+        lastArgument
 
 (someLongItemOne, someLongItemTwo)
 |> Prefix.fnName

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1209,19 +1209,18 @@ let genExpr (e: Expr) =
                 let longExpression (ctx: Context) =
                     let startColumn = ctx.Column
 
-                    let ensureArgsAreIndent f (ctx: Context) =
-                        if
-                            startColumn < Math.Max(ctx.WriterModel.AtColumn, ctx.WriterModel.Indent)
-                                          + ctx.Config.IndentSize
-                        then
-                            indentSepNlnUnindent f ctx
-                        else
-                            // TODO: this most likely doesn't work when there are even more parentheses involved.
-                            // Just adding one extra indent won't always cut it.
+                    let ensureArgumentsAreNotAlignedWithFunctionName f (ctx: Context) =
+                        let nextColumn =
+                            Math.Max(ctx.WriterModel.AtColumn, ctx.WriterModel.Indent)
+                            + ctx.Config.IndentSize
+
+                        if startColumn = nextColumn then
                             (indent +> indent +> sepNln +> f +> unindent +> unindent) ctx
+                        else
+                            indentSepNlnUnindent f ctx
 
                     (genExpr node.FunctionExpr
-                     +> ensureArgsAreIndent (col sepNln node.Arguments genExpr))
+                     +> ensureArgumentsAreNotAlignedWithFunctionName (col sepNln node.Arguments genExpr))
                         ctx
 
                 expressionFitsOnRestOfLine shortExpression longExpression ctx


### PR DESCRIPTION
An initial attempt to fix #2943.
