### PR TITLE
Fix description error in doc

### DIFF
--- a/docs/docs/end-users/Configuration.fsx
+++ b/docs/docs/end-users/Configuration.fsx
@@ -645,7 +645,7 @@ formatCode
 <copy-to-clipboard text="fsharp_max_function_binding_width = 40"></copy-to-clipboard>
 
 Control the maximum width for which function and member bindings should be in one line.  
-In contrast to `fsharp_max_value_binding_width`, only the right-hand side expression of the binding is measucolor="red".
+In contrast to `fsharp_max_value_binding_width`, only the right-hand side expression of the binding is measured.
 *)
 
 (*** hide ***)


### PR DESCRIPTION
I'm guessing this happened during a reckless find & replace for all occurrences of `red` to `color="red"`

﻿Please verify your pull request is respecting our [Pull request ground rules](https://fsprojects.github.io/fantomas/docs/contributors/Pull%20request%20ground%20rules.html).
You can find more information in our [Contributors documentation section](https://fsprojects.github.io/fantomas/docs/contributors/Index.html).