### PR TITLE
Fix 2854, accidental treatment of old flags as folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 * Unmatched '{' error when formatting the code. [#3017](https://github.com/fsprojects/fantomas/issues/3017)
 * Comment lost after named pat pair. [#2953](https://github.com/fsprojects/fantomas/issues/2953)
+* Fix accidental treatment of old flags as folder args. [#2854](https://github.com/fsprojects/fantomas/issues/2854)
 
 ## 6.3.0-alpha-004 - 2023-12-06
 

--- a/src/Fantomas/Program.fs
+++ b/src/Fantomas/Program.fs
@@ -221,11 +221,7 @@ let main argv =
         | None -> OutputPath.NotKnown
 
     let inputPath =
-        let maybeInput =
-            results.TryGetResult <@ Arguments.Input @>
-            |> Option.map (fun input ->
-                input
-                |> List.filter (fun s -> not (s.StartsWith("--", StringComparison.Ordinal)))) // don't accidentally treat old flags as folders
+        let maybeInput = results.TryGetResult <@ Arguments.Input @>
 
         match maybeInput with
         | Some [ input ] ->
@@ -238,25 +234,31 @@ let main argv =
             else
                 InputPath.NotFound input
         | Some inputs ->
-            let isFolder (path: string) =
-                String.IsNullOrWhiteSpace(Path.GetExtension(path))
+            let missing =
+                inputs |> List.tryFind (fun x -> not (Directory.Exists(x) || File.Exists(x)))
 
-            let rec loop
-                (files: string list)
-                (finalContinuation: string list * string list -> string list * string list)
-                =
-                match files with
-                | [] -> finalContinuation ([], [])
-                | h :: rest ->
-                    loop rest (fun (files, folders) ->
-                        if isFolder h then
-                            files, (h :: folders)
-                        else
-                            (h :: files), folders
-                        |> finalContinuation)
+            match missing with
+            | Some x -> InputPath.NotFound x
+            | None ->
+                let isFolder (path: string) =
+                    String.IsNullOrWhiteSpace(Path.GetExtension(path))
 
-            let filesAndFolders = loop inputs id
-            InputPath.Multiple filesAndFolders
+                let rec loop
+                    (files: string list)
+                    (finalContinuation: string list * string list -> string list * string list)
+                    =
+                    match files with
+                    | [] -> finalContinuation ([], [])
+                    | h :: rest ->
+                        loop rest (fun (files, folders) ->
+                            if isFolder h then
+                                files, (h :: folders)
+                            else
+                                (h :: files), folders
+                            |> finalContinuation)
+
+                let filesAndFolders = loop inputs id
+                InputPath.Multiple filesAndFolders
         | None -> InputPath.Unspecified
 
     let force = results.Contains <@ Arguments.Force @>

--- a/src/Fantomas/Program.fs
+++ b/src/Fantomas/Program.fs
@@ -221,7 +221,11 @@ let main argv =
         | None -> OutputPath.NotKnown
 
     let inputPath =
-        let maybeInput = results.TryGetResult <@ Arguments.Input @>
+        let maybeInput =
+            results.TryGetResult <@ Arguments.Input @>
+            |> Option.map (fun input ->
+                input
+                |> List.filter (fun s -> not (s.StartsWith("--", StringComparison.Ordinal)))) // don't accidentally treat old flags as folders
 
         match maybeInput with
         | Some [ input ] ->


### PR DESCRIPTION
fixes #2854 

It's a bit complicated, but 
first we treated unknown flags as input folders
these input folders weren't found and then we treated these folders as output folders
these output folders didn't exist, so we created them, hence the famous `--recurse` folder came into life.