### PR TITLE
Add fsharp_keep_single_case_union_multiline setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- New `fsharp_keep_single_case_union_multiline` setting to keep single-case discriminated union declarations on a separate line instead of collapsing them onto the type name. [#3373](https://github.com/fsprojects/fantomas/pull/3373)
+- New `fsharp_keep_single_case_union_multiline` setting to keep single-case discriminated union declarations on a separate line instead of collapsing them onto the type name. [#3377](https://github.com/fsprojects/fantomas/pull/3377)
 
 ## [8.0.0-alpha-012] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- New `fsharp_keep_single_case_union_multiline` setting to keep single-case discriminated union declarations on a separate line instead of collapsing them onto the type name. [#3373](https://github.com/fsprojects/fantomas/pull/3373)
+
 ## [8.0.0-alpha-012] - 2026-04-16
 
 ### Changed

--- a/docs/docs/end-users/Configuration.fsx
+++ b/docs/docs/end-users/Configuration.fsx
@@ -1020,11 +1020,34 @@ printfn
 (*** include-output ***)
 
 formatCode
-    """ 
+    """
     type MyDU = Short of int
     """
     """
 fsharp_bar_before_discriminated_union_declaration = true
+    """
+
+(*** include-output ***)
+
+(**
+<fantomas-setting green></fantomas-setting>
+### fsharp_keep_single_case_union_multiline
+<copy-to-clipboard text="fsharp_keep_single_case_union_multiline = true"></copy-to-clipboard>
+
+Keep the declaration of a single-case discriminated union on a separate line, instead of collapsing it onto the same line as the type name when it is short enough to fit.
+*)
+
+(*** hide ***)
+printfn
+    $"# Default\n{toEditorConfigName (nameof FormatConfig.Default.KeepSingleCaseUnionMultiline)} = {FormatConfig.Default.KeepSingleCaseUnionMultiline.ToString().ToLower()}"
+(*** include-output ***)
+
+formatCode
+    """
+    type MyDU = Short of int
+    """
+    """
+fsharp_keep_single_case_union_multiline = true
     """
 
 (*** include-output ***)

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -82,6 +82,7 @@
     <Compile Include="BlankLinesAroundNestedMultilineExpressions.fs" />
     <Compile Include="ColMultilineItemTests.fs" />
     <Compile Include="BarBeforeDiscriminatedUnionDeclarationTests.fs" />
+    <Compile Include="KeepSingleCaseUnionMultilineTests.fs" />
     <Compile Include="SpaceBeforeColonTests.fs" />
     <Compile Include="LibraryOnlySynExprTests.fs" />
     <Compile Include="IndexSyntaxTests.fs" />

--- a/src/Fantomas.Core.Tests/KeepSingleCaseUnionMultilineTests.fs
+++ b/src/Fantomas.Core.Tests/KeepSingleCaseUnionMultilineTests.fs
@@ -1,0 +1,141 @@
+module Fantomas.Core.Tests.KeepSingleCaseUnionMultilineTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelpers
+
+let config =
+    { config with
+        KeepSingleCaseUnionMultiline = true }
+
+[<Test>]
+let ``single case union with field is kept multiline`` () =
+    formatSourceString
+        """
+type MyDU = Short of int
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type MyDU =
+    | Short of int
+"""
+
+[<Test>]
+let ``single case union without field is kept multiline`` () =
+    formatSourceString
+        """
+type A = | A
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type A =
+    | A
+"""
+
+[<Test>]
+let ``single case union with access modifier is kept multiline`` () =
+    formatSourceString
+        """
+type Foo = private Foo of int
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Foo =
+    private | Foo of int
+"""
+
+[<Test>]
+let ``result is idempotent`` () =
+    let source =
+        """
+type MyDU =
+    | Short of int
+"""
+
+    formatSourceString source config
+    |> fun formatted -> formatSourceString formatted config
+    |> prepend newline
+    |> should
+        equal
+        """
+type MyDU =
+    | Short of int
+"""
+
+[<Test>]
+let ``combines with bar before discriminated union declaration`` () =
+    formatSourceString
+        """
+type MyDU = Short of int
+"""
+        { config with
+            BarBeforeDiscriminatedUnionDeclaration = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+type MyDU =
+    | Short of int
+"""
+
+[<Test>]
+let ``multi case union is unaffected`` () =
+    formatSourceString
+        """
+type MyDU =
+    | Short of int
+    | Long of string
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type MyDU =
+    | Short of int
+    | Long of string
+"""
+
+[<Test>]
+let ``single case union with member stays multiline`` () =
+    formatSourceString
+        """
+type MyDU =
+    | Short of int
+    member this.Value = 1
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type MyDU =
+    | Short of int
+
+    member this.Value = 1
+"""
+
+[<Test>]
+let ``single case union in signature file is kept multiline`` () =
+    formatSignatureString
+        """namespace meh
+
+type Foo = Bar of int
+"""
+        config
+    |> should
+        equal
+        """namespace meh
+
+type Foo =
+    | Bar of int
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -3549,10 +3549,13 @@ let genTypeDefn (td: TypeDefn) =
                         genSingleTextNode vis +> onlyIfNot singleCase.XmlDoc.IsNone sepNln)
                     +> genUnionCase hasVerticalBar singleCase
 
-                expressionFitsOnRestOfLine
-                    (sepSpace +> genCase hasVerticalBar)
-                    (indentSepNlnUnindent (genCase true))
-                    ctx
+                if ctx.Config.KeepSingleCaseUnionMultiline then
+                    indentSepNlnUnindent (genCase true) ctx
+                else
+                    expressionFitsOnRestOfLine
+                        (sepSpace +> genCase hasVerticalBar)
+                        (indentSepNlnUnindent (genCase true))
+                        ctx
             | xs ->
                 indentSepNlnUnindent
                     (opt sepNln node.Accessibility genSingleTextNode

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -222,6 +222,11 @@ type FormatConfig =
       BarBeforeDiscriminatedUnionDeclaration: bool
 
       [<Category("Convention")>]
+      [<DisplayName("Keep single-case Discriminated Union declarations multiline")>]
+      [<Description("Do not collapse a short single-case union onto the same line as the type name.")>]
+      KeepSingleCaseUnionMultiline: bool
+
+      [<Category("Convention")>]
       [<DisplayName("How to format bracket expressions (arrays, objects, etc.) that span multiple lines")>]
       [<Description("Possible options include cramped (default), aligned, and stroustrup")>]
       MultilineBracketStyle: MultilineBracketStyle
@@ -273,6 +278,7 @@ type FormatConfig =
           ExperimentalKeepIndentInBranch = false
           BlankLinesAroundNestedMultilineExpressions = true
           BarBeforeDiscriminatedUnionDeclaration = false
+          KeepSingleCaseUnionMultiline = false
           MultilineBracketStyle = Aligned
           KeepMaxNumberOfBlankLines = 100
           NewlineBeforeMultilineComputationExpression = true


### PR DESCRIPTION
### What
Adds an opt-in setting `fsharp_keep_single_case_union_multiline` (default `false`, so existing output is unchanged). When enabled, a single-case discriminated union declaration is kept on its own line instead of being collapsed onto the type name when it fits:

```fsharp
// default (false) — unchanged
type MyDU = Short of int

// fsharp_keep_single_case_union_multiline = true
type MyDU =
    | Short of int
```

### Why
The goal is to let users uphold the [G-Research F# formatting conventions](https://github.com/G-Research/fsharp-formatting-conventions#formatting-discriminated-union-declarations), which list the multiline layout as the **Preferred** form for a single-case DU:

```fsharp
// Preferred
type Foo =
    | Foo of int
```

Today Fantomas collapses a short single-case DU onto one line — even with `fsharp_bar_before_discriminated_union_declaration = true` it produces `type Foo = | Foo of int` — so that Preferred multiline form only appears once the declaration is long enough to wrap. This setting lets people following those conventions get the Preferred shape consistently, and (independently) gives teams the uniform "one case per line regardless of case count" style, which also keeps diffs smaller when a second case is later added.

It is opt-in and off by default, so nothing changes for anyone who doesn't set it. Related prior discussion: fsharp/fslang-design#762.

### How
- `FormatConfig`: new field `KeepSingleCaseUnionMultiline` (+ default). The editorconfig key is derived by reflection, so parsing/serialization are automatic.
- `CodePrinter`: in the single-case branch of `genTypeDefn` (`TypeDefn.Union`), use the existing multiline layout when the flag is set instead of `expressionFitsOnRestOfLine`. Signature files share this path.
- Docs section + CHANGELOG entry.

### Tested
- New `KeepSingleCaseUnionMultilineTests.fs` (8 tests: fields / no-field / access modifier / bar-combination / multi-case unaffected / member case / signature file / idempotency).
- Full `Fantomas.Core.Tests` green (2849 passed); changed files pass `fantomas --check`.

Happy to bikeshed the setting name.
