### PR TITLE
use __SOURCE_DIRECTORY__ for the analyzersProjectPath

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -58,7 +58,7 @@ let pushPackage nupkg =
         return result.ExitCode
     }
 
-let analyzersProjectPath = "./analyzers/analyzers.fsproj"
+let analyzersProjectPath = __SOURCE_DIRECTORY__ </> "analyzers/analyzers.fsproj"
 
 let analyzersVersion =
     let s = File.ReadAllText(analyzersProjectPath)


### PR DESCRIPTION
With this PR, you can do a simple `dotnet fsi build.fsx` after a `git clean -xdf`.
Before, you had to do a `dotnet fsi build.fsx -p Init` prior to the `Build` pipeline.