### PR TITLE
Add active pattern for empty computation expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 7.0.0-alpha-004 - 2024-12-12
+
+### Fixed
+* (Empty/NoEmpty)-bodied named computation expression produces inconsistent formatting. [#3140](https://github.com/fsprojects/fantomas/issues/3140)
+
 ## 7.0.0-alpha-003 - 2024-11-29
 
 ### Removed

--- a/src/Fantomas.Core.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/ComputationExpressionTests.fs
@@ -1,6 +1,5 @@
 module Fantomas.Core.Tests.ComputationExpressionTests
 
-open Internal.Utilities.Library.Extras
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelpers

--- a/src/Fantomas.Core.Tests/ComputationExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/ComputationExpressionTests.fs
@@ -1,5 +1,6 @@
 module Fantomas.Core.Tests.ComputationExpressionTests
 
+open Internal.Utilities.Library.Extras
 open NUnit.Framework
 open FsUnit
 open Fantomas.Core.Tests.TestHelpers
@@ -2452,4 +2453,18 @@ let zero =
 let zero =
     async { () } // foo
     |> ignore
+"""
+
+[<Test>]
+let ``empty computation expression with application`` () =
+    formatSourceString
+        """
+A() {}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+A() { }
 """

--- a/src/Fantomas.FCS/Fantomas.FCS.fsproj
+++ b/src/Fantomas.FCS/Fantomas.FCS.fsproj
@@ -303,9 +303,9 @@
     <Compile Include="$(FsYaccOutputFolder)pplex.fs">
       <Link>SyntaxTree\FsLexOutput\pplex.fs</Link>
     </Compile>
-    <Compile Include="$(FsYaccOutputFolder)\lex.fsi">
-      <Link>SyntaxTree\FsLexOutput\lex.fsi</Link>
-    </Compile>
+<!--    <Compile Include="$(FsYaccOutputFolder)\lex.fsi">-->
+<!--      <Link>SyntaxTree\FsLexOutput\lex.fsi</Link>-->
+<!--    </Compile>-->
     <Compile Include="$(FsYaccOutputFolder)\lex.fs">
       <Link>SyntaxTree\FsLexOutput\lex.fs</Link>
     </Compile>


### PR DESCRIPTION
Fixes #3140 

I took a bit of a shortcut, that is why there is an additional space after formatting.
This might be ok to for now.