### PR TITLE
Add write permissions for github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-      contents: read
+      contents: write
     steps:
     - uses: actions/checkout@v6
     - name: Setup .NET Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [7.0.5] - 2025-12-06
+
+### Fixed
+
+- Fixed automated GitHub releases. [#3205](https://github.com/fsprojects/fantomas/pull/3205)
+
 ## [7.0.4] - 2025-12-05
 
 ### Changed


### PR DESCRIPTION
Trusted publishing on NuGet is working, but they Action did not have enough permissions to create a GitHub release.

@Smaug123 if I can have your autograph again.