### PR TITLE
Fix 2953 - Comment lost after named pat pair.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 * Unmatched '{' error when formatting the code. [#3017](https://github.com/fsprojects/fantomas/issues/3017)
+* Comment lost after named pat pair. [#2953](https://github.com/fsprojects/fantomas/issues/2953)
 
 ## 6.3.0-alpha-004 - 2023-12-06
 

--- a/src/Fantomas.Core.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Core.Tests/PatternMatchingTests.fs
@@ -2281,7 +2281,8 @@ Some ident.idRange
         equal
         """
 match synExpr with
-| SynExpr.App(argExpr = SynExpr.Match _) -> // CCC
-    Some ident.idRange
+| SynExpr.App(
+    argExpr = SynExpr.Match _ // CCC
+    ) -> Some ident.idRange
 | _ -> defaultTraverse synExpr
 """

--- a/src/Fantomas.Core.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Core.Tests/PatternMatchingTests.fs
@@ -2262,3 +2262,26 @@ match subcategory with
 // Just treat as an unknown-to-LanguageService error.
  -> false
 """
+
+[<Test>]
+let ``comment lost after named pat pair, 2953`` () =
+    formatSourceString
+        """
+match synExpr with
+| SynExpr.App(
+    argExpr = SynExpr.Match _ // CCC
+    )
+     ->
+Some ident.idRange
+| _ -> defaultTraverse synExpr
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+match synExpr with
+| SynExpr.App(argExpr = SynExpr.Match _) -> // CCC
+    Some ident.idRange
+| _ -> defaultTraverse synExpr
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2594,6 +2594,7 @@ let genPat (p: Pattern) =
             +> genSingleTextNode node.Equals
             +> sepSpace
             +> genPat node.Pattern
+            |> genNode node
 
         let pats =
             expressionFitsOnRestOfLine

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2605,7 +2605,11 @@ let genPat (p: Pattern) =
         +> optSingle genTyparDecls node.TyparDecls
         +> addSpaceBeforeParenInPattern node.Identifier
         +> genSingleTextNode node.OpeningParen
-        +> autoIndentAndNlnIfExpressionExceedsPageWidth (sepNlnWhenWriteBeforeNewlineNotEmpty +> pats)
+        +> autoIndentAndNlnIfExpressionExceedsPageWidth (
+            sepNlnWhenWriteBeforeNewlineNotEmpty
+            +> pats
+            +> sepNlnWhenWriteBeforeNewlineNotEmpty
+        )
         +> genSingleTextNode node.ClosingParen
         |> genNode node
 


### PR DESCRIPTION
fixes #2953 

Currently, just a draft as the fix is not idempotent.