### PR TITLE
Correctly print out attributes of SynMemberDefn.GetSetMember

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.3.12 - 2024-09-05
+
+### Fixed
+* Fantomas deletes attributes from getters. [#3114](https://github.com/fsprojects/fantomas/issues/3114)
+
 ## 6.3.11 - 2024-08-16
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/AttributeTests.fs
+++ b/src/Fantomas.Core.Tests/AttributeTests.fs
@@ -1050,3 +1050,51 @@ let ``trivia in nested multiline tuple expression in attribute, 2525`` () =
                             Justification = "Bytecode delta only")>]
 ()
 """
+
+[<Test>]
+let ``attributes on member and get, set properties`` () =
+    formatSourceString
+        """
+type Object3D() =
+    [<X>]
+    member this.position
+        with [<Y>] set v = _position <- v 
+        and [<Z>] get () = _position
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Object3D() =
+    [<X>]
+    member this.position
+        with [<Y>] set v = _position <- v
+        and [<Z>] get () = _position
+"""
+
+[<Test>]
+let ``attributes on get,set properties, 3114`` () =
+    formatSourceString
+        """
+[<Erase>]
+type Object3D() =
+    let mutable _position: Vector3 = null
+
+    member this.position
+        with [<Emit("$0.position")>] set v = _position <- v 
+        and [<Emit("$0.position = $1")>] get () = _position
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<Erase>]
+type Object3D() =
+    let mutable _position: Vector3 = null
+
+    member this.position
+        with [<Emit("$0.position")>] set v = _position <- v
+        and [<Emit("$0.position = $1")>] get () = _position
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3877,6 +3877,7 @@ let genMemberDefn (md: MemberDefn) =
     | MemberDefn.PropertyGetSet node ->
         let genProperty (node: PropertyGetSetBindingNode) =
             genInlineOpt node.Inline
+            +> genOnelinerAttributes node.Attributes
             +> genAccessOpt node.Accessibility
             +> genSingleTextNode node.LeadingKeyword
             +> sepSpace

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -2521,6 +2521,7 @@ type MemberDefnAbstractSlotNode
 type PropertyGetSetBindingNode
     (
         inlineNode: SingleTextNode option,
+        attributes: MultipleAttributeListNode option,
         accessibility: SingleTextNode option,
         leadingKeyword: SingleTextNode,
         parameters: Pattern list,
@@ -2533,6 +2534,7 @@ type PropertyGetSetBindingNode
 
     override val Children: Node array =
         [| yield! noa inlineNode
+           yield! noa attributes
            yield! noa accessibility
            yield leadingKeyword
            yield! List.map Pattern.Node parameters
@@ -2541,6 +2543,7 @@ type PropertyGetSetBindingNode
            yield Expr.Node expr |]
 
     member val Inline = inlineNode
+    member val Attributes = attributes
     member val Accessibility = accessibility
     member val LeadingKeyword = leadingKeyword
     member val Parameters = parameters


### PR DESCRIPTION
Okay, this one was mildly interesting, turns out we the attributes AST can have duplicate entries for the properties. I don't think we ever got this right, v4 in the online tool does not produce the right code either.

Fixes #3114 