### PR TITLE
Don't put `=` on the same line for when last parameter is single line tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Equals sign should only be on same line if last tuple is multiline. [#3040](https://github.com/fsprojects/fantomas/issues/3040)
+
 ## 6.3.0-alpha-007 - 2024-01-27
 
 ### Changed

--- a/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
+++ b/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
@@ -1490,7 +1490,8 @@ type RequestParser<'ctx, 'a> =
           prohibited: ProhibitedRequestGetter list }
 
     static member internal Create
-        (consumedFields, parse: 'ctx -> Request -> Async<Result<'a, Error list>>) : RequestParser<'ctx, 'a> =
+        (consumedFields, parse: 'ctx -> Request -> Async<Result<'a, Error list>>)
+        : RequestParser<'ctx, 'a> =
         { consumedFields = consumedFields
           parse = parse
           prohibited = [] }

--- a/src/Fantomas.Core.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Core.Tests/FunctionDefinitionTests.fs
@@ -1106,7 +1106,8 @@ let longFunctionWithLongTupleParameter
         equal
         """
 let longFunctionWithLongTupleParameter
-    (aVeryLongParam, aSecondVeryLongParam, aThirdVeryLongParam, aFourthVeryLongParam) =
+    (aVeryLongParam, aSecondVeryLongParam, aThirdVeryLongParam, aFourthVeryLongParam)
+    =
     // ... the body of the method follows
     ()
 """

--- a/src/Fantomas.Core.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Core.Tests/LetBindingTests.fs
@@ -2284,3 +2284,31 @@ let bar
     //
     ()
 """
+
+[<Test>]
+let ``equals sign should not be on same line when last tuple is single line, 3040`` () =
+    formatSourceString
+        """
+let processSnippetLine
+    (checkResults: FSharpCheckFileResults)
+    (semanticRanges: SemanticClassificationItem array)
+    (lines: string array)
+    (line: int, lineTokens: SnippetLine)
+    =
+    let lineStr = lines.[line]
+    ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let processSnippetLine
+    (checkResults: FSharpCheckFileResults)
+    (semanticRanges: SemanticClassificationItem array)
+    (lines: string array)
+    (line: int, lineTokens: SnippetLine)
+    =
+    let lineStr = lines.[line]
+    ()
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2876,7 +2876,7 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
                 ///         p2_3
                 ///     ) : rt =
                 ///
-                /// AlignFunctionSignatureToIndentation will always place `rt` and `=` on there own lines:
+                /// AlignFunctionSignatureToIndentation will always place `rt` and `=` on their own lines:
                 /// let fn
                 ///     p1
                 ///     p2

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2839,6 +2839,8 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
                         ifElse addSpaceBeforeParensInFunDef sepSpace sepNone
                     | _ -> sepSpace
 
+                /// Format everything in one line:
+                /// let fn p1 p2 : rt =
                 let short =
                     afterLetKeyword
                     +> sepSpace
@@ -2849,12 +2851,54 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
                     +> sepSpace
                     +> genSingleTextNode b.Equals
 
+                /// Format over multiple lines
+                /// AlternativeLongMemberDefinitions or AlignFunctionSignatureToIndentation can influence the equals and return type.
+                ///
+                /// By default we go with:
+                /// let fn
+                ///     p1
+                ///     p2
+                ///     : rt =
+                ///
+                /// When `rt` is multiline, `=` is placed on the next line:
+                /// let fn
+                ///     p1
+                ///     p2
+                ///     : rt
+                ///     =
+                ///
+                /// When the p2 is a multiline tuple, there are different rules formatting rules:
+                /// let fn
+                ///     p1
+                ///     (
+                ///         p2_1,
+                ///         p2_2,
+                ///         p2_3
+                ///     ) : rt =
+                ///
+                /// AlignFunctionSignatureToIndentation will always place `rt` and `=` on there own lines:
+                /// let fn
+                ///     p1
+                ///     p2
+                ///     : rt
+                ///     =
+                ///
+                /// This happens regardless whether p2 is a multiline tuple:
+                /// let fn
+                ///     p1
+                ///     (
+                ///         p2_1,
+                ///         p2_2,
+                ///         p2_3
+                ///     )
+                ///     : rt
+                ///     =
                 let long (ctx: Context) =
-                    let endsWithTupleParameter =
+                    let endsWithMultilineTupleParameter =
                         match List.tryLast b.Parameters with
-                        | Some(Pattern.Paren parenNode) ->
+                        | Some(Pattern.Paren parenNode as p) ->
                             match parenNode.Pattern with
-                            | Pattern.Tuple _ -> true
+                            | Pattern.Tuple _ -> futureNlnCheck (genLongParenPatParameter p) ctx
                             | _ -> false
                         | _ -> false
 
@@ -2875,6 +2919,8 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
 
                         beforeInline || beforeIdentifier || beforeAccessibility
 
+                    let nlnOnSeparateLine = not endsWithMultilineTupleParameter || alternativeSyntax
+
                     (onlyIf hasTriviaAfterLeadingKeyword indent
                      +> afterLetKeyword
                      +> sepSpace
@@ -2882,14 +2928,12 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
                      +> indent
                      +> sepNln
                      +> genParameters
-                     +> onlyIf (not endsWithTupleParameter || alternativeSyntax) sepNln
-                     +> leadingExpressionIsMultiline
-                         (genReturnType (not endsWithTupleParameter || alternativeSyntax))
-                         (fun isMultiline ->
-                             if (alternativeSyntax && Option.isSome b.ReturnType) || isMultiline then
-                                 sepNln +> genSingleTextNode b.Equals
-                             else
-                                 sepSpace +> genSingleTextNode b.Equals)
+                     +> onlyIf nlnOnSeparateLine sepNln
+                     +> leadingExpressionIsMultiline (genReturnType nlnOnSeparateLine) (fun isMultiline ->
+                         if (alternativeSyntax && Option.isSome b.ReturnType) || isMultiline then
+                             sepNln +> genSingleTextNode b.Equals
+                         else
+                             sepSpace +> genSingleTextNode b.Equals)
                      +> unindent
                      +> onlyIf hasTriviaAfterLeadingKeyword unindent)
                         ctx


### PR DESCRIPTION
Fixes #3040.

Ready for review @josh-degraw.

It also makes me wonder whether having the return type on the same line for multiline tuple really is worth the exception. [Sample](https://fsprojects.github.io/fantomas-tools/#/fantomas/main?data=N4KABGBEDGD2AmBTSAuKAbRAXMAzAdgDoBOh%2BEEADgIwlkVgAUd5DFlATAPrUA0Lbdtw79SrQZy4BmARQCUYNMRwBeWREZyWLLAE9KiMAA11TLWIZqLFALaIbAI0TEwADwB0ATVMMaPiszWgr7cfP4SwqL0wSHS4WAKSqrxmtpimDgEHKZ%2BQUzxsWF5MZIiBUJxeebRVDJ5SWAqZmlkegbG2XmpeVY1YHaOzm5enX2%2BtMUB5VShUeIxYKVzCxV1Y-LxlGvzDA29OwHV%2BJC84FAAzthYAJb4AObnqGAA2mcQoIKQACRtyGiQtywJzeFG%2BADcAIboACufxeIIYAAZTjFIABJfBIfBYADK1wAXsgUcEACwIsAAXRBAF9ie9yd9fk8AdjgZ8vpCYXDXjE%2BOSIJAALIQ1wAGVuiFFiHuWAAFmzgtRyVSGLSQR82Iz9HDINL4AB5XDi-CIHF6TAKhjgqGwp484IiflQACimMNxqJTsg6FwkGVNLpYA1Vp%2B2uZDlgsHQltBHJt3KdUkDVoxl2UADFblCAHKIADu6AlMYYWGIsP9qsDwdjTP%2BEajxagca5dqdJOToJxlAh0EQACFELhYMREAAFCHECF2LDORsQUvlwQqihqhjVgWhgzhyPRjvWltoe2CACsHYFXZ7-cHw8lsDzzmgEMuGLBsEfN1gxzPYAXiArK6rBlNx1etdyAzlbUPJ0ADZv0gC9ewHIcRwAVUoAxiEfZ98Ffd9rk-Oc8ChS5-wgVcKHXJtaygUDG33SD4RiAB2OCEKvZDEAAYXQJ9zk4z9zgXaAsGHQjcGIv8lwDdUgOoyBaL3ZsGKPNgAA5WO7RDrxHQV7CcYgxIk0iwHI%2Bl2TkhTwPjVsYgATg0y8kJvfj0AI79xPQEipMrGTzLDOsdzopSE15ZEvTYgBBXAZ2IfibBsCFCN-YzTKDWT-JowLFIgkLFT5VE2KckccXsa44Fcr8nQ8ry2GXMjAL8rcAobbLrKg3lHQKzTECimKSpsMqozcp1ku8gDfM1YDtxaqyD0YxUk3C7qIuIWBoUxAARRBCwGmKkrLSTauktd0qaqBASCnKbMVdsvWFVw0VwAAVWVpRxWVhywAB1a54DlQjERShrJrki7WrmlSGGoU87pFR6XulZ1PNND7lB%2Bv75W-aDAbG%2BqJpDUHWXB5SnWoWDYYe-BcGuVx9QwiEROIZ1XEoEdznOfDKpiVScaOnyTsanUwdmkneRYimACVEDgYh4HR-7vxJXmGDqkzgYJjKWSBYncsEah1Ml6Xh3gbNoUGYhDTRGcbEeb8lVxtX8ZrTWbGhdAbkLE102HBKsBip6wx1669fsr0pZl%2BBBTdj2JW94hfb2uDoFlCcexirg81%2B-6gadjdCe1kXdbYDgwtRe6VsnXR9WIcVBPlzGnR5nOBZBzXhfZK72odfLgiFEUK4hKua%2BuQTTfNy3rdt0nm4o06dVd93rk9xA44T5wA63IOu8EDhOt7geh9rrAo8X5fV4ZxOvWT1PhOcDOs-lGezNbs6tcutr5p3xay5FAA1eM%2By3HgLcO49dCJNwdqlSiWpX7t0mp3T%2Bxdbo-1cOmdawlOaAMxCAsBitlYUFVlAuezI4EhgQZDCgHAYYoI2rALAABxbAzNWaIHZpzXBjd8EQEIerZ2r9LIdw-hQiAHByaolzAWCUA4sD3mlBvRAW1qb4GuB%2BfAEVMS6XNlPGIo0%2BbjRbhrfhWVC7B2LuLVEEVCx3HwGg-AGDPx4msQzaEI4nqwAxFiLADNOaGWRk-NKgtppgUERDJ0HADYWPds4fA3iwS3nuJo-SijbgqM5to4I1VDoq2OrPQJzVgnwKEWE0OZdo7XA9KKKcDh4AQm4rADm9wJHL18TVbJ-NckvxAsYkJotghSFLr3Zhzhrh2GxFCAA0ogRAlAPHSiwBiPsk47ENxiJk-x0Cpr5PfqEmIUge6fD7DxfAABrD05wVprUxLmQSiBI5lOXswtmHMBL7UXHovGBi%2BFdJmj0ouDApB7wOROIqCiR7QGICMrMM54AoWUZ%2BLa0AeKTlUS0rJBCcnP0MfPe5UjJzQGOdgM0ugLRb0Qf87%2BvcT4xxNIsnsBLcTmk9KicFU4DDwD9JA3hec25ExMdvNgUhkG90mdM%2B6Y99KGkORCE5ZzCLUERFwykGKAmdKCds3pggpDUN7k0qR2lEBUqXhKOKlBoReNUY81hzyubBF0W0-RHSsVqtJcIsAUgxGDJZsM0ZXj0BIwGucFZGSjKQLOBSYkAJzjpg5k8NZ1IgA)