### PR TITLE
Fix space between uppercase function name and parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [8.0.0-alpha-006] - 2026-03-09
+
+### Fixed
+
+- Space between uppercase function name and uppercase parameter was dropped. [#3264](https://github.com/fsprojects/fantomas/pull/3264)
+
 ## [8.0.0-alpha-005] - 2026-03-09
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Core.Tests/LetBindingTests.fs
@@ -2324,3 +2324,13 @@ let processSnippetLine
     let lineStr = lines.[line]
     ()
 """
+
+[<Test>]
+let ``uppercase function name with uppercase parameter should preserve space`` () =
+    formatSourceString "let F P = 1" config
+    |> prepend newline
+    |> should
+        equal
+        """
+let F P = 1
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2914,7 +2914,8 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
                             | _, Pattern.Paren _
                             | _, Pattern.Unit _ -> spaceBefore
                             | _, Pattern.Named _
-                            | _, Pattern.Wild _ -> true
+                            | _, Pattern.Wild _
+                            | _, Pattern.LongIdent _ -> true
                             | content, _ ->
                                 match List.tryLast content with
                                 | None -> false


### PR DESCRIPTION
When a function name started with an uppercase letter and had a single non-parenthesized parameter (e.g. `let F P = 1`), the formatter incorrectly omitted the space, producing `let FP = 1`.