### PR TITLE
Fix empty array/list trivia indentation in Stroustrup style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - End of line comments after infix operators are preserved correctly. [#2287](https://github.com/fsprojects/fantomas/issues/2287)
+- Empty array with trivia inside now has correct indentation in Stroustrup style. [#3098](https://github.com/fsprojects/fantomas/issues/3098)
 
 ## [8.0.0-alpha-002] - 2025-12-15
 

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -611,7 +611,7 @@ let newState = {|
 let ``app node with single record arg`` () =
     formatSourceString
         """
-let newState =
+let newState = 
     Some
         {
             F1 = 0
@@ -635,7 +635,7 @@ let newState =
 let ``lowercase app node with single record arg`` () =
     formatSourceString
         """
-let newState =
+let newState = 
     someFunc
         {
             F1 = 0
@@ -659,7 +659,7 @@ let newState =
 let ``lowercase app node with multiple args ending in a single record arg`` () =
     formatSourceString
         """
-let newState =
+let newState = 
     myFn a b c { D = d; E = e }
 """
         { config with
@@ -679,7 +679,7 @@ let newState =
 let ``lowercase app node with multiple args ending in a single anonymous record arg`` () =
     formatSourceString
         """
-let newState =
+let newState = 
     myFn a b c {| D = d; E = e |}
 """
         { config with
@@ -838,7 +838,6 @@ let ``empty array with blank line inside, 3098`` () =
     formatSourceString
         """
 let myArray = [|
-
   |]
 """
         config
@@ -847,7 +846,6 @@ let myArray = [|
         equal
         """
 let myArray = [|
-
     |]
 """
 

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -838,6 +838,7 @@ let ``empty array with blank line inside, 3098`` () =
     formatSourceString
         """
 let myArray = [|
+  
   |]
 """
         config
@@ -846,6 +847,7 @@ let myArray = [|
         equal
         """
 let myArray = [|
+
     |]
 """
 

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -611,7 +611,7 @@ let newState = {|
 let ``app node with single record arg`` () =
     formatSourceString
         """
-let newState = 
+let newState =
     Some
         {
             F1 = 0
@@ -635,7 +635,7 @@ let newState =
 let ``lowercase app node with single record arg`` () =
     formatSourceString
         """
-let newState = 
+let newState =
     someFunc
         {
             F1 = 0
@@ -659,7 +659,7 @@ let newState =
 let ``lowercase app node with multiple args ending in a single record arg`` () =
     formatSourceString
         """
-let newState = 
+let newState =
     myFn a b c { D = d; E = e }
 """
         { config with
@@ -679,7 +679,7 @@ let newState =
 let ``lowercase app node with multiple args ending in a single anonymous record arg`` () =
     formatSourceString
         """
-let newState = 
+let newState =
     myFn a b c {| D = d; E = e |}
 """
         { config with
@@ -831,4 +831,40 @@ let list =
 #endif
     // comment
     ]
+"""
+
+[<Test>]
+let ``empty array with blank line inside, 3098`` () =
+    formatSourceString
+        """
+let myArray = [|
+
+  |]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let myArray = [|
+
+    |]
+"""
+
+[<Test>]
+let ``empty array with comment inside, 3098`` () =
+    formatSourceString
+        """
+let myArray2 = [|
+  // Some comment
+  |]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let myArray2 = [|
+    // Some comment
+    |]
 """


### PR DESCRIPTION
When an empty array contains trivia (blank lines or comments) before the closing bracket and Stroustrup style is used, the closing bracket and its trivia are now properly indented.

Fixes #3098
