### PR TITLE
Fix exn in (|UppercaseExpr|LowercaseExpr|)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Fix case determination issue with ExprAppSingleParenArgNode. [#3088](https://github.com/fsprojects/fantomas/issues/3088)
+
 ## 6.3.5 - 2024-05-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 6.3.6 - 2024-06-01
 
 ### Fixed
 * Fix case determination issue with ExprAppSingleParenArgNode. [#3088](https://github.com/fsprojects/fantomas/issues/3088)

--- a/src/Fantomas.Core.Tests/DynamicOperatorTests.fs
+++ b/src/Fantomas.Core.Tests/DynamicOperatorTests.fs
@@ -76,3 +76,37 @@ let ``preserve back ticks from checked keyword, 937`` () =
         """
 let toggle = unbox<bool> (e.target?``checked``)
 """
+
+[<Test>]
+let ``case determination issue with ExprAppSingleParenArgNode, 3088`` () =
+    formatSourceString
+        """
+let doc = x?a("")?b(t)?b(t)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let doc = x?a ("")?b (t)?b (t)
+"""
+
+[<Test>]
+let ``case determination issue with ExprAppSingleParenArgNode uppercase with config lower, 3088`` () =
+    // We want to disobey SpaceBefore(Upper|Lower)caseInvocation inside of the ? chain because mixing it up can generate invalid code like x?a("arg")?B ("barg")?c("carg")
+    // The space config that is used (Upper or Lower) depends on the case of the dynamic object, here x
+    formatSourceString
+        """
+let doc1 = x?a("arg")?B("barg")?c("carg")
+let doc2 = X?a("arg")?B("barg")?c("carg")
+"""
+        { config with
+            SpaceBeforeLowercaseInvocation = false
+            SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let doc1 = x?a("arg")?B("barg")?c("carg")
+let doc2 = X?a ("arg")?B ("barg")?c ("carg")
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -57,6 +57,7 @@ let rec (|UppercaseExpr|LowercaseExpr|) (expr: Expr) =
     | Expr.DotIndexedGet node -> (|UppercaseExpr|LowercaseExpr|) node.ObjectExpr
     | Expr.TypeApp node -> (|UppercaseExpr|LowercaseExpr|) node.Identifier
     | Expr.Dynamic node -> (|UppercaseExpr|LowercaseExpr|) node.FuncExpr
+    | Expr.AppSingleParenArg node -> (|UppercaseExpr|LowercaseExpr|) node.FunctionExpr
     | _ -> failwithf "cannot determine if Expr %A is uppercase or lowercase" expr
 
 let (|ParenExpr|_|) (e: Expr) =


### PR DESCRIPTION
fixes #3088 

As written in the comment in the tests, I think we are better off not trying to apply the SpaceBefore(Upper|Lower)caseInvocation setting in the ? call chain as that can easily produce invalid code.