### PR TITLE
Fix release pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [8.0.0-alpha-001] - 2025-12-12
+
+### Changed
+
+- Update FCS to 'Remove LetOrUseKeyword from SynExprLetOrUseTrivia', commit 43932b4c7984d6562e91e5f1484868cd4f5befcf [#3167](https://github.com/fsprojects/fantomas/pull/3167)
+
 ## [7.0.5] - 2025-12-06
 
 ### Fixed

--- a/build.fsx
+++ b/build.fsx
@@ -19,6 +19,10 @@ open Humanizer
 
 let (</>) a b = Path.Combine(a, b)
 
+let isDryRun =
+    let args = fsi.CommandLineArgs
+    Array.exists (fun arg -> arg = "--dry-run") args
+
 let cleanFolders (input: string seq) =
     async {
         input
@@ -40,15 +44,19 @@ let semanticVersioning =
 
 let pushPackage nupkg =
     async {
-        let key = Environment.GetEnvironmentVariable("NUGET_KEY")
-        let! result =
-            Cli
-                .Wrap("dotnet")
-                .WithArguments($"nuget push {nupkg} --api-key {key} --source https://api.nuget.org/v3/index.json")
-                .ExecuteAsync()
-                .Task
-            |> Async.AwaitTask
-        return result.ExitCode
+        if isDryRun then
+            printfn $"[DRY-RUN] Would push package: {nupkg}"
+            return 0
+        else
+            let key = Environment.GetEnvironmentVariable("NUGET_KEY")
+            let! result =
+                Cli
+                    .Wrap("dotnet")
+                    .WithArguments($"nuget push {nupkg} --api-key {key} --source https://api.nuget.org/v3/index.json")
+                    .ExecuteAsync()
+                    .Task
+                |> Async.AwaitTask
+            return result.ExitCode
     }
 
 let analysisReportsDir = "analysisreports"
@@ -321,23 +329,35 @@ pipeline "Init" {
 }
 
 type GithubRelease =
-    { Version: string
-      Title: string
-      Date: DateTime
-      PublishedDate: string option
-      Draft: string }
+    {
+        Version: string
+        Title: string
+        Date: DateTime
+        /// Optional because new releases don't have a published date yet
+        PublishedDate: string option
+        Draft: string
+    }
 
 let mkGithubRelease (v: SemanticVersion, d: DateTime, cd: ChangelogData option) =
     match cd with
     | None -> failwith "Each Fantomas release is expected to have at least one section."
     | Some cd ->
-        let version = $"{v.Major}.{v.Minor}.{v.Patch}"
+        let version =
+            if String.IsNullOrEmpty v.Prerelease then
+                $"{v.Major}.{v.Minor}.{v.Patch}"
+            else
+                $"{v.Major}.{v.Minor}.{v.Patch}-{v.Prerelease}"
+
+        printfn $"Parsing release version: {version} (prerelease: {not (String.IsNullOrEmpty v.Prerelease)})"
+
         let title =
             let month = d.ToString("MMMM")
             let day = d.Day.Ordinalize()
             $"{month} {day} Release"
 
         let prefixedVersion = $"v{version}"
+        printfn $"Checking if release {prefixedVersion} already exists on GitHub..."
+
         let publishDate =
             let cmdResult =
                 Cli
@@ -347,11 +367,14 @@ let mkGithubRelease (v: SemanticVersion, d: DateTime, cd: ChangelogData option) 
                     .ExecuteBufferedAsync()
                     .Task.Result
             if cmdResult.ExitCode <> 0 then
+                printfn $"Release {prefixedVersion} does not exist yet"
                 None
             else
                 let output = cmdResult.StandardOutput.Trim()
                 let lastIdx = output.LastIndexOf("Z", StringComparison.Ordinal)
-                Some(output.Substring(0, lastIdx))
+                let dateStr = output.Substring(0, lastIdx)
+                printfn $"Release {prefixedVersion} already exists, published at: {dateStr}"
+                Some(dateStr)
 
         let sections =
             [ "Added", cd.Added
@@ -384,32 +407,144 @@ let mkGithubRelease (v: SemanticVersion, d: DateTime, cd: ChangelogData option) 
           Draft = draft }
 
 let getReleaseNotes currentRelease (lastRelease: GithubRelease) =
-    let date = lastRelease.PublishedDate.Value
+    let date =
+        match lastRelease.PublishedDate with
+        | Some d ->
+            printfn $"Using last release published date for author attribution: {d}"
+            d
+        | None ->
+            // Query GitHub for the most recent published release
+            printfn "Last release has no published date, querying GitHub for most recent release..."
+            let ghReleaseResult =
+                Cli
+                    .Wrap("gh")
+                    .WithArguments("release list --limit 1 --json createdAt")
+                    .WithValidation(CommandResultValidation.None)
+                    .ExecuteBufferedAsync()
+                    .Task.Result
+
+            if
+                ghReleaseResult.ExitCode = 0
+                && not (String.IsNullOrWhiteSpace(ghReleaseResult.StandardOutput.Trim()))
+            then
+                try
+                    let jsonOutput = ghReleaseResult.StandardOutput.Trim()
+                    let jsonValue = FSharp.Data.JsonValue.Parse(jsonOutput)
+                    let releases = jsonValue.AsArray()
+                    if releases.Length > 0 then
+                        let createdAt = releases.[0].GetProperty("createdAt").AsString()
+                        let lastIdx = createdAt.LastIndexOf("Z", StringComparison.Ordinal)
+                        if lastIdx > 0 then
+                            let ghDate = createdAt.Substring(0, lastIdx)
+                            printfn $"Using most recent GitHub release date for author attribution: {ghDate}"
+                            ghDate
+                        else
+                            let fallbackDate = DateTime.UtcNow.ToString("yyyy-MM-dd")
+                            printfn $"Could not parse GitHub release date format, using current date: {fallbackDate}"
+                            fallbackDate
+                    else
+                        let fallbackDate = DateTime.UtcNow.ToString("yyyy-MM-dd")
+                        printfn $"No GitHub releases found, using current date: {fallbackDate}"
+                        fallbackDate
+                with ex ->
+                    let fallbackDate = DateTime.UtcNow.ToString("yyyy-MM-dd")
+                    printfn $"Could not parse GitHub release JSON, using current date: {fallbackDate}"
+                    fallbackDate
+            else
+                let fallbackDate = DateTime.UtcNow.ToString("yyyy-MM-dd")
+                printfn $"Could not query GitHub releases, using current date: {fallbackDate}"
+                fallbackDate
+
+    printfn $"Querying PRs closed after {date} for author attribution..."
+
     let authorMsg =
-        let authors =
+        let queryResult =
             Cli
                 .Wrap("gh")
                 .WithArguments(
-                    $"pr list -S \"state:closed base:main closed:>{date} -author:app/robot\" --json author --jq \".[].author.login\""
+                    $"pr list -S \"state:closed base:main closed:>{date} -author:app/robot\" --json commits,mergedAt"
                 )
+                .WithValidation(CommandResultValidation.None)
                 .ExecuteBufferedAsync()
-                .Task.Result.StandardOutput.Split([| '\n' |], StringSplitOptions.RemoveEmptyEntries)
-            |> Array.distinct
-            |> Array.sort
+                .Task.Result
 
-        if authors.Length = 1 then
-            $"Special thanks to @%s{authors.[0]}!"
+        if queryResult.ExitCode <> 0 then
+            printfn $"Warning: Failed to query PRs for author attribution (exit code: {queryResult.ExitCode})"
+            String.Empty
         else
-            let lastAuthor = Array.last authors
-            let otherAuthors =
-                if authors.Length = 2 then
-                    $"@{authors.[0]}"
-                else
-                    authors
-                    |> Array.take (authors.Length - 1)
-                    |> Array.map (sprintf "@%s")
-                    |> String.concat ", "
-            $"Special thanks to %s{otherAuthors} and @%s{lastAuthor}!"
+            let jsonOutput = queryResult.StandardOutput.Trim()
+
+            // Parse JSON to filter by mergedAt timestamp
+            let jsonValue = FSharp.Data.JsonValue.Parse(jsonOutput)
+            let prs = jsonValue.AsArray()
+
+            // Parse the last release published date as ISO timestamp for comparison
+            let cutoffTimestamp =
+                try
+                    DateTime.Parse(date).ToUniversalTime()
+                with _ ->
+                    // If parsing fails, try to parse as ISO format
+                    try
+                        DateTime.ParseExact(date, "yyyy-MM-ddTHH:mm:ss", null).ToUniversalTime()
+                    with _ ->
+                        DateTime.ParseExact(date, "yyyy-MM-dd", null).ToUniversalTime()
+
+            printfn $"Filtering PRs merged after: {cutoffTimestamp:O}"
+
+            let authors =
+                prs
+                |> Array.collect (fun (pr: FSharp.Data.JsonValue) ->
+                    let mergedAtOpt =
+                        try
+                            let mergedAtStr = pr.GetProperty("mergedAt").AsString()
+                            Some(DateTime.Parse(mergedAtStr).ToUniversalTime())
+                        with _ ->
+                            None
+
+                    match mergedAtOpt with
+                    | Some mergedAt when mergedAt > cutoffTimestamp ->
+                        try
+                            let commits = pr.GetProperty("commits").AsArray()
+                            commits
+                            |> Array.collect (fun (commit: FSharp.Data.JsonValue) ->
+                                try
+                                    let commitAuthors = commit.GetProperty("authors").AsArray()
+                                    commitAuthors
+                                    |> Array.choose (fun (author: FSharp.Data.JsonValue) ->
+                                        try
+                                            let login = author.GetProperty("login").AsString()
+                                            // Filter out bots
+                                            if login.EndsWith("[bot]", StringComparison.Ordinal) then
+                                                None
+                                            else
+                                                Some(login)
+                                        with _ ->
+                                            None)
+                                with _ ->
+                                    [||])
+                        with _ ->
+                            [||]
+                    | _ -> [||])
+                |> Array.distinct
+                |> Array.sort
+
+            printfn $"Found {authors.Length} contributors for this release"
+
+            if authors.Length = 0 then
+                String.Empty
+            elif authors.Length = 1 then
+                $"Special thanks to @%s{authors.[0]}!"
+            else
+                let lastAuthor = Array.last authors
+                let otherAuthors =
+                    if authors.Length = 2 then
+                        $"@{authors.[0]}"
+                    else
+                        authors
+                        |> Array.take (authors.Length - 1)
+                        |> Array.map (sprintf "@%s")
+                        |> String.concat ", "
+                $"Special thanks to %s{otherAuthors} and @%s{lastAuthor}!"
 
     $"""{currentRelease.Draft}
 
@@ -419,20 +554,38 @@ let getReleaseNotes currentRelease (lastRelease: GithubRelease) =
     """
 
 let getCurrentAndLastReleaseFromChangelog () =
+    printfn "Parsing CHANGELOG.md to find current and last release..."
     let changelog = FileInfo(__SOURCE_DIRECTORY__ </> "CHANGELOG.md")
     let changeLogResult =
         match Parser.parseChangeLog changelog with
-        | Error error -> failwithf "%A" error
-        | Ok result -> result
+        | Error error -> failwithf "Failed to parse changelog: %A" error
+        | Ok result ->
+            printfn $"Found {result.Releases.Length} releases in changelog"
+            result
 
     let lastReleases =
         changeLogResult.Releases
-        |> List.filter (fun (v, _, _) -> String.IsNullOrEmpty v.Prerelease)
         |> List.sortByDescending (fun (_, d, _) -> d)
         |> List.take 2
 
     match lastReleases with
-    | [ current; last ] -> mkGithubRelease current, mkGithubRelease last
+    | [ current; last ] ->
+        let currentVersion, _, _ = current
+        let lastVersion, _, _ = last
+        let currentPrerelease =
+            if String.IsNullOrEmpty currentVersion.Prerelease then
+                ""
+            else
+                $" (prerelease: {currentVersion.Prerelease})"
+        let lastPrerelease =
+            if String.IsNullOrEmpty lastVersion.Prerelease then
+                ""
+            else
+                $" (prerelease: {lastVersion.Prerelease})"
+        printfn
+            $"Current release: {currentVersion.Major}.{currentVersion.Minor}.{currentVersion.Patch}{currentPrerelease}"
+        printfn $"Last release: {lastVersion.Major}.{lastVersion.Minor}.{lastVersion.Patch}{lastPrerelease}"
+        mkGithubRelease current, mkGithubRelease last
     | _ -> failwith "Could not find the current and last release from CHANGELOG.md"
 
 pipeline "Release" {
@@ -443,45 +596,112 @@ pipeline "Release" {
     stage "Release" {
         run (fun _ ->
             async {
+                if isDryRun then
+                    printfn "[DRY-RUN] Starting release pipeline in dry-run mode"
+                else
+                    printfn "Starting release pipeline"
+
                 let currentRelease, lastRelease = getCurrentAndLastReleaseFromChangelog ()
 
                 if Option.isSome currentRelease.PublishedDate then
+                    printfn $"Release {currentRelease.Version} already exists on GitHub. Skipping release process."
                     return 0
                 else
+                    printfn $"Release {currentRelease.Version} does not exist yet. Proceeding with release process."
+
+                    // Determine if this is a prerelease
+                    let isPrerelease = currentRelease.Version.Contains("-")
+                    if isPrerelease then
+                        printfn $"Detected prerelease version: {currentRelease.Version}"
+
                     // Push packages to NuGet
                     let nugetPackages =
                         Directory.EnumerateFiles("artifacts/package/release", "*.nupkg", SearchOption.TopDirectoryOnly)
                         |> Seq.filter (fun nupkg -> not (nupkg.Contains("Fantomas.Client")))
                         |> Seq.toArray
 
+                    printfn $"Found {nugetPackages.Length} packages to push to NuGet:"
+                    nugetPackages |> Array.iter (fun pkg -> printfn $"  - {Path.GetFileName(pkg)}")
+
                     let! nugetExitCodes = nugetPackages |> Array.map pushPackage |> Async.Sequential
 
+                    let nugetSuccess = nugetExitCodes |> Array.forall (fun code -> code = 0)
+                    if nugetSuccess then
+                        printfn "All NuGet packages pushed successfully"
+                    else
+                        let exitCodesStr = nugetExitCodes |> Array.map string |> String.concat ", "
+                        printfn $"Warning: Some NuGet packages failed to push. Exit codes: {exitCodesStr}"
+
                     let notes = getReleaseNotes currentRelease lastRelease
+                    printfn "Release notes that will be used:"
+                    printfn "---"
+                    printfn "%s" notes
+                    printfn "---"
                     let noteFile = Path.GetTempFileName()
                     File.WriteAllText(noteFile, notes)
                     let files = nugetPackages |> String.concat " "
 
                     // We create a draft release for minor and majors. Those that requires a manual publish.
                     // This is to allow us to add additional release notes when it makes sense.
-                    let! draftResult =
-                        let isDraft =
-                            let isRevision = lastRelease.Version.Split('.') |> Array.last |> int |> (<>) 0
-                            if isRevision then String.Empty else "--draft"
+                    // Extract patch version from currentRelease.Version (handle prerelease format)
+                    let versionParts = currentRelease.Version.Split('-')
+                    let mainVersion = versionParts.[0]
+                    let patchVersion =
+                        let parts = mainVersion.Split('.')
+                        if parts.Length >= 3 then
+                            match Int32.TryParse(parts.[2]) with
+                            | true, p -> p
+                            | _ -> 0
+                        else
+                            0
 
-                        Cli
-                            .Wrap("gh")
-                            .WithArguments(
-                                $"release create v{currentRelease.Version} {files} {isDraft} --title \"{currentRelease.Title}\" --notes-file \"{noteFile}\""
-                            )
-                            .WithValidation(CommandResultValidation.None)
-                            .ExecuteAsync()
-                            .Task
-                        |> Async.AwaitTask
+                    let isRevision = patchVersion <> 0
+                    // Draft only for stable minor/major releases (patch = 0 and not prerelease)
+                    let isDraftFlag =
+                        if isRevision || isPrerelease then
+                            String.Empty
+                        else
+                            "--draft"
+                    let prereleaseFlag = if isPrerelease then "--prerelease" else String.Empty
+
+                    let releaseType =
+                        if isPrerelease then "prerelease (published)"
+                        elif isRevision then "revision (published)"
+                        else "minor/major (draft)"
+                    printfn $"Release type: {releaseType}"
+                    if isPrerelease then
+                        printfn "This is a prerelease version"
+
+                    let releaseCommand =
+                        $"release create v{currentRelease.Version} {files} {isDraftFlag} {prereleaseFlag} --title \"{currentRelease.Title}\" --notes-file \"{noteFile}\""
+
+                    let! draftExitCode =
+                        if isDryRun then
+                            printfn $"[DRY-RUN] Would execute: gh {releaseCommand}"
+                            async { return 0 }
+                        else
+                            printfn $"Creating GitHub release: v{currentRelease.Version}"
+                            async {
+                                let! result =
+                                    Cli
+                                        .Wrap("gh")
+                                        .WithArguments(releaseCommand)
+                                        .WithValidation(CommandResultValidation.None)
+                                        .ExecuteAsync()
+                                        .Task
+                                    |> Async.AwaitTask
+                                return result.ExitCode
+                            }
 
                     if File.Exists noteFile then
                         File.Delete(noteFile)
 
-                    return Seq.max [| yield! nugetExitCodes; yield draftResult.ExitCode |]
+                    if draftExitCode = 0 then
+                        printfn $"Successfully created GitHub release: v{currentRelease.Version}"
+                    else
+                        printfn $"Warning: GitHub release creation returned exit code: {draftExitCode}"
+
+                    return Seq.max [| yield! nugetExitCodes; yield draftExitCode |]
             })
     }
     runIfOnlySpecified true

--- a/build.fsx
+++ b/build.fsx
@@ -461,9 +461,7 @@ let getReleaseNotes currentRelease (lastRelease: GithubRelease) =
         let queryResult =
             Cli
                 .Wrap("gh")
-                .WithArguments(
-                    $"pr list -S \"state:closed base:main closed:>{date} -author:app/robot\" --json commits,mergedAt"
-                )
+                .WithArguments($"pr list -S \"state:closed base:main closed:>{date}\" --json commits,mergedAt")
                 .WithValidation(CommandResultValidation.None)
                 .ExecuteBufferedAsync()
                 .Task.Result
@@ -490,15 +488,12 @@ let getReleaseNotes currentRelease (lastRelease: GithubRelease) =
                     let mergedAtOpt =
                         match pr.TryGetProperty("mergedAt") with
                         | Some mergedAtJson ->
-                            try
-                                let mergedAtStr = mergedAtJson.AsString()
-                                Some(
-                                    DateTime
-                                        .Parse(mergedAtStr, null, System.Globalization.DateTimeStyles.RoundtripKind)
-                                        .ToUniversalTime()
-                                )
-                            with _ ->
-                                None
+                            let mergedAtStr = mergedAtJson.AsString()
+                            match
+                                DateTime.TryParse(mergedAtStr, null, System.Globalization.DateTimeStyles.RoundtripKind)
+                            with
+                            | true, dt -> Some(dt.ToUniversalTime())
+                            | false, _ -> None
                         | None -> None
 
                     match mergedAtOpt with


### PR DESCRIPTION
A bit more goodness to automate the release notes.
What we had, had some limitations:
- [x] Allow prerelease to be published.
- [x] Don't error when we release twice a day.
- [x] Include all authors of a PR.

 