### PR TITLE
POC double indentation.

### DIFF
--- a/src/Fantomas.Core.Tests/ExperimentalDoubleIdentParametersTests.fs
+++ b/src/Fantomas.Core.Tests/ExperimentalDoubleIdentParametersTests.fs
@@ -1,0 +1,30 @@
+﻿module Fantomas.Core.Tests.ExperimentalDoubleIdentParametersTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelpers
+
+let config =
+    { config with
+        ExperimentalDoubleIndentParameters = true
+        MaxLineLength = 10 }
+
+[<Test>]
+let ``initial sample`` () =
+    formatSourceString
+        """
+let sillyfuncWithParams parameterName1 ignoredParameterName2 ignoredParameterName3 =
+    longBody
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let sillyfuncWithParams
+        parameterName1
+        ignoredParameterName2
+        ignoredParameterName3
+        =
+    longBody
+"""

--- a/src/Fantomas.Core.Tests/ExperimentalDoubleIdentParametersTests.fs
+++ b/src/Fantomas.Core.Tests/ExperimentalDoubleIdentParametersTests.fs
@@ -28,3 +28,37 @@ let sillyfuncWithParams
         =
     longBody
 """
+
+[<Test>]
+let ``sample in long member`` () =
+    formatSourceString
+        """
+type X() =
+    member x.Y(a:int, b:int, c:int, d:int, e:int) =
+    
+        // Long body goes here...
+        longBody
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type X() =
+    member x.Y
+            (
+                a:
+                    int,
+                b:
+                    int,
+                c:
+                    int,
+                d:
+                    int,
+                e:
+                    int
+            ) =
+
+        // Long body goes here...
+        longBody
+"""

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -132,6 +132,7 @@
     <Compile Include="DotLambdaTests.fs" />
     <Compile Include="ConstraintIntersectionTests.fs" />
     <Compile Include="BeginEndTests.fs" />
+    <Compile Include="ExperimentalDoubleIdentParametersTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Core\Fantomas.Core.fsproj" />

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2925,7 +2925,7 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
                      +> afterLetKeyword
                      +> sepSpace
                      +> genFunctionName
-                     +> indent
+                     +> experimentalDoubleIndent
                      +> sepNln
                      +> genParameters
                      +> onlyIf nlnOnSeparateLine sepNln
@@ -2934,7 +2934,7 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
                              sepNln +> genSingleTextNode b.Equals
                          else
                              sepSpace +> genSingleTextNode b.Equals)
-                     +> unindent
+                     +> experimentalDoubleUnindent
                      +> onlyIf hasTriviaAfterLeadingKeyword unindent)
                         ctx
 

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -391,6 +391,24 @@ let indent (ctx: Context) =
 let unindent (ctx: Context) =
     writerEvent (UnIndentBy ctx.Config.IndentSize) ctx
 
+let experimentalDoubleIndent (ctx: Context) =
+    let indentSize =
+        if not ctx.Config.ExperimentalDoubleIndentParameters then
+            ctx.Config.IndentSize
+        else
+            2 * ctx.Config.IndentSize
+
+    writerEvent (IndentBy indentSize) ctx
+
+let experimentalDoubleUnindent (ctx: Context) =
+    let indentSize =
+        if not ctx.Config.ExperimentalDoubleIndentParameters then
+            ctx.Config.IndentSize
+        else
+            2 * ctx.Config.IndentSize
+
+    writerEvent (UnIndentBy indentSize) ctx
+
 /// Apply function f at an absolute indent level (use with care)
 let atIndentLevel alsoSetIndent level (f: Context -> Context) (ctx: Context) =
     if level < 0 then

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -78,6 +78,15 @@ val lastWriteEventIsNewline: ctx: Context -> bool
 val indent: ctx: Context -> Context
 /// Unindent one more level based on configuration
 val unindent: ctx: Context -> Context
+
+/// Add double indent if  ExperimentalDoubleIndentParameters is active
+/// Otherwise, add single indent
+val experimentalDoubleIndent: ctx: Context -> Context
+
+/// Add double unindent if  ExperimentalDoubleIndentParameters is active
+/// Otherwise, add single unindent
+val experimentalDoubleUnindent: ctx: Context -> Context
+
 // /// Apply function f at an absolute indent level (use with care)
 val atIndentLevel: alsoSetIndent: bool -> level: int -> f: (Context -> Context) -> ctx: Context -> Context
 // /// Set minimal indentation (`atColumn`) at current column position - next newline will be indented on `max indent atColumn`

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -227,7 +227,12 @@ type FormatConfig =
 
       [<Category("Convention")>]
       [<DisplayName("Applies the Stroustrup style to the final (two) array or list argument(s) in a function application")>]
-      ExperimentalElmish: bool }
+      ExperimentalElmish: bool
+
+      [<Category("Indentation")>]
+      [<DisplayName("Double indent parameters")>]
+      [<Description("Use double indentation for parameters.")>]
+      ExperimentalDoubleIndentParameters: bool }
 
     member x.IsStroustrupStyle = x.MultilineBracketStyle = Stroustrup
 
@@ -268,4 +273,5 @@ type FormatConfig =
           MultilineBracketStyle = Cramped
           KeepMaxNumberOfBlankLines = 100
           NewlineBeforeMultilineComputationExpression = true
-          ExperimentalElmish = false }
+          ExperimentalElmish = false
+          ExperimentalDoubleIndentParameters = false }

--- a/src/Fantomas.Tests/EditorConfigurationTests.fs
+++ b/src/Fantomas.Tests/EditorConfigurationTests.fs
@@ -507,7 +507,7 @@ fsharp_multiline_bracket_style = cramped
     Assert.That(config.MultilineBracketStyle, Is.EqualTo Cramped)
 
 [<Test>]
-let fsharp_prefer_computation_expression_name_on_same_line () =
+let fsharp_newline_before_multiline_computation_expression () =
     let rootDir = tempName ()
 
     let editorConfig =
@@ -526,7 +526,7 @@ fsharp_newline_before_multiline_computation_expression = false
     Assert.That(config.NewlineBeforeMultilineComputationExpression, Is.False)
 
 [<Test>]
-let fsharp_stroustrup_final_list_arguments () =
+let fsharp_experimental_elmish () =
     let rootDir = tempName ()
 
     let editorConfig =
@@ -543,3 +543,22 @@ fsharp_experimental_elmish = true
     let config = EditorConfig.readConfiguration fsharpFile.FSharpFile
 
     Assert.That(config.ExperimentalElmish, Is.True)
+
+[<Test>]
+let fsharp_experimental_double_indent_parameters () =
+    let rootDir = tempName ()
+
+    let editorConfig =
+        """
+[*.fs]
+fsharp_experimental_double_indent_parameters = true
+"""
+
+    use configFixture =
+        new ConfigurationFile(defaultConfig, rootDir, content = editorConfig)
+
+    use fsharpFile = new FSharpFile(rootDir)
+
+    let config = EditorConfig.readConfiguration fsharpFile.FSharpFile
+
+    Assert.That(config.ExperimentalDoubleIndentParameters, Is.True)


### PR DESCRIPTION
Quick implementation of having double indentation for long function signature parameters.

//cc @auduchinok @dawedawe @josh-degraw @Smaug123 

Note that the equals sign rule didn't change. The [guide](https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting) is pretty clear on that. It goes on its own line. 
Unless the last parameter is a long tuple.

For the sake of source control, I wouldn't change that:

![image](https://github.com/fsprojects/fantomas/assets/2621499/9e7a69d4-5e86-48fb-bc3a-5506605f862c)

![image](https://github.com/fsprojects/fantomas/assets/2621499/2fe957eb-3814-46fb-a161-418cb1e2b7c6)
