### PR TITLE
Tweaks to Trivia::findNodeWhereRangeFitsIn

### DIFF
--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -158,12 +158,9 @@ let rec findNodeWhereRangeFitsIn (root: Node) (range: range) : Node option =
         // The more specific the node fits the selection, the better
         let betterChildNode =
             root.Children
-            |> Array.choose (fun childNode -> findNodeWhereRangeFitsIn childNode range)
-            |> Array.tryHead
+            |> Array.tryPick (fun childNode -> findNodeWhereRangeFitsIn childNode range)
 
-        match betterChildNode with
-        | Some betterChild -> Some betterChild
-        | None -> Some root
+        betterChildNode |> Option.orElseWith (fun () -> Some root)
 
 let triviaBeforeOrAfterEntireTree (rootNode: Node) (trivia: TriviaNode) : unit =
     let isBefore = trivia.Range.EndLine < rootNode.Range.StartLine


### PR DESCRIPTION
refs https://github.com/fsprojects/fantomas/pull/3164#issuecomment-2966080341

- Use Array.tryPick rather than Array.choose |> Array.tryHead
- Use Option.orElseWith rather than 'Some betterChild -> Some betterChild'

Rather trivial in the grand scheme of things, but results of the Benchmarks project:

Before:
```
| Method | Mean     | Error   | StdDev   | Median   | Rank | Gen0     | Allocated |
|------- |---------:|--------:|---------:|---------:|-----:|---------:|----------:|
| Format | 174.5 ms | 8.05 ms | 23.22 ms | 164.4 ms |    1 | 333.3333 | 155.61 MB |
```

After:
```
| Method | Mean     | Error   | StdDev  | Rank | Gen0     | Allocated |
|------- |---------:|--------:|--------:|-----:|---------:|----------:|
| Format | 163.6 ms | 3.27 ms | 7.38 ms |    1 | 500.0000 | 155.17 MB |

```

My laptop is a bit variable with the runtime, but there' no real time change, just a small memory change (155.61MB to 155.24MB with the tryPick change, and to 155.17MB from orElseWith 