### PR TITLE
Fix NamedIndexedPropertySet with two SynLongIdent removing space

### DIFF
--- a/.claude/skills/fantomas-issue/SKILL.md
+++ b/.claude/skills/fantomas-issue/SKILL.md
@@ -1,0 +1,81 @@
+---
+description: Investigate and fix a Fantomas formatting issue from GitHub
+---
+
+The input is a Fantomas GitHub issue URL (e.g. https://github.com/fsprojects/fantomas/issues/1234).
+
+Follow these steps in order:
+
+## 1. Fetch the issue
+
+Use `gh issue view <number> --repo fsprojects/fantomas --json title,body,labels` to get the issue details. Extract the example code and expected behavior. Note the labels — `bug (soundness)` vs `bug (stylistic)` affects the changelog entry.
+
+## 2. Reproduce the problem
+
+Use the /format skill to format the example code and confirm the bug exists. If confirmed, try to trim the example down to the minimal reproduction case.
+
+## 3. Add a failing unit test
+
+Find a suitable test file in `src/Fantomas.Core.Tests/`. Look for existing tests related to the same AST node or concept using grep. If no good file exists, ask the user where to create a new file.
+
+A new test file should follow this template:
+
+```fsharp
+module Fantomas.Core.Tests.MyNewConceptTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelpers
+
+// add tests here...
+```
+
+Test naming rules:
+- Test names must start with a **lowercase** letter.
+- When linked to a GitHub issue, add the issue number at the back with a comma: `` let ``my test description, 1234`` () = ``
+- You don't need to repeat the issue number for tests that are variations of the original report.
+
+### Verify signature files
+
+Check if the fix should also apply to signature files (`*.fsi`). If so, add a test using `formatSignatureString` or the `--signature` flag.
+
+### Verify slight variations
+
+- Check if additional tests are needed for different setting combinations.
+- If the code involves `#if`/`#else` directives, use `formatSourceStringWithDefines` to test each define combination separately, plus a `formatSourceString` test for the merged result. Name suffixes: `, no defines`, `, DEBUG`, `, 1234`.
+
+Run the test and **assert it fails** before proceeding to the fix.
+
+## 4. Investigate the root cause
+
+Use the /ast, /oak, and /writer-events skills to understand what's happening. Key files to inspect:
+- `src/Fantomas.Core/CodePrinter.fs` — the main printer
+- `src/Fantomas.Core/Context.fs` — writer context
+- `src/Fantomas.Core/ASTTransformer.fs` — AST to Oak transformation
+- `src/Fantomas.Core/Trivia.fs` — trivia (comments, blank lines, directives)
+
+## 5. Implement the fix
+
+Make the minimal change needed. Run the new test to confirm it passes.
+
+## 6. Run all tests
+
+Run `dotnet test src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj`. If many tests fail, the fix is likely too broad — make it more targeted. If only a few tests fail and the new behavior is arguably better, update those tests and ask the user for their opinion (a git diff is easiest to review).
+
+## 7. Update CHANGELOG.md
+
+Add an entry under the `## [Unreleased]` section. Never add to an already-published version section. If there is no `Unreleased` section, create one at the top above the most recent version.
+
+- For `bug (soundness)` fixes, add under `### Fixed` using the original issue title:
+  `- <Original GitHub issue title>. [#1234](https://github.com/fsprojects/fantomas/issues/1234)`
+- For `bug (stylistic)` fixes (not related to a style guide), also add under `### Fixed`.
+- For `bug (stylistic)` fixes related to a style guide, add under `### Changed`:
+  `- Update style of xyz. [#1234](https://github.com/fsprojects/fantomas/issues/1234)`
+
+## 8. Run analyzers
+
+Run `dotnet msbuild /t:AnalyzeSolution` to check for analyzer warnings/errors.
+
+## 9. Format edited files
+
+Run `dotnet fantomas <file>` on all `.fs` and `.fsx` files you edited to ensure they conform to the project's formatting standard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Multiline `val` body in signature files was not indented correctly. [#3269](https://github.com/fsprojects/fantomas/pull/3269)
 - `///` doc comment without associated declaration (e.g. at end of file) was duplicated when formatting. [#2499](https://github.com/fsprojects/fantomas/issues/2499)
+- NamedIndexedPropertySet with two SynLongIdent removed space. [#3273](https://github.com/fsprojects/fantomas/issues/3273)
 
 ## [8.0.0-alpha-007] - 2026-03-10
 

--- a/src/Fantomas.Core.Tests/SynExprSetTests.fs
+++ b/src/Fantomas.Core.Tests/SynExprSetTests.fs
@@ -284,3 +284,17 @@ let xs = [| 42 |]
 
 xs.Items.Item 0 <- 20
 """
+
+[<Test>]
+let ``namedIndexedPropertySet with two SynLongIdent removes space, 3273`` () =
+    formatSourceString
+        """
+a.B c.DE <- 0
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+a.B c.DE <- 0
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1500,7 +1500,8 @@ let genExpr (e: Expr) =
             let sep =
                 match node.Index with
                 | Expr.Constant _
-                | Expr.Ident _ -> sepSpace
+                | Expr.Ident _
+                | Expr.OptVar _ -> sepSpace
                 | _ -> sepNone
 
             genIdentListNode node.Identifier


### PR DESCRIPTION
Add Expr.OptVar to the cases that produce a space separator in NamedIndexedPropertySet, so `a.B c.DE <- 0` no longer loses the space.

Fixes #3273