### PR TITLE
Remove ExprAppSingleParenArgNode from Oak model.

### DIFF
--- a/src/Fantomas.Core.Tests/DallasTests.fs
+++ b/src/Fantomas.Core.Tests/DallasTests.fs
@@ -1918,3 +1918,21 @@ let answerToUniverse =
         TransformersModule.tryTransformToAnswerToUniverse value
         |> Option.defaultValue 42
 """
+
+[<Test>]
+let ``smooth criminal`` () =
+    formatSourceString
+        false
+        """
+let initialAbs =
+    initialFeeWithAMinimumGasPriceInWeiDictatedByAvailablePublicFullNodes
+        .CalculateAbsoluteValue()
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let initialAbs =
+    initialFeeWithAMinimumGasPriceInWeiDictatedByAvailablePublicFullNodes.CalculateAbsoluteValue()
+"""

--- a/src/Fantomas.Core.Tests/DallasTests.fs
+++ b/src/Fantomas.Core.Tests/DallasTests.fs
@@ -1918,21 +1918,3 @@ let answerToUniverse =
         TransformersModule.tryTransformToAnswerToUniverse value
         |> Option.defaultValue 42
 """
-
-[<Test>]
-let ``smooth criminal`` () =
-    formatSourceString
-        false
-        """
-let initialAbs =
-    initialFeeWithAMinimumGasPriceInWeiDictatedByAvailablePublicFullNodes
-        .CalculateAbsoluteValue()
-"""
-        { config with MaxLineLength = 50 }
-    |> prepend newline
-    |> should
-        equal
-        """
-let initialAbs =
-    initialFeeWithAMinimumGasPriceInWeiDictatedByAvailablePublicFullNodes.CalculateAbsoluteValue()
-"""

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -1237,9 +1237,6 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
     | AppSingleParenArg(SynExpr.LongIdent(longDotId = longDotId), px) ->
         ExprAppLongIdentAndSingleParenArgNode(mkSynLongIdent longDotId, mkExpr creationAide px, exprRange)
         |> Expr.AppLongIdentAndSingleParenArg
-    | AppSingleParenArg(e, px) ->
-        ExprAppSingleParenArgNode(mkExpr creationAide e, mkExpr creationAide px, exprRange)
-        |> Expr.AppSingleParenArg
 
     | SynExpr.App(funcExpr = App(fe, args); argExpr = ParenLambda(lpr, pats, mArrow, body, mLambda, rpr)) ->
         let lambdaNode = mkLambda creationAide pats mArrow body mLambda

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -871,17 +871,6 @@ let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list option =
         Some(visit e id)
     | _ -> None
 
-let (|AppSingleParenArg|_|) =
-    function
-    | App(SynExpr.DotGet _, [ (SynExpr.Paren(expr = SynExpr.Tuple _)) ]) -> None
-    | App(e, [ UnitExpr _ as px ]) -> Some(e, px)
-    | App(e, [ SynExpr.Paren(expr = singleExpr) as px ]) ->
-        match singleExpr with
-        | SynExpr.Lambda _
-        | SynExpr.MatchLambda _ -> None
-        | _ -> Some(e, px)
-    | _ -> None
-
 let mkParenExpr creationAide lpr e rpr m =
     ExprParenNode(stn "(" lpr, mkExpr creationAide e, stn ")" rpr, m)
 
@@ -1233,10 +1222,6 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
                 | link -> failwithf "cannot map %A" link)
 
         ExprChain(chainLinks, exprRange) |> Expr.Chain
-
-    | AppSingleParenArg(SynExpr.LongIdent(longDotId = longDotId), px) ->
-        ExprAppLongIdentAndSingleParenArgNode(mkSynLongIdent longDotId, mkExpr creationAide px, exprRange)
-        |> Expr.AppLongIdentAndSingleParenArg
 
     | SynExpr.App(funcExpr = App(fe, args); argExpr = ParenLambda(lpr, pats, mArrow, body, mLambda, rpr)) ->
         let lambdaNode = mkLambda creationAide pats mArrow body mLambda

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -235,9 +235,6 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ExprChain as node ->
         let expr = Expr.Chain node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprAppLongIdentAndSingleParenArgNode as node ->
-        let expr = Expr.AppLongIdentAndSingleParenArg node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprAppWithLambdaNode as node ->
         let expr = Expr.AppWithLambda node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -238,9 +238,6 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ExprAppLongIdentAndSingleParenArgNode as node ->
         let expr = Expr.AppLongIdentAndSingleParenArg node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprAppSingleParenArgNode as node ->
-        let expr = Expr.AppSingleParenArg node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprAppWithLambdaNode as node ->
         let expr = Expr.AppWithLambda node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1214,12 +1214,6 @@ type ExprAppLongIdentAndSingleParenArgNode(functionName: IdentListNode, argExpr:
     member val FunctionName = functionName
     member val ArgExpr = argExpr
 
-type ExprAppSingleParenArgNode(functionExpr: Expr, argExpr: Expr, range) =
-    inherit NodeBase(range)
-    override val Children: Node array = [| yield Expr.Node functionExpr; yield Expr.Node argExpr |]
-    member val FunctionExpr = functionExpr
-    member val ArgExpr = argExpr
-
 type ExprAppWithLambdaNode
     (
         functionName: Expr,
@@ -1669,7 +1663,6 @@ type Expr =
     | InfixApp of ExprInfixAppNode
     | IndexWithoutDot of ExprIndexWithoutDotNode
     | AppLongIdentAndSingleParenArg of ExprAppLongIdentAndSingleParenArgNode
-    | AppSingleParenArg of ExprAppSingleParenArgNode
     | AppWithLambda of ExprAppWithLambdaNode
     | NestedIndexWithoutDot of ExprNestedIndexWithoutDotNode
     | App of ExprAppNode
@@ -1736,7 +1729,6 @@ type Expr =
         | InfixApp n -> n
         | IndexWithoutDot n -> n
         | AppLongIdentAndSingleParenArg n -> n
-        | AppSingleParenArg n -> n
         | AppWithLambda n -> n
         | NestedIndexWithoutDot n -> n
         | App n -> n

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1207,13 +1207,6 @@ type ExprChain(links: ChainLink list, range) =
     override val Children: Node array = List.map ChainLink.Node links |> List.toArray
     member val Links = links
 
-type ExprAppLongIdentAndSingleParenArgNode(functionName: IdentListNode, argExpr: Expr, range) =
-    inherit NodeBase(range)
-
-    override val Children: Node array = [| yield functionName; yield Expr.Node argExpr |]
-    member val FunctionName = functionName
-    member val ArgExpr = argExpr
-
 type ExprAppWithLambdaNode
     (
         functionName: Expr,
@@ -1662,7 +1655,6 @@ type Expr =
     | SameInfixApps of ExprSameInfixAppsNode
     | InfixApp of ExprInfixAppNode
     | IndexWithoutDot of ExprIndexWithoutDotNode
-    | AppLongIdentAndSingleParenArg of ExprAppLongIdentAndSingleParenArgNode
     | AppWithLambda of ExprAppWithLambdaNode
     | NestedIndexWithoutDot of ExprNestedIndexWithoutDotNode
     | App of ExprAppNode
@@ -1728,7 +1720,6 @@ type Expr =
         | SameInfixApps n -> n
         | InfixApp n -> n
         | IndexWithoutDot n -> n
-        | AppLongIdentAndSingleParenArg n -> n
         | AppWithLambda n -> n
         | NestedIndexWithoutDot n -> n
         | App n -> n


### PR DESCRIPTION
This is an example of something I mentioned in [comment](https://github.com/fsprojects/fantomas/pull/2852#issuecomment-1818870225).

I'm not quite sure if this improves things and we should merge this.

But my reasoning is that `SyntakOak` should "strictly" not have any knowledge of how `CodePrinter` deals with the details of the captured nodes.

Right now: `f(g)` is represented as `ExprAppSingleParenArgNode` while it could have easily been an `ExprAppNode`. We make the distinction based on what we are about to do with it in `CodePrinter`.

I'm not sure that this is a good reason to do it. It covers the representation of the typed code just as well. The significance of arguments being a single `paren expr` should be kept inside of CodePrinter, where it actually matters.

This PR also isn't a plea to move everything back into `ExprAppNode`. I still think it makes a lot of sense to have `ExprInfixApp` and others. As a rule of thumb, I think we should try and keep **style** out of `SyntaxOak`. So groupings like `Expr.AppLongIdentAndSingleParenArg` and `Expr.AppWithLambda` should be ported to `CodePrinter` instead.

//cc @dawedawe @josh-degraw 