### PR TITLE
Update FCS and fix #3263

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [8.0.0-alpha-007] - 2026-03-10
+
+### Fixed
+
+- `#nowarn` in arbitrary places produces a parsing failure. [#3263](https://github.com/fsprojects/fantomas/issues/3263)
+
+### Changed
+
+- Update FCS to 'Treat warn directives as trivia', commit ab1f6ceaaec997d2854ac1c07a6c0f107675d95c [#3263](https://github.com/fsprojects/fantomas/issues/3263)
+
 ## [8.0.0-alpha-006] - 2026-03-09
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,12 +42,12 @@ Some common use cases include:
         <ServerGarbageCollection>true</ServerGarbageCollection>
         <OtherFlags>$(OtherFlags) --test:GraphBasedChecking --test:ParallelOptimization --test:ParallelIlxGen --strict-indentation+ --realsig+</OtherFlags>
     </PropertyGroup>
-    
+
     <!-- Versions -->
     <PropertyGroup>
-        <FCSCommitHash>43932b4c7984d6562e91e5f1484868cd4f5befcf</FCSCommitHash>
+        <FCSCommitHash>ab1f6ceaaec997d2854ac1c07a6c0f107675d95c</FCSCommitHash>
     </PropertyGroup>
-    
+
     <PropertyGroup>
         <FsDocsLicenseLink>https://github.com/fsprojects/fantomas/blob/main/LICENSE.md</FsDocsLicenseLink>
         <FsDocsReleaseNotesLink>https://github.com/fsprojects/fantomas/blob/main/CHANGELOG.md</FsDocsReleaseNotesLink>
@@ -55,7 +55,7 @@ Some common use cases include:
         <FsDocsFaviconSource>images/favicon.ico</FsDocsFaviconSource>
         <RepositoryUrl>https://github.com/fsprojects/fantomas</RepositoryUrl>
     </PropertyGroup>
-    
+
    <ItemGroup>
         <PackageReference Include="G-Research.FSharp.Analyzers">
             <PrivateAssets>all</PrivateAssets>

--- a/build.fsx
+++ b/build.fsx
@@ -238,7 +238,7 @@ pipeline "Init" {
         run (fun _ ->
             [| "src/Compiler/FSComp.txt"
                "src/Compiler/FSStrings.resx"
-               "src/Compiler/Utilities/NullnessShims.fs"
+               "src/Compiler/Utilities/NullHelpers.fs"
                "src/Compiler/Utilities/Activity.fsi"
                "src/Compiler/Utilities/Activity.fs"
                "src/Compiler/Utilities/Caches.fsi"

--- a/src/Fantomas.Core.Tests/HashDirectiveTests.fs
+++ b/src/Fantomas.Core.Tests/HashDirectiveTests.fs
@@ -251,6 +251,60 @@ let ``#help without string`` () =
 """
 
 // As of F# 10.0, warn directives are treated as trivia like #if, so arguments are not formatted
+
+[<Test>]
+let ``nowarn and warnon in arbitrary places, 3263`` () =
+    formatSourceString
+        """
+let SingleChoiceTextValueType =
+    Define.Object<CustomValue> (
+        name = "SingleChoiceTextValue",
+        fields = [
+#nowarn 25 // Incomplete pattern match
+            Define.Field ("options", ListOf StringType, fun _ (SingleChoiceTextValue sctv) -> sctv.Options)
+            Define.Field (
+                "optionsTranslations",
+                ListOf SelectTypeOptionsTranslationsType,
+                fun _ (SingleChoiceTextValue sctv) -> sctv.OptionsTranslations
+            )
+            Define.Field ("value", StructNullable StringType, fun _ (SingleChoiceTextValue sctv) -> sctv.Value)
+            Define.Field (
+                "renderType",
+                StructNullable CustomFieldRenderTypeType,
+                fun _ (SingleChoiceTextValue sctv) -> sctv.RenderType
+#warnon 25 // Incomplete pattern match
+            )
+        ]
+    )
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let SingleChoiceTextValueType =
+    Define.Object<CustomValue>(
+        name = "SingleChoiceTextValue",
+        fields =
+            [
+                #nowarn 25 // Incomplete pattern match
+                Define.Field("options", ListOf StringType, fun _ (SingleChoiceTextValue sctv) -> sctv.Options)
+                Define.Field(
+                    "optionsTranslations",
+                    ListOf SelectTypeOptionsTranslationsType,
+                    fun _ (SingleChoiceTextValue sctv) -> sctv.OptionsTranslations
+                )
+                Define.Field("value", StructNullable StringType, fun _ (SingleChoiceTextValue sctv) -> sctv.Value)
+                Define.Field(
+                    "renderType",
+                    StructNullable CustomFieldRenderTypeType,
+                    fun _ (SingleChoiceTextValue sctv) -> sctv.RenderType
+                #warnon 25 // Incomplete pattern match
+                )
+            ]
+    )
+"""
+
 [<Test>]
 let ``#nowarn with integer`` () =
     formatSourceString

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -3653,6 +3653,7 @@ let includeTrivia (baseRange: range) (trivia: ParsedInputTrivia) : range =
                   (function
                   | ConditionalDirectiveTrivia.If(range = range)
                   | ConditionalDirectiveTrivia.Else(range = range)
+                  | ConditionalDirectiveTrivia.Elif(range = range)
                   | ConditionalDirectiveTrivia.EndIf(range = range) -> range)
                   trivia.ConditionalDirectives
 

--- a/src/Fantomas.Core/Defines.fs
+++ b/src/Fantomas.Core/Defines.fs
@@ -246,6 +246,7 @@ module Defines =
 
                 match hashLine with
                 | ConditionalDirectiveTrivia.If(expr, _) -> expr :: contextExprs, contextExpr expr :: exprAcc
+                | ConditionalDirectiveTrivia.Elif _ -> failwith "ConditionalDirectiveTrivia.Elif is not yet support"
                 | ConditionalDirectiveTrivia.Else _ ->
                     contextExprs,
                     IfDirectiveExpression.Not(contextExprs |> List.reduce (fun x y -> IfDirectiveExpression.And(x, y)))

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -134,6 +134,7 @@ type ConditionalDirectiveTrivia with
         match x with
         | ConditionalDirectiveTrivia.If(_, m)
         | ConditionalDirectiveTrivia.Else m
+        | ConditionalDirectiveTrivia.Elif(_, m)
         | ConditionalDirectiveTrivia.EndIf m -> m
 
 let internal collectTriviaFromDirectiveRanges

--- a/src/Fantomas.FCS/Fantomas.FCS.fsproj
+++ b/src/Fantomas.FCS/Fantomas.FCS.fsproj
@@ -24,8 +24,8 @@
       <Link>FSStrings.resx</Link>
       <LogicalName>FSStrings.resources</LogicalName>
     </EmbeddedResource>
-    <Compile Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\Utilities\NullnessShims.fs">
-      <Link>Utilities\NullnessShims.fs</Link>
+    <Compile Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\Utilities\NullHelpers.fs">
+      <Link>Utilities\NullHelpers.fs</Link>
     </Compile>
     <Compile Include="..\..\.deps\$(FCSCommitHash)\src\Compiler\Utilities\Activity.fsi">
       <Link>Utilities\Activity.fsi</Link>

--- a/src/Fantomas.FCS/Parse.fs
+++ b/src/Fantomas.FCS/Parse.fs
@@ -26,8 +26,6 @@ open Fantomas.FCS.ParseHelpers
 
 let FSharpSigFileSuffixes = [ ".mli"; ".fsi" ]
 
-let mlCompatSuffixes = [ ".mli"; ".ml" ]
-
 let FSharpImplFileSuffixes = [ ".ml"; ".fs"; ".fsscript"; ".fsx" ]
 
 let FSharpScriptFileSuffixes = [ ".fsscript"; ".fsx" ]
@@ -302,12 +300,6 @@ let ParseInput
     use _ = UseBuildPhase BuildPhase.Parse
 
     try
-        if mlCompatSuffixes |> List.exists (FileSystemUtils.checkSuffix lower) then
-            if lexbuf.SupportsFeature LanguageFeature.MLCompatRevisions then
-                errorR (Error(FSComp.SR.buildInvalidSourceFileExtensionML filename, rangeStartup))
-            else
-                mlCompatWarning (FSComp.SR.buildCompilingExtensionIsForML ()) rangeStartup
-
         // Call the appropriate parser - for signature files or implementation files
         if FSharpImplFileSuffixes |> List.exists (FileSystemUtils.checkSuffix lower) then
             let impl = Parser.implementationFile lexer lexbuf
@@ -315,10 +307,8 @@ let ParseInput
         elif FSharpSigFileSuffixes |> List.exists (FileSystemUtils.checkSuffix lower) then
             let intfs = Parser.signatureFile lexer lexbuf
             PostParseModuleSpecs(defaultNamespace, filename, isLastCompiland, intfs, lexbuf)
-        else if lexbuf.SupportsFeature LanguageFeature.MLCompatRevisions then
-            error (Error(FSComp.SR.buildInvalidSourceFileExtensionUpdated filename, rangeStartup))
         else
-            error (Error(FSComp.SR.buildInvalidSourceFileExtension filename, rangeStartup))
+            error (Error(FSComp.SR.buildInvalidSourceFileExtensionUpdated filename, rangeStartup))
     finally
         // OK, now commit the errors, since the ScopedPragmas will (hopefully) have been scraped
         let filteringErrorLogger = errorLogger // TODO: does this matter? //GetErrorLoggerFilteringByScopedPragmas(false, scopedPragmas, diagnosticOptions, errorLogger)
@@ -349,13 +339,11 @@ let createLexbuf langVersion sourceText =
     UnicodeLexing.SourceTextAsLexbuf(true, LanguageVersion(langVersion), Some true, sourceText)
 
 let createLexerFunction (defines: string list) lexbuf (errorLogger: CapturingDiagnosticsLogger) =
-    let lightStatus = IndentationAwareSyntaxStatus(true, true)
-
     // Note: we don't really attempt to intern strings across a large scope.
     let lexResourceManager = LexResourceManager()
 
     let lexargs =
-        mkLexargs (defines, lightStatus, lexResourceManager, [], errorLogger, PathMap.empty, false)
+        mkLexargs (defines, lexResourceManager, [], errorLogger, PathMap.empty, false)
 
     let lexargs =
         { lexargs with
@@ -364,7 +352,7 @@ let createLexerFunction (defines: string list) lexbuf (errorLogger: CapturingDia
     let compilingFsLib = false
 
     let tokenizer =
-        LexFilter.LexFilter(lightStatus, compilingFsLib, Lexer.token lexargs true, lexbuf, false)
+        LexFilter.LexFilter(compilingFsLib, Lexer.token lexargs true, lexbuf, false)
 
     (fun _ -> tokenizer.GetToken())
 
@@ -696,7 +684,6 @@ let getSyntaxErrorMessage ctxt =
         | Parser.TOKEN_HIGH_PRECEDENCE_BRACK_APP -> getErrorString "Parser.TOKEN.HIGH.PRECEDENCE.BRACK.APP"
         | Parser.TOKEN_BEGIN -> getErrorString "Parser.TOKEN.BEGIN"
         | Parser.TOKEN_END -> getErrorString "Parser.TOKEN.END"
-        | Parser.TOKEN_HASH_LIGHT
         | Parser.TOKEN_HASH_LINE
         | Parser.TOKEN_HASH_IF
         | Parser.TOKEN_HASH_ELSE
@@ -987,7 +974,7 @@ let parseFile
 
     let diagnostics =
         List.map
-            (fun (p, severity) ->
+            (fun (p) ->
                 // See https://github.com/dotnet/fsharp/blob/2a25184293e39a635217670652b00680de04472a/src/Compiler/Driver/CompilerDiagnostics.fs#L214
                 // for the error codes
                 let range, message, errorNumber =
@@ -999,7 +986,7 @@ let parseFile
                     | :? ReservedKeyword as rkw -> Some rkw.Data1, rkw.Data0, Some 46
                     | _ -> None, p.Exception.Message, None
 
-                { Severity = severity
+                { Severity = p.Severity
                   SubCategory = "parse"
                   Range = range
                   ErrorNumber = errorNumber


### PR DESCRIPTION
Update FCS to 'Remove leading spaces from warn directive range'
Fixes #3263