### PR TITLE
rolForward to latestPatch to let build succeed on systems with 8.0.30…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
         <PackageVersion Include="Serilog" Version="3.1.1"/>
         <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.1" />
         <PackageVersion Include="SerilogTraceListener" Version="3.2.1-dev-00011" />
-        <PackageVersion Include="Argu" Version="6.1.1" />
+        <PackageVersion Include="Argu" Version="6.2.4" />
         <PackageVersion Include="Thoth.Json.Net" Version="8.0.0" />
         <PackageVersion Include="editorconfig" Version="0.15.0" />
         <PackageVersion Include="Ignore" Version="0.1.50" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.200",
-    "rollForward": "latestPatch"
+    "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.200",
-    "rollForward": "latestMinor"
+    "rollForward": "latestPatch"
   }
 }

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -825,7 +825,7 @@
       "fantomas": {
         "type": "Project",
         "dependencies": {
-          "Argu": "[6.1.1, )",
+          "Argu": "[6.2.4, )",
           "FSharp.Core": "[6.0.1, )",
           "Fantomas.Client": "[1.0.0, )",
           "Fantomas.Core": "[1.0.0, )",
@@ -867,11 +867,11 @@
       },
       "Argu": {
         "type": "CentralTransitive",
-        "requested": "[6.1.1, )",
-        "resolved": "6.1.1",
-        "contentHash": "5SBLYihaZ6/YNpRU+0v0QLsCk7ABmOWNOUwkXVUql2w7kJ6Hi4AFhgIv5XLTtxTid5/xrJAL+PglQkNcjANCJg==",
+        "requested": "[6.2.4, )",
+        "resolved": "6.2.4",
+        "contentHash": "RuANu8+L1P2HWozmbRXkj6MQGYwP5DL2wdARfBPtRjsLS8TSgwYjOKxMnY5LtjmHLlMBD3u2+MfbAy8xMGg8Qg==",
         "dependencies": {
-          "FSharp.Core": "4.3.2",
+          "FSharp.Core": "6.0.7",
           "System.Configuration.ConfigurationManager": "4.4.0"
         }
       },

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -4,11 +4,11 @@
     "net6.0": {
       "Argu": {
         "type": "Direct",
-        "requested": "[6.1.1, )",
-        "resolved": "6.1.1",
-        "contentHash": "5SBLYihaZ6/YNpRU+0v0QLsCk7ABmOWNOUwkXVUql2w7kJ6Hi4AFhgIv5XLTtxTid5/xrJAL+PglQkNcjANCJg==",
+        "requested": "[6.2.4, )",
+        "resolved": "6.2.4",
+        "contentHash": "RuANu8+L1P2HWozmbRXkj6MQGYwP5DL2wdARfBPtRjsLS8TSgwYjOKxMnY5LtjmHLlMBD3u2+MfbAy8xMGg8Qg==",
         "dependencies": {
-          "FSharp.Core": "4.3.2",
+          "FSharp.Core": "6.0.7",
           "System.Configuration.ConfigurationManager": "4.4.0"
         }
       },


### PR DESCRIPTION
I might be missing something, but on my system LangVersion Preview and 8.0.300 have the effect that the argu attributes are reported as errors. So while argu has no compatible version out yet, let's stay with latestPatch