### PR TITLE
fix idempotency for single case union w/o pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [Unreleased]
+## 6.3.13 - 2024-09-10
 
 ### Fixed
-* Fix idempotency issue when defining a single case union with an extension [#3102](https://github.com/fsprojects/fantomas/issues/3102)
+* Idempotency problem when adding members to a single case union without a pipe [#3102](https://github.com/fsprojects/fantomas/issues/3102)
 
 ## 6.3.12 - 2024-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Fix idempotency issue when defining a single case union with an extension [#3102](https://github.com/fsprojects/fantomas/issues/3102)
+
 ## 6.3.12 - 2024-09-05
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -3643,3 +3643,42 @@ type FSharpChecker with
         : Async<(FSharpParseFileResults * ParsedInput * FSharpCheckFileResults) option> =
         ()
 """
+
+[<Test>]
+let ``single member union extensions without pipe, 3102`` () =
+    formatSourceString
+        """
+type X = X
+    with
+        static member x = 1
+    """
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type X = X
+    with
+
+        static member x = 1
+"""
+
+[<Test>]
+let ``single member union extensions without pipe idempotent, 3102`` () =
+    formatSourceString
+        """
+type X = X
+    with
+
+        static member x = 1
+    """
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type X = X
+    with
+
+        static member x = 1
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3585,18 +3585,16 @@ let genTypeDefn (td: TypeDefn) =
              | _ ->
                  header
                  +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (genType node.Type)
-                 +> onlyIf
-                     hasMembers
-                     (optSingle
-                         (fun withNode ->
-                             indentSepNlnUnindent (
-                                 genSingleTextNode withNode
-                                 +> onlyIfCtx
-                                     (fun ctx -> ctx.Config.NewlineBetweenTypeDefinitionAndMembers)
-                                     (sepNlnUnlessContentBefore (MemberDefn.Node members.[0]))
-                                 +> indentSepNlnUnindent (genMemberDefnList members)
-                             ))
-                         typeName.WithKeyword)
+                 +> (match List.tryHead members, typeName.WithKeyword with
+                     | Some firstMember, Some withNode ->
+                         indentSepNlnUnindent (
+                             genSingleTextNode withNode
+                             +> onlyIfCtx
+                                 (fun ctx -> ctx.Config.NewlineBetweenTypeDefinitionAndMembers)
+                                 (sepNlnUnlessContentBefore (MemberDefn.Node firstMember))
+                             +> indentSepNlnUnindent (genMemberDefnList members)
+                         )
+                     | _ -> sepNone)
                  |> genNode node)
                 ctx
     | TypeDefn.Explicit node ->

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3591,7 +3591,9 @@ let genTypeDefn (td: TypeDefn) =
                          (fun withNode ->
                              indentSepNlnUnindent (
                                  genSingleTextNode withNode
-                                 +> onlyIfCtx (fun ctx -> ctx.Config.NewlineBetweenTypeDefinitionAndMembers) sepNln
+                                 +> onlyIfCtx
+                                     (fun ctx -> ctx.Config.NewlineBetweenTypeDefinitionAndMembers)
+                                     (sepNlnUnlessContentBefore (MemberDefn.Node members.[0]))
                                  +> indentSepNlnUnindent (genMemberDefnList members)
                              ))
                          typeName.WithKeyword)


### PR DESCRIPTION
Fixes idempotency issue when a single-case union extension is not started with a pipe #3102. Without this change, the body of the extension body is moved one line downward on each format run.