### PR TITLE
Fix multiple line type expression with dotget idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
+## 6.3.16 - 2024-10-29
+
+### Fixed
+* Idempotency problem when calling multi-line discriminated union with generic type parameter. [#3132](https://github.com/fsprojects/fantomas/issues/3132)
+
 ## 6.3.15 - 2024-09-14
 
 ### Fixed
-* Non needed parentheses are added around lambda call from tuple/members [#3082](https://github.com/fsprojects/fantomas/issues/3082)
+* Non needed parentheses are added around lambda call from tuple/members. [#3082](https://github.com/fsprojects/fantomas/issues/3082)
 
 ## 6.3.14 - 2024-09-14
 

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -414,3 +414,29 @@ v().w.x.y.z['a'].b
         """
 v().w.x.y.z['a'].b
 """
+
+[<Test>]
+let ``multiple line type expression with dotget, 3132`` () =
+    formatSourceString
+        """
+Animal<
+    Identifier
+ >
+    .Dog(
+        "Spot"
+    )
+"""
+        { config with
+            MaxDotGetExpressionWidth = 0
+            MaxLineLength = 10 }
+    |> prepend newline
+    |> should
+        equal
+        """
+Animal<
+    Identifier
+ >
+    .Dog(
+        "Spot"
+    )
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1014,7 +1014,7 @@ let genExpr (e: Expr) =
                         (coli sepNone leadingChain (fun idx -> genLink (idx = lastIndex)))
                         (match leadingChain with
                          | [] -> sepNone
-                         | head :: rest -> genLink false head +> indentSepNlnUnindent (genIndentedLinks false rest))
+                         | head :: rest -> genLink false head +> indent +> genIndentedLinks true rest +> unindent)
                     +> indentSepNlnUnindent (genIndentedLinks false links)
 
             | head :: links -> genFirstLinkAndIndentOther head links

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1014,8 +1014,9 @@ let genExpr (e: Expr) =
                         (coli sepNone leadingChain (fun idx -> genLink (idx = lastIndex)))
                         (match leadingChain with
                          | [] -> sepNone
-                         | head :: rest -> genLink false head +> indent +> genIndentedLinks true rest +> unindent)
-                    +> indentSepNlnUnindent (genIndentedLinks false links)
+                         | [ head ] -> genLink false head
+                         | head :: rest -> genLink false head +> indentSepNlnUnindent (genIndentedLinks true rest))
+                    +> indentSepNlnUnindent (genIndentedLinks true links)
 
             | head :: links -> genFirstLinkAndIndentOther head links
 


### PR DESCRIPTION
Fixes https://github.com/fsprojects/fantomas/issues/3132

I don't fully understand the mechanism behind this idempotency problem, but it seems to only happen with a LeadingSimpleChain of length one, followed by a DotGet call. I changed the logic of printing multi-line leading chains to match how it is done if there are no links that follow the leading chain.

Please let me know if this change makes sense! I tested it to the best of my ability but I am not totally familiar with FSharp syntax and fantomas formatting guidelines.