### PR TITLE
Don't put a space before a prefix operator, unless we have to.

### DIFF
--- a/src/Fantomas.Core.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Core.Tests/ControlStructureTests.fs
@@ -644,7 +644,7 @@ let genPropertyWithGetSet astContext (b1, b2) rangeOfMember =
             genPreXmlDoc px
             +> genAttributes astContext ats
             +> genMemberFlags astContext mf1
-            +> ifElse isInline (!- "inline ") sepNone
+            +> ifElse isInline (!-"inline ") sepNone
             +> opt sepSpace ao genAccess
 
         assert (ps1 |> Seq.map fst |> Seq.forall Option.isNone)

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -134,6 +134,7 @@
     <Compile Include="BeginEndTests.fs" />
     <Compile Include="NullnessTests.fs" />
     <Compile Include="AutoPropertiesTests.fs" />
+    <Compile Include="PrefixTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Core\Fantomas.Core.fsproj" />

--- a/src/Fantomas.Core.Tests/InterpolatedStringTests.fs
+++ b/src/Fantomas.Core.Tests/InterpolatedStringTests.fs
@@ -166,20 +166,6 @@ $\"\"\"one: {1}<
 "
 
 [<Test>]
-let ``prefix application, 1414`` () =
-    formatSourceString
-        """
-!- $".{s}"
-"""
-        config
-    |> prepend newline
-    |> should
-        equal
-        """
-!- $".{s}"
-"""
-
-[<Test>]
 let ``format in FillExpr, 1549`` () =
     formatSourceString
         """

--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -354,7 +354,7 @@ let genMemberFlagsForMemberBinding astContext (mf: MemberFlags) (rangeOfBindingA
                     | Token { TokenInfo = { TokenName = "MEMBER" } } -> r.StartLine = rangeOfBindingAndRhs.StartLine
 
                     | _ -> false)
-                |> Option.defaultValue (!- "override ")
+                |> Option.defaultValue (!-"override ")
                 <| ctx)
         <| ctx
 """

--- a/src/Fantomas.Core.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Core.Tests/LetBindingTests.fs
@@ -1342,7 +1342,7 @@ let internal sepSpace =
         then
             ctx
         else
-            (!- " ") ctx
+            (!-" ") ctx
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -268,7 +268,7 @@ let expr =
         es
         (fun e ->
             match e with
-            | Paren(_, Lambda _, _) -> !- "lambda"
+            | Paren(_, Lambda _, _) -> !-"lambda"
             | _ -> genExpr astContext e
         )
 """

--- a/src/Fantomas.Core.Tests/OperatorTests.fs
+++ b/src/Fantomas.Core.Tests/OperatorTests.fs
@@ -6,41 +6,6 @@ open Fantomas.Core.Tests.TestHelpers
 open Fantomas.Core
 
 [<Test>]
-let ``should format prefix operators`` () =
-    formatSourceString
-        """let x = -y
-let z = !!x
-    """
-        config
-    |> should
-        equal
-        """let x = -y
-let z = !!x
-"""
-
-[<Test>]
-let ``should keep triple ~~~ operator`` () =
-    formatSourceString
-        """x ~~~FileAttributes.ReadOnly
-    """
-        config
-    |> should
-        equal
-        """x ~~~FileAttributes.ReadOnly
-"""
-
-[<Test>]
-let ``should keep single triple ~~~ operator`` () =
-    formatSourceString
-        """~~~FileAttributes.ReadOnly
-    """
-        config
-    |> should
-        equal
-        """~~~FileAttributes.ReadOnly
-"""
-
-[<Test>]
 let ``should keep parens around ? operator definition`` () =
     formatSourceString
         """let (?) f s = f s
@@ -60,17 +25,6 @@ let ``should keep parens around ?<- operator definition`` () =
     |> should
         equal
         """let (?<-) f s = f s
-"""
-
-[<Test>]
-let ``should keep parens around !+ prefix operator definition`` () =
-    formatSourceString
-        """let (!+) x = Include x
-    """
-        config
-    |> should
-        equal
-        """let (!+) x = Include x
 """
 
 [<Test>]
@@ -472,19 +426,6 @@ let ``equal sign operator should not move to next line`` () =
         """
 let result =
     (typ.GetInterface(typeof<System.Collections.IEnumerable>.FullName) = null)
-"""
-
-[<Test>]
-let ``operator before verbatim string add extra space, 736`` () =
-    formatSourceString
-        """Target M.Tools (fun _ -> !! @"Tools\Tools.sln" |> rebuild)
-"""
-        config
-    |> prepend newline
-    |> should
-        equal
-        """
-Target M.Tools (fun _ -> !! @"Tools\Tools.sln" |> rebuild)
 """
 
 [<Test>]
@@ -1178,42 +1119,6 @@ module Foo =
             | false -> id)
 """
 
-let operator_application_literal_values =
-    [ "-86y"
-      "86uy"
-      "-86s"
-      "86us"
-      "-86"
-      "-86l"
-      "86u"
-      "86ul"
-      "-123n"
-      "0x00002D3Fun"
-      "-86L"
-      "86UL"
-      "-4.41F"
-      "-4.14"
-      "-12456I"
-      "-0.7833M"
-      "'a'"
-      "\"text\""
-      "'a'B"
-      "\"text\"B" ]
-
-[<TestCaseSource("operator_application_literal_values")>]
-let ``operators maintain spacing from literal values`` (literalValue: string) =
-    formatSourceString
-        $"""
-let subtractTwo = + %s{literalValue}
-"""
-        config
-    |> prepend newline
-    |> should
-        equal
-        $"""
-let subtractTwo = + %s{literalValue}
-"""
-
 [<Test>]
 let ``qualified name to active pattern, 1937`` () =
     formatSourceString
@@ -1514,26 +1419,4 @@ let allDecls =
     inheritsL
     @+ iimplsLs
     @+ ctorLs
-"""
-
-[<Test>]
-let ``adding space after prefix operator breaks code, 2796`` () =
-    formatSourceString
-        """
-let inline (~%%) id = int id
-
-let f a b = a + b
-
-let foo () = f %%"17" %%"42"
-"""
-        config
-    |> prepend newline
-    |> should
-        equal
-        """
-let inline (~%%) id = int id
-
-let f a b = a + b
-
-let foo () = f %%"17" %%"42"
 """

--- a/src/Fantomas.Core.Tests/PrefixTests.fs
+++ b/src/Fantomas.Core.Tests/PrefixTests.fs
@@ -1,0 +1,169 @@
+﻿module Fantomas.Core.Tests.PrefixTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelpers
+open Fantomas.Core
+
+[<Test>]
+let ``should format prefix operators`` () =
+    formatSourceString
+        """let x = -y
+let z = !!x
+    """
+        config
+    |> should
+        equal
+        """let x = -y
+let z = !!x
+"""
+
+[<Test>]
+let ``should keep triple ~~~ operator`` () =
+    formatSourceString
+        """x ~~~FileAttributes.ReadOnly
+    """
+        config
+    |> should
+        equal
+        """x ~~~FileAttributes.ReadOnly
+"""
+
+[<Test>]
+let ``should keep single triple ~~~ operator`` () =
+    formatSourceString
+        """~~~FileAttributes.ReadOnly
+    """
+        config
+    |> should
+        equal
+        """~~~FileAttributes.ReadOnly
+"""
+
+[<Test>]
+let ``operator before verbatim string add extra space, 736`` () =
+    formatSourceString
+        """Target M.Tools (fun _ -> !! @"Tools\Tools.sln" |> rebuild)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+Target M.Tools (fun _ -> !! @"Tools\Tools.sln" |> rebuild)
+"""
+
+[<Test>]
+let ``should keep parens around !+ prefix operator definition`` () =
+    formatSourceString
+        """let (!+) x = Include x
+    """
+        config
+    |> should
+        equal
+        """let (!+) x = Include x
+"""
+
+[<Test>]
+let ``adding space after prefix operator breaks code, 2796`` () =
+    formatSourceString
+        """
+let inline (~%%) id = int id
+
+let f a b = a + b
+
+let foo () = f %%"17" %%"42"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let inline (~%%) id = int id
+
+let f a b = a + b
+
+let foo () = f %%"17" %%"42"
+"""
+
+[<Test>]
+let ``tilde unary operator with literal and variable, 3131`` () =
+    formatSourceString
+        """
+let x = ~~1
+let y = ~~x
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x = ~~1
+let y = ~~x
+"""
+
+[<Test>]
+let ``prefix application with interpolated string, 1414`` () =
+    formatSourceString
+        """
+!- $".{s}"
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+!- $".{s}"
+"""
+
+let operator_application_literal_values_with_sign =
+    [ "-86y"
+      "-86s"
+      "-86"
+      "-86l"
+      "-123n"
+      "-86L"
+      "-4.41F"
+      "-4.14"
+      "-12456I"
+      "-0.7833M" ]
+
+[<TestCaseSource("operator_application_literal_values_with_sign")>]
+let ``operators maintain spacing from literal values which start with + or -`` (literalValue: string) =
+    formatSourceString
+        $"""
+let subtractTwo = + %s{literalValue}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        $"""
+let subtractTwo = + %s{literalValue}
+"""
+
+let operator_application_literal_values_without_sign =
+    [ "86uy"
+      "86us"
+      "86u"
+      "86ul"
+      "0x00002D3Fun"
+      "86UL"
+      "'a'"
+      "\"text\""
+      "'a'B"
+      "\"text\"B" ]
+
+[<TestCaseSource("operator_application_literal_values_without_sign")>]
+let ``operators maintain spacing from literal values which start without + or -`` (literalValue: string) =
+    formatSourceString
+        $"""
+let subtractTwo = + %s{literalValue}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        $"""
+let subtractTwo = +%s{literalValue}
+"""

--- a/src/Fantomas.Core.Tests/PrefixTests.fs
+++ b/src/Fantomas.Core.Tests/PrefixTests.fs
@@ -195,7 +195,7 @@ let _ = + <@ 1 @>
 """
 
 [<Test>]
-let ``add space between prefix and measure`` () =
+let ``add space between prefix and measure literal that starts with a symbol`` () =
     formatSourceString
         """
 let _ = - +1<m>

--- a/src/Fantomas.Core.Tests/PrefixTests.fs
+++ b/src/Fantomas.Core.Tests/PrefixTests.fs
@@ -126,7 +126,17 @@ let operator_application_literal_values_with_sign =
       "-4.41F"
       "-4.14"
       "-12456I"
-      "-0.7833M" ]
+      "-0.7833M"
+      "+46y"
+      "+46s"
+      "+46"
+      "+46l"
+      "+423n"
+      "+46L"
+      "+3.41F"
+      "+3.14"
+      "+32456I"
+      "+0.7833M" ]
 
 [<TestCaseSource("operator_application_literal_values_with_sign")>]
 let ``operators maintain spacing from literal values which start with + or -`` (literalValue: string) =
@@ -155,7 +165,9 @@ let operator_application_literal_values_without_sign =
       "\"text\"B" ]
 
 [<TestCaseSource("operator_application_literal_values_without_sign")>]
-let ``operators maintain spacing from literal values which start without + or -`` (literalValue: string) =
+let ``no space added between prefix operators and literal values that do not start with a symbol``
+    (literalValue: string)
+    =
     formatSourceString
         $"""
 let subtractTwo = + %s{literalValue}
@@ -166,4 +178,34 @@ let subtractTwo = + %s{literalValue}
         equal
         $"""
 let subtractTwo = +%s{literalValue}
+"""
+
+[<Test>]
+let ``add space between prefix and quotation`` () =
+    formatSourceString
+        """
+let _ = + <@ 1 @>
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let _ = + <@ 1 @>
+"""
+
+[<Test>]
+let ``add space between prefix and measure`` () =
+    formatSourceString
+        """
+let _ = - +1<m>
+let _ = - -1<m>
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let _ = - +1<m>
+let _ = - -1<m>
 """

--- a/src/Fantomas.Core.Tests/PrefixTests.fs
+++ b/src/Fantomas.Core.Tests/PrefixTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelpers
-open Fantomas.Core
 
 [<Test>]
 let ``should format prefix operators`` () =

--- a/src/Fantomas.Core.Tests/SpaceBeforeLowercaseInvocationTests.fs
+++ b/src/Fantomas.Core.Tests/SpaceBeforeLowercaseInvocationTests.fs
@@ -217,9 +217,9 @@ let ``ignore setting when function call is the argument of prefix application`` 
     |> should
         equal
         """
-!- String.Empty.padLeft(braceSize + spaceAround)
-(!- System.String.Empty.padRight(delta)) ({ ctx with RecordBraceStart = rest })
-!- meh()
+!-String.Empty.padLeft(braceSize + spaceAround)
+(!-System.String.Empty.padRight(delta)) ({ ctx with RecordBraceStart = rest })
+!-meh()
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/SpaceBeforeUppercaseInvocationTests.fs
+++ b/src/Fantomas.Core.Tests/SpaceBeforeUppercaseInvocationTests.fs
@@ -251,9 +251,9 @@ let ``ignore setting when function call is the argument of prefix application, 1
     |> should
         equal
         """
-!- String.Empty.PadLeft(braceSize + spaceAround)
-(!- System.String.Empty.PadRight(delta)) ({ ctx with RecordBraceStart = rest })
-!- Meh()
+!-String.Empty.PadLeft(braceSize + spaceAround)
+(!-System.String.Empty.PadRight(delta)) ({ ctx with RecordBraceStart = rest })
+!-Meh()
 """
 
 [<Test>]

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -756,21 +756,22 @@ let genExpr (e: Expr) =
         let genWithoutSpace = genSingleTextNode node.Operator +> genExpr node.Expr
         let genWithSpace = genSingleTextNode node.Operator +> sepSpace +> genExpr node.Expr
 
-        match node.Expr with
-        // E.g. + <@ 1 @>
-        | Expr.Quote _ -> genWithSpace
-        | Expr.Constant(constant) ->
-            // E.g. !! @"foobar", because !!@ would be mistaken for an operator.
-            match constant with
+        let rec (|ConstantWithSign|_|) =
+            function
             | Constant.FromText(stn) ->
                 match stn.Text.[0] with
                 | '@'
                 | '-'
-                | '+' -> genWithSpace
-                | _ -> genWithoutSpace
-            // E.g. - +1<m>
-            | Constant.Measure _ -> genWithSpace
-            | Constant.Unit _ -> genWithoutSpace
+                | '+' -> Some()
+                | _ -> None
+            | Constant.Measure measure -> (|ConstantWithSign|_|) measure.Constant
+            | Constant.Unit _ -> None
+
+        match node.Expr with
+        // E.g. + <@ 1 @>
+        | Expr.Quote _ -> genWithSpace
+        // E.g. !! @"foobar", because !!@ would be mistaken for an operator.
+        | Expr.Constant(ConstantWithSign) -> genWithSpace
         // !- $"blah{s}"
         | Expr.InterpolatedStringExpr _ -> genWithSpace
         // We don't respect SpaceBeforeLowercaseInvocation here because it can alter the meaning of the code.

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -757,13 +757,20 @@ let genExpr (e: Expr) =
         let genWithSpace = genSingleTextNode node.Operator +> sepSpace +> genExpr node.Expr
 
         match node.Expr with
-        // E.g. !! @"foobar", because !!@ would be mistaken for an operator.
-        | Expr.Constant(Constant.FromText(stn)) ->
-            match stn.Text.[0] with
-            | '@'
-            | '-'
-            | '+' -> genWithSpace
-            | _ -> genWithoutSpace
+        // E.g. + <@ 1 @>
+        | Expr.Quote _ -> genWithSpace
+        | Expr.Constant(constant) ->
+            // E.g. !! @"foobar", because !!@ would be mistaken for an operator.
+            match constant with
+            | Constant.FromText(stn) ->
+                match stn.Text.[0] with
+                | '@'
+                | '-'
+                | '+' -> genWithSpace
+                | _ -> genWithoutSpace
+            // E.g. - +1<m>
+            | Constant.Measure _ -> genWithSpace
+            | Constant.Unit _ -> genWithoutSpace
         // !- $"blah{s}"
         | Expr.InterpolatedStringExpr _ -> genWithSpace
         // We don't respect SpaceBeforeLowercaseInvocation here because it can alter the meaning of the code.


### PR DESCRIPTION
Fixes https://github.com/fsprojects/fantomas/issues/3131

- Moved some related tests around to new testfile.
- Targeting v7.0 because it can lead to a git diff when folks would update.

Could you review this one for me @brianrourkeboll? Just to make sure I didn't miss anything.
@dawedawe please review the Fantomas' side of things.

Thanks all!