### PR TITLE
Check if we just wrote a DotLambda on a record value before deciding on space before parens, fix 3120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Idempotency problem when _.Property shorthand with record value. [#3120](https://github.com/fsprojects/fantomas/issues/3120)
+
 ## 6.3.13 - 2024-09-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 6.3.14 - 2024-09-14
 
 ### Fixed
 * Idempotency problem when _.Property shorthand with record value. [#3120](https://github.com/fsprojects/fantomas/issues/3120)

--- a/src/Fantomas.Core.Tests/DotLambdaTests.fs
+++ b/src/Fantomas.Core.Tests/DotLambdaTests.fs
@@ -76,7 +76,7 @@ let ``idempotency problem when _.Property shorthand, 3050`` () =
 """
 
 [<Test>]
-let ``idempotency problem with _.Property shorthand with record value,`` () =
+let ``idempotency problem with _.Property shorthand with record value, 3120`` () =
     formatSourceString
         """
 _.A.ToLower()

--- a/src/Fantomas.Core.Tests/DotLambdaTests.fs
+++ b/src/Fantomas.Core.Tests/DotLambdaTests.fs
@@ -76,6 +76,21 @@ let ``idempotency problem when _.Property shorthand, 3050`` () =
 """
 
 [<Test>]
+let ``idempotency problem with _.Property shorthand with record value,`` () =
+    formatSourceString
+        """
+_.A.ToLower()
+"""
+        { config with
+            SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+_.A.ToLower()
+"""
+
+[<Test>]
 let ``idempotency problem when _.property shorthand lowercase, 3050`` () =
     formatSourceString
         """

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1572,6 +1572,7 @@ let genExpr (e: Expr) =
         let genDotLambdaExpr expr =
             match expr with
             | Expr.AppSingleParenArg p -> genAppSingleParenArgExpr sepNone p // be always atomic, see 3050
+            | Expr.AppLongIdentAndSingleParenArg p -> genAppLongIdentAndSingleParenArgExpr sepNone p
             | _ -> genExpr expr
 
         genSingleTextNode node.Underscore

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1572,7 +1572,7 @@ let genExpr (e: Expr) =
         let genDotLambdaExpr expr =
             match expr with
             | Expr.AppSingleParenArg p -> genAppSingleParenArgExpr sepNone p // be always atomic, see 3050
-            | Expr.AppLongIdentAndSingleParenArg p -> genAppLongIdentAndSingleParenArgExpr sepNone p
+            | Expr.AppLongIdentAndSingleParenArg p -> genAppLongIdentAndSingleParenArgExpr sepNone p // see 3120
             | _ -> genExpr expr
 
         genSingleTextNode node.Underscore


### PR DESCRIPTION
fixes #3120 