### PR TITLE
Assert comment trivia is preserved during formatting

### DIFF
--- a/src/Fantomas.Core/Trivia.fsi
+++ b/src/Fantomas.Core/Trivia.fsi
@@ -5,6 +5,7 @@ open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 
 val findNodeWhereRangeFitsIn: root: Node -> range: range -> Node option
+val collectCommentTextsFromAST: sourceText: ISourceText -> ast: ParsedInput -> Set<TriviaContent>
 val enrichTree: config: FormatConfig -> sourceText: ISourceText -> ast: ParsedInput -> tree: Oak -> Oak
 
 /// Try and insert a cursor position as Trivia inside the Oak


### PR DESCRIPTION
Add collectCommentTextsFromAST to Trivia.fs that collects a normalized Set<TriviaContent> from a parsed AST. Inline the validity check in formatFSharpString and reuse the parse result to compare input and output comments, failing with a clear diff when comments are lost.

Resolves #2431