### PR TITLE
Try to fix problems with the integration tests when there is a space …

### DIFF
--- a/src/Fantomas.Tests/Integration/ByteOrderMarkTests.fs
+++ b/src/Fantomas.Tests/Integration/ByteOrderMarkTests.fs
@@ -20,7 +20,7 @@ let private getInitialBytes file =
 let ``byte-order mark should be preserved, 795`` () =
     use fileFixture = new TemporaryFileCodeSample(Source, true)
 
-    let { ExitCode = exitCode } = runFantomasTool fileFixture.Filename
+    let { ExitCode = exitCode } = runFantomasTool [ fileFixture.Filename ]
     exitCode |> should equal 0
 
     let expectedPreamble = Encoding.UTF8.GetPreamble()
@@ -34,8 +34,7 @@ let ``preserve byte-order from original file`` () =
     use outputFixture = new OutputFile()
 
     let { ExitCode = exitCode } =
-        sprintf "--out %s %s" outputFixture.Filename inputFixture.Filename
-        |> runFantomasTool
+        [ "--out"; outputFixture.Filename; inputFixture.Filename ] |> runFantomasTool
 
     exitCode |> should equal 0
 

--- a/src/Fantomas.Tests/Integration/CheckTests.fs
+++ b/src/Fantomas.Tests/Integration/CheckTests.fs
@@ -131,7 +131,7 @@ let ``honor ignore file when processing a folder`` () =
     use inputFixture = new FantomasIgnoreFile("*.fsx")
 
     let { Output = output } =
-        runFantomasTool (sprintf "--check .%c%s" Path.DirectorySeparatorChar subFolder)
+        runFantomasTool [ "--check"; $".%c{Path.DirectorySeparatorChar}%s{subFolder}" ]
 
     output |> should not' (contain "ignored")
 

--- a/src/Fantomas.Tests/Integration/ConfigTests.fs
+++ b/src/Fantomas.Tests/Integration/ConfigTests.fs
@@ -5,8 +5,7 @@ open NUnit.Framework
 open FsUnit
 open Fantomas.Tests.TestHelpers
 
-[<Literal>]
-let DetailedVerbosity = "--verbosity d"
+let DetailedVerbosity = [ "--verbosity"; "d" ]
 
 [<Literal>]
 let NormalVerbosity = "--verbosity n"
@@ -28,7 +27,7 @@ end_of_line=lf
 """
         )
 
-    let args = sprintf "%s %s" DetailedVerbosity fileFixture.Filename
+    let args = DetailedVerbosity @ [ fileFixture.Filename ]
     let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 0
     output |> should contain (sprintf "Processing %s" fileFixture.Filename)
@@ -48,7 +47,7 @@ end_of_line=cr
 """
         )
 
-    let args = sprintf "%s %s" DetailedVerbosity fileFixture.Filename
+    let args = DetailedVerbosity @ [ fileFixture.Filename ]
     let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 1
     Assert.That(output, Does.Contain "Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'")
@@ -77,7 +76,7 @@ end_of_line = %s
                 setting
         )
 
-    let { ExitCode = exitCode } = runFantomasTool fileFixture.Filename
+    let { ExitCode = exitCode } = runFantomasTool [ fileFixture.Filename ]
     exitCode |> should equal 0
 
     let result = System.IO.File.ReadAllText(fileFixture.Filename)
@@ -99,7 +98,7 @@ end_of_line = lf
 """
         )
 
-    let { ExitCode = exitCode } = runFantomasTool fileFixture.Filename
+    let { ExitCode = exitCode } = runFantomasTool [ fileFixture.Filename ]
     exitCode |> should equal 0
 
     let result = System.IO.File.ReadAllText(fileFixture.Filename)

--- a/src/Fantomas.Tests/Integration/ForceTests.fs
+++ b/src/Fantomas.Tests/Integration/ForceTests.fs
@@ -5,8 +5,7 @@ open NUnit.Framework
 open FsUnit
 open Fantomas.Tests.TestHelpers
 
-[<Literal>]
-let Verbosity = "--verbosity d"
+let Verbosity = [ "--verbosity"; "d" ]
 
 // The day this test fails because Fantomas can format the file, is the day you can remove this file.
 
@@ -24,7 +23,7 @@ let ``code that was invalid should be still be written`` () =
     use outputFixture = new OutputFile()
 
     let { ExitCode = exitCode; Output = output } =
-        runFantomasTool $"%s{Verbosity} --force --out %s{outputFixture.Filename} %s{sourceFile}"
+        runFantomasTool (Verbosity @ [ "--force"; "--out"; outputFixture.Filename; sourceFile ])
 
     exitCode |> should equal 0
     output |> should contain "was not valid after formatting"

--- a/src/Fantomas.Tests/Integration/MultiplePathsTests.fs
+++ b/src/Fantomas.Tests/Integration/MultiplePathsTests.fs
@@ -11,8 +11,7 @@ let UserCode = "let a  =   9"
 [<Literal>]
 let FormattedCode = "let a = 9\n"
 
-[<Literal>]
-let Verbosity = "--verbosity d"
+let Verbosity = [ "--verbosity"; "d" ]
 
 let private fileContentMatches (expectedContent: string) (actualPath: string) : unit =
     if File.Exists(actualPath) then
@@ -48,7 +47,7 @@ let ``format multiple paths recursively`` () =
     use fileFixtureThree = new TemporaryFileCodeSample(UserCode, subFolder = "sub")
 
     let arguments =
-        sprintf "%s \"%s\" \"%s\" \"sub\"" Verbosity fileFixtureOne.Filename fileFixtureTwo.Filename
+        Verbosity @ [ fileFixtureOne.Filename; fileFixtureTwo.Filename; "sub" ]
 
     let { ExitCode = exitCode; Output = output } = runFantomasTool arguments
 

--- a/src/Fantomas.Tests/Integration/WriteTests.fs
+++ b/src/Fantomas.Tests/Integration/WriteTests.fs
@@ -11,8 +11,7 @@ let FormattedCode = "let a = 9\n"
 [<Literal>]
 let UnformattedCode = "let a =   9"
 
-[<Literal>]
-let Verbosity = "--verbosity d"
+let Verbosity = [ "--verbosity"; "d" ]
 
 [<Test>]
 let ``correctly formatted file should not be written, 1984`` () =
@@ -27,7 +26,7 @@ end_of_line=lf
         )
 
     use inputFixture = new TemporaryFileCodeSample(FormattedCode, fileName = fileName)
-    let args = sprintf "%s %s" Verbosity inputFixture.Filename
+    let args = Verbosity @ [ inputFixture.Filename ]
     let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 0
 
@@ -38,7 +37,7 @@ let ``incorrectly formatted file should be written`` () =
     let fileName = "A"
 
     use inputFixture = new TemporaryFileCodeSample(UnformattedCode, fileName = fileName)
-    let args = sprintf "%s %s" Verbosity inputFixture.Filename
+    let args = Verbosity @ [ inputFixture.Filename ]
     let { ExitCode = exitCode; Output = output } = runFantomasTool args
     exitCode |> should equal 0
 
@@ -52,7 +51,8 @@ let ``file should be written to out folder when input folder has trailing slash`
     use outputFolder = new OutputFolder()
 
     let arguments =
-        sprintf @"%s subsrc%c --out %s" Verbosity Path.DirectorySeparatorChar outputFolder.Foldername
+        Verbosity
+        @ [ $"subsrc%c{Path.DirectorySeparatorChar}"; "--out"; outputFolder.Foldername ]
 
     let { ExitCode = exitCode; Output = output } = runFantomasTool arguments
 
@@ -67,7 +67,7 @@ let ``file should be written to out folder when input folder has no trailing sla
 
     use outputFolder = new OutputFolder()
 
-    let arguments = sprintf @"%s subsrc --out %s" Verbosity outputFolder.Foldername
+    let arguments = Verbosity @ [ "subsrc"; "--out"; outputFolder.Foldername ]
 
     let { ExitCode = exitCode; Output = output } = runFantomasTool arguments
 

--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -130,9 +130,9 @@ let getFantomasToolStartInfo arguments : ProcessStartInfo =
     if not (File.Exists fantomasDll) then
         failwithf $"The fantomas dll at \"%s{fantomasDll}\" does not exist!"
 
-    let startInfo = ProcessStartInfo("dotnet")
+    let argumentArray = [ fantomasDll; yield! arguments ]
+    let startInfo = ProcessStartInfo("dotnet", argumentArray)
     startInfo.UseShellExecute <- false
-    startInfo.Arguments <- sprintf "%s %s" fantomasDll arguments
     startInfo.WorkingDirectory <- Path.GetTempPath()
     startInfo.RedirectStandardOutput <- true
     startInfo.RedirectStandardError <- true
@@ -150,14 +150,7 @@ let runFantomasTool arguments : FantomasToolResult =
       Error = error }
 
 let checkCode (files: string list) : FantomasToolResult =
-    let files =
-        files |> List.map (fun file -> sprintf "\"%s\"" file) |> String.concat " "
-
-    let arguments = sprintf "--check %s" files
+    let arguments = [ "--check" ] @ files
     runFantomasTool arguments
 
-let formatCode (files: string list) : FantomasToolResult =
-    let arguments =
-        files |> List.map (fun file -> sprintf "\"%s\"" file) |> String.concat " "
-
-    runFantomasTool arguments
+let formatCode (files: string list) : FantomasToolResult = runFantomasTool files

--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -130,7 +130,7 @@ let getFantomasToolStartInfo arguments : ProcessStartInfo =
     if not (File.Exists fantomasDll) then
         failwithf $"The fantomas dll at \"%s{fantomasDll}\" does not exist!"
 
-    let argumentArray = [ fantomasDll; yield! arguments ]
+    let argumentArray = fantomasDll :: arguments
     let startInfo = ProcessStartInfo("dotnet", argumentArray)
     startInfo.UseShellExecute <- false
     startInfo.WorkingDirectory <- Path.GetTempPath()
@@ -150,7 +150,7 @@ let runFantomasTool arguments : FantomasToolResult =
       Error = error }
 
 let checkCode (files: string list) : FantomasToolResult =
-    let arguments = [ "--check" ] @ files
+    let arguments = "--check" :: files
     runFantomasTool arguments
 
 let formatCode (files: string list) : FantomasToolResult = runFantomasTool files


### PR DESCRIPTION
…in the system temp path by using the version of ProcessStartInfo which takes the arguments as a collection, and leave the argument escaping up to that.

Hi,
I tried to run the Fantomas tests locally, and got a bunch of failures in the integration tests because the system has a space in the path to the temp directory. e.g.
```
 Failed end_of_line=cr should throw an exception [224 ms]
  Error Message:
     Assert.That(, )
  Expected: String containing "Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'"
  But was:  "[16:02:08 DBG] Fantomas v7.0.2+d21ab681da1328407aa4d607e67e1174d6214629
[16:02:08 ERR] Input path 'Webb\AppData\Local\Temp\d46e43d9-5f59-4ac8-b06e-feba421f533d.fs' not found.
"
```
So I had a look at changing it to get the tests to work.

I'm not sure if the preferred solution would be to review all the escaping and make sure that all the temp path parameters are escaped, or to change it to use the newer ProcessStartInfo APIs which take the arguments as a collection and do the escaping for you and remove all the local string construction work (which is the approach used in this PR).

Any thoughts?
