### PR TITLE
Remove MaxDotGetExpressionWidth

### DIFF
--- a/docs/docs/end-users/Configuration.fsx
+++ b/docs/docs/end-users/Configuration.fsx
@@ -730,28 +730,6 @@ fsharp_max_function_binding_width = 10
 (*** include-output ***)
 
 (**
-<fantomas-setting green></fantomas-setting>
-### fsharp_max_dot_get_expression_width
-<copy-to-clipboard text="fsharp_max_dot_get_expression_width = 100"></copy-to-clipboard>
-
-Control the maximum width for which (nested) [SynExpr.DotGet](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-syntax-synexpr.html#DotGet) expressions should be in one line.
-*)
-
-(*** hide ***)
-printfn
-    $"# Default\n{toEditorConfigName (nameof FormatConfig.Default.MaxDotGetExpressionWidth)} = {FormatConfig.Default.MaxDotGetExpressionWidth}"
-(*** include-output ***)
-
-formatCode
-    """ 
-   let job = JobBuilder.UsingJobData(jobDataMap).Create<WrapperJob>().Build()
-    """
-    """
-fsharp_max_dot_get_expression_width = 60
-    """
-(*** include-output ***)
-
-(**
 <fantomas-setting green gr></fantomas-setting>
 ### fsharp_multiline_bracket_style
 <copy-to-clipboard text="fsharp_multiline_bracket_style = stroustrup"></copy-to-clipboard>

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -181,8 +181,7 @@ let ``identifier dot appUnit dot typed appUnit `` () =
         """
 A.B().C<'d>()
 """
-        { config with
-            MaxDotGetExpressionWidth = 0 }
+        { config with MaxLineLength = 10 }
     |> prepend newline
     |> should
         equal
@@ -198,8 +197,7 @@ let ``identifier dot appUnit dot typed identifier `` () =
         """
 A.B().C<'d>
 """
-        { config with
-            MaxDotGetExpressionWidth = 0 }
+        { config with MaxLineLength = 10 }
     |> prepend newline
     |> should
         equal
@@ -215,8 +213,7 @@ let ``identifier dot identifier dot appExpr dot appUnit dot index expr`` () =
         """
 A.B.C(D).E().[0]
 """
-        { config with
-            MaxDotGetExpressionWidth = 0 }
+        { config with MaxLineLength = 10 }
     |> prepend newline
     |> should
         equal
@@ -233,8 +230,7 @@ let ``identifier dot identifier dot appExpr dot identifier dot index expr`` () =
         """
 A.B.C(D).E.[0]
 """
-        { config with
-            MaxDotGetExpressionWidth = 0 }
+        { config with MaxLineLength = 10 }
     |> prepend newline
     |> should
         equal
@@ -288,8 +284,7 @@ Map
     .empty<_, obj>
     .Add("headerAction", modifyHeader.Action.ArmValue)
 """
-        { config with
-            MaxDotGetExpressionWidth = 0 }
+        { config with MaxLineLength = 55 }
     |> prepend newline
     |> should
         equal
@@ -310,7 +305,7 @@ let d = Duck()
 
 d.Duck.Duck.Duck.Goose().Duck.Goose().Duck.Duck.Goose().Duck.Duck.Duck.Goose().Duck.Duck.Duck.Duck.Goose()
 """
-        config
+        { config with MaxLineLength = 45 }
     |> prepend newline
     |> should
         equal
@@ -335,9 +330,7 @@ let ``very long chain with a some index expressions`` () =
         """
 Universe.Galaxy.SolarSystem.Planet.[3].Countries.[9].People.Count
 """
-        { config with
-            MaxDotGetExpressionWidth = 0
-            MaxLineLength = 50 }
+        { config with MaxLineLength = 50 }
     |> prepend newline
     |> should
         equal
@@ -353,9 +346,7 @@ let ``even longer chain with only simple links`` () =
 Fooooooooooo.Baaaaaaaaaaaaaaaaar.Foooooooooooooooooo.Baaaaaaaar.Basssss.Baazzzzzzzzzzzzzzzzzz.[0].Meeeeeeeeeeeeeeeeeh
     .Moooooooooooooooo.Booooooooooooooooooooh.Yooooooooooooooou.Meeeeeeh.Meh2
 """
-        { config with
-            MaxDotGetExpressionWidth = 0
-            MaxLineLength = 50 }
+        { config with MaxLineLength = 50 }
     |> prepend newline
     |> should
         equal
@@ -426,9 +417,7 @@ Animal<
         "Spot"
     )
 """
-        { config with
-            MaxDotGetExpressionWidth = 0
-            MaxLineLength = 10 }
+        { config with MaxLineLength = 10 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/CommentTests.fs
+++ b/src/Fantomas.Core.Tests/CommentTests.fs
@@ -1587,8 +1587,7 @@ Host
 
 //
 """
-        { config with
-            MaxDotGetExpressionWidth = 40 }
+        { config with MaxLineLength = 55 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
@@ -651,8 +651,7 @@ type FunctionComponent =
 
     static member Foo = ()
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> should
         equal
         """namespace Fable.React
@@ -673,8 +672,7 @@ type FunctionComponent =
         let elemType =
             ReactBindings.React.``lazy`` (fun () ->
                 // React.lazy requires a default export
-                (importValueDynamic f)
-                    .``then`` (fun x -> createObj [ "default" ==> x ]))
+                (importValueDynamic f).``then`` (fun x -> createObj [ "default" ==> x ]))
 
         fun props ->
             ReactElementType.create
@@ -845,8 +843,7 @@ type FunctionComponent =
 
     static member Foo = ()
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> should
         equal
         """namespace Fable.React
@@ -867,8 +864,7 @@ type FunctionComponent =
         let elemType =
             ReactBindings.React.``lazy`` (fun () ->
                 // React.lazy requires a default export
-                (importValueDynamic f)
-                    .``then`` (fun x -> createObj [ "default" ==> x ]))
+                (importValueDynamic f).``then`` (fun x -> createObj [ "default" ==> x ]))
 
         fun props ->
             ReactElementType.create
@@ -2214,7 +2210,6 @@ let loader (projectRoot: string) (siteContent: SiteContents) =
   disableLiveRefresh
 """
         { config with
-            MaxDotGetExpressionWidth = 50
             MaxInfixOperatorExpression = 50 }
     |> prepend newline
     |> should

--- a/src/Fantomas.Core.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/ComputationExpressionTests.fs
@@ -1001,18 +1001,13 @@ let ``let bang + do expression + let + return in ce`` () =
         return Ok(user.Identity.Name, collectClaims user)
     }
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> prepend newline
     |> should
         equal
         """
 task {
-    let! config =
-        manager
-            .GetConfigurationAsync()
-            .ConfigureAwait(false)
-
+    let! config = manager.GetConfigurationAsync().ConfigureAwait(false)
     parameters.IssuerSigningKeys <- config.SigningKeys
     let user, _ = handler.ValidateToken((token: string), parameters)
     return Ok(user.Identity.Name, collectClaims user)
@@ -2300,8 +2295,7 @@ aggregateResult {
 }
 """
         { config with
-            MaxInfixOperatorExpression = 40
-            MaxDotGetExpressionWidth = 50 }
+            MaxInfixOperatorExpression = 40 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/ControlStructureTests.fs
+++ b/src/Fantomas.Core.Tests/ControlStructureTests.fs
@@ -723,8 +723,7 @@ let ``keep new line before for loop, 1317`` () =
 
       state
 """
-        { config with
-            MaxDotGetExpressionWidth = 60 }
+        { config with MaxLineLength = 85 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
+++ b/src/Fantomas.Core.Tests/CrampedMultilineBracketStyleTests.fs
@@ -778,9 +778,7 @@ let expect =
                                   args = []
                                   commands = [] }
 """
-        { config with
-            MaxDotGetExpressionWidth = 50
-            MaxArrayOrListWidth = 40 }
+        { config with MaxArrayOrListWidth = 40 }
     |> prepend newline
     |> should
         equal
@@ -1988,7 +1986,6 @@ let defaultTestOptions fwk common (o: DotNet.TestOptions) =
           Configuration = DotNet.BuildConfiguration.Debug }
 """
         { config with
-            MaxDotGetExpressionWidth = 50
             MaxInfixOperatorExpression = 50
             MaxRecordWidth = 55 }
     |> prepend newline

--- a/src/Fantomas.Core.Tests/DallasTests.fs
+++ b/src/Fantomas.Core.Tests/DallasTests.fs
@@ -1464,7 +1464,7 @@ let longExpr = genExpr e +> indentSepNlnUnindent (genSynLongIdentMultiline true 
 
 fun ctx ->
     isShortExpression
-        ctx.Config.MaxDotGetExpressionWidth
+        ctx.Config.Blaaaaaaaaaaaaaaaaaaaaaaaaah
         shortExpr
         longExpr
         ctx
@@ -1477,7 +1477,7 @@ fun ctx ->
 let shortExpr = genExpr e +> genSynLongIdent true sli
 let longExpr = genExpr e +> indentSepNlnUnindent (genSynLongIdentMultiline true sli)
 
-fun ctx -> isShortExpression ctx.Config.MaxDotGetExpressionWidth shortExpr longExpr ctx
+fun ctx -> isShortExpression ctx.Config.Blaaaaaaaaaaaaaaaaaaaaaaaaah shortExpr longExpr ctx
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/DotGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotGetTests.fs
@@ -11,18 +11,13 @@ let ``a TypeApp inside a DotGet should stay on the same line, 994`` () =
         """
 Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<option<option<unit>>>.GetGenericTypeDefinition().MakeGenericType(t)).Assembly
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> prepend newline
     |> should
         equal
         """
 Microsoft.FSharp.Reflection.FSharpType
-    .GetUnionCases(
-        typeof<option<option<unit>>>
-            .GetGenericTypeDefinition()
-            .MakeGenericType(t)
-    )
+    .GetUnionCases(typeof<option<option<unit>>>.GetGenericTypeDefinition().MakeGenericType(t))
     .Assembly
 """
 
@@ -33,19 +28,13 @@ let ``a DotGetApp inside a DotGet should stay on the same line, 1051`` () =
 System.Diagnostics.FileVersionInfo.GetVersionInfo(
                System.Reflection.Assembly.GetExecutingAssembly().Location).FileVersion
 """
-        { config with
-            MaxLineLength = 80
-            MaxDotGetExpressionWidth = 50 }
+        { config with MaxLineLength = 80 }
     |> prepend newline
     |> should
         equal
         """
 System.Diagnostics.FileVersionInfo
-    .GetVersionInfo(
-        System.Reflection.Assembly
-            .GetExecutingAssembly()
-            .Location
-    )
+    .GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location)
     .FileVersion
 """
 
@@ -60,7 +49,6 @@ let ``split chained method call expression, 246`` () =
                System.Reflection.Assembly.GetExecutingAssembly().Location).FileVersion)
 """
         { config with
-            MaxDotGetExpressionWidth = 50
             MaxInfixOperatorExpression = 50 }
     |> prepend newline
     |> should
@@ -70,11 +58,7 @@ root.SetAttribute(
     "driverVersion",
     "AltCover.Recorder "
     + System.Diagnostics.FileVersionInfo
-        .GetVersionInfo(
-            System.Reflection.Assembly
-                .GetExecutingAssembly()
-                .Location
-        )
+        .GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location)
         .FileVersion
 )
 """
@@ -139,9 +123,7 @@ module Services =
             ) =
             match storage with
             | Storage.MemoryStore store ->
-                Equinox.MemoryStore
-                    .Resolver(store, FsCodec.Box.Codec.Create(), fold, initial)
-                    .Resolve
+                Equinox.MemoryStore.Resolver(store, FsCodec.Box.Codec.Create(), fold, initial).Resolve
             | Storage.EventStore(gateway, cache) ->
                 let accessStrategy = Equinox.EventStore.AccessStrategy.RollingSnapshots snapshot
 
@@ -196,10 +178,7 @@ let main args =
     Host
         .CreateDefaultBuilder(args)
         .ConfigureWebHostDefaults(fun builder ->
-            builder
-                .CaptureStartupErrors(true)
-                .UseSerilog(dispose = true)
-                .UseStartup<Startup>()
+            builder.CaptureStartupErrors(true).UseSerilog(dispose = true).UseStartup<Startup>()
             |> ignore)
         .Build()
         .Run()
@@ -218,7 +197,7 @@ let job =
         .WithIdentity(taskName, groupName)
         .Build()
 """
-        config
+        { config with MaxLineLength = 50 }
     |> prepend newline
     |> should
         equal
@@ -241,7 +220,7 @@ let c =
         .UseSerilog(dispose = true)
         .UseStartup<Startup>()
 """
-        config
+        { config with MaxLineLength = 40 }
     |> prepend newline
     |> should
         equal
@@ -283,7 +262,7 @@ let ``long ident with dots inside app inside dotget`` () =
 Equinox.MemoryStore.Resolver(store, FsCodec.Box.Codec.Create(), fold, initial)
                     .Resolve
 """
-        config
+        { config with MaxLineLength = 65 }
     |> prepend newline
     |> should
         equal
@@ -305,7 +284,7 @@ let ``long ident with dots inside type app inside dotget`` () =
                                                                accessStrategy)
                     .Resolve
 """
-        config
+        { config with MaxLineLength = 100 }
     |> prepend newline
     |> should
         equal
@@ -862,8 +841,7 @@ let PublishValueDefn cenv env declKind (vspec: Val) =
 
     ()
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> prepend newline
     |> should
         equal
@@ -871,16 +849,14 @@ let PublishValueDefn cenv env declKind (vspec: Val) =
 let PublishValueDefn cenv env declKind (vspec: Val) =
     if
         (declKind = ModuleOrMemberBinding)
-        && ((GetCurrAccumulatedModuleOrNamespaceType env)
-               .ModuleOrNamespaceKind = Namespace)
+        && ((GetCurrAccumulatedModuleOrNamespaceType env).ModuleOrNamespaceKind = Namespace)
         && (Option.isNone vspec.MemberInfo)
     then
         errorR (Error(FSComp.SR.tcNamespaceCannotContainValues (), vspec.Range))
 
     if
         (declKind = ExtrinsicExtensionBinding)
-        && ((GetCurrAccumulatedModuleOrNamespaceType env)
-               .ModuleOrNamespaceKind = Namespace)
+        && ((GetCurrAccumulatedModuleOrNamespaceType env).ModuleOrNamespaceKind = Namespace)
     then
         errorR (Error(FSComp.SR.tcNamespaceCannotContainExtensionMembers (), vspec.Range))
 
@@ -912,9 +888,7 @@ type Foobar =
             FileSystem.SafeExists filename
             && ((tcConfig.GetTargetFrameworkDirectories()
                  |> List.exists (fun clrRoot -> clrRoot = Path.GetDirectoryName filename))
-                || (tcConfig.FxResolver
-                       .GetSystemAssemblies()
-                       .Contains(fileNameWithoutExtension filename))
+                || (tcConfig.FxResolver.GetSystemAssemblies().Contains(fileNameWithoutExtension filename))
                 || tcConfig.FxResolver.IsInReferenceAssemblyPackDirectory filename)
         with _ ->
             false
@@ -950,8 +924,7 @@ services
     .AddIdentityCore(fun options -> ())
     .AddUserManager<UserManager<web.ApplicationUser>>()
 """
-        { config with
-            MaxDotGetExpressionWidth = 200 }
+        { config with MaxLineLength = 200 }
     |> prepend newline
     |> should
         equal
@@ -1137,8 +1110,7 @@ let ``dotget function application should add space before argument, long`` () =
         """
 m.Property(fun p -> p.Name).IsRequired().HasColumnName("ModelName").HasMaxLength 64
 """
-        { config with
-            MaxDotGetExpressionWidth = 70 }
+        { config with MaxLineLength = 70 }
     |> prepend newline
     |> should
         equal
@@ -1157,8 +1129,7 @@ let ``dotget lambda multiline application`` () =
         """
 m.Property(fun p -> p.Name).IsRequired().HasColumnName("ModelName").HasMaxLength
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        { config with MaxLineLength = 50 }
     |> prepend newline
     |> should
         equal
@@ -1195,12 +1166,7 @@ db.Schema.Users.Query
         | Role.User companyId -> companyId
         | _ -> __
     )
-    .In(
-        db.Schema.Companies.Query
-            .Where(fun x -> x.LicenceId)
-            .Equals(licenceId)
-            .Select(fun x -> x.Id)
-    )
+    .In(db.Schema.Companies.Query.Where(fun x -> x.LicenceId).Equals(licenceId).Select(fun x -> x.Id))
 """
 
 [<Test>]
@@ -1229,8 +1195,7 @@ module Program =
         builder.Build().RunAsync() |> ignore
         0
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> prepend newline
     |> should
         equal
@@ -1266,17 +1231,12 @@ let ``dotget inside a quotation, 2154`` () =
         """
 (fun (Singleton arg) -> <@@ ((%%arg: Indicators) :> IIndicators).AsyncGetIndicator(indicatorIdVal) @@>)
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> prepend newline
     |> should
         equal
         """
-(fun (Singleton arg) ->
-    <@@
-        ((%%arg: Indicators) :> IIndicators)
-            .AsyncGetIndicator(indicatorIdVal)
-    @@>)
+(fun (Singleton arg) -> <@@ ((%%arg: Indicators) :> IIndicators).AsyncGetIndicator(indicatorIdVal) @@>)
 """
 
 [<Test>]
@@ -1285,7 +1245,7 @@ let ``argument in short type app as function name, 2683`` () =
         """
 Assembly.GetExecutingAssembly().GetCustomAttribute<MyCustomAttribute>().SomeProperty
 """
-        config
+        { config with MaxLineLength = 50 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/DotGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotGetTests.fs
@@ -611,7 +611,8 @@ Log.Logger <-
         .CreateLogger()
 """
         { config with
-            SpaceBeforeUppercaseInvocation = true }
+            SpaceBeforeUppercaseInvocation = true
+            MaxLineLength = 40 }
     |> prepend newline
     |> should
         equal
@@ -634,7 +635,8 @@ Log.Logger <-
         .CreateLogger()
 """
         { config with
-            SpaceBeforeUppercaseInvocation = true }
+            SpaceBeforeUppercaseInvocation = true
+            MaxLineLength = 40 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/DotIndexedGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotIndexedGetTests.fs
@@ -86,7 +86,6 @@ let mySampleMethod() =
             AlignFunctionSignatureToIndentation = true
             AlternativeLongMemberDefinitions = true
             MultiLineLambdaClosingNewline = true
-            MaxDotGetExpressionWidth = 50
             MaxInfixOperatorExpression = 50 }
     |> prepend newline
     |> should

--- a/src/Fantomas.Core.Tests/IfThenElseTests.fs
+++ b/src/Fantomas.Core.Tests/IfThenElseTests.fs
@@ -1656,10 +1656,7 @@ let private tryGetUrlWithExactMatch
   (urlPattern: string<Url>)
   (document: Document)
   =
-  if
-    (UMX.untag pathPattern)
-      .Equals(UMX.untag document.Name, System.StringComparison.Ordinal)
-  then
+  if (UMX.untag pathPattern).Equals(UMX.untag document.Name, System.StringComparison.Ordinal) then
     Some(urlPattern, normalizeRepoPath (UMX.cast<SourcelinkPattern, RepoPathSegment> pathPattern), document)
   else
     None
@@ -1669,10 +1666,7 @@ let private tryGetUrlWithExactMatch
   (urlPattern: string<Url>)
   (document: Document)
   =
-  if
-    (UMX.untag pathPattern)
-      .Equals(UMX.untag document.Name, System.StringComparison.Ordinal)
-  then
+  if (UMX.untag pathPattern).Equals(UMX.untag document.Name, System.StringComparison.Ordinal) then
     Some(urlPattern, normalizeRepoPath (UMX.cast<SourcelinkPattern, RepoPathSegment> pathPattern), document)
   else
     None
@@ -2362,8 +2356,7 @@ module Foo =
             None
         else Some "hi"
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        { config with MaxLineLength = 80 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/LambdaTests.fs
+++ b/src/Fantomas.Core.Tests/LambdaTests.fs
@@ -295,7 +295,6 @@ CloudStorageAccount.SetConfigurationSettingPublisher(fun configName configSettin
             configSettingPublisher.Invoke(connectionString) |> ignore)
 """
         { config with
-            MaxDotGetExpressionWidth = 50
             MaxInfixOperatorExpression = 50 }
     |> prepend newline
     |> should

--- a/src/Fantomas.Core.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Core.Tests/LetBindingTests.fs
@@ -110,8 +110,8 @@ let tomorrow =
         .AddDays(1.)
 """
         { config with
-            MaxValueBindingWidth = 70
-            MaxDotGetExpressionWidth = 50 }
+            MaxValueBindingWidth = 60
+            MaxLineLength = 70 }
     |> prepend newline
     |> should
         equal
@@ -850,8 +850,7 @@ let private authenticateRequest (logger: ILogger) header =
         logger.LogError(sprintf "Could not authenticate token %s\n%A" token exn)
         task { return None }
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> prepend newline
     |> should
         equal
@@ -878,11 +877,7 @@ let private authenticateRequest (logger: ILogger) header =
 
     try
         task {
-            let! config =
-                manager
-                    .GetConfigurationAsync()
-                    .ConfigureAwait(false)
-
+            let! config = manager.GetConfigurationAsync().ConfigureAwait(false)
             parameters.IssuerSigningKeys <- config.SigningKeys
 
             let user, _ = handler.ValidateToken((token: string), parameters)
@@ -1043,8 +1038,7 @@ let ``don't add additional newline before SynExpr.New, 1049`` () =
         new HttpResponseMessage(HttpStatusCode.OK,
                                 Content = new StringContent(version, System.Text.Encoding.UTF8, "application/text"))
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> prepend newline
     |> should
         equal
@@ -1193,8 +1187,7 @@ let x =
            else
                false
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> prepend newline
     |> should
         equal
@@ -1254,8 +1247,7 @@ let x =
            else
                false
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -922,8 +922,7 @@ configuration
     .WriteTo
     .Logger(fun x -> x * x)
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        { config with MaxLineLength = 50 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/QuotationTests.fs
+++ b/src/Fantomas.Core.Tests/QuotationTests.fs
@@ -41,8 +41,7 @@ let logger =
         .Returns(())
         .Create()
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        { config with MaxLineLength = 50 }
     |> prepend newline
     |> should
         equal
@@ -69,8 +68,7 @@ let action =
     @>
 """
         { config with
-            MaxInfixOperatorExpression = 50
-            MaxDotGetExpressionWidth = 50 }
+            MaxInfixOperatorExpression = 50 }
     |> prepend newline
     |> should
         equal

--- a/src/Fantomas.Core.Tests/SpaceBeforeUppercaseInvocationTests.fs
+++ b/src/Fantomas.Core.Tests/SpaceBeforeUppercaseInvocationTests.fs
@@ -54,15 +54,12 @@ let ``spaceBeforeUppercaseInvocation should not have impact when member is calle
         """
 let x = DateTimeOffset(2017,6,1,10,3,14,TimeSpan(1,30,0)).LocalDateTime
 """
-        { spaceBeforeConfig with
-            MaxDotGetExpressionWidth = 50 }
+        spaceBeforeConfig
     |> prepend newline
     |> should
         equal
         """
-let x =
-    DateTimeOffset(2017, 6, 1, 10, 3, 14, TimeSpan (1, 30, 0))
-        .LocalDateTime
+let x = DateTimeOffset(2017, 6, 1, 10, 3, 14, TimeSpan (1, 30, 0)).LocalDateTime
 """
 
 // Space before parentheses (a+b) in Uppercase function call

--- a/src/Fantomas.Core.Tests/SynConstTests.fs
+++ b/src/Fantomas.Core.Tests/SynConstTests.fs
@@ -604,7 +604,6 @@ a:hover {color: #ecc;}
     xmlform.Save packable
 "
         { config with
-            MaxDotGetExpressionWidth = 50
             MaxInfixOperatorExpression = 50
             MaxArrayOrListWidth = 40 }
     |> prepend newline

--- a/src/Fantomas.Core.Tests/SynExprSetTests.fs
+++ b/src/Fantomas.Core.Tests/SynExprSetTests.fs
@@ -262,11 +262,7 @@ Log.Logger <-
     |> should
         equal
         """
-Log.Logger <-
-    LoggerConfiguration<Foo>()
-        .Destructure.FSharpTypes()
-        .WriteTo.Console()
-        .CreateLogger ()
+Log.Logger <- LoggerConfiguration<Foo>().Destructure.FSharpTypes().WriteTo.Console().CreateLogger ()
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/SynLongIdentTests.fs
+++ b/src/Fantomas.Core.Tests/SynLongIdentTests.fs
@@ -18,8 +18,7 @@ Log.Logger <-
     .Destructure.FSharpTypes()
     .WriteTo.Console()
     .CreateLogger()"""
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        { config with MaxLineLength = 60 }
     |> prepend newline
     |> should
         equal
@@ -117,8 +116,7 @@ let main _ =
     finally
         Log.CloseAndFlush()
 """
-        { config with
-            MaxDotGetExpressionWidth = 50 }
+        config
     |> prepend newline
     |> should
         equal
@@ -132,9 +130,7 @@ let main _ =
             Config.Logger.configure ()
 
             let config =
-                ConfigurationBuilder()
-                    .SetBasePath(Directory.GetCurrentDirectory())
-                    .Build()
+                ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory()).Build()
 
             WebHostBuilder()
                 .UseConfiguration(config)

--- a/src/Fantomas.Core.Tests/TestHelpers.fs
+++ b/src/Fantomas.Core.Tests/TestHelpers.fs
@@ -31,6 +31,8 @@ let formatFSharpString isFsiFile (s: string) config =
         if formattedCode <> secondFormattedCode then
             failwith $"The formatted result was not idempotent.\n%s{formattedCode}\n%s{secondFormattedCode}"
 
+        printfn "formatted code:\n%s\n" formattedCode
+
         return formattedCode
     }
     |> Async.RunSynchronously

--- a/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeDeclarationTests.fs
@@ -816,7 +816,6 @@ type BlobHelper(Account : CloudStorageAccount) =
         BlobHelper(CloudStorageAccount.FromConfigurationSetting(configurationSettingName))
     """
         { config with
-            MaxDotGetExpressionWidth = 50
             MaxInfixOperatorExpression = 40 }
     |> prepend newline
     |> should

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1009,14 +1009,11 @@ let genExpr (e: Expr) =
             | LeadingSimpleChain(leadingChain, links) ->
                 match links with
                 | [] ->
-                    fun ctx ->
-                        isShortExpression
-                            ctx.Config.MaxDotGetExpressionWidth
-                            short
-                            (match leadingChain with
-                             | [] -> sepNone
-                             | head :: links -> genLink false head +> indent +> genIndentedLinks true links +> unindent)
-                            ctx
+                    expressionFitsOnRestOfLine
+                        short
+                        (match leadingChain with
+                         | [] -> sepNone
+                         | head :: links -> genLink false head +> indent +> genIndentedLinks true links +> unindent)
                 | _ ->
                     expressionFitsOnRestOfLine
                         (coli sepNone leadingChain (fun idx -> genLink (idx = lastIndex)))
@@ -1028,8 +1025,7 @@ let genExpr (e: Expr) =
 
             | head :: links -> genFirstLinkAndIndentOther head links
 
-        (fun ctx -> isShortExpression ctx.Config.MaxDotGetExpressionWidth short long ctx)
-        |> genNode node
+        expressionFitsOnRestOfLine short long |> genNode node
 
     // path.Replace("../../../", "....")
     | Expr.AppLongIdentAndSingleParenArg node ->

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -179,10 +179,6 @@ type FormatConfig =
       [<DisplayName("Maximum function-binding width")>]
       MaxFunctionBindingWidth: Num
 
-      [<Category("Boundaries")>]
-      [<DisplayName("Maximum dot get expression width")>]
-      MaxDotGetExpressionWidth: Num
-
       [<Category("Convention")>]
       [<DisplayName("Newline between type definition and members")>]
       NewlineBetweenTypeDefinitionAndMembers: bool
@@ -257,7 +253,6 @@ type FormatConfig =
           ArrayOrListMultilineFormatter = MultilineFormatterType.CharacterWidth
           MaxValueBindingWidth = 80
           MaxFunctionBindingWidth = 40
-          MaxDotGetExpressionWidth = 80
           NewlineBetweenTypeDefinitionAndMembers = true
           AlignFunctionSignatureToIndentation = false
           AlternativeLongMemberDefinitions = false


### PR DESCRIPTION
As we prepare for a major version update to support F# 9, I would like to propose the removal of the `MaxDotGetExpressionWidth` setting.

### Description
This setting controls the maximum width for which nested [SynExpr.DotGet](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-syntax-synexpr.html#DotGet) expressions can remain on a single line.

### Key Reasons for Removal:
- Since the introduction of the [Chain AST node](https://github.com/fsprojects/fantomas/pull/2696), this setting has become somewhat awkward and inconsistent.
- I am unaware of any users who actively utilize this setting; most people do not even know of its existence.
- In hindsight, I regret adding this as a configurable option, as there was no significant demand for it. The community's focus was on resolving [the original problem](https://github.com/fsprojects/fantomas/issues/501), which has been addressed and remains so after the removal of this setting.
- This is one less setting to maintain, little things like this [keep the lights on a bit longer](https://github.com/fsprojects/fantomas/issues/3112).

@dawedawe, @josh-degraw & @Smaug123 (or @pleaseletmesearch) please let me know if you are on board with this.