### PR TITLE
Print version in detailed verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* Pring version at beginning of execution when detailed verbosity is set. [3148](https://github.com/fsprojects/fantomas/issues/3148)
+* Print version at beginning of execution when detailed verbosity is set. [3148](https://github.com/fsprojects/fantomas/issues/3148)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+* Pring version at beginning of execution when detailed verbosity is set. [3148](https://github.com/fsprojects/fantomas/issues/3148)
+
 ### Fixed
 
 * Idempotency problem with comments in applications on lambda expressions. [#3128](https://github.com/fsprojects/fantomas/issues/3128)

--- a/src/Fantomas/Program.fs
+++ b/src/Fantomas/Program.fs
@@ -462,9 +462,15 @@ Join our Discord community:      https://discord.gg/Cpq9vf8BJH
 
     let asyncRunner = Async.Parallel >> Async.RunSynchronously
 
-    if Option.isSome version then
+    let versionLog =
         let version = CodeFormatter.GetVersion()
-        stdlog $"Fantomas v%s{version}"
+        $"Fantomas v%s{version}"
+
+    if Option.isNone version then
+        logGrEqDetailed versionLog
+
+    if Option.isSome version then
+        stdlog versionLog
     elif isDaemon then
         let daemon =
             new FantomasDaemon(Console.OpenStandardOutput(), Console.OpenStandardInput())


### PR DESCRIPTION
should go in after #3160 

fixes #3148 

One could argue it should only be reported when there are format results but I think it makes sense to have it also with all the error cases like `InputPath.NoFSharpFile` etc.