### PR TITLE
Fix indentation of module declaration with hash directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Long delegate type with generic args no longer breaks around arrow. [#2468](https://github.com/fsprojects/fantomas/issues/2468)
 - Idempotency problem when formatting NUnit Assert.That with lambda argument. [#1740](https://github.com/fsprojects/fantomas/issues/1740)
 - Comment between lines of no-break infix expression no longer loses indentation. [#2944](https://github.com/fsprojects/fantomas/issues/2944)
+- Hash directives around access modifier in module declaration no longer lose indentation. [#3188](https://github.com/fsprojects/fantomas/issues/3188)
 
 ## [8.0.0-alpha-002] - 2025-12-15
 

--- a/src/Fantomas.Core.Tests/ModuleTests.fs
+++ b/src/Fantomas.Core.Tests/ModuleTests.fs
@@ -1088,3 +1088,27 @@ namespace ``G-Research``.``FSharp X``.``Analyzers Y``
 module StringAnalyzers =
     ()
 """
+
+[<Test>]
+let ``hash directives around access modifier in module, 3188`` () =
+    formatSourceString
+        """
+[<RequireQualifiedAccess>]
+module
+#if !MCP
+    internal
+#endif
+        Fantomas.Core.CodeFormatterImpl
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<RequireQualifiedAccess>]
+module
+#if !MCP
+    internal
+#endif
+    Fantomas.Core.CodeFormatterImpl
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -4050,10 +4050,12 @@ let genModule (m: ModuleOrNamespaceNode) =
             (genXml header.XmlDoc
              +> genAttributes header.Attributes
              +> genMultipleTextsNode header.LeadingKeyword
+             +> indent
              +> sepSpace
              +> genAccessOpt header.Accessibility
              +> onlyIf header.IsRecursive (sepSpace +> !-"rec" +> sepSpace)
              +> optSingle genIdentListNode header.Name
+             +> unindent
              |> genNode header)
             +> newline)
         m.Header


### PR DESCRIPTION
When hash directives surrounded the access modifier in a module declaration, the access modifier and module name lost their indentation. Wrapping the post-keyword content with indent/unindent preserves correct indentation when directive trivia forces newlines.

Fixes #3188

﻿Please verify your pull request is respecting our [Pull request ground rules](https://fsprojects.github.io/fantomas/docs/contributors/Pull%20request%20ground%20rules.html).
You can find more information in our [Contributors documentation section](https://fsprojects.github.io/fantomas/docs/contributors/Index.html).