### PR TITLE
Fix issue in build.fsx

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -167,7 +167,7 @@ pipeline "FormatChanged" {
                                     || line.EndsWith(".fsx", StringComparison.Ordinal)
                                     || line.EndsWith(".fsi", StringComparison.Ordinal))
                             then
-                                Some(line.Replace("AM ", "").Replace("M ", ""))
+                                Some(line.Replace("AM ", "").Replace("MM ", "").Replace("M ", ""))
                             else
                                 None)
                         |> String.concat " "


### PR DESCRIPTION
This fixes an issue where the `formatChanged` pipeline fails if there are both staged and unstaged changes for the same file. 