### PR TITLE
Remove nuget

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,3 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "nuget"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-


### PR DESCRIPTION
Now I remember why we didn't do this in the first place.
Dependabot doesn't do lock files.
Sorry for the noise.