### PR TITLE
Elevate debug assert to release mode as well

### DIFF
--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -1629,7 +1629,8 @@ let mkTuplePat (creationAide: CreationAide) (pats: SynPat list) (commas: range l
     | [] -> failwith "SynPat.Tuple with no elements"
     | head :: tail ->
         let rest =
-            assert (tail.Length = commas.Length)
+            if tail.Length <> commas.Length then
+                failwith $"Number of elements in tail of tuple (%i{tail.Length}) was not equal to number of commas (%i{commas.Length}), at range %O{m}."
 
             List.zip commas tail
             |> List.collect (fun (c, e) -> [ yield Choice2Of2(stn "," c); yield Choice1Of2(mkPat creationAide e) ])


### PR DESCRIPTION
I've run into this particular problem several times while using Myriad. This is user error (Fantomas does not define its behaviour if run on ASTs which are not the output of the F# compiler's parse phase), but this message would help the user track down what they've got wrong.

On `main` the assert appears to be optimised away: I just get the following stack trace.
```
OTHER: System.ArgumentException: The lists had different lengths.
list2 is 1 element shorter than list1 (Parameter 'list2')
   at Microsoft.FSharp.Core.DetailedExceptions.invalidArgDifferentListLength[?](String arg1, String arg2, Int32 diff) in D:\a\_work\1\s\src\FSharp.Core\local.fs:line 26
   at Microsoft.FSharp.Primitives.Basics.List.zip[T1,T2](FSharpList`1 xs1, FSharpList`1 xs2) in D:\a\_work\1\s\src\FSharp.Core\local.fs:line 926
   at Microsoft.FSharp.Collections.ListModule.Zip[T1,T2](FSharpList`1 list1, FSharpList`1 list2) in D:\a\_work\1\s\src\FSharp.Core\list.fs:line 598
   at Fantomas.Core.ASTTransformer.mkTuplePat(CreationAide creationAide, FSharpList`1 pats, FSharpList`1 commas, Range m) in /_//src/Fantomas.Core/ASTTransformer.fs:line 1597
```