### PR TITLE
Remove blank line between type extension.

### DIFF
--- a/src/Fantomas.Core.Tests/DallasTests.fs
+++ b/src/Fantomas.Core.Tests/DallasTests.fs
@@ -481,7 +481,6 @@ type Foo with
         equal
         """
 type Foo with
-
     member x.Bar = ()
 """
 

--- a/src/Fantomas.Core.Tests/NewlineBetweenTypeDefinitionAndMembersTests.fs
+++ b/src/Fantomas.Core.Tests/NewlineBetweenTypeDefinitionAndMembersTests.fs
@@ -120,7 +120,7 @@ type Color =
 """
 
 [<Test>]
-let ``type augmentation with members`` () =
+let ``type augmentation with members should not add newline`` () =
     formatSourceString
         false
         """
@@ -133,7 +133,6 @@ type HttpContext with
         equal
         """
 type HttpContext with
-
     member this.QueryString() = "?"
 """
 
@@ -232,7 +231,6 @@ type HttpContext with
 namespace Signature
 
 type HttpContext with
-
     member QueryString: unit -> string
 """
 

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3518,7 +3518,7 @@ let genTypeDefn (td: TypeDefn) =
         header
         +> sepSpace
         +> optSingle genSingleTextNode typeName.WithKeyword
-        +> indentSepNlnUnindent (sepNlnBetweenTypeAndMembers typeDefnNode +> genMemberDefnList members)
+        +> indentSepNlnUnindent (genMemberDefnList members)
         |> genNode node
     | TypeDefn.Delegate node ->
         header


### PR DESCRIPTION
See https://github.com/G-Research/fsharp-formatting-conventions/issues/42

We probably want to ship this as the next minor. Since this would change the code style.
Although it is safe to update, as existing code would not be updated. The trivia would be respected.