### PR TITLE
Preserve backticked idents in Active Pattern idents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+* Preserve backticks in active pattern idents. [#3126](https://github.com/fsprojects/fantomas/issues/3126)
 * New lines are added after comment in measure type. [#3145](https://github.com/fsprojects/fantomas/issues/3145)
 * Idempotency problem with comments in applications on lambda expressions. [#3128](https://github.com/fsprojects/fantomas/issues/3128)
 

--- a/src/Fantomas.Core.Tests/ActivePatternTests.fs
+++ b/src/Fantomas.Core.Tests/ActivePatternTests.fs
@@ -95,3 +95,44 @@ match expr with
 match expr with
 | SpecificCall <@@ ( ** ) @@> (_, _, [ s1; s2 ]) -> ()
 """
+
+[<Test>]
+let ``active pattern with backticks in ident, 3126`` () =
+    formatSourceString
+        """
+let (|``Custom Prefix``|_|) (p: string) (s: string) =
+    if s.StartsWith(p) then
+        Some(s.Substring(p.Length))
+    else
+        None
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let (|``Custom Prefix``|_|) (p: string) (s: string) =
+    if s.StartsWith(p) then
+        Some(s.Substring(p.Length))
+    else
+        None
+"""
+
+[<Test>]
+let ``multiple backticked idents in active pattern are preserved`` () =
+    formatSourceString
+        """
+let (|``Is Even``|``Is Odd``|) (p: int) =
+    if p % 2 = 0 then
+        ``Is Even``
+    else
+        ``Is Odd``
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let (|``Is Even``|``Is Odd``|) (p: int) =
+    if p % 2 = 0 then ``Is Even`` else ``Is Odd``
+"""


### PR DESCRIPTION
fixes #3126 

we can't directly reuse `mkIdent` as the backticks are inside the idText between the bars.