### PR TITLE
Break long & (AND) patterns across multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - End of line comments after infix operators are preserved correctly. [#2287](https://github.com/fsprojects/fantomas/issues/2287)
+- Long `&` (AND) patterns now break across multiple lines to respect max line length. [#1780](https://github.com/fsprojects/fantomas/issues/1780)
 
 ## [8.0.0-alpha-002] - 2025-12-15
 

--- a/src/Fantomas.Core.Tests/PatternMatchingTests.fs
+++ b/src/Fantomas.Core.Tests/PatternMatchingTests.fs
@@ -2313,3 +2313,29 @@ let value =
          "111111111111111111111111111111111111111111111111111111111111111111111", "22222222222222222222222222222222222")
     ||> createTuple
 """
+
+[<Test>]
+let ``long and pattern respects max line length, 1780`` () =
+    formatSourceString
+        """
+let v, x =
+    match n with
+    | Voluptatem voluptatem & Praesentium praesentium & Molestiae molestiae & Repudiandae repudiandae & Exercitationem exercitationem & Assumenda assumenda ->
+        libero, []
+    | _ -> saepe, delectus
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let v, x =
+    match n with
+    | Voluptatem voluptatem
+        & Praesentium praesentium
+        & Molestiae molestiae
+        & Repudiandae repudiandae
+        & Exercitationem exercitationem
+        & Assumenda assumenda -> libero, []
+    | _ -> saepe, delectus
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2618,7 +2618,17 @@ let genPat (p: Pattern) =
     match p with
     | Pattern.OptionalVal n -> genSingleTextNode n
     | Pattern.Or node -> genPatLeftMiddleRight node
-    | Pattern.Ands node -> col (!-" & ") node.Patterns genPat |> genNode node
+    | Pattern.Ands node ->
+        let short = col (!-" & ") node.Patterns genPat
+
+        let long =
+            match node.Patterns with
+            | [] -> sepNone
+            | head :: rest ->
+                genPat head
+                +> indentSepNlnUnindent (col sepNln rest (fun p -> !-"& " +> genPat p))
+
+        expressionFitsOnRestOfLine short long |> genNode node
     | Pattern.Null node
     | Pattern.Wild node -> genSingleTextNode node
     | Pattern.Parameter node ->


### PR DESCRIPTION
When a Pattern.Ands exceeds the max line length, each subsequent & pattern is now placed on its own indented line instead of keeping everything on a single line.

Fixes #1780
