### PR TITLE
Turn on strict indentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+* Turn on strict indentation in the lexer in Fantomas.FCS. [#3014](https://github.com/fsprojects/fantomas/pull/3014)
+
 ## 6.3.0-alpha-004 - 2023-12-06
 
 ### Fixed

--- a/src/Fantomas.FCS/Parse.fs
+++ b/src/Fantomas.FCS/Parse.fs
@@ -407,7 +407,7 @@ let EmptyParsedInput (filename, isLastCompiland) =
         )
 
 let createLexbuf langVersion sourceText =
-    UnicodeLexing.SourceTextAsLexbuf(true, LanguageVersion(langVersion), None, sourceText)
+    UnicodeLexing.SourceTextAsLexbuf(true, LanguageVersion(langVersion), Some true, sourceText)
 
 let createLexerFunction (defines: string list) lexbuf (errorLogger: CapturingDiagnosticsLogger) =
     let lightStatus = IndentationAwareSyntaxStatus(true, true)


### PR DESCRIPTION
As expected, the strict indentation in the `Fantomas.FCS` parser was not enabled.
I don't think it matters much for Fantomas, as we expect a valid tree anyway.
This could be useful for the online tool though.

//cc @auduchinok 