### PR TITLE
Doc reference to G-Research/../.editorconfig incorrect

### DIFF
--- a/docs/.README.md
+++ b/docs/.README.md
@@ -6,6 +6,4 @@ To run the website locally:
 
 To build the website:
 
-> dotnet fsi .\docs\\.style\style.fsx
-
 > dotnet fsdocs build --eval

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,7 +10,7 @@ F# source code formatter, inspired by [scalariform](https://github.com/mdr/scala
 This project aims at formatting F# source files based on a given configuration.
 Fantomas will ensure correct indentation and consistent spacing between elements in the source files.
 We assume that the source files are *parsable by F# compiler* before feeding into the tool.
-Fantomas follows two F# style guides: the [F# code formatting guidelines](https://docs.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting) from Microsoft by default and the [G-Research F# code formatting guidelines](https://github.com/G-Research/fsharp-formatting-conventions) via various [settings](https://github.com/G-Research/fsharp-formatting-conventions/blob/main/.editorconfig).
+Fantomas follows two F# style guides: the [F# code formatting guidelines](https://docs.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting) from Microsoft by default and the [G-Research F# code formatting guidelines](https://github.com/G-Research/fsharp-formatting-conventions) via various [settings](https://github.com/G-Research/fsharp-formatting-conventions/blob/master/.editorconfig).
 
 ## Contributing Guidelines
 


### PR DESCRIPTION
Fixes #3157
Doc reference to G-Research/../.editorconfig fixed.
Build step `dotnet fsi .\docs\.style\style.fsx` removed as file doesn't exist and doesn't cause build failure.
