### PR TITLE
Remove duplicated code across ASTTransformer, CodePrinter, Context, Trivia, Daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ tests/.repositories/**
 
 # LLM stuff
 .claude/settings.local.json
+
+
+.deslop-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,4 @@ tests/.repositories/**
 
 # LLM stuff
 .claude/settings.local.json
-
-
 .deslop-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -200,10 +200,10 @@ tests/.repositories/**
 # Analyzer files
 .analyzerpackages
 *.sarif
+.deslop-cache/
 
 # vscode history plugin
 .history/
 
 # LLM stuff
 .claude/settings.local.json
-.deslop-cache/

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -999,6 +999,15 @@ let mkParenExpr creationAide lpr e rpr m =
 let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
     let exprRange = e.Range
 
+    let mkAnonRecordFields (recordFields: (SynLongIdent * range option * SynExpr) list) =
+        recordFields
+        |> List.choose (function
+            | sli, Some mEq, e ->
+                let m = unionRanges sli.Range e.Range
+                let longIdent = mkSynLongIdent creationAide sli
+                Some(RecordFieldNode(longIdent, stn "=" mEq, mkExpr creationAide e, m))
+            | _ -> None)
+
     match e with
     | SynExpr.Lazy(e, StartRange 4 (lazyKeyword, _range)) ->
         ExprLazyNode(stn "lazy" lazyKeyword, mkExpr creationAide e, exprRange)
@@ -1107,15 +1116,7 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
                        recordFields,
                        (StartRange 6 (mStruct, _) & EndRange 2 (mClose, _)),
                        { OpeningBraceRange = mOpen }) ->
-        let fields =
-            recordFields
-            |> List.choose (function
-                | sli, Some mEq, e ->
-                    let m = unionRanges sli.Range e.Range
-                    let longIdent = mkSynLongIdent creationAide sli
-
-                    Some(RecordFieldNode(longIdent, stn "=" mEq, mkExpr creationAide e, m))
-                | _ -> None)
+        let fields = mkAnonRecordFields recordFields
 
         ExprAnonStructRecordNode(
             stn "struct" mStruct,
@@ -1127,14 +1128,7 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
         )
         |> Expr.AnonStructRecord
     | SynExpr.AnonRecd(false, copyInfo, recordFields, EndRange 2 (mClose, _), { OpeningBraceRange = mOpen }) ->
-        let fields =
-            recordFields
-            |> List.choose (function
-                | sli, Some mEq, e ->
-                    let m = unionRanges sli.Range e.Range
-                    let longIdent = mkSynLongIdent creationAide sli
-                    Some(RecordFieldNode(longIdent, stn "=" mEq, mkExpr creationAide e, m))
-                | _ -> None)
+        let fields = mkAnonRecordFields recordFields
 
         ExprRecordNode(
             stn "{|" mOpen,
@@ -2579,6 +2573,13 @@ let mkImplicitCtor
         range
     )
 
+let mkTypeDefnObjectModelKind (tdk: SynTypeDefnKind) (range: range) =
+    match tdk, range with
+    | SynTypeDefnKind.Class, StartRange 5 (mClass, _) -> stn "class" mClass
+    | SynTypeDefnKind.Interface, StartRange 9 (mInterface, _) -> stn "interface" mInterface
+    | SynTypeDefnKind.Struct, StartRange 6 (mStruct, _) -> stn "struct" mStruct
+    | _ -> failwith "unexpected kind"
+
 let mkTypeDefn
     (creationAide: CreationAide)
     (SynTypeDefn(typeInfo, typeRepr, members, implicitConstructor, range, trivia))
@@ -2690,12 +2691,7 @@ let mkTypeDefn
         kind = SynTypeDefnKind.Class | SynTypeDefnKind.Interface | SynTypeDefnKind.Struct as tdk
         members = objectMembers
         range = range) ->
-        let kindNode =
-            match tdk, range with
-            | SynTypeDefnKind.Class, StartRange 5 (mClass, _) -> stn "class" mClass
-            | SynTypeDefnKind.Interface, StartRange 9 (mInterface, _) -> stn "interface" mInterface
-            | SynTypeDefnKind.Struct, StartRange 6 (mStruct, _) -> stn "struct" mStruct
-            | _ -> failwith "unexpected kind"
+        let kindNode = mkTypeDefnObjectModelKind tdk range
 
         let objectMembers =
             objectMembers
@@ -3277,20 +3273,19 @@ let rec mkModuleDecls
     | head :: tail ->
         mkModuleDecls creationAide tail (fun nodes -> mkModuleDecl creationAide head :: nodes |> finalContinuation)
 
-let mkModuleOrNamespace
+let mkModuleOrNamespaceHeader
     (creationAide: CreationAide)
-    (SynModuleOrNamespace(
-        xmlDoc = xmlDoc
-        attribs = attribs
-        accessibility = accessibility
-        longId = longId
-        isRecursive = isRecursive
-        kind = kind
-        decls = decls
-        trivia = trivia) as mn)
+    leadingKeyword
+    kind
+    longId
+    xmlDoc
+    attribs
+    accessibility
+    isRecursive
+    (range: range)
     =
     let leadingKeyword =
-        match trivia.LeadingKeyword with
+        match leadingKeyword with
         | SynModuleOrNamespaceLeadingKeyword.Module mModule ->
             Some(MultipleTextsNode([ stn "module" mModule ], mModule))
         | SynModuleOrNamespaceLeadingKeyword.Namespace mNamespace ->
@@ -3306,39 +3301,62 @@ let mkModuleOrNamespace
         | SynModuleOrNamespaceKind.GlobalNamespace -> None
         | _ -> Some(mkLongIdent longId)
 
+    match leadingKeyword with
+    | None -> None
+    | Some leadingKeyword ->
+        match name with
+        | None ->
+            let m = mkFileIndexRange range.FileIndex range.Start leadingKeyword.Range.End
+
+            ModuleOrNamespaceHeaderNode(
+                mkXmlDoc xmlDoc,
+                mkAttributes creationAide attribs,
+                leadingKeyword,
+                mkSynAccess accessibility,
+                isRecursive,
+                None,
+                m
+            )
+            |> Some
+        | Some name ->
+            let m = mkFileIndexRange range.FileIndex range.Start name.Range.End
+
+            ModuleOrNamespaceHeaderNode(
+                mkXmlDoc xmlDoc,
+                mkAttributes creationAide attribs,
+                leadingKeyword,
+                mkSynAccess accessibility,
+                isRecursive,
+                Some name,
+                m
+            )
+            |> Some
+
+let mkModuleOrNamespace
+    (creationAide: CreationAide)
+    (SynModuleOrNamespace(
+        xmlDoc = xmlDoc
+        attribs = attribs
+        accessibility = accessibility
+        longId = longId
+        isRecursive = isRecursive
+        kind = kind
+        decls = decls
+        trivia = trivia) as mn)
+    =
     let range: range = mkSynModuleOrNamespaceFullRange mn
 
     let header =
-        match leadingKeyword with
-        | None -> None
-        | Some leadingKeyword ->
-            match name with
-            | None ->
-                let m = mkFileIndexRange range.FileIndex range.Start leadingKeyword.Range.End
-
-                ModuleOrNamespaceHeaderNode(
-                    mkXmlDoc xmlDoc,
-                    mkAttributes creationAide attribs,
-                    leadingKeyword,
-                    mkSynAccess accessibility,
-                    isRecursive,
-                    None,
-                    m
-                )
-                |> Some
-            | Some name ->
-                let m = mkFileIndexRange range.FileIndex range.Start name.Range.End
-
-                ModuleOrNamespaceHeaderNode(
-                    mkXmlDoc xmlDoc,
-                    mkAttributes creationAide attribs,
-                    leadingKeyword,
-                    mkSynAccess accessibility,
-                    isRecursive,
-                    Some name,
-                    m
-                )
-                |> Some
+        mkModuleOrNamespaceHeader
+            creationAide
+            trivia.LeadingKeyword
+            kind
+            longId
+            xmlDoc
+            attribs
+            accessibility
+            isRecursive
+            range
 
     let decls = mkModuleDecls creationAide decls id
 
@@ -3528,12 +3546,7 @@ let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRep
         memberSigs = objectMembers
         range = range) ->
 
-        let kindNode =
-            match tdk, range with
-            | SynTypeDefnKind.Class, StartRange 5 (mClass, _) -> stn "class" mClass
-            | SynTypeDefnKind.Interface, StartRange 9 (mInterface, _) -> stn "interface" mInterface
-            | SynTypeDefnKind.Struct, StartRange 6 (mStruct, _) -> stn "struct" mStruct
-            | _ -> failwith "unexpected kind"
+        let kindNode = mkTypeDefnObjectModelKind tdk range
 
         let objectMembers = objectMembers |> List.map (mkMemberSig creationAide)
 
@@ -3627,57 +3640,20 @@ let mkModuleOrNamespaceSig
         decls = decls
         trivia = trivia) as mn)
     =
-    let leadingKeyword =
-        match trivia.LeadingKeyword with
-        | SynModuleOrNamespaceLeadingKeyword.Module mModule ->
-            Some(MultipleTextsNode([ stn "module" mModule ], mModule))
-        | SynModuleOrNamespaceLeadingKeyword.Namespace mNamespace ->
-            match kind with
-            | SynModuleOrNamespaceKind.GlobalNamespace ->
-                Some(MultipleTextsNode([ stn "namespace" mNamespace; stn "global" range0 ], mNamespace))
-            | _ -> Some(MultipleTextsNode([ stn "namespace" mNamespace ], mNamespace))
-        | SynModuleOrNamespaceLeadingKeyword.None -> None
-
-    let name =
-        match kind with
-        | SynModuleOrNamespaceKind.AnonModule
-        | SynModuleOrNamespaceKind.GlobalNamespace -> None
-        | _ -> Some(mkLongIdent longId)
-
     let decls = mkModuleSigDecls creationAide decls id
     let range: range = mkSynModuleOrNamespaceSigFullRange mn
 
     let header =
-        match leadingKeyword with
-        | None -> None
-        | Some leadingKeyword ->
-            match name with
-            | None ->
-                let m = mkFileIndexRange range.FileIndex range.Start leadingKeyword.Range.End
-
-                ModuleOrNamespaceHeaderNode(
-                    mkXmlDoc xmlDoc,
-                    mkAttributes creationAide attribs,
-                    leadingKeyword,
-                    mkSynAccess accessibility,
-                    isRecursive,
-                    None,
-                    m
-                )
-                |> Some
-            | Some name ->
-                let m = mkFileIndexRange range.FileIndex range.Start name.Range.End
-
-                ModuleOrNamespaceHeaderNode(
-                    mkXmlDoc xmlDoc,
-                    mkAttributes creationAide attribs,
-                    leadingKeyword,
-                    mkSynAccess accessibility,
-                    isRecursive,
-                    Some name,
-                    m
-                )
-                |> Some
+        mkModuleOrNamespaceHeader
+            creationAide
+            trivia.LeadingKeyword
+            kind
+            longId
+            xmlDoc
+            attribs
+            accessibility
+            isRecursive
+            range
 
     ModuleOrNamespaceNode(header, decls, range)
 

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1160,13 +1160,7 @@ let genExpr (e: Expr) =
                         +> genArrayOrList lastList
                         +> unindent
                     else
-                        genExpr node.FunctionExpr
-                        +> sepSpace
-                        +> col sepSpace sequentialArgs genExpr
-                        +> onlyIfNot sequentialArgs.IsEmpty sepSpace
-                        +> genArrayOrList firstList
-                        +> sepSpace
-                        +> genArrayOrList lastList
+                        short
 
                 if futureNlnCheck singleLineTestExpr ctx then
                     long ctx

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -280,6 +280,10 @@ let dump (isSelection: bool) (ctx: Context) =
     let mutable atColumn = 0
     let mutable writeBeforeNewline = ""
 
+    let trimTrailingSpaces () =
+        while sb.Length > 0 && sb.[sb.Length - 1] = ' ' do
+            sb.Remove(sb.Length - 1, 1) |> ignore
+
     let doNewline () =
         indent <- max indent atColumn
 
@@ -288,8 +292,7 @@ let dump (isSelection: bool) (ctx: Context) =
             writeBeforeNewline <- ""
 
         // Trim trailing spaces on the current line
-        while sb.Length > 0 && sb.[sb.Length - 1] = ' ' do
-            sb.Remove(sb.Length - 1, 1) |> ignore
+        trimTrailingSpaces ()
 
         sb.Append(newline) |> ignore
         sb.Append(String.replicate indent " ") |> ignore
@@ -315,8 +318,7 @@ let dump (isSelection: bool) (ctx: Context) =
         | Placeholder -> ()
 
     // Trim trailing spaces on the last line
-    while sb.Length > 0 && sb.[sb.Length - 1] = ' ' do
-        sb.Remove(sb.Length - 1, 1) |> ignore
+    trimTrailingSpaces ()
 
     let code = sb.ToString()
 

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -455,11 +455,13 @@ let addToTree (tree: Oak) (trivia: TriviaNode array) =
             | BlockComment _
             | Cursor -> blockCommentToTriviaInstruction parentNode trivia
 
+let private parsedInputTrivia (ast: ParsedInput) =
+    match ast with
+    | ParsedInput.ImplFile(ParsedImplFileInput(trivia = t))
+    | ParsedInput.SigFile(ParsedSigFileInput(trivia = t)) -> t
+
 let internal collectCommentTextsFromAST (sourceText: ISourceText) (ast: ParsedInput) : Set<TriviaContent> =
-    let parsedTrivia =
-        match ast with
-        | ParsedInput.ImplFile(ParsedImplFileInput(trivia = t))
-        | ParsedInput.SigFile(ParsedSigFileInput(trivia = t)) -> t
+    let parsedTrivia = parsedInputTrivia ast
 
     let fullRange =
         let startPos = Position.mkPos 0 0
@@ -480,10 +482,7 @@ let internal collectCommentTextsFromAST (sourceText: ISourceText) (ast: ParsedIn
 let enrichTree (config: FormatConfig) (sourceText: ISourceText) (ast: ParsedInput) (tree: Oak) : Oak =
     let fullTreeRange = tree.Range
 
-    let parsedTrivia =
-        match ast with
-        | ParsedInput.ImplFile(ParsedImplFileInput(trivia = t))
-        | ParsedInput.SigFile(ParsedSigFileInput(trivia = t)) -> t
+    let parsedTrivia = parsedInputTrivia ast
 
     let trivia =
         let newlines =

--- a/src/Fantomas/Daemon.fs
+++ b/src/Fantomas/Daemon.fs
@@ -14,6 +14,13 @@ open Fantomas.Client.LSPFantomasServiceTypes
 open Fantomas.Core
 open Fantomas.EditorConfig
 
+let private configForRequest (filePath: string) configOverride =
+    match configOverride with
+    | Some configProperties ->
+        let config = readConfiguration filePath
+        parseOptionsFromEditorConfig config configProperties
+    | None -> readConfiguration filePath
+
 type FantomasDaemon(sender: Stream, reader: Stream) as this =
     let rpc: JsonRpc = JsonRpc.Attach(sender, reader, this)
     let traceListener = new DefaultTraceListener()
@@ -52,12 +59,7 @@ type FantomasDaemon(sender: Stream, reader: Stream) as this =
             then
                 return FormatDocumentResponse.IgnoredFile request.FilePath
             else
-                let config =
-                    match request.Config with
-                    | Some configProperties ->
-                        let config = readConfiguration request.FilePath
-                        parseOptionsFromEditorConfig config configProperties
-                    | None -> readConfiguration request.FilePath
+                let config = configForRequest request.FilePath request.Config
 
                 let cursor =
                     request.Cursor
@@ -90,12 +92,7 @@ type FantomasDaemon(sender: Stream, reader: Stream) as this =
     [<JsonRpcMethod(Methods.FormatSelection, UseSingleObjectParameterDeserialization = true)>]
     member _.FormatSelectionAsync(request: FormatSelectionRequest) : Task<FormatSelectionResponse> =
         task {
-            let config =
-                match request.Config with
-                | Some configProperties ->
-                    let config = readConfiguration request.FilePath
-                    parseOptionsFromEditorConfig config configProperties
-                | None -> readConfiguration request.FilePath
+            let config = configForRequest request.FilePath request.Config
 
             let selection =
                 let r = request.Range


### PR DESCRIPTION
Seven byte-identical blocks were copy-pasted across five files, mostly where the impl and sig paths (or the short and long paths) grew by duplication. Each pair folds into one shared definition:

- ASTTransformer: `mkAnonRecordFields`, `mkTypeDefnObjectModelKind`, `mkModuleOrNamespaceHeader`
- CodePrinter: the `long` branch was an identical `+>` pipeline of `short`, so reuse `short`
- Context: `trimTrailingSpaces`
- Trivia: `parsedInputTrivia`
- Daemon: `configForRequest`

No behaviour change. 

Fixes #3374

Dupes found with [Deslop.live](https://deslop.live)
<img src="https://deslop.live/assets/img/logo.svg" width="200" alt="Deslop">