### PR TITLE
Replace Fantomas Discord with F# Discord channel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ The maintainers know the code and will be able to tell.
 
 # Community
 
-There is a [Discord](https://discord.gg/D5QXvQrBVa) server or you can try the `#editor_support` channel in the [F# Foundation Slack](https://fsharp.slack.com).
+You can ask questions in the [#fantomas channel on the F# Discord](https://discord.com/channels/196693847965696000/1493226271767924747) or the `#editor_support` channel in the [F# Foundation Slack](https://fsharp.slack.com).
 
 ## Talks
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fantomas
 ![Fantomas logo](https://raw.githubusercontent.com/fsprojects/fantomas/main/fantomas_logo.png)
 
 ![GitHub Workflow Status (event)](https://img.shields.io/github/actions/workflow/status/fsprojects/fantomas/main.yml?branch=main&label=Build%20main&style=flat-square)
-[![Discord](https://img.shields.io/discord/940511234179096586?label=Fantomas%20Discord&style=flat-square)](https://discord.gg/D5QXvQrBVa)
+[![Discord](https://img.shields.io/discord/196693847965696000?label=F%23%20Discord&style=flat-square)](https://discord.com/channels/196693847965696000/1493226271767924747)
 [![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/fantomas?style=flat-square)](https://www.nuget.org/packages/fantomas/absoluteLatest)
 
 An [**opinionated**](https://fsprojects.github.io/fantomas/docs/end-users/StyleGuide.html) F# source code formatter.                  

--- a/docs/docs/contributors/Releases.md
+++ b/docs/docs/contributors/Releases.md
@@ -98,7 +98,7 @@ To add a nickname:
 
 ## Spread the word
 
-Share the newly created release on our Discord server in the `#announcements` channel.  
+Share the newly created release in the [#fantomas channel on the F# Discord](https://discord.com/channels/196693847965696000/1493226271767924747).  
 Optionally share (minor or major) releases on other social media. 
 
 <fantomas-nav previous="{{fsdocs-previous-page-link}}" next="{{fsdocs-next-page-link}}"></fantomas-nav>

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,7 +2,7 @@
 ========
 
 [![Build Status Github Actions](https://github.com/fsprojects/fantomas/workflows/Build%20main/badge.svg?branch=main&event=push)](https://github.com/fsprojects/fantomas/actions)
-[![Discord](https://img.shields.io/discord/940511234179096586?label=Fantomas%20Discord&style=flat-square)](https://discord.gg/D5QXvQrBVa)
+[![Discord](https://img.shields.io/discord/196693847965696000?label=F%23%20Discord&style=flat-square)](https://discord.com/channels/196693847965696000/1493226271767924747)
 
 F# source code formatter, inspired by [scalariform](https://github.com/mdr/scalariform) for Scala, [ocp-indent](https://github.com/OCamlPro/ocp-indent) for OCaml and [PythonTidy](https://pypi.org/project/PythonTidy/) for Python.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -443,10 +443,10 @@
     </footer>
 </main>
 <div class="discord">
-    <strong>Join us on Discord</strong>
-    <a href="https://discord.gg/D5QXvQrBVa">
+    <strong>Join us on the F# Discord</strong>
+    <a href="https://discord.com/channels/196693847965696000/1493226271767924747">
         <img alt="Discord image link"
-             src="https://img.shields.io/discord/940511234179096586?style=for-the-badge&logo=discord"/>
+             src="https://img.shields.io/discord/196693847965696000?style=for-the-badge&logo=discord"/>
     </a>
 </div>
 <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/src/Fantomas/Program.fs
+++ b/src/Fantomas/Program.fs
@@ -212,7 +212,7 @@ let main argv =
 
     let helpTextMessage =
         """Learn more about Fantomas:       https://fsprojects.github.io/fantomas/docs
-Join our Discord community:      https://discord.gg/Cpq9vf8BJH
+Join us on the F# Discord:       https://discord.com/channels/196693847965696000/1493226271767924747
 """
 
     let parser =


### PR DESCRIPTION
We no longer have our own Discord, there now is a [channel](https://discord.com/channels/196693847965696000/1493226271767924747) in the F# Discord.

<img width="282" height="89" alt="image" src="https://github.com/user-attachments/assets/4dc802c3-7115-4f70-8a64-67ef6a5e5027" />
