### PR TITLE
Check Hash Directive more strictly inside of lists or arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.3.4 - 2024-04-16
+
+### Fixed
+* Regression: An empty line or comment at the end of a list breaks Stroustrup formatting. [#3079](https://github.com/fsprojects/fantomas/issues/3079)
+
 ## 6.3.3 - 2024-04-12
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionExpressionTests.fs
@@ -96,31 +96,6 @@ let x y = [
 """
 
 [<Test>]
-let ``hash directive before closing list bracket, 3070`` () =
-    formatSourceString
-        """
-let private knownProviders = [
-#if !FABLE_COMPILER
-    (SerilogProvider.isAvailable, SerilogProvider.create)
-    (MicrosoftExtensionsLoggingProvider.isAvailable, MicrosoftExtensionsLoggingProvider.create)
-#endif
-                                        ]
-"""
-        config
-    |> prepend newline
-    |> should
-        equal
-        """
-let private knownProviders =
-    [
-#if !FABLE_COMPILER
-        (SerilogProvider.isAvailable, SerilogProvider.create)
-        (MicrosoftExtensionsLoggingProvider.isAvailable, MicrosoftExtensionsLoggingProvider.create)
-#endif
-    ]
-"""
-
-[<Test>]
 let ``hash directive before closing list bracket, nested let binding`` () =
     formatSourceString
         """

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -736,3 +736,99 @@ let b = // Build an inbound for the specified subnet.
         Tags = Map.empty
     }
 """
+
+[<Test>]
+let ``hash directive before closing list bracket, 3070`` () =
+    formatSourceString
+        """
+let private knownProviders = [
+#if !FABLE_COMPILER
+    (SerilogProvider.isAvailable, SerilogProvider.create)
+    (MicrosoftExtensionsLoggingProvider.isAvailable, MicrosoftExtensionsLoggingProvider.create)
+#endif
+                                        ]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let private knownProviders =
+    [
+#if !FABLE_COMPILER
+        (SerilogProvider.isAvailable, SerilogProvider.create)
+        (MicrosoftExtensionsLoggingProvider.isAvailable, MicrosoftExtensionsLoggingProvider.create)
+#endif
+    ]
+"""
+
+[<Test>]
+let ``empty line before closing list bracket, 3079`` () =
+    formatSourceString
+        """
+let list = [
+    someItem
+
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let list = [
+    someItem
+
+]
+"""
+
+[<Test>]
+let ``comment before closing list bracket, 3079`` () =
+    formatSourceString
+        """
+let list = [
+    someItem
+    // comment
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let list = [
+    someItem
+// comment
+]
+"""
+
+[<Test>]
+let ``comment before closing list bracket with hash directive`` () =
+    formatSourceString
+        """
+let list = [
+    someItem
+    #if something
+    item1
+    #else
+    item2
+    #endif
+    // comment
+                ]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let list =
+    [
+        someItem
+#if something
+        item1
+#else
+        item2
+#endif
+    // comment
+    ]
+"""

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -938,7 +938,12 @@ let indentSepNlnUnindentUnlessStroustrup f (e: Expr) (ctx: Context) =
     let shouldUseStroustrup =
         let isArrayOrListWithHashDirectiveBeforeClosingBracket () =
             match e with
-            | Expr.ArrayOrList node -> Seq.isEmpty node.Closing.ContentBefore
+            | Expr.ArrayOrList node ->
+                node.Closing.ContentBefore
+                |> Seq.forall (fun x ->
+                    match x.Content with
+                    | TriviaContent.Directive _ -> false
+                    | _ -> true)
             | _ -> true
 
         isStroustrupStyleExpr ctx.Config e


### PR DESCRIPTION
Resolves https://github.com/fsprojects/fantomas/issues/3079

Instead of giving up on Stroustrup-Formatting whenever there is Trivia on the closing brackets, only do that for HashDirectives and allow any other kind of Trivia such as comments or NewLines