### PR TITLE
Also accept alignment from if keyword in genKeepIdentIfThenElse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+* ExperimentalKeepIndentInBranch should fire when first branch was all on one line. [#2973](https://github.com/fsprojects/fantomas/issues/2973)
+
 ## 6.2.3 - 2023-11-2
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/KeepIndentInBranchTests.fs
+++ b/src/Fantomas.Core.Tests/KeepIndentInBranchTests.fs
@@ -2183,3 +2183,55 @@ module Foo =
 
         failwith ""
 """
+
+[<Test>]
+let ``if keyword and elseBranch align, 2973`` () =
+    formatSourceString
+        false
+        """
+module Program =
+    let main _ =
+        if false then 1 else
+        printfn "hi!"
+        0
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Program =
+    let main _ =
+        if false then
+            1
+        else
+
+        printfn "hi!"
+        0
+"""
+
+[<Test>]
+let ``elif keyword and elseBranch align`` () =
+    formatSourceString
+        false
+        """
+if false then
+    1
+elif false then 2 else
+printfn "hi!"
+0
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+if false then
+    1
+elif false then
+    2
+else
+
+printfn "hi!"
+0
+"""

--- a/src/Fantomas.Core.Tests/KeepIndentInBranchTests.fs
+++ b/src/Fantomas.Core.Tests/KeepIndentInBranchTests.fs
@@ -2235,3 +2235,31 @@ else
 printfn "hi!"
 0
 """
+
+[<Test>]
+let ``elseBranch aligns with if keyword in computation expression`` () =
+    formatSourceString
+        false
+        """
+async {
+    if not (proc.Start ()) then return Error "failed to start" else
+    use stdout = proc.StandardOutput
+    let! ct = Async.CancellationToken
+    return! Async.AwaitTask (stdout.ReadToEndAsync ct)
+}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+async {
+    if not (proc.Start()) then
+        return Error "failed to start"
+    else
+
+    use stdout = proc.StandardOutput
+    let! ct = Async.CancellationToken
+    return! Async.AwaitTask(stdout.ReadToEndAsync ct)
+}
+"""


### PR DESCRIPTION
See #2973.

@Smaug123 your desired result doesn't have a blank line after `else`:

```
module Program =
    let main _ =
        if false then
            1
        else
        printfn "hi!"
        0
``` 

We currently always add a blank line there. Do you want to change that behaviour as well?