### PR TITLE
Ensure endsWithMultilineTupleParameter happens with correct Context.

### DIFF
--- a/src/Fantomas.Core.Tests/ClassTests.fs
+++ b/src/Fantomas.Core.Tests/ClassTests.fs
@@ -1323,3 +1323,22 @@ type X() =
         // some comment
         with get, set
 """
+
+[<Test>]
+let ``long tuple on single line, 3124`` () =
+    formatSourceString
+        """
+type Y =
+    static member putItem (client: AmazonDynamoDBClient, tableName: string,  attributeValueDict: Dictionary<string, AttributeValue>) : TaskResult<unit,Error> =   ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Y =
+    static member putItem
+        (client: AmazonDynamoDBClient, tableName: string, attributeValueDict: Dictionary<string, AttributeValue>)
+        : TaskResult<unit, Error> =
+        ()
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2924,7 +2924,7 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
                 ///     : rt
                 ///     =
                 let long (ctx: Context) =
-                    let endsWithMultilineTupleParameter =
+                    let endsWithMultilineTupleParameter ctx =
                         match List.tryLast b.Parameters with
                         | Some(Pattern.Paren parenNode as p) ->
                             match parenNode.Pattern with
@@ -2949,21 +2949,24 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
 
                         beforeInline || beforeIdentifier || beforeAccessibility
 
-                    let nlnOnSeparateLine = not endsWithMultilineTupleParameter || alternativeSyntax
-
                     (onlyIf hasTriviaAfterLeadingKeyword indent
                      +> afterLetKeyword
                      +> sepSpace
                      +> genFunctionName
                      +> indent
                      +> sepNln
-                     +> genParameters
-                     +> onlyIf nlnOnSeparateLine sepNln
-                     +> leadingExpressionIsMultiline (genReturnType nlnOnSeparateLine) (fun isMultiline ->
-                         if (alternativeSyntax && Option.isSome b.ReturnType) || isMultiline then
-                             sepNln +> genSingleTextNode b.Equals
-                         else
-                             sepSpace +> genSingleTextNode b.Equals)
+                     +> (fun ctx ->
+                         let nlnOnSeparateLine =
+                             not (endsWithMultilineTupleParameter ctx) || alternativeSyntax
+
+                         (genParameters
+                          +> onlyIf nlnOnSeparateLine sepNln
+                          +> leadingExpressionIsMultiline (genReturnType nlnOnSeparateLine) (fun isMultiline ->
+                              if (alternativeSyntax && Option.isSome b.ReturnType) || isMultiline then
+                                  sepNln +> genSingleTextNode b.Equals
+                              else
+                                  sepSpace +> genSingleTextNode b.Equals))
+                             ctx)
                      +> unindent
                      +> onlyIf hasTriviaAfterLeadingKeyword unindent)
                         ctx


### PR DESCRIPTION
The check we are doing in `endsWithMultilineTupleParameter` was happening with a context at the start of the binding. This is not accurate and is fixed in this PR.

Fixes #3124

Targeting v7 because style fix.