### PR TITLE
Add verbosity levels for warnings and errors

### DIFF
--- a/src/Fantomas/Logging.fs
+++ b/src/Fantomas/Logging.fs
@@ -6,6 +6,8 @@ open Serilog
 type VerbosityLevel =
     | Normal
     | Detailed
+    | Warnings
+    | Errors
 
 let initLogger (level: VerbosityLevel) : VerbosityLevel =
     let logger =
@@ -16,6 +18,16 @@ let initLogger (level: VerbosityLevel) : VerbosityLevel =
                 .WriteTo.Console(outputTemplate = "{Message:lj}{NewLine}{Exception}")
                 .CreateLogger()
         | VerbosityLevel.Detailed -> LoggerConfiguration().MinimumLevel.Debug().WriteTo.Console().CreateLogger()
+        | VerbosityLevel.Warnings ->
+            LoggerConfiguration()
+                .MinimumLevel.Warning()
+                .WriteTo.Console(outputTemplate = "{Message:lj}{NewLine}{Exception}")
+                .CreateLogger()
+        | VerbosityLevel.Errors ->
+            LoggerConfiguration()
+                .MinimumLevel.Error()
+                .WriteTo.Console(outputTemplate = "{Message:lj}{NewLine}{Exception}")
+                .CreateLogger()
 
     Log.Logger <- logger
     level

--- a/src/Fantomas/Logging.fsi
+++ b/src/Fantomas/Logging.fsi
@@ -4,6 +4,8 @@ module Fantomas.Logging
 type VerbosityLevel =
     | Normal
     | Detailed
+    | Warnings
+    | Errors
 
 val initLogger: level: VerbosityLevel -> VerbosityLevel
 

--- a/src/Fantomas/Program.fs
+++ b/src/Fantomas/Program.fs
@@ -35,7 +35,7 @@ type Arguments =
                 sprintf
                     "Input paths: can be multiple folders or files with %s extension."
                     (Seq.map (fun s -> "*" + s) extensions |> String.concat ",")
-            | Verbosity _ -> "Set the verbosity level. Allowed values are n[ormal] and d[etailed]."
+            | Verbosity _ -> "Set the verbosity level. Allowed values are n[ormal], d[etailed], w[arnings], and e[rrors]."
 
 [<RequireQualifiedAccess>]
 type InputPath =
@@ -285,6 +285,10 @@ Join us on the F# Discord:       https://discord.com/channels/196693847965696000
         | Some "normal" -> initLogger VerbosityLevel.Normal
         | Some "d"
         | Some "detailed" -> initLogger VerbosityLevel.Detailed
+        | Some "w"
+        | Some "warnings" -> initLogger VerbosityLevel.Warnings
+        | Some "e"
+        | Some "errors" -> initLogger VerbosityLevel.Errors
         | Some _ ->
             elog "Invalid verbosity level"
             exit 1
@@ -380,7 +384,7 @@ Join us on the F# Discord:       https://discord.com/channels/196693847965696000
         let reportError (file: string, exn: Exception) =
             let message =
                 match verbosity with
-                | VerbosityLevel.Normal ->
+                | VerbosityLevel.Normal | VerbosityLevel.Warnings | VerbosityLevel.Errors ->
                     match exn with
                     | :? ParseException -> "Could not parse the file."
                     | :? DefineParseException as dpe ->


### PR DESCRIPTION
These behave the same as normal in terms of output formatting, but have a minimum log level of warning and error respectively.

This is useful when formatting to stdout with e.g. `--out /dev/fd/1` to avoid the `"<file> was formatted."`
message appearing in the formatted output.

(Being able to format to stdout seems to be essential for e.g. hooking Fantomas into Emacs Aphelia.)

Relates to #2665