### PR TITLE
Use DOTNET_CLI_HOME for finding fantomas as global tool (Fixes #3104)

### DIFF
--- a/src/Fantomas.Client/CHANGELOG.md
+++ b/src/Fantomas.Client/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 This is the changelog for the Fantomas.Client package specifically. It's distinct from that of the overall libraries and command-line tool.
 
-## [Unreleased]
+## 0.9.1 - 2024-08-19
 
-### Changed
-* Fixed: Fantomas.Client does not respect DOTNET_CLI_HOME env variable. [#3104](https://github.com/fsprojects/fantomas/issues/3104)
+### Fixed
+* Fantomas.Client does not respect DOTNET_CLI_HOME env variable. [#3104](https://github.com/fsprojects/fantomas/issues/3104)
 
 ## 0.9.0 - 2023-02-24
 * Fix JSON serialization of new cursor API. [#2778](https://github.com/fsprojects/fantomas/issues/2778)

--- a/src/Fantomas.Client/CHANGELOG.md
+++ b/src/Fantomas.Client/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is the changelog for the Fantomas.Client package specifically. It's distinct from that of the overall libraries and command-line tool.
 
+## [Unreleased]
+
+### Changed
+* Fixed: Fantomas.Client does not respect DOTNET_CLI_HOME env variable. [#3104](https://github.com/fsprojects/fantomas/issues/3104)
+
 ## 0.9.0 - 2023-02-24
 * Fix JSON serialization of new cursor API. [#2778](https://github.com/fsprojects/fantomas/issues/2778)
 

--- a/src/Fantomas.Client/FantomasToolLocator.fs
+++ b/src/Fantomas.Client/FantomasToolLocator.fs
@@ -202,11 +202,16 @@ let createFor (startInfo: FantomasToolStartInfo) : Result<RunningFantomasTool, P
             ps.Arguments <- "fantomas --daemon"
             ps
         | FantomasToolStartInfo.GlobalTool ->
-            let userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+
+            let globalToolsPath =
+                match Option.ofObj (Environment.GetEnvironmentVariable("DOTNET_CLI_HOME")) with
+                | Some s -> Path.Combine(s, "tools")
+                | None ->
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet", "tools")
 
             let fantomasExecutable =
                 let fileName = if isWindows then "fantomas.exe" else "fantomas"
-                Path.Combine(userProfile, ".dotnet", "tools", fileName)
+                Path.Combine(globalToolsPath, fileName)
 
             let ps = ProcessStartInfo(fantomasExecutable)
             ps.Arguments <- "--daemon"


### PR DESCRIPTION
See issue: https://github.com/fsprojects/fantomas/issues/3104

```DOTNET_CLI_HOME``` can be used to specify alternate locations of global tools rather than the user's home directory.

See: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables

Tested using local script:

fsharp
```
#r "artifacts/bin/Fantomas.Client/release/Fantomas.Client.dll"
#r "nuget: SemanticVersioning"
#r "nuget: StreamJsonRpc"

open System
open Fantomas.Client
open Fantomas.Client.FantomasToolLocator
open Fantomas.Client.LSPFantomasServiceTypes

Environment.CurrentDirectory <- "/home/jovyan"
let cwd = Environment.CurrentDirectory
let cwdFolder = Fantomas.Client.LSPFantomasServiceTypes.Folder cwd

let fantomasToolResult: Result<FantomasToolFound, FantomasToolError> =
    findFantomasTool cwdFolder


let toolInfo = 
    match fantomasToolResult with
    | Ok (FantomasToolFound (version, toolInfo)) -> toolInfo
    | Error error ->
        // Handle the error case
        failwithf "Error: %A" error

let cfRes = createFor toolInfo
```

with ```DOTNET_CLI_HOME``` set to ```/opt/dotnet```