### PR TITLE
Redesign ExprChain around a head, segments and a terminal call

### DIFF
--- a/.claude/commands/chain.md
+++ b/.claude/commands/chain.md
@@ -1,0 +1,20 @@
+---
+description: Show the ExprChain structure (head, segments, terminal) of F# source code
+allowed-tools: Bash(dotnet fsi:*), Bash(echo:*), Bash(dotnet build:*)
+---
+
+First build the project: `dotnet build src/Fantomas.Core/Fantomas.Core.fsproj`
+
+Then run the chain script. Pass a file path as argument:
+
+```
+dotnet fsi scripts/chain.fsx [--signature] <file>
+```
+
+Or pipe inline source via stdin:
+
+```
+echo '<source>' | dotnet fsi scripts/chain.fsx [--signature]
+```
+
+$ARGUMENTS

--- a/.claude/skills/style-guides/SKILL.md
+++ b/.claude/skills/style-guides/SKILL.md
@@ -67,9 +67,11 @@ the settings that style implies. Three traps make a naive pass-rate meaningless,
   `// Not OK` comment, so Fantomas rewriting it is the guide being obeyed, not broken.
 - Many blocks are **fragments** that do not parse alone, or illustrate naming and structure rather
   than layout. `if cond then e1 else e2` shown across four lines is not a claim about line breaks.
-- The **settings have to be right**, and are best read off the guide's own examples rather than off
-  our documentation: the G-Research examples use `aligned` brackets and a space before the colon in
-  record fields, which does not match every badge in `docs/docs/end-users/Configuration.fsx`.
+- The **settings have to be right**, and are best read off the guide's own examples: the
+  G-Research ones use `aligned` brackets and a space before the colon in record fields. That does
+  not always line up with the badges in `docs/docs/end-users/Configuration.fsx`, and the badges are
+  not necessarily wrong when it does not. They carry history this skill does not know, so treat a
+  mismatch as a question for nojaf rather than a documentation bug to fix.
 
 So classify a block before diffing it, and say what was excluded and why. A pass rate without that
 classification says nothing.

--- a/.claude/skills/style-guides/SKILL.md
+++ b/.claude/skills/style-guides/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: style-guides
+description: Look up what the F# style guides say about a formatting question. Use when deciding or defending a layout rule in Fantomas, when a Chains.md or design discussion needs a citation, or when the user asks what Microsoft or G-Research prescribe.
+---
+
+# F# style guides
+
+Fantomas does not decide F# style, it implements it. Two documents are the authority, and a
+layout decision that contradicts them needs a reason written down.
+
+## The sources
+
+- **Microsoft**, the default style Fantomas follows:
+  <https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting>
+  Fetch the raw markdown instead of the rendered page when you want to quote it:
+  <https://raw.githubusercontent.com/dotnet/docs/main/docs/fsharp/style-guide/formatting.md>
+- **G-Research**, the alternative style behind the `fsharp_*` G-Research settings:
+  <https://github.com/G-Research/fsharp-formatting-conventions>
+  Raw: <https://raw.githubusercontent.com/G-Research/fsharp-formatting-conventions/master/README.md>
+
+Style discussions themselves happen at <https://github.com/fsharp/fslang-design#style-guide>, not
+in this repository. See `docs/docs/end-users/StyleGuide.md`.
+
+## How to use them
+
+The Microsoft page is large. Fetching it whole returns tens of kilobytes, so pull the section you
+need rather than the page. Its headings are stable and worth knowing:
+
+- `Formatting application expressions`
+- `Formatting lambda expressions`
+- `Formatting function and member arguments`
+- `Formatting pipeline expressions`
+- `Formatting if expressions`
+- `Formatting record expressions`
+
+Quote verbatim, including the ✔️ and ❌ examples. The ❌ ones carry the reasoning, and the reason
+is usually the part that settles an argument. One example: the guide rejects lambda parameters
+aligned under an opening parenthesis, because the column then depends on the length of the
+identifier in front of it.
+
+## What to do with the answer
+
+- Cite the guide in the design note or the doc change, with the rule quoted, so the next person
+  does not have to re-derive it.
+- When both guides agree, say so; that is a strong signal.
+- When Fantomas disagrees with the guide, that is a bug report or a proposal to fslang-design, not
+  a local preference to encode quietly.

--- a/.claude/skills/style-guides/SKILL.md
+++ b/.claude/skills/style-guides/SKILL.md
@@ -8,23 +8,43 @@ description: Look up what the F# style guides say about a formatting question. U
 Fantomas does not decide F# style, it implements it. Two documents are the authority, and a
 layout decision that contradicts them needs a reason written down.
 
+## Always work from the local copies
+
+Both guides belong in `.deps/style-guides/`, which is gitignored, so keeping them costs nothing and
+leaves no trace. Never answer from the rendered pages or from memory: grep the local file and quote
+it. Local copies are also what makes the examples testable, since you can run them through
+Fantomas.
+
+Refresh them at the start of the task. Both raw URLs return an `ETag`, so a conditional request
+downloads only when the document changed and is free otherwise:
+
+```bash
+mkdir -p .deps/style-guides
+cd .deps/style-guides
+fetch() { curl -sS --etag-compare "$2.etag" --etag-save "$2.etag" -o "$2" "$1"; }
+fetch https://raw.githubusercontent.com/dotnet/docs/main/docs/fsharp/style-guide/formatting.md microsoft-formatting.md
+fetch https://raw.githubusercontent.com/G-Research/fsharp-formatting-conventions/master/README.md g-research-conventions.md
+```
+
+The `.etag` files next to the documents are what make the second run free; keep them. Verified that
+a repeat run leaves the file byte for byte intact rather than truncating it.
+
 ## The sources
 
-- **Microsoft**, the default style Fantomas follows:
-  <https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting>
-  Fetch the raw markdown instead of the rendered page when you want to quote it:
-  <https://raw.githubusercontent.com/dotnet/docs/main/docs/fsharp/style-guide/formatting.md>
-- **G-Research**, the alternative style behind the `fsharp_*` G-Research settings:
-  <https://github.com/G-Research/fsharp-formatting-conventions>
-  Raw: <https://raw.githubusercontent.com/G-Research/fsharp-formatting-conventions/master/README.md>
+- **Microsoft**, the default style Fantomas follows.
+  Local: `.deps/style-guides/microsoft-formatting.md`
+  Rendered: <https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting>
+- **G-Research**, the alternative style behind the G-Research settings.
+  Local: `.deps/style-guides/g-research-conventions.md`
+  Rendered: <https://github.com/G-Research/fsharp-formatting-conventions>
 
 Style discussions themselves happen at <https://github.com/fsharp/fslang-design#style-guide>, not
 in this repository. See `docs/docs/end-users/StyleGuide.md`.
 
 ## How to use them
 
-The Microsoft page is large. Fetching it whole returns tens of kilobytes, so pull the section you
-need rather than the page. Its headings are stable and worth knowing:
+The Microsoft document is large, tens of kilobytes, so grep the local copy for the section you need
+rather than reading it whole. Its headings are stable and worth knowing:
 
 - `Formatting application expressions`
 - `Formatting lambda expressions`
@@ -37,6 +57,22 @@ Quote verbatim, including the ✔️ and ❌ examples. The ❌ ones carry the re
 is usually the part that settles an argument. One example: the guide rejects lambda parameters
 aligned under an opening parenthesis, because the column then depends on the length of the
 identifier in front of it.
+
+## Checking our output against the examples
+
+The code blocks are testable: extract them from the local copy and run them through Fantomas with
+the settings that style implies. Three traps make a naive pass-rate meaningless, all seen for real:
+
+- Some blocks mark the bad version by **variable name**, `let bad = ...`, rather than by a
+  `// Not OK` comment, so Fantomas rewriting it is the guide being obeyed, not broken.
+- Many blocks are **fragments** that do not parse alone, or illustrate naming and structure rather
+  than layout. `if cond then e1 else e2` shown across four lines is not a claim about line breaks.
+- The **settings have to be right**, and are best read off the guide's own examples rather than off
+  our documentation: the G-Research examples use `aligned` brackets and a space before the colon in
+  record fields, which does not match every badge in `docs/docs/end-users/Configuration.fsx`.
+
+So classify a block before diffing it, and say what was excluded and why. A pass rate without that
+classification says nothing.
 
 ## What to do with the answer
 

--- a/.claude/skills/style-guides/SKILL.md
+++ b/.claude/skills/style-guides/SKILL.md
@@ -24,6 +24,7 @@ cd .deps/style-guides
 fetch() { curl -sS --etag-compare "$2.etag" --etag-save "$2.etag" -o "$2" "$1"; }
 fetch https://raw.githubusercontent.com/dotnet/docs/main/docs/fsharp/style-guide/formatting.md microsoft-formatting.md
 fetch https://raw.githubusercontent.com/G-Research/fsharp-formatting-conventions/master/README.md g-research-conventions.md
+fetch https://raw.githubusercontent.com/G-Research/fsharp-formatting-conventions/master/.editorconfig g-research.editorconfig
 ```
 
 The `.etag` files next to the documents are what make the second run free; keep them. Verified that
@@ -37,6 +38,21 @@ a repeat run leaves the file byte for byte intact rather than truncating it.
 - **G-Research**, the alternative style behind the G-Research settings.
   Local: `.deps/style-guides/g-research-conventions.md`
   Rendered: <https://github.com/G-Research/fsharp-formatting-conventions>
+
+## Which settings a guide means
+
+Do not infer these from the prose, from the examples, or from our own documentation.
+
+Microsoft is the Fantomas defaults. Nothing to configure, so format with `FormatConfig.Default`,
+and a deviation is a Fantomas bug rather than a settings question.
+
+G-Research ships its settings, and `.deps/style-guides/g-research.editorconfig` is the whole
+answer. Use it verbatim.
+
+One warning about `docs/docs/end-users/Configuration.fsx`. The `gr` badge marks a setting as part
+of the G-Research set, but the value in the copy-to-clipboard box is the value that section
+demonstrates, usually the non-default one. It is not a claim about what G-Research chose. Read
+those boxes as G-Research values and you will get it wrong.
 
 Style discussions themselves happen at <https://github.com/fsharp/fslang-design#style-guide>, not
 in this repository. See `docs/docs/end-users/StyleGuide.md`.
@@ -67,11 +83,9 @@ the settings that style implies. Three traps make a naive pass-rate meaningless,
   `// Not OK` comment, so Fantomas rewriting it is the guide being obeyed, not broken.
 - Many blocks are **fragments** that do not parse alone, or illustrate naming and structure rather
   than layout. `if cond then e1 else e2` shown across four lines is not a claim about line breaks.
-- The **settings have to be right**, and are best read off the guide's own examples: the
-  G-Research ones use `aligned` brackets and a space before the colon in record fields. That does
-  not always line up with the badges in `docs/docs/end-users/Configuration.fsx`, and the badges are
-  not necessarily wrong when it does not. They carry history this skill does not know, so treat a
-  mismatch as a question for nojaf rather than a documentation bug to fix.
+- The **settings have to be right**. Take them from `g-research.editorconfig`, never from the
+  examples or from our documentation. A hand-assembled set produces a number that says more about
+  the set than about Fantomas.
 
 So classify a block before diffing it, and say what was excluded and why. A pass rate without that
 classification says nothing.

--- a/.claude/skills/upgrade-trial/SKILL.md
+++ b/.claude/skills/upgrade-trial/SKILL.md
@@ -40,6 +40,26 @@ Establish these, and report them back before running anything long:
 
 Say up front that the builds are long and CPU heavy, and run them in the background one at a time.
 
+## Rung zero: the base state must pass its own check
+
+Before touching any version, run the pinned version's `--check` and establish the scope it must
+pass. When the docs and CI disagree on which paths to format, trust CI: that is the scope the
+project actually enforces, and the rest is drift they have chosen to live with. FsAutoComplete's
+CONTRIBUTING says to format `src/ test/`, but its CI has only ever checked `build.fsx src`; its
+`test/` tree holds intentionally unparseable fixtures and has never been formatted. Reformatting
+that scope on their behalf is churn they did not ask for, and can break fixture-sensitive tests in
+ways a build will not catch. Only widen beyond the CI scope when they clearly want it.
+
+If the check fails on the enforced scope, the base state is dirty, and the first commit on the
+trial branch is fixing that: format with the pinned version, build, and commit as the rung-zero
+baseline. Do this before any version bump, so each rung's diff isolates the version's effect
+instead of inheriting drift. If the base state already passes, say so; that is information too.
+
+Some files in scope may be genuinely unformattable: fixtures that are intentionally incomplete F#,
+or code in syntax the pinned parser rejects (F# 7 relaxed indentation is a live example). Record
+that set explicitly — file by file, with the reason — and compare each rung's check against it,
+rather than demanding exit 0 from a repo that cannot give it.
+
 ## The rungs
 
 For each of: **latest stable**, **latest alpha**, **a local build of the branch under test**:

--- a/.claude/skills/upgrade-trial/SKILL.md
+++ b/.claude/skills/upgrade-trial/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: upgrade-trial
+description: Try a Fantomas upgrade against a real code base on this machine. Takes the path to a local repository, walks it from its pinned version up to latest stable, latest alpha, and a local build, formatting, checking and building at each step, committing on a test branch. Use to find out whether a change breaks or improves real projects before releasing it.
+---
+
+# Upgrade trial
+
+Format a real code base with successively newer Fantomas versions and prove it still builds. This
+is the check that catches what the test suite cannot: what our changes do to code nobody on this
+team wrote.
+
+**Input**: the path to a local git repository. Without one, ask for it rather than guessing.
+
+## Never work on the branch they have checked out
+
+This trial rewrites files across the whole repository and commits several times. Doing that on
+someone's working branch is destructive, and the mess is theirs to clean up.
+
+Before touching anything: record the current branch, confirm the working tree is clean, and create
+a dedicated branch for the trial, `fantomas-upgrade-trial` or similar. If a branch by that name is
+already there, reuse it only after checking it holds nothing but earlier trials. If the tree is
+dirty, stop and say so; do not stash their work to get going. Leave the repository on the trial
+branch when you finish and tell them which branch that is and which branch they were on, so
+switching back is one command.
+
+Never push. The commits are evidence for a decision, not something to publish.
+
+## Before starting
+
+Establish these, and report them back before running anything long:
+
+- How to get back: the branch they started on.
+- How it pins Fantomas: usually `dotnet tool restore` against `.config/dotnet-tools.json`. Note the
+  version already pinned; that is rung zero.
+- How it formats: usually `dotnet fantomas .`. Check `DEVGUIDE.md`, `CONTRIBUTING.md` or the CI
+  yaml for the exact invocation, including which paths.
+- How it builds: `./build.sh`, `build.cmd`, or a plain `dotnet build`.
+- Whether it has a `.fantomasignore`. Large repos exclude a lot, and the exclusions tell you what
+  they already know is awkward.
+
+Say up front that the builds are long and CPU heavy, and run them in the background one at a time.
+
+## The rungs
+
+For each of: **latest stable**, **latest alpha**, **a local build of the branch under test**:
+
+1. Point the repository at that version. For published versions, edit the tool manifest and
+   `dotnet tool restore`. For the local build, do **not** package and install it; build the CLI in
+   Release and invoke the dll directly:
+   `dotnet <fantomas>/artifacts/bin/Fantomas/release/fantomas.dll . --check`.
+2. Confirm the version actually in use with `--version`. The commit hash in it is worth recording.
+3. Format the repository.
+4. Run the same command with `--check`. It must exit 0: the formatter has to agree with its own
+   output. A failure here is an idempotency bug, and worth reporting rather than working around.
+5. Build. Skip this when formatting changed nothing, since there is nothing for it to prove; say so
+   rather than silently skipping.
+6. Commit on the test branch: the manifest change together with whatever formatting changed. Never
+   push.
+
+Report per rung: files reformatted out of files considered, ignored, errored, whether `--check`
+passed, and the build result.
+
+## Traps this hit for real
+
+- **Feeds.** Repos that restore from mirrors, dnceng for instance, lag behind nuget.org, so a
+  freshly published version is not there yet. Add
+  `--add-source https://api.nuget.org/v3/index.json` to `dotnet tool restore` rather than editing
+  their `NuGet.config`, and note it in the commit message.
+- **Package source mapping** makes `--add-source` fail outright. When installing to a
+  `--tool-path`, run the install from a neutral directory so no repository `NuGet.config` applies.
+- **Read our own CHANGELOG before blaming the branch.** A large diff is usually a documented
+  breaking change in a setting default, not the work under test. Check whether the repository sets
+  that setting for `[*.fs]` but not `[*.fsi]`, which is a common way to be surprised.
+- **A version bump with zero changes is a result**, not a failure to find anything.
+
+## Timing, if asked
+
+Measure with `--check` so nothing is written, discard a warmup run, and interleave the versions to
+cancel drift. Report the **minimum** of several runs, and prefer **wall clock**: user CPU time
+varies by nearly 2x run to run on a laptop and will swamp any real difference. If the ranges of two
+versions overlap, say the measurement was inconclusive instead of quoting a ratio. For a real
+number, use `dotnet fsi build.fsx -- -p Benchmark`, which runs BenchmarkDotNet.

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "fsdocs-tool": {
-      "version": "22.0.0",
+      "version": "22.1.0",
       "commands": [
         "fsdocs"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -29,6 +29,13 @@
         "fsharp-analyzers"
       ],
       "rollForward": false
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.11",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,8 @@ tests/.repositories/**
 
 # LLM stuff
 .claude/settings.local.json
+
+# Coverage reports (see the Coverage pipeline in build.fsx)
+coverage.xml
+coveragereport/
+coverage.xml.*.acv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Run these after completing a task, not during iterative development — analyzer
 ### Format
 
 ```bash
-dotnet fantomas src docs build.fsx
+dotnet fsi build.fsx -- -p FormatAll
 ```
 
 ### Analyzers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ All scripts accept a file path or stdin, with optional `--signature` and `--edit
 - `scripts/oak.fsx` — Oak tree
 - `scripts/format.fsx` — format with local build
 - `scripts/writer-events.fsx` — writer events produced during formatting
+- `scripts/chain.fsx` - ExprChain structure (head, segments, terminal); ignores `--editorconfig`
 
 Scripts require a debug build first (`dotnet build src/Fantomas/Fantomas.fsproj`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 # Changelog
 
-## [Unreleased]
+## [8.0.0-alpha-014] - 2026-08-20
 
 ### Changed
 
 - Bump `StreamJsonRpc` to `2.25.29`. This clears the NuGet vulnerability warnings coming from the transitive `MessagePack` and `Nerdbank.MessagePack` dependencies. [#3393](https://github.com/fsprojects/fantomas/pull/3393)
+- Breaking: `Expr.Chain` is redesigned around a head, a list of `ChainSegment` and a `ChainTerminal`. `Expr.DotLambda`, `Expr.DotIndexedGet`, `Expr.AppLongIdentAndSingleParenArg` and `Expr.NestedIndexWithoutDot` are removed, and a dotted long identifier now yields `Expr.Chain` instead of `Expr.OptVar` in expression position. See the [upgrade guide](https://fsprojects.github.io/fantomas/docs/end-users/UpgradeGuide.html) for how to migrate. [#3385](https://github.com/fsprojects/fantomas/pull/3385)
+- Chains are laid out by a documented set of rules, written up in full under [Chains](https://fsprojects.github.io/fantomas/docs/contributors/Chains.html). They are a proposal for the F# style guide and may still change. A chain that fits on one line is left alone. When one has to break, only a call claims a line of its own and plain property access rides along in front of it, where a comment between the steps previously put every step on its own line. A long run of property access now wraps into balanced lines instead of overflowing the margin. [#3385](https://github.com/fsprojects/fantomas/pull/3385)
+- With `fsharp_multi_line_lambda_closing_newline = false` (the default), a match lambda argument keeps `function` beside the `(` when the call is reached through a dot, matching what a call without a receiver already did. [#3385](https://github.com/fsprojects/fantomas/pull/3385)
+- With `fsharp_multi_line_lambda_closing_newline = true`, a lambda argument whose opening line does not fit moves onto its own line instead of hanging its parameters under the opening parenthesis. This applies to calls with and without a receiver. [#3385](https://github.com/fsprojects/fantomas/pull/3385)
+- Added `InvariantViolationException`, raised when Fantomas reaches a state its own model says is impossible. It derives from `FormatException`, carries the source range of the construct involved, and points at the issue tracker. [#3385](https://github.com/fsprojects/fantomas/pull/3385)
 
 ### Fixed
 
 - CLI refuses to format files containing IWSAM types (warning 3535 fails output validation). [#3396](https://github.com/fsprojects/fantomas/issues/3396)
+- A space was added before the parenthesis of a call inside a `_.` shorthand lambda when `fsharp_space_before_uppercase_invocation` was enabled, producing code that does not compile. [#3364](https://github.com/fsprojects/fantomas/issues/3364)
 
 ## [8.0.0-alpha-013] - 2026-08-19
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,5 +38,6 @@
         <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
         <PackageVersion Include="FsCheck" Version="3.3.2" />
         <PackageVersion Include="FsUnit" Version="7.1.1" />
+        <PackageVersion Include="AltCover" Version="9.0.102" />
     </ItemGroup>
 </Project>

--- a/build.fsx
+++ b/build.fsx
@@ -69,7 +69,7 @@ pipeline "Build" {
     workingDir __SOURCE_DIRECTORY__
     stage "RestoreTools" { run "dotnet tool restore" }
     stage "Clean" { run (cleanFolders [| analysisReportsDir; "artifacts" |]) }
-    stage "CheckFormat" { run "dotnet fantomas src docs build.fsx --check" }
+    stage "CheckFormat" { run "dotnet fantomas src docs scripts build.fsx --check" }
     stage "Build" { run "dotnet build -c Release --tl" }
     stage "UnitTests" { run "dotnet test -c Release --tl" }
     stage "Pack" { run "dotnet pack --no-restore -c Release --tl" }
@@ -222,7 +222,7 @@ pipeline "Docs" {
 
 pipeline "FormatAll" {
     workingDir __SOURCE_DIRECTORY__
-    stage "Fantomas" { run "dotnet fantomas src docs build.fsx" }
+    stage "Fantomas" { run "dotnet fantomas src docs scripts build.fsx" }
     runIfOnlySpecified true
 }
 

--- a/build.fsx
+++ b/build.fsx
@@ -61,6 +61,10 @@ let pushPackage nupkg =
 
 let analysisReportsDir = "analysisreports"
 
+let coverageReportDir = "coveragereport"
+
+let coverageXml = "src" </> "Fantomas.Core.Tests" </> "coverage.xml"
+
 pipeline "Build" {
     workingDir __SOURCE_DIRECTORY__
     stage "RestoreTools" { run "dotnet tool restore" }
@@ -84,6 +88,45 @@ pipeline "Benchmark" {
     workingDir __SOURCE_DIRECTORY__
     stage "Prepare" { run "dotnet build -c Release src/Fantomas.Benchmarks --tl" }
     stage "Benchmark" { run $"dotnet {benchmarkAssembly}" }
+    runIfOnlySpecified true
+}
+
+// Line and branch coverage for Fantomas.Core, via AltCover's MSBuild integration.
+//
+// The filter is a negative lookahead: instrument Fantomas.Core and nothing else, which keeps the
+// generated Fantomas.FCS parser (and the test assembly itself) out of the report and makes the
+// run fast. AltCover writes OpenCover XML, which is for tooling rather than reading, so
+// ReportGenerator turns it into a browsable HTML report afterwards.
+//
+// Produces:
+//   src/Fantomas.Core.Tests/coverage.xml   raw OpenCover XML
+//   coveragereport/index.html              browsable report, per file and per line
+pipeline "Coverage" {
+    workingDir __SOURCE_DIRECTORY__
+    stage "RestoreTools" { run "dotnet tool restore" }
+    stage "Clean" { run (cleanFolders [| coverageReportDir |]) }
+
+    stage "Coverage" {
+        run
+            @"dotnet test src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj -c Release /p:AltCover=true ""/p:AltCoverAssemblyFilter=^(?!Fantomas\.Core$)"""
+    }
+
+    stage "Report" {
+        run
+            $"dotnet reportgenerator -reports:{coverageXml} -targetdir:{coverageReportDir} -reporttypes:Html;TextSummary"
+        run (fun _ ->
+            async {
+                let summary = coverageReportDir </> "Summary.txt"
+                let index = coverageReportDir </> "index.html"
+
+                if File.Exists summary then
+                    printfn "%s" (File.ReadAllText summary)
+
+                printfn $"Browse the full report at {index}"
+                return 0
+            })
+    }
+
     runIfOnlySpecified true
 }
 

--- a/docs/_body.html
+++ b/docs/_body.html
@@ -7,7 +7,25 @@
     })
 </script>
 <script type="module">
-    import mermaid from "https://esm.sh/mermaid@9.2.2";
+    import mermaid from "https://esm.sh/mermaid@11.16.1";
+
+    // A ```mermaid fenced block renders on github.com but reaches fsdocs as a syntax-highlighted
+    // code block, so it would show as source rather than a diagram. Promote those blocks to the
+    // <div class="mermaid"> elements mermaid looks for, so a page can use a plain fence and have
+    // it render both here and on GitHub. Pages using the <div> form directly keep working.
+    for (const code of document.querySelectorAll('code[lang="mermaid"]')) {
+        // fsdocs wraps the snippet in <table class="pre"><tr><td><pre><code>…; replace the
+        // outermost wrapper so no table scaffolding is left behind around the diagram.
+        const snippet = code.closest("table.pre") ?? code.closest("pre");
+        if (!snippet) continue;
+        const diagram = document.createElement("div");
+        diagram.className = "mermaid text-center";
+        // textContent, not innerHTML: the source arrives HTML-escaped (`--&gt;`) and mermaid
+        // needs the raw arrows back.
+        diagram.textContent = code.textContent;
+        snippet.replaceWith(diagram);
+    }
+
     mermaid.initialize({
         startOnLoad: true,
         theme: "base",

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -28,9 +28,10 @@ If you disagree with a rule, the discussion belongs at [fsharp/fslang-design](ht
 Fantomas does not edit your text.
 Think of it like a word processor: it re-types your entire file from scratch, following its own rules.
 
-When it re-types a piece of code, it asks one question first:
+Most of that re-typing is mechanical: spacing, indentation and parentheses follow fixed rules with nothing to decide.
+The one real choice is **where to put line breaks**, and it comes down to a single question:
 
-> Does this fit on the current line?
+> Does this fit within the max line length?
 
 If the answer is yes, it stays on one line and there is nothing more to decide.
 Everything below is about what happens when the answer is **no**.
@@ -86,7 +87,7 @@ a.Foo(x).Bar()    // parsed the way you intended
 
 The parser reads `(x).Bar()` as a single parenthesised argument handed to `a.Foo`. So for every call except the last one, tightness is a grammar requirement rather than a preference, and no setting can override it.
 
-The same constraint turns up wherever an expression has to stay glued to its neighbour. In `getBuilder().Build()` the receiver keeps its own `()` tight, in `x.Foo()[0]` the indexed call keeps its own `()` tight, and a `?` access does the same. In each case a space there would rebind the parentheses to the wrong thing. (The *final* call is still free to take a space: with the setting on, that first example formats as `getBuilder().Build ()`.)
+The same constraint turns up wherever an expression has to stay glued to its neighbour. In `getBuilder().Build()` the receiver keeps its own `()` tight, in `x.Foo()[0]` the indexed call keeps its own `()` tight, and the dynamic-access operator `?` behaves the same way: `settings?Section("db")?ConnectionString` stays tight throughout. In each case a space there would rebind the parentheses to the wrong thing. (The *final* call is still free to take a space: with the setting on, that first example formats as `getBuilder().Build ()`.)
 
 There is one place where even the last call stays tight: the body of a `_.` shorthand lambda, covered in the final section of this page.
 
@@ -122,8 +123,6 @@ That is the one pair worth keeping straight:
 .Cast<T>()      // action, this calls something
 ```
 
-An index or a set of type arguments is navigation while it stays on one line, and becomes an action if its contents grow big enough to need several lines.
-
 ## The rule for line breaks
 
 ```text
@@ -141,6 +140,10 @@ In one sentence:
 > As soon as there are two or more calls, the chain is a pipeline and each call gets its own line.
 
 Navigation is never worth a line of its own. It rides at the front of the line belonging to the action it introduces.
+
+Riding along only works while the navigation itself stays on one line.
+If an index (or a set of type arguments) has to break across several lines, it can no longer be a passenger, and the question above then counts it as an action: it claims a line of its own, and the chain around it becomes a pipeline.
+It is still navigation in what it *does*; it has simply grown too big to ride along.
 
 ## Examples
 
@@ -188,6 +191,28 @@ document.Body.FirstChild
 
 `.Body` and `.FirstChild` lead the first line.
 `.ParentElement` is navigation introducing `.RemoveChild(oldNode)`, so it rides at the front of that line instead of claiming one of its own.
+
+### An index too big to ride along
+
+```fsharp
+lookupTable.[0].AppendEntry(
+    newEntryForTheBucket
+)
+```
+
+A short index is navigation, so there is a single action at the end and only its arguments break.
+
+Grow the index until it needs several lines of its own and it can no longer ride along:
+
+```fsharp
+lookupTable
+    .[computeBucketIndex
+        hashOfTheKeyValue
+        tableSizeInBuckets]
+    .AppendEntry(newEntry)
+```
+
+Nothing about the index started executing. It just stopped fitting on someone else's line.
 
 ### A chain that ends in navigation
 

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -3,10 +3,23 @@ category: Contributors
 categoryindex: 2
 index: 19
 ---
+
 # Chains
 
-A *chain* is one of the few shapes where Fantomas has a real choice to make about line breaks.
+A _chain_ is a starting value followed by a series of steps, where every step is reached through a dot:
+
+```fsharp
+document.Body.FirstChild.AppendChild(newNode)
+```
+
+Here `document` is the starting value, and `.Body`, `.FirstChild` and `.AppendChild(newNode)` are the steps.
+
+Chains are one of the few shapes where Fantomas has a real choice to make about line breaks.
 This page states the rules it follows and the reasoning behind each one, in plain language and without reference to any internal types.
+
+Every code block on this page is Fantomas output, except where marked ⛔.
+A ⛔ block is the alternative that was considered and turned down, shown so that the reasoning is visible rather than implied, and ✅ marks what Fantomas does instead.
+The two markers appear wherever there was a real choice to make; elsewhere the output speaks for itself and goes unmarked.
 
 ## Status: a proposal, backed by an implementation
 
@@ -38,14 +51,6 @@ Everything below is about what happens when the answer is **no**.
 
 ## What counts as a chain
 
-A chain is a starting value followed by a series of steps, where **every step is reached through a dot**.
-
-```fsharp
-document.Body.FirstChild.AppendChild(newNode)
-```
-
-Here `document` is the starting value, and `.Body`, `.FirstChild` and `.AppendChild(newNode)` are the steps.
-
 The dot is what matters. If there is no dot, there is no step:
 
 ```fsharp
@@ -61,7 +66,7 @@ An expression without any dots is laid out by other rules, not the ones on this 
 Formatting a chain settles two questions that have nothing to do with each other:
 
 1. **Where do the line breaks go?** A style decision, and the bulk of this page.
-2. **May a space sit between a method name and its `(`?** Mostly *not* a style decision, and the shorter of the two, so it is settled first.
+2. **May a space sit between a method name and its `(`?** Mostly _not_ a style decision, and the shorter of the two, so it is settled first.
 
 ## Only the last call may have a space before its parentheses
 
@@ -78,18 +83,51 @@ a.Foo(x).Bar (y)    // in a chain: only the final .Bar takes the space,
                     // the intermediate .Foo stays tight
 ```
 
-This is not Fantomas being inconsistent. A space in the middle of a chain changes what the code *means*:
+This is not Fantomas being inconsistent. A space in the middle of a chain changes what the code _means_:
 
 ```fsharp
-a.Foo (x).Bar()   // parsed as a.Foo ((x).Bar())
-a.Foo(x).Bar()    // parsed the way you intended
+// ⛔ parsed as a.Foo ((x).Bar()) — a different program
+a.Foo (x).Bar()
+
+// ✅ parsed the way you intended
+a.Foo(x).Bar()
 ```
 
 The parser reads `(x).Bar()` as a single parenthesised argument handed to `a.Foo`. So for every call except the last one, tightness is a grammar requirement rather than a preference, and no setting can override it.
 
-The same constraint turns up wherever an expression has to stay glued to its neighbour. In `getBuilder().Build()` the receiver keeps its own `()` tight, in `x.Foo()[0]` the indexed call keeps its own `()` tight, and the dynamic-access operator `?` behaves the same way: `settings?Section("db")?ConnectionString` stays tight throughout. In each case a space there would rebind the parentheses to the wrong thing. (The *final* call is still free to take a space: with the setting on, that first example formats as `getBuilder().Build ()`.)
+The same constraint turns up wherever an expression has to stay glued to its neighbour. In `getBuilder().Build()` the starting value keeps its own `()` tight, in `x.Foo()[0]` the indexed call keeps its own `()` tight, and the dynamic-access operator `?` behaves the same way: `settings?Section("db")?ConnectionString` stays tight throughout. In each case a space there would rebind the parentheses to the wrong thing. (The _final_ call is still free to take a space: with the setting on, that first example formats as `getBuilder().Build ()`.)
 
-There is one place where even the last call stays tight: the body of a `_.` shorthand lambda, covered in the final section of this page.
+### The `_.` shorthand lambda
+
+There is one place where even the last call stays tight.
+F# lets you write `_.Property` as a short lambda, and Fantomas treats it as a chain whose starting value is `_`:
+
+```fsharp
+"yow" |> _.Substring(0, 16).ToLower()
+```
+
+Everywhere else the _last_ call of a chain may take a space when a setting asks for one. Here it may not: the F# compiler requires the body of a `_.` lambda to stay atomic.
+
+```fsharp
+// both with space_before_uppercase_invocation = true
+
+// ⛔ what the setting would ask for here — this fails to compile with FS3584
+"yow" |> _.Substring(0, 16).ToLower ()
+
+// ✅ the body of a `_.` lambda stays tight regardless of the setting
+"yow" |> _.Substring(0, 16).ToLower()
+```
+
+This was [issue 3364](https://github.com/fsprojects/fantomas/issues/3364).
+
+That is the only thing that makes `_.` special, and it is a question of tightness rather than of line breaks.
+Everything from here on applies to it exactly as to any other chain. The example above has two calls, so if it does not fit it becomes a pipeline:
+
+```fsharp
+_
+    .Substring(0, 16)
+    .ToLower()
+```
 
 Everything from here on is about the first question, where the line breaks go.
 
@@ -123,27 +161,273 @@ That is the one pair worth keeping straight:
 .Cast<T>()      // action, this calls something
 ```
 
-## The rule for line breaks
+## Working through a chain
+
+Before the rules are stated one by one, here is the whole process applied to a single chain, at a max line length of 60.
+Everything after this section is the detail behind one of these five steps.
+
+```fsharp
+// ⛔ the chain as written: 95 characters against a margin of 60
+builder.Connect(hostName).Configuration.Database.PrimaryConnection.Settings.Apply(spec).Build()
+```
+
+**Step 1. Does it fit?** No: 95 characters against a margin of 60. Had it fitted, that would have been the end of it and no rule below would ever have been consulted.
+
+**Step 2. Label every part.** The starting value, then each step as either navigation or an action:
 
 ```text
-Does the whole chain fit on one line?
-├── Yes  Leave it on one line.
-└── No   Is there exactly one action, and is it the last step?
-         ├── Yes  Keep everything up to the method name together,
-         │        and break the call's ARGUMENTS.
-         └── No   Give each action its own line, led by its dot.
+builder               starting value
+  .Connect(hostName)  action        — it calls something
+  .Configuration      navigation    — it only names something
+  .Database           navigation
+  .PrimaryConnection  navigation
+  .Settings           navigation
+  .Apply(spec)        action
+  .Build()            action
 ```
+
+**Step 3. Count the actions to pick a layout.** There are three, so this is a pipeline and every action gets a line of its own, led by its dot.
+Only a chain with exactly one action, as its last step, after a plain starting value, is kept together instead.
+
+**Step 4. Let the navigation ride.** Navigation never claims a line of its own. Each step rides at the front of the line belonging to the action it introduces, so the four navigation steps join `.Apply(spec)`:
+
+```fsharp
+// ⛔ not finished: the third line is 66 characters
+builder
+    .Connect(hostName)
+    .Configuration.Database.PrimaryConnection.Settings.Apply(spec)
+    .Build()
+```
+
+**Step 5. Is any line still too long?** The third one is. Its run of navigation wraps, balanced so that the longest line comes out as short as possible, and wrapped one step earlier than strictly necessary so that `.Apply(spec)` is not forced to break its argument:
+
+```fsharp
+// ✅ the finished layout
+builder
+    .Connect(hostName)
+    .Configuration.Database
+    .PrimaryConnection.Settings.Apply(spec)
+    .Build()
+```
+
+Those five steps are the whole algorithm. To apply it to a chain of your own: check the width, label the parts, count the actions, let the navigation ride, then wrap any line that is still too long.
+
+## Steps 1 to 3: the rule for line breaks
+
+The rule behind the first three steps:
+
+```mermaid
+graph TD
+    A{"Does the whole chain fit on one line?"}
+    A -->|Yes| B["Leave it on one line"]
+    A -->|No| C{"Is there exactly one action,\nand is it the last step?"}
+    C -->|No| P
+    C -->|Yes| D{"Is the starting value a plain value?"}
+    D -->|No| P
+    D -->|Yes| E{"Does everything up to the method name\nfit on one line?"}
+    E -->|No| P
+    E -->|Yes| K["Keep the chain together,\nand break the call's arguments"]
+    P["Pipeline: give each action its own line, led by its dot"]
+```
+
+The three questions after the first are the conditions for keeping the chain together, and a "no" to any one of them lands in the same place.
 
 In one sentence:
 
-> A single `receiver.Method(args)` breaks its arguments, like any other call.
+> A plain `value.Method(args)` breaks its arguments, like any other call.
 > As soon as there are two or more calls, the chain is a pipeline and each call gets its own line.
+
+**Step 1 is the first question**, and for most chains it is also the last. At a max line length of 50:
+
+```fsharp
+// ✅ 32 characters, so nothing moves
+config.Settings.GetValue(theKey)
+```
+
+Every example from here to the end of the page is a chain that did _not_ fit, so this question is answered "no" from now on.
+
+**Step 3 is the second question**, and of its three conditions the first is the interesting one. The other two are guards, and each is worth a sentence.
+
+**The starting value must be a plain value.** Lengthen the argument until the chain runs past the margin:
+
+```fsharp
+// ⛔ 65 characters at a margin of 50
+config.Settings.GetValue(theConfigurationKeyNameThatIsRatherLong)
+```
+
+A bare identifier or dotted path qualifies as a plain starting value, so this chain is kept together and only the argument moves:
+
+```fsharp
+// ✅ a plain starting value: the chain is kept together
+config.Settings.GetValue(
+    theConfigurationKeyNameThatIsRatherLong
+)
+```
+
+A call, a parenthesised expression or a generic name does not qualify. Doing the same thing to one of those would be the obvious move, since such a chain still has just one action and that action is still last:
+
+```fsharp
+// ⛔ the starting value is a call, glued to the navigation behind it
+getConfiguration().Settings.GetValue(
+    theConfigurationKeyNameThatIsRatherLong
+)
+```
+
+Fantomas leads a pipeline instead:
+
+```fsharp
+// ✅ the starting value gets the opening line
+getConfiguration()
+    .Settings.GetValue(
+        theConfigurationKeyNameThatIsRatherLong
+    )
+```
+
+The two inputs differ only in their starting value. A compound one is already doing something, so it earns the opening line rather than serving as a prefix to the navigation behind it.
+
+**Everything up to the method name must fit on one line.** When it does not, or when a comment falls between the steps, there is nothing left to keep together and the pipeline takes over:
+
+```fsharp
+// ✅ the comment splits the steps, so there is nothing to keep together
+config.Settings
+    // the primary one
+    .GetValue(theKeyName)
+```
+
+That second guard is also why step 5, wrapping a long run of navigation, never applies to this branch: if the chain is kept together then everything up to the method name fits by definition, so there is no wrap to be made.
+
+## Step 4: navigation rides along
 
 Navigation is never worth a line of its own. It rides at the front of the line belonging to the action it introduces.
 
 Riding along only works while the navigation itself stays on one line.
 If an index (or a set of type arguments) has to break across several lines, it can no longer be a passenger, and the question above then counts it as an action: it claims a line of its own, and the chain around it becomes a pipeline.
-It is still navigation in what it *does*; it has simply grown too big to ride along.
+It is still navigation in what it _does_; it has simply grown too big to ride along.
+
+## Step 5: when a line is still too long
+
+Steps 3 and 4 decide which steps share a line. They leave one question open, because navigation accumulates: a line they hand you can itself be too long.
+So the fit question from step 1 comes round a second time, now asked of a line the rules have just produced rather than of the chain as a whole.
+
+Here is a chain that runs into it, at a max line length of 100:
+
+```fsharp
+// ⛔ 118 characters, well past the margin, so a break has to go somewhere
+getConfiguration().Configuration.Database.PrimaryConnection.Settings.Timeouts.IdleTimeout.Duration.Total.Seconds.Value
+```
+
+The rule above will not place that break. `getConfiguration()` is the starting value, every step after it is navigation, and there is no action anywhere to lead a second line.
+
+The obvious answer is to fill greedily, packing each line up to the margin before starting a new one. That is what a text editor does to a paragraph:
+
+```fsharp
+// ⛔ greedy: one line packed to the margin, then a stub
+getConfiguration()
+    .Configuration.Database.PrimaryConnection.Settings.Timeouts.IdleTimeout.Duration.Total.Seconds
+    .Value
+```
+
+Ninety-four characters, and then `.Value` on its own. Fantomas instead chooses the wrap that makes **the longest resulting line as short as possible**:
+
+```fsharp
+// ✅ balanced: fifty characters on each line
+getConfiguration()
+    .Configuration.Database.PrimaryConnection.Settings
+    .Timeouts.IdleTimeout.Duration.Total.Seconds.Value
+```
+
+When two wraps tie, the longer first line wins.
+
+The reason to prefer the second is that neither break point _means_ anything.
+A run of navigation has no internal structure that makes one dot a better stopping place than another, unlike the boundary between two actions, which is a real seam in what the code does.
+When the choice is arbitrary the only thing left to weigh is how easy the result is to read, and two comparable lines are easier to scan than a full one followed by a remnant.
+
+### The starting value never sits alone
+
+A run of navigation often begins on the same line as the starting value, which is `defineCombinationValue` in the example below.
+That value is not a step, so a line holding it and nothing else has nothing on it to balance: it is a wasted line rather than a short one.
+Whenever there is room beside it for the first step, it keeps that step, and the rest of the run is balanced from there.
+
+```fsharp
+// ⛔ balancing on its own: the shortest longest line, but the starting value is stranded
+defineCombinationValue
+    .Value.IsEmpty
+
+// ✅ the starting value keeps a step
+defineCombinationValue.Value
+    .IsEmpty
+```
+
+With only two steps to place, no split avoids a short line, and stranding the starting value costs more than a short last line does.
+This matters much less as a run grows: once there are several steps, the first line is full anyway and the rule never comes up.
+
+### The wrap makes room for the arguments
+
+When a wrapped line ends in a call, there are two ways to find the width it needs: move some navigation down, or break the call's arguments.
+
+Balancing on width alone would take the second. The navigation stops just short of the margin, which leaves the arguments nowhere to go:
+
+```fsharp
+// ⛔ the navigation fills its line and pushes the argument below
+getConfiguration()
+    .Configuration.Database.PrimaryConnection.Settings.Timeouts.GetValue(
+        keyName
+    )
+```
+
+Moving navigation is the cheaper of the two, so Fantomas wraps one step earlier than it strictly had to, which keeps `keyName` beside the method that takes it:
+
+```fsharp
+// ✅ the navigation gives way and the call stays whole
+getConfiguration()
+    .Configuration.Database.PrimaryConnection
+    .Settings.Timeouts.GetValue(keyName)
+```
+
+The same holds mid-pipeline, where it is an intermediate call that stays intact:
+
+```fsharp
+// ✅ `spec` is never pushed onto a line of its own
+builder
+    .Connect(hostName)
+    .Configuration.Database
+    .PrimaryConnection.Settings.Apply(spec)
+    .Build()
+```
+
+When no wrap can hold the whole call, because the arguments are too wide however the navigation is arranged, only the opening `(` has to fit and the arguments break as they normally would.
+
+None of this contradicts _Arguments are not the chain's business_ below.
+The chain still never decides how the arguments are laid out; it only prefers, among its own wrap points, one that leaves the call intact.
+And a call that has left the starting value's line already has a line of its own, so there is nothing for the navigation to make room for:
+
+```fsharp
+Microsoft.FSharp.Reflection.FSharpType
+    .GetUnionCases(typeof<option<option<unit>>>.GetGenericTypeDefinition().MakeGenericType(t))
+    .Assembly
+```
+
+### Balancing never crosses an action
+
+Only a run of consecutive navigation steps is balanced.
+Widths alone would suggest pulling the first call up onto the starting value's line, since that evens the lines out nicely:
+
+```fsharp
+// ⛔ balanced on width, but the seam between the two calls is gone
+serviceCollection.AddSingleton<IClock>(systemClock)
+    .AddOptions<MyOptions>(configureOptions)
+```
+
+Fantomas will not do that. An action always starts its own line, and that is a decision about what the code _does_ rather than about width, so nothing in this section can move it:
+
+```fsharp
+// ✅ one action per line, placed by the rule above
+serviceCollection
+    .AddSingleton<IClock>(systemClock)
+    .AddOptions<MyOptions>(configureOptions)
+```
+
+The boundary between two actions is a real seam in the code. The dots inside a run of navigation are not, which is exactly why balancing is free to move those and not these.
 
 ## Examples
 
@@ -158,7 +442,7 @@ config.GetConnectionString(
 ```
 
 There is a single action and it is the last step, so `config.GetConnectionString(` stays together and only the argument moves.
-This is exactly how an ordinary call breaks. Having a receiver in front of it changes nothing.
+This is exactly how an ordinary call breaks. Having a starting value in front of it changes nothing.
 
 ### Navigation in front of a single call: still just the arguments
 
@@ -169,7 +453,7 @@ response.Content.Headers.GetValues(
 ```
 
 `.Content` and `.Headers` are navigation, so there is still only one action.
-The chain is not a pipeline and the navigation stays with the receiver.
+The chain is not a pipeline and the navigation stays with the starting value.
 
 ### Two or more calls: a pipeline
 
@@ -216,25 +500,34 @@ Nothing about the index started executing. It just stopped fitting on someone el
 
 ### A chain that ends in navigation
 
+There is only one call here, but it is **not** the last step. Breaking just its arguments would leave the navigation stranded after the closing `)`:
+
 ```fsharp
+// ⛔ `.Entries.[indexWithinTheBucket]` is left dangling off the `)`
+lookupTable.GetBucketForHash(
+    hashOfTheKeyValue
+).Entries.[indexWithinTheBucket]
+```
+
+So the pipeline layout is used instead:
+
+```fsharp
+// ✅ every step is reachable by reading down the dots
 lookupTable
     .GetBucketForHash(hashOfTheKeyValue)
     .Entries.[indexWithinTheBucket]
 ```
 
-There is only one call here, but it is **not** the last step.
-Breaking only the arguments would strand `.Entries.[indexWithinTheBucket]`, so the pipeline layout is used instead.
-
 ### A chain with no calls at all
 
 ```fsharp
-this.Configuration.Database.PrimaryConnection.Settings
-    .IdleTimeoutInSeconds
+this.Configuration.Database.PrimaryConnection
+    .Settings.IdleTimeoutInSeconds
 ```
 
-With no actions to lead any lines, the steps simply fill the line and break before a dot when the line is full.
+There are no actions to lead any lines, so the whole chain is one long line of navigation and it is wrapped by the rule in [step 5](#step-5-when-a-line-is-still-too-long).
 
-### A receiver that is itself a call
+### A starting value that is itself a call
 
 ```fsharp
 getConfiguredServiceBuilder()
@@ -245,6 +538,8 @@ getConfiguredServiceBuilder()
 The opening call stays glued to its `()` and acts as the starting value.
 It has to stay glued: a space there would change what the code means.
 
+This one is a pipeline on the strength of its two calls alone, but a starting value of this shape leads a pipeline even with a single call, as noted in the rule above.
+
 ## Arguments are not the chain's business
 
 It is worth stating the boundary explicitly, because it is what keeps the rules above so short:
@@ -252,7 +547,7 @@ It is worth stating the boundary explicitly, because it is what keeps the rules 
 > The chain rules decide where lines break **between** steps.
 > They say nothing about what happens **inside** a call's parentheses.
 
-Everything between `(` and `)` is laid out by the ordinary rules for call arguments, exactly as it would be if that call had no receiver in front of it.
+Everything between `(` and `)` is laid out by the ordinary rules for call arguments, exactly as it would be if that call had no starting value in front of it.
 A chain never overrides them.
 That is the same idea as "break the call's arguments" in the rule above: at that point Fantomas stops making chain decisions and hands the argument to the normal machinery.
 
@@ -300,13 +595,36 @@ repo
     .ToList()
 ```
 
-### The one place position does matter
+### Match lambdas are no exception
 
-Match lambdas, written `(function`, are the single shape where a call's position in the chain changes the layout.
+Match lambdas, written `(function`, are the argument shape most likely to look like an exception, so it is worth showing in full that they are not one.
+The F# style guide asks for them to be treated the same as `fun` lambdas ("Treat match lambda's in a similar fashion"), and they are: where the call sits in its chain makes no difference to either form.
 
-`(function` is kept together only when all of the following hold: the call is the **last** step, `multi_line_lambda_closing_newline` is `false`, and you did not already break after the `(` yourself.
+Here are both lambda forms, in both positions, under the default settings:
 
 ```fsharp
+// ✅ fun, mid-pipeline
+builder
+    .Configure(fun v ->
+        handleSomeValue v |> andThenSomethingElse v)
+    .Build()
+    .Result
+
+// ✅ fun, last step
+builder
+    .Build()
+    .Configure(fun v ->
+        handleSomeValue v |> andThenSomethingElse v)
+
+// ✅ function, mid-pipeline
+builder
+    .Configure(function
+        | Some v -> handleSome v
+        | None -> handleNone ())
+    .Build()
+    .Result
+
+// ✅ function, last step
 builder
     .Build()
     .Configure(function
@@ -314,9 +632,27 @@ builder
         | None -> handleNone ())
 ```
 
-If any one of those is not true, `function` moves down to its own line and the closing `)` goes to its own line too:
+Read down the column: each form keeps its shape when the call moves. Read across the pair: both forms keep the opener attached to the `(`.
+
+Now the same four with `multi_line_lambda_closing_newline` set to `true`:
 
 ```fsharp
+// ✅ fun, mid-pipeline
+builder
+    .Configure(fun v ->
+        handleSomeValue v |> andThenSomethingElse v
+    )
+    .Build()
+    .Result
+
+// ✅ fun, last step
+builder
+    .Build()
+    .Configure(fun v ->
+        handleSomeValue v |> andThenSomethingElse v
+    )
+
+// ✅ function, mid-pipeline
 builder
     .Configure(
         function
@@ -325,34 +661,23 @@ builder
     )
     .Build()
     .Result
+
+// ✅ function, last step
+builder
+    .Build()
+    .Configure(
+        function
+        | Some v -> handleSome v
+        | None -> handleNone ()
+    )
 ```
 
-The reason position is involved at all: mid-pipeline, the clauses would run on underneath a line that still continues with further steps, which reads poorly.
-So this is a readability judgement rather than a rule forced by the language.
+Position still makes no difference. What the setting changes is the closing `)`, which now takes a line of its own in all four.
 
-It is also a good illustration of the boundary above rather than an exception to it.
-`multi_line_lambda_closing_newline` is still being respected here; it simply has a visible effect on the opener as well as on the closing `)` for this particular argument shape.
-And the `(` itself never leaves `.Configure`, for the parsing reason given at the end of this page.
+The one difference left between the two forms is that `function` also moves down off the `(`, while `(fun v ->` stays put. That is not about the chain either: a `fun` lambda's parameters have to stay with their arrow, so there is nothing to move, whereas `function` takes no parameters and can. The setting simply has a visible effect on the opener as well as on the closing `)` for that one argument shape.
 
-## The `_.` shorthand lambda
+One further thing moves `function` down onto its own line, and it belongs to the argument rather than the chain: having broken after the `(` yourself, which Fantomas leaves as you wrote it.
 
-F# lets you write `_.Property` as a short lambda. Fantomas treats it as a chain whose starting value is `_`:
-
-```fsharp
-"yow" |> _.Substring(0, 16).ToLower()
-```
-
-There is one thing that makes it special, and it concerns [the space before a call](#only-the-last-call-may-have-a-space-before-its-parentheses).
-Everywhere else the *last* call of a chain may take a space when a setting asks for one. Here it may not: the F# compiler requires the body of a `_.` lambda to stay atomic, so `ToLower ()` would not compile.
-Fantomas therefore keeps it tight even with [`space_before_uppercase_invocation`](../end-users/Configuration.html) enabled. This was [issue 3364](https://github.com/fsprojects/fantomas/issues/3364).
-
-Apart from that, it follows the same rule as any other chain.
-The example above has two calls, so if it does not fit, it becomes a pipeline:
-
-```fsharp
-_
-    .Substring(0, 16)
-    .ToLower()
-```
+The only thing the chain decides here is that the `(` never leaves `.Configure`, for the parsing reason given in [Only the last call may have a space before its parentheses](#only-the-last-call-may-have-a-space-before-its-parentheses).
 
 <fantomas-nav previous="{{fsdocs-previous-page-link}}" next="{{fsdocs-next-page-link}}"></fantomas-nav>

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -708,5 +708,33 @@ The one difference left between the two forms is that `function` also moves down
 One further thing moves `function` down onto its own line, and it belongs to the argument rather than the chain: having broken after the `(` yourself, which Fantomas leaves as you wrote it.
 
 The only thing the chain decides here is that the `(` never leaves `.Configure`, for the parsing reason given in [Only the last call may have a space before its parentheses](#only-the-last-call-may-have-a-space-before-its-parentheses).
+A comment written between the two is the one thing that can separate them, and that is the next section.
+
+### A comment beside the parentheses
+
+A comment can sit on either side of a call's opening parenthesis, and which side it is on decides what moves.
+
+In front of the argument, the comment is written after the `(`. The parenthesis has no reason to leave the method name, so it stays where it is and only the argument moves down:
+
+```fsharp
+// ✅ the comment is inside the parentheses, so only the argument moves
+builder.UseUrls(
+    // the public endpoint
+    url
+)
+```
+
+In front of the parenthesis, the comment is written before the `(` and ends its line. The parenthesis can no longer follow the method name, so the whole call moves down instead:
+
+```fsharp
+// ✅ the comment is between the method name and the `(`, so the call moves
+builder.UseUrls
+    // pick the endpoint
+    (url)
+```
+
+The first of these happens wherever the call sits in the chain. The second can only ever happen to the last call: anything between a method name and its `(`, a comment as much as a line break, makes the parser read the parentheses as a separate argument, so an earlier call cannot carry a comment there and still mean the same thing.
+
+Which side the comment is on is the whole of it. How the call was spread over lines in the source has no say, and in both layouts the argument between the parentheses is laid out by the ordinary rules, exactly as the rest of this section promises.
 
 <fantomas-nav previous="{{fsdocs-previous-page-link}}" next="{{fsdocs-next-page-link}}"></fantomas-nav>

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -705,7 +705,7 @@ Position still makes no difference. What the setting changes is the closing `)`,
 
 The one difference left between the two forms is that `function` also moves down off the `(`, while `(fun v ->` stays put. That is not about the chain either: a `fun` lambda's parameters have to stay with their arrow, so there is nothing to move, whereas `function` takes no parameters and can. The setting simply has a visible effect on the opener as well as on the closing `)` for that one argument shape.
 
-One further thing moves `function` down onto its own line, and it belongs to the argument rather than the chain: having broken after the `(` yourself, which Fantomas leaves as you wrote it.
+The setting is the only thing that moves it. Writing `function` on the line below the `(` yourself makes no difference: the same call written across more lines is still the same call, and Fantomas has to land on one answer for both.
 
 The only thing the chain decides here is that the `(` never leaves `.Configure`, for the parsing reason given in [Only the last call may have a space before its parentheses](#only-the-last-call-may-have-a-space-before-its-parentheses).
 A comment written between the two is the one thing that can separate them, and that is the next section.

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -75,24 +75,11 @@ An expression without any dots is laid out by other rules, not the ones on this 
 Formatting a chain settles two questions that have nothing to do with each other:
 
 1. **Where do the line breaks go?** A style decision, and the bulk of this page.
-2. **May a space sit between a method name and its `(`?** Mostly _not_ a style decision, and the shorter of the two, so it is settled first.
+2. **Is the method name welded to its argument?** Mostly _not_ a style decision, and the shorter of the two, so it is settled first.
 
-## Only the last call may have a space before its parentheses
+## An intermediate call is welded to its parenthesis
 
-Fantomas has settings that ask for a space before the parentheses of a call, [`space_before_uppercase_invocation`](../end-users/Configuration.html) and [`space_before_lowercase_invocation`](../end-users/Configuration.html).
-
-In a chain, **those settings apply to the final call only**. Every earlier call stays tight, whatever the settings say:
-
-```fsharp
-// both examples with space_before_uppercase_invocation = true
-
-obj.Bar ()          // a call on its own: the setting applies
-
-a.Foo(x).Bar (y)    // in a chain: only the final .Bar takes the space,
-                    // the intermediate .Foo stays tight
-```
-
-This is not Fantomas being inconsistent. A space in the middle of a chain changes what the code _means_:
+A call in the middle of a chain may not be separated from its `(` by anything at all, because that changes what the code _means_:
 
 ```fsharp
 // ⛔ parsed as a.Foo ((x).Bar()) — a different program
@@ -102,7 +89,26 @@ a.Foo (x).Bar()
 a.Foo(x).Bar()
 ```
 
-The parser reads `(x).Bar()` as a single parenthesised argument handed to `a.Foo`. So for every call except the last one, tightness is a grammar requirement rather than a preference, and no setting can override it.
+The parser reads `(x).Bar()` as a single parenthesised argument handed to `a.Foo`. So for every call except the last one, tightness is a grammar requirement rather than a preference, and nothing on this page can override it. A space, a line break and a comment are all the same gap as far as the parser is concerned.
+
+**The last call is under no such constraint.** Nothing follows it to be reparsed, so its `(` is free to leave the method name. Three things make use of that freedom, and each is covered where it belongs:
+
+- a setting asking for a space, just below;
+- a comment written between the name and the argument, see [A comment beside the parentheses](#a-comment-beside-the-parentheses);
+- an argument that needs a line of its own, see [Arguments are not the chain's business](#arguments-are-not-the-chains-business).
+
+That is the whole of it. What follows are those three, not three exceptions to a rule. One shape takes the freedom away again, the `_.` lambda body below.
+
+Fantomas has settings that ask for a space before the parentheses of a call, [`space_before_uppercase_invocation`](../end-users/Configuration.html) and [`space_before_lowercase_invocation`](../end-users/Configuration.html). In a chain, **they apply to the final call only**. Every earlier call stays tight, whatever the settings say:
+
+```fsharp
+// both examples with space_before_uppercase_invocation = true
+
+obj.Bar ()          // a call on its own: the setting applies
+
+a.Foo(x).Bar (y)    // in a chain: only the final .Bar takes the space,
+                    // the intermediate .Foo stays tight
+```
 
 The same constraint turns up wherever an expression has to stay glued to its neighbour. In `getBuilder().Build()` the starting value keeps its own `()` tight, in `x.Foo()[0]` the indexed call keeps its own `()` tight, and the dynamic-access operator `?` behaves the same way: `settings?Section("db")?ConnectionString` stays tight throughout. In each case a space there would rebind the parentheses to the wrong thing. (The _final_ call is still free to take a space: with the setting on, that first example formats as `getBuilder().Build ()`.)
 
@@ -229,23 +235,16 @@ The rule behind the first three steps:
 graph TD
     A{"Does the whole chain fit on one line?"}
     A -->|Yes| B["Leave it on one line"]
-    A -->|No| C{"Is there exactly one action,\nand is it the last step?"}
-    C -->|No| P
-    C -->|Yes| D{"Is the starting value a plain value?"}
-    D -->|No| P
-    D -->|Yes| E{"Does everything up to the method name\nfit on one line?"}
-    E -->|No| F{"Is the method name itself\nthe overflow?"}
-    F -->|No| P
-    F -->|Yes| K
-    E -->|Yes| K["Keep the chain together,\nand break the call's arguments"]
-    P["Pipeline: give each action its own line, led by its dot"]
+    A -->|No| C{"Does it read as a single call:\na plain starting value, navigation,\nand one call as its last step?"}
+    C -->|Yes| K["Keep the chain together,\nand hand the argument over"]
+    C -->|No| P["Pipeline: give each action its own line, led by its dot"]
 ```
 
-The questions after the first are the conditions for keeping the chain together, and a "no" to any one of them lands in the same place, bar the last one's escape hatch.
+Two questions, and only two outcomes. The second one packs three conditions, taken one at a time below, and a "no" to any of them lands in the pipeline.
 
 In one sentence:
 
-> A plain `value.Method(args)` breaks its arguments, like any other call.
+> A plain `value.Method(args)` hands its argument to the ordinary rules, like any other call.
 > As soon as there are two or more calls, the chain is a pipeline and each call gets its own line.
 
 **Step 1 is the first question**, and for most chains it is also the last. At a max line length of 50:
@@ -392,7 +391,7 @@ This matters much less as a run grows: once there are several steps, the first l
 
 ### The wrap makes room for the arguments
 
-When a wrapped line ends in a call, there are two ways to find the width it needs: move some navigation down, or break the call's arguments.
+When a wrapped line ends in a call, there are two ways to find the width it needs: move some navigation down, or let the argument break.
 
 Balancing on width alone would take the second. The navigation stops just short of the margin, which leaves the arguments nowhere to go:
 
@@ -424,7 +423,7 @@ builder
     .Build()
 ```
 
-When no wrap can hold the whole call, because the arguments are too wide however the navigation is arranged, only the opening `(` has to fit and the arguments break as they normally would.
+When no wrap can hold the whole call, because the argument is too wide however the navigation is arranged, the chain stops trying and hands the argument over, which breaks it as it normally would, or moves it down a line if that is what its own rules ask for.
 
 None of this contradicts _Arguments are not the chain's business_ below.
 The chain still never decides how the arguments are laid out; it only prefers, among its own wrap points, one that leaves the call intact.
@@ -574,23 +573,13 @@ This one is a pipeline on the strength of its two calls alone, but a starting va
 It is worth stating the boundary explicitly, because it is what keeps the rules above so short:
 
 > The chain rules decide where lines break **between** steps.
-> They say nothing about what happens **inside** a call's parentheses.
+> The argument owns everything from its `(` onwards, including whether that `(` starts a line of its own.
 
-Everything between `(` and `)` is laid out by the ordinary rules for call arguments, exactly as it would be if that call had no starting value in front of it.
+An argument is laid out by the ordinary rules for call arguments, exactly as it would be if the call had no starting value in front of it.
 A chain never overrides them.
-That is the same idea as "break the call's arguments" in the rule above: at that point Fantomas stops making chain decisions and hands the argument to the normal machinery.
+That is the same idea as "hand the argument over" in the rule above: at that point Fantomas stops making chain decisions and hands the argument to the normal machinery.
 
-Which includes the decision to move the argument itself. A lambda whose parameters no longer fit beside the method name takes a line of its own, and the terminal call's `(` goes down with it, exactly as it would with no starting value in front:
-
-```fsharp
-// ✅ the opener no longer fits, so the whole argument moves down one level
-ifaces
-|> List.tryPick
-    (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) ->
-        Some(ty, withRange))
-```
-
-This is the one thing that separates a terminal `(` from its method name without a setting asking for it, and it is allowed for the same reason a setting may ask: the last call of a chain has nothing behind it to reparse. Every earlier call keeps its parenthesis welded, so its argument breaks after the `(` instead.
+The boundary is drawn there, rather than at the `(`, because moving the argument is one of the answers those rules can give, shown under [Any part of a chain can grow](#any-part-of-a-chain-can-grow) below. Only a terminal call can be moved that way, for the reason given under [An intermediate call is welded to its parenthesis](#an-intermediate-call-is-welded-to-its-parenthesis). An earlier call keeps its `(` where it is, so its argument breaks after the parenthesis instead.
 
 The practical consequence is that **every setting that governs argument layout keeps working unchanged inside a chain**.
 The one you are most likely to notice is [`multi_line_lambda_closing_newline`](../end-users/Configuration.html), which decides where the closing `)` lands when a lambda argument needs several lines.
@@ -635,6 +624,52 @@ repo
     .Select(projector)
     .ToList()
 ```
+
+### Any part of a chain can grow
+
+The rules above are stated with short steps, but any part of a chain can turn out to be an expression that needs several lines of its own. Where that happens is what decides the consequence, and each case is already covered above:
+
+- **the starting value**, when it is a call or a parenthesised expression, leads a pipeline rather than serving as a prefix, see [Steps 1 to 3](#steps-1-to-3-the-rule-for-line-breaks);
+- **an index or a set of type arguments** stops being able to ride along, claims a line of its own and turns the chain into a pipeline, see [Step 4](#step-4-navigation-rides-along);
+- **a run of navigation** that overflows wraps, balanced, see [Step 5](#step-5-when-a-line-is-still-too-long);
+- **the final argument** is the one the chain has no say over, and it has two answers of its own.
+
+Those two answers are worth seeing side by side. All three examples are at a max line length of 70.
+
+A lambda is the case where the argument moves. Its opener, everything up to the arrow, no longer fits beside the method name, so the whole argument takes the line below and the `(` goes with it:
+
+```fsharp
+// ✅ the opener does not fit, so the argument moves down
+let publishSettings () =
+    storage.SetConfigurationSettingPublisher
+        (fun configName publisher -> publish configName publisher)
+```
+
+Grow the body and the lambda breaks further, but nothing about the chain changes: the argument was already handed over, and this is the argument's business:
+
+```fsharp
+// ✅ the same layout, with the body broken by the ordinary rules
+let publishAndReport () =
+    storage.SetConfigurationSettingPublisher
+        (fun configName publisher ->
+            publishTheConfigurationValue
+                configName
+                publisher
+                andThenSomethingElse)
+```
+
+Every other argument shape keeps the parenthesis where it is and breaks between the parentheses instead. A tuple, a record and a long expression all behave this way:
+
+```fsharp
+// ✅ the parenthesis stays with the method name, the argument breaks inside it
+let connectionString () =
+    config.GetConnectionString(
+        primaryReadOnlyReplicaName,
+        theFallbackConnectionValue
+    )
+```
+
+The difference is not the chain choosing between them. It is the same deference twice: a lambda opener wants to sit on one line with its arrow, and a tuple does not care, so the ordinary argument rules answer differently.
 
 ### Match lambdas are no exception
 
@@ -719,8 +754,7 @@ The one difference left between the two forms is that `function` also moves down
 
 The setting is the only thing that moves it. Writing `function` on the line below the `(` yourself makes no difference: the same call written across more lines is still the same call, and Fantomas has to land on one answer for both.
 
-The only thing the chain decides here is that the `(` never leaves `.Configure`, for the parsing reason given in [Only the last call may have a space before its parentheses](#only-the-last-call-may-have-a-space-before-its-parentheses).
-A comment written between the two is the one thing that can separate them, and that is the next section.
+In none of these does the chain have a say. `.Configure` is an intermediate call in half of them, so its `(` is welded to it either way; where the lambda goes is the argument's business, and it answers the same way in both positions.
 
 ### A comment beside the parentheses
 
@@ -745,8 +779,8 @@ builder.UseUrls
     (url)
 ```
 
-The first of these happens wherever the call sits in the chain. The second can only ever happen to the last call: anything between a method name and its `(`, a comment as much as a line break, makes the parser read the parentheses as a separate argument, so an earlier call cannot carry a comment there and still mean the same thing.
+The first of these happens wherever the call sits in the chain. The second can only ever happen to the last call, since an earlier one is welded to its parenthesis and a comment is the same gap as a space.
 
-Which side the comment is on is the whole of it. How the call was spread over lines in the source has no say, and in both layouts the argument between the parentheses is laid out by the ordinary rules, exactly as the rest of this section promises.
+Which side the comment is on is the whole of it. How the call was spread over lines in the source has no say, and in both layouts the argument is laid out by the ordinary rules, exactly as the rest of this section promises.
 
 <fantomas-nav previous="{{fsdocs-previous-page-link}}" next="{{fsdocs-next-page-link}}"></fantomas-nav>

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -580,6 +580,18 @@ Everything between `(` and `)` is laid out by the ordinary rules for call argume
 A chain never overrides them.
 That is the same idea as "break the call's arguments" in the rule above: at that point Fantomas stops making chain decisions and hands the argument to the normal machinery.
 
+Which includes the decision to move the argument itself. A lambda whose parameters no longer fit beside the method name takes a line of its own, and the terminal call's `(` goes down with it, exactly as it would with no starting value in front:
+
+```fsharp
+// ✅ the opener no longer fits, so the whole argument moves down one level
+ifaces
+|> List.tryPick
+    (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) ->
+        Some(ty, withRange))
+```
+
+This is the one thing that separates a terminal `(` from its method name without a setting asking for it, and it is allowed for the same reason a setting may ask: the last call of a chain has nothing behind it to reparse. Every earlier call keeps its parenthesis welded, so its argument breaks after the `(` instead.
+
 The practical consequence is that **every setting that governs argument layout keeps working unchanged inside a chain**.
 The one you are most likely to notice is [`multi_line_lambda_closing_newline`](../end-users/Configuration.html), which decides where the closing `)` lands when a lambda argument needs several lines.
 

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -86,7 +86,7 @@ a.Foo(x).Bar()    // parsed the way you intended
 
 The parser reads `(x).Bar()` as a single parenthesised argument handed to `a.Foo`. So for every call except the last one, tightness is a grammar requirement rather than a preference, and no setting can override it.
 
-The same applies wherever an expression has to stay glued to its neighbour: a receiver that is itself a call (`getBuilder().Build()`), an indexed call (`x.Foo()[0]`), or a `?` access. In each case a space would rebind the parentheses to the wrong thing.
+The same constraint turns up wherever an expression has to stay glued to its neighbour. In `getBuilder().Build()` the receiver keeps its own `()` tight, in `x.Foo()[0]` the indexed call keeps its own `()` tight, and a `?` access does the same. In each case a space there would rebind the parentheses to the wrong thing. (The *final* call is still free to take a space: with the setting on, that first example formats as `getBuilder().Build ()`.)
 
 There is one place where even the last call stays tight: the body of a `_.` shorthand lambda, covered in the final section of this page.
 

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -49,6 +49,15 @@ The one real choice is **where to put line breaks**, and it comes down to a sing
 If the answer is yes, it stays on one line and there is nothing more to decide.
 Everything below is about what happens when the answer is **no**.
 
+One thing overrides the fit question: trivia the user wrote between the steps.
+A trailing comment on the starting value, or an `#if` directive in front of a step, pins that step to its own line no matter how much room is left.
+
+```fsharp
+// ✅ at a max line length of 80 this fits on one line, and is still broken up
+config // note
+    .Settings.GetValue(theKeyName)
+```
+
 ## What counts as a chain
 
 The dot is what matters. If there is no dot, there is no step:
@@ -225,12 +234,14 @@ graph TD
     C -->|Yes| D{"Is the starting value a plain value?"}
     D -->|No| P
     D -->|Yes| E{"Does everything up to the method name\nfit on one line?"}
-    E -->|No| P
+    E -->|No| F{"Is the method name itself\nthe overflow?"}
+    F -->|No| P
+    F -->|Yes| K
     E -->|Yes| K["Keep the chain together,\nand break the call's arguments"]
     P["Pipeline: give each action its own line, led by its dot"]
 ```
 
-The three questions after the first are the conditions for keeping the chain together, and a "no" to any one of them lands in the same place.
+The questions after the first are the conditions for keeping the chain together, and a "no" to any one of them lands in the same place, bar the last one's escape hatch.
 
 In one sentence:
 
@@ -285,6 +296,15 @@ getConfiguration()
 
 The two inputs differ only in their starting value. A compound one is already doing something, so it earns the opening line rather than serving as a prefix to the navigation behind it.
 
+One compound starting value is exempt: a parenthesised expression whose only step is an index, with no call after it. Indexing a parenthesised value reads as a plain access rather than a pipeline, so the index rides tight onto the closing paren:
+
+```fsharp
+// ✅ at a max line length of 30, the index stays welded to the `)`
+let x =
+    (someVeryLongExpression
+     + otherLongThing).[0]
+```
+
 **Everything up to the method name must fit on one line.** When it does not, or when a comment falls between the steps, there is nothing left to keep together and the pipeline takes over:
 
 ```fsharp
@@ -294,7 +314,16 @@ config.Settings
     .GetValue(theKeyName)
 ```
 
-That second guard is also why step 5, wrapping a long run of navigation, never applies to this branch: if the chain is kept together then everything up to the method name fits by definition, so there is no wrap to be made.
+With one exception: when the method name alone would still overflow on a line of its own, moving it down gains nothing, so the chain stays together and the arguments wrap anyway.
+
+```fsharp
+// ✅ at a max line length of 40, `.AVeryVery...` overflows wherever you put it
+config.AVeryVeryLongMethodNameThatIsCertainlyTooLong(
+    arg
+)
+```
+
+That second guard is also why step 5, wrapping a long run of navigation, never applies to this branch: a chain is only kept together when its navigation already fits on one line, and in the escape-hatch case the overflow is the method name, which wrapping the navigation would not fix either.
 
 ## Step 4: navigation rides along
 

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -55,6 +55,43 @@ arr.[i]         // a chain, this indexing syntax does have a dot
 
 An expression without any dots is laid out by other rules, not the ones on this page.
 
+## Two decisions, not one
+
+Formatting a chain settles two questions that have nothing to do with each other:
+
+1. **Where do the line breaks go?** A style decision, and the bulk of this page.
+2. **May a space sit between a method name and its `(`?** Mostly *not* a style decision, and the shorter of the two, so it is settled first.
+
+## Only the last call may have a space before its parentheses
+
+Fantomas has settings that ask for a space before the parentheses of a call, [`space_before_uppercase_invocation`](../end-users/Configuration.html) and [`space_before_lowercase_invocation`](../end-users/Configuration.html).
+
+In a chain, **those settings apply to the final call only**. Every earlier call stays tight, whatever the settings say:
+
+```fsharp
+// both examples with space_before_uppercase_invocation = true
+
+obj.Bar ()          // a call on its own: the setting applies
+
+a.Foo(x).Bar (y)    // in a chain: only the final .Bar takes the space,
+                    // the intermediate .Foo stays tight
+```
+
+This is not Fantomas being inconsistent. A space in the middle of a chain changes what the code *means*:
+
+```fsharp
+a.Foo (x).Bar()   // parsed as a.Foo ((x).Bar())
+a.Foo(x).Bar()    // parsed the way you intended
+```
+
+The parser reads `(x).Bar()` as a single parenthesised argument handed to `a.Foo`. So for every call except the last one, tightness is a grammar requirement rather than a preference, and no setting can override it.
+
+The same applies wherever an expression has to stay glued to its neighbour: a receiver that is itself a call (`getBuilder().Build()`), an indexed call (`x.Foo()[0]`), or a `?` access. In each case a space would rebind the parentheses to the wrong thing.
+
+There is one place where even the last call stays tight: the body of a `_.` shorthand lambda, covered in the final section of this page.
+
+Everything from here on is about the first question, where the line breaks go.
+
 ## Two kinds of step
 
 Once Fantomas has to break a chain, it sorts the steps into two weights.
@@ -87,7 +124,7 @@ That is the one pair worth keeping straight:
 
 An index or a set of type arguments is navigation while it stays on one line, and becomes an action if its contents grow big enough to need several lines.
 
-## The rule
+## The rule for line breaks
 
 ```text
 Does the whole chain fit on one line?
@@ -280,9 +317,9 @@ F# lets you write `_.Property` as a short lambda. Fantomas treats it as a chain 
 "yow" |> _.Substring(0, 16).ToLower()
 ```
 
-There is one thing that makes it special.
-The F# compiler requires the body of a `_.` lambda to stay tightly joined, so Fantomas will **never** insert a space before a `(` here.
-This holds even when [`space_before_uppercase_invocation`](../end-users/Configuration.html) is enabled, which would otherwise produce `ToLower ()` and fail to compile.
+There is one thing that makes it special, and it concerns [the space before a call](#only-the-last-call-may-have-a-space-before-its-parentheses).
+Everywhere else the *last* call of a chain may take a space when a setting asks for one. Here it may not: the F# compiler requires the body of a `_.` lambda to stay atomic, so `ToLower ()` would not compile.
+Fantomas therefore keeps it tight even with [`space_before_uppercase_invocation`](../end-users/Configuration.html) enabled. This was [issue 3364](https://github.com/fsprojects/fantomas/issues/3364).
 
 Apart from that, it follows the same rule as any other chain.
 The example above has two calls, so if it does not fit, it becomes a pipeline:
@@ -292,19 +329,5 @@ _
     .Substring(0, 16)
     .ToLower()
 ```
-
-## Why intermediate calls never get a space
-
-Settings such as [`space_before_uppercase_invocation`](../end-users/Configuration.html) can ask Fantomas to write `obj.Bar ()` with a space.
-You may notice that this never happens to a call in the middle of a chain.
-That is not a style preference. In F#, a space in the middle of a chain changes how the code is parsed:
-
-```fsharp
-a.Foo (x).Bar()   // means a.Foo ((x).Bar())
-a.Foo(x).Bar()    // means what you intended
-```
-
-So only the very last call in a chain can be given a space, and only when a setting asks for one.
-Every call before it stays tight, always.
 
 <fantomas-nav previous="{{fsdocs-previous-page-link}}" next="{{fsdocs-next-page-link}}"></fantomas-nav>

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -1,0 +1,310 @@
+---
+category: Contributors
+categoryindex: 2
+index: 19
+---
+# Chains
+
+A *chain* is one of the few shapes where Fantomas has a real choice to make about line breaks.
+This page states the rules it follows and the reasoning behind each one, in plain language and without reference to any internal types.
+
+## Status: a proposal, backed by an implementation
+
+The [F# style guide](https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting) currently says very little about how to lay out a long chain.
+The rules described here are meant to fill that gap and to eventually become part of that guide.
+This page lives under Contributors for that reason: until the rules are officially adopted, they are a proposal we are testing, not settled guidance to hand to end-users.
+
+As noted in the [Fantomas style guide page](../end-users/StyleGuide.html), the style itself is not decided in the Fantomas repository.
+Those conversations happen at [fsharp/fslang-design](https://github.com/fsharp/fslang-design#style-guide), and they go much better when there is something concrete to react to.
+A written proposal invites arguments about hypothetical snippets.
+A proposal that is already implemented lets everyone run it over a real code base and see what it does to code they care about.
+
+That is the order of work here: implement the rules in Fantomas first, use the implementation to find the awkward cases and settle them, then pitch the result upstream.
+So treat this page as the current best answer rather than a settled one.
+If you disagree with a rule, the discussion belongs at [fsharp/fslang-design](https://github.com/fsharp/fslang-design#style-guide), and having the implementation in hand is exactly what makes that discussion productive.
+
+## A reminder of how Fantomas works
+
+Fantomas does not edit your text.
+Think of it like a word processor: it re-types your entire file from scratch, following its own rules.
+
+When it re-types a piece of code, it asks one question first:
+
+> Does this fit on the current line?
+
+If the answer is yes, it stays on one line and there is nothing more to decide.
+Everything below is about what happens when the answer is **no**.
+
+## What counts as a chain
+
+A chain is a starting value followed by a series of steps, where **every step is reached through a dot**.
+
+```fsharp
+document.Body.FirstChild.AppendChild(newNode)
+```
+
+Here `document` is the starting value, and `.Body`, `.FirstChild` and `.AppendChild(newNode)` are the steps.
+
+The dot is what matters. If there is no dot, there is no step:
+
+```fsharp
+xs[i]           // not a chain, there is no dot
+f (args)        // not a chain, there is no dot
+arr.[i]         // a chain, this indexing syntax does have a dot
+```
+
+An expression without any dots is laid out by other rules, not the ones on this page.
+
+## Two kinds of step
+
+Once Fantomas has to break a chain, it sorts the steps into two weights.
+
+**Navigation** is a step that just gets you somewhere:
+
+```fsharp
+.Name           // a plain member
+.[0]            // a short index
+.Cast<T>        // short type arguments
+```
+
+**Action** is a step where something happens, meaning a call:
+
+```fsharp
+.Foo(x)
+.Bar()
+.Cast<T>()      // a generic call is still a call
+```
+
+A call is always an action, no matter how short it is.
+Type arguments make no difference to this: what makes `.Cast<T>()` an action is the `()`, not the `<T>`.
+
+That is the one pair worth keeping straight:
+
+```fsharp
+.Cast<T>        // navigation, this only names something
+.Cast<T>()      // action, this calls something
+```
+
+An index or a set of type arguments is navigation while it stays on one line, and becomes an action if its contents grow big enough to need several lines.
+
+## The rule
+
+```text
+Does the whole chain fit on one line?
+├── Yes  Leave it on one line.
+└── No   Is there exactly one action, and is it the last step?
+         ├── Yes  Keep everything up to the method name together,
+         │        and break the call's ARGUMENTS.
+         └── No   Give each action its own line, led by its dot.
+```
+
+In one sentence:
+
+> A single `receiver.Method(args)` breaks its arguments, like any other call.
+> As soon as there are two or more calls, the chain is a pipeline and each call gets its own line.
+
+Navigation is never worth a line of its own. It rides at the front of the line belonging to the action it introduces.
+
+## Examples
+
+The examples below assume a narrower [max line length](../end-users/Configuration.html) than the default, so the breaks are visible on this page.
+
+### One call at the end: the arguments break
+
+```fsharp
+config.GetConnectionString(
+    "primary-database-readonly-replica-connection-string"
+)
+```
+
+There is a single action and it is the last step, so `config.GetConnectionString(` stays together and only the argument moves.
+This is exactly how an ordinary call breaks. Having a receiver in front of it changes nothing.
+
+### Navigation in front of a single call: still just the arguments
+
+```fsharp
+response.Content.Headers.GetValues(
+    "Content-Type-And-Transfer-Encoding-Header"
+)
+```
+
+`.Content` and `.Headers` are navigation, so there is still only one action.
+The chain is not a pipeline and the navigation stays with the receiver.
+
+### Two or more calls: a pipeline
+
+```fsharp
+serviceCollection
+    .AddSingleton<IClock>(systemClock)
+    .AddOptions<MyOptions>(configureOptions)
+```
+
+Two actions, so each one gets its own line led by its dot.
+
+### Navigation between calls rides along
+
+```fsharp
+document.Body.FirstChild
+    .AppendChild(newNode)
+    .ParentElement.RemoveChild(oldNode)
+```
+
+`.Body` and `.FirstChild` lead the first line.
+`.ParentElement` is navigation introducing `.RemoveChild(oldNode)`, so it rides at the front of that line instead of claiming one of its own.
+
+### A chain that ends in navigation
+
+```fsharp
+lookupTable
+    .GetBucketForHash(hashOfTheKeyValue)
+    .Entries.[indexWithinTheBucket]
+```
+
+There is only one call here, but it is **not** the last step.
+Breaking only the arguments would strand `.Entries.[indexWithinTheBucket]`, so the pipeline layout is used instead.
+
+### A chain with no calls at all
+
+```fsharp
+this.Configuration.Database.PrimaryConnection.Settings
+    .IdleTimeoutInSeconds
+```
+
+With no actions to lead any lines, the steps simply fill the line and break before a dot when the line is full.
+
+### A receiver that is itself a call
+
+```fsharp
+getConfiguredServiceBuilder()
+    .AddLogging(loggingOptions)
+    .Build()
+```
+
+The opening call stays glued to its `()` and acts as the starting value.
+It has to stay glued: a space there would change what the code means.
+
+## Arguments are not the chain's business
+
+It is worth stating the boundary explicitly, because it is what keeps the rules above so short:
+
+> The chain rules decide where lines break **between** steps.
+> They say nothing about what happens **inside** a call's parentheses.
+
+Everything between `(` and `)` is laid out by the ordinary rules for call arguments, exactly as it would be if that call had no receiver in front of it.
+A chain never overrides them.
+That is the same idea as "break the call's arguments" in the rule above: at that point Fantomas stops making chain decisions and hands the argument to the normal machinery.
+
+The practical consequence is that **every setting that governs argument layout keeps working unchanged inside a chain**.
+The one you are most likely to notice is [`multi_line_lambda_closing_newline`](../end-users/Configuration.html), which decides where the closing `)` lands when a lambda argument needs several lines.
+
+With the default (`false`), the `)` trails the last line of the lambda:
+
+```fsharp
+storage.SetConfigurationSettingPublisher(fun configName publisher ->
+    publish configName publisher)
+```
+
+With `true`, it drops to its own line:
+
+```fsharp
+storage.SetConfigurationSettingPublisher(fun configName publisher ->
+    publish configName publisher
+)
+```
+
+Because the setting belongs to the argument and not to the chain, it is honoured wherever the call sits.
+Above it was the single trailing call. Here it is three calls inside a pipeline, with the same `true` setting:
+
+```fsharp
+builder
+    .FirstThing<X>(fun lambda ->
+        processFirst lambda
+    )
+    .SecondThing<Y>(fun next ->
+        processSecond next
+    )
+    .ThirdThing<Z>()
+    .Result
+```
+
+For the same reason, each call decides independently whether it needs several lines.
+A long call does not drag the short ones open:
+
+```fsharp
+repo
+    .Where(fun customer ->
+        customer.IsActive && customer.Region = targetRegion)
+    .Select(projector)
+    .ToList()
+```
+
+### The one place position does matter
+
+Match lambdas, written `(function`, are the single shape where a call's position in the chain changes the layout.
+
+`(function` is kept together only when all of the following hold: the call is the **last** step, `multi_line_lambda_closing_newline` is `false`, and you did not already break after the `(` yourself.
+
+```fsharp
+builder
+    .Build()
+    .Configure(function
+        | Some v -> handleSome v
+        | None -> handleNone ())
+```
+
+If any one of those is not true, `function` moves down to its own line and the closing `)` goes to its own line too:
+
+```fsharp
+builder
+    .Configure(
+        function
+        | Some v -> handleSome v
+        | None -> handleNone ()
+    )
+    .Build()
+    .Result
+```
+
+The reason position is involved at all: mid-pipeline, the clauses would run on underneath a line that still continues with further steps, which reads poorly.
+So this is a readability judgement rather than a rule forced by the language.
+
+It is also a good illustration of the boundary above rather than an exception to it.
+`multi_line_lambda_closing_newline` is still being respected here; it simply has a visible effect on the opener as well as on the closing `)` for this particular argument shape.
+And the `(` itself never leaves `.Configure`, for the parsing reason given at the end of this page.
+
+## The `_.` shorthand lambda
+
+F# lets you write `_.Property` as a short lambda. Fantomas treats it as a chain whose starting value is `_`:
+
+```fsharp
+"yow" |> _.Substring(0, 16).ToLower()
+```
+
+There is one thing that makes it special.
+The F# compiler requires the body of a `_.` lambda to stay tightly joined, so Fantomas will **never** insert a space before a `(` here.
+This holds even when [`space_before_uppercase_invocation`](../end-users/Configuration.html) is enabled, which would otherwise produce `ToLower ()` and fail to compile.
+
+Apart from that, it follows the same rule as any other chain.
+The example above has two calls, so if it does not fit, it becomes a pipeline:
+
+```fsharp
+_
+    .Substring(0, 16)
+    .ToLower()
+```
+
+## Why intermediate calls never get a space
+
+Settings such as [`space_before_uppercase_invocation`](../end-users/Configuration.html) can ask Fantomas to write `obj.Bar ()` with a space.
+You may notice that this never happens to a call in the middle of a chain.
+That is not a style preference. In F#, a space in the middle of a chain changes how the code is parsed:
+
+```fsharp
+a.Foo (x).Bar()   // means a.Foo ((x).Bar())
+a.Foo(x).Bar()    // means what you intended
+```
+
+So only the very last call in a chain can be given a space, and only when a setting asks for one.
+Every call before it stays tight, always.
+
+<fantomas-nav previous="{{fsdocs-previous-page-link}}" next="{{fsdocs-next-page-link}}"></fantomas-nav>

--- a/docs/docs/contributors/Conditional Compilation Directives.md
+++ b/docs/docs/contributors/Conditional Compilation Directives.md
@@ -93,7 +93,7 @@ As the combination of directives has an influence on the tree, Fantomas first pa
 This base tree is then being inspected for [ConditionalDirectiveTrivia](https://fsprojects.github.io/fantomas/reference/fsharp-compiler-syntaxtrivia-conditionaldirectivetrivia.html).
 We determine the different combinations in the `Defines` module.
 
-<div class="mermaid text-center">
+```mermaid
 graph TD
     A["Parse base tree"] --> B
     B["Figure out all compiler define combinations"] --> C
@@ -103,7 +103,7 @@ graph TD
     C --> E
     D --> E
     E["Merge results"]
- </div>
+```
 
 As trivia is being restored in each tree, they all will have gaps in them.
 

--- a/docs/docs/contributors/Formatted Code.md
+++ b/docs/docs/contributors/Formatted Code.md
@@ -8,12 +8,12 @@ index: 7
 After the `Context` travelled through the composed `CodePrinter` function, all events are captured.  
 These can be converted to a string of formatted code.
 
-<div class="mermaid text-center">
+```mermaid
 graph TD
     A[Transform source code to tree] --> B
     B[Traverse Oak to get formatted code] --> C[Formatted code]
     style C stroke:#338CBB,stroke-width:2px
- </div>
+```
 
 ## Post processing
 

--- a/docs/docs/contributors/Solution Structure.md
+++ b/docs/docs/contributors/Solution Structure.md
@@ -8,7 +8,7 @@ index: 4
 Fantomas has a modular project structure.  
 The parser (`Fantomas.FCS`), the core library (`Fantomas.Core`) and the command line application (`fantomas`) are the main components of the solution.
 
-<div class="mermaid text-center">
+```mermaid
 graph TD
     A[Fantomas.FCS] --> B
     B[Fantomas.Core] --> C[Fantomas]
@@ -16,7 +16,7 @@ graph TD
     B --> E[Fantomas.Core.Tests]
     C --> F[Fantomas.Tests]
     G[Fantomas.Client] --> H[Fantomas.Client.Tests]
- </div>
+```
 
 ## Fantomas.FCS
 

--- a/docs/docs/contributors/Transforming.md
+++ b/docs/docs/contributors/Transforming.md
@@ -7,12 +7,12 @@ index: 5
 
 In its simplest form, Fantomas.Core works in two major phases: transform the raw source code to a custom tree model and traverse that custom tree to print the formatted code.
 
-<div class="mermaid text-center">
+```mermaid
 graph TD
     A[Transform source code to Oak] --> B
     B[Traverse Oak to get formatted code] --> C[Formatted code]
     style A stroke:#338CBB,stroke-width:2px
- </div>
+```
 
 Unfortunately, both phases are not always very straight forward.  
 But once you get hang of the first phase, you can easily understand the second phase.
@@ -24,12 +24,12 @@ We can parse the source code into an untyped syntax tree. This tree isn't really
 An `Oak` is the toplevel root node of the Fantomas tree. We use a custom tree because it better suites our needs to reconstruct the output code.
 
 
-<div class="mermaid text-center">
+```mermaid
 graph TD
     A[Parse AST] --> B
     B[Transfrom untyped AST to OAK] --> C
     C[Enrich the Oak with Trivia]
-</div>
+```
 
 ### Parse AST
 
@@ -164,10 +164,10 @@ Once we have the trivia, we can insert them to a `Node` they belong to.
 This is one of the key reasons why we work with our own tree. We can add the trivia information to the best suitable child node in the `Oak`.
 Every `Node` can have `ContentBefore` and `ContentAfter`, this is how we try to reconstruct everything.
 
-<div class="mermaid text-center">
+```mermaid
 graph TD
     A[Capture all trivia from AST and ISourceText] --> B
     B[Insert trivia into nodes]
- </div>
+```
 
 <fantomas-nav previous="{{fsdocs-previous-page-link}}" next="{{fsdocs-next-page-link}}"></fantomas-nav>

--- a/docs/docs/contributors/Traverse.md
+++ b/docs/docs/contributors/Traverse.md
@@ -7,12 +7,12 @@ index: 6
 
 Once the `Oak` is populated with all the found trivia, we can traverse the `Oak` to capture all the `WriterEvent`s.
 
-<div class="mermaid text-center">
+```mermaid
 graph TD
     A[Transform source code to tree] --> B
     B[Traverse Oak to get formatted code] --> C[Formatted code]
     style B stroke:#338CBB,stroke-width:2px
- </div>
+```
 
 We enter the module of `CodePrinter` and try and reconstruct the code based on the given configuration.
 

--- a/docs/docs/end-users/UpgradeGuide.md
+++ b/docs/docs/end-users/UpgradeGuide.md
@@ -95,4 +95,209 @@ fsharp_experimental_stroustrup_style = true
 ### .editorconfig
 - The default setting for `fsharp_multiline_bracket_style` is now `aligned`, to restore the previous behaviour use `fsharp_multiline_bracket_style = cramped`.
 
+### console application
+- Target framework is now `net10.0`.
+
+### Formatting
+
+Chains (dotted member access and calls) are laid out by a new set of rules, written up in full in
+[Chains](../contributors/Chains.html). They are a proposal for the F# style guide and may still
+change before `v8.0.0` is final.
+
+The rules only apply once a chain has to break, so a chain that already fits on one line is left
+alone. Reformatting the whole of `Fantomas.Core` with `v8` moves a handful of lines, none of them
+in a chain. The changes below are the ones you are most likely to notice.
+
+#### A run of property access wraps instead of overflowing
+
+Navigation that does not fit is spread over balanced lines, chosen so the longest resulting line is
+as short as possible. Previously it was left to overflow the margin. At `max_line_length = 80`:
+
+```fsharp
+// v7
+let navigation =
+    builder.Services.Configuration.Providers.Defaults.Primary.Fallback.Value.Inner
+
+// v8
+let navigation =
+    builder.Services.Configuration.Providers
+        .Defaults.Primary.Fallback.Value.Inner
+```
+
+#### A comment no longer fans the chain out one step per line
+
+A comment between the steps forces the chain to break, whatever the line length allows. In `v7`
+that break was taken by every step. In `v8` only a call claims a line of its own, and plain
+property access rides along at the front of the line belonging to the call it introduces:
+
+```fsharp
+// v7
+let a =
+    config
+        // note
+        .Settings
+        .GetValue(key)
+
+// v8
+let a =
+    config
+        // note
+        .Settings.GetValue(key)
+```
+
+A chain whose steps are all calls is unaffected, because each of those claims a line either way.
+
+#### A match lambda keeps `function` beside the `(`
+
+This applies with **`fsharp_multi_line_lambda_closing_newline = false`**, which is the default.
+With the setting set to `true` nothing changes.
+
+In `v7` a call reached through a dot pushed `function` onto its own line, while the very same
+call without a receiver kept it beside the `(`. The two disagreed about the same argument.
+A chain now follows what the receiverless call already did:
+
+```fsharp
+// v7 and v8 agree here: no receiver, `function` stays beside the `(`
+let a =
+    configureTheThing (function
+        | Some v -> handleSome v
+        | None -> handleNone ())
+
+// v7: the same argument, reached through a dot, was laid out differently
+let b =
+    builder
+        .Build()
+        .Configure(
+            function
+            | Some v -> handleSome v
+            | None -> handleNone ()
+        )
+
+// v8: the dot makes no difference any more
+let b =
+    builder
+        .Build()
+        .Configure(function
+            | Some v -> handleSome v
+            | None -> handleNone ())
+```
+
+#### A lambda whose opening line does not fit moves to its own line
+
+This applies with **`fsharp_multi_line_lambda_closing_newline = true`**. With the setting left at
+its default of `false` nothing changes.
+
+In `v7` the parameters were hung underneath the opening parenthesis, which pushed them far to the
+right and could force the pattern itself to break. Now the whole argument moves down one line and
+indents normally. This affects calls with and without a receiver alike. At `max_line_length = 80`:
+
+```fsharp
+// v7
+let dotted ifaces =
+    ifaces
+    |> List.tryPick (fun
+                         (SynInterfaceImpl(
+                             interfaceTy = ty; withKeyword = withRange)) ->
+        Some(ty, withRange)
+    )
+
+// v8
+let dotted ifaces =
+    ifaces
+    |> List.tryPick
+        (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) ->
+            Some(ty, withRange)
+        )
+```
+
+### Fantomas.Core API
+
+These only affect you if you consume `Fantomas.Core` as a library. Formatting source text through
+`CodeFormatter.FormatDocumentAsync` is unaffected.
+
+#### Exceptions
+
+- `InvariantViolationException` was added. It derives from `FormatException` and is raised when Fantomas reaches a state its own model says is impossible, which always means a bug in Fantomas rather than a problem with your code.
+  If you catch `FormatException`, you already catch this.
+- `DefineParseException` was added, raised when one or more conditional compilation define combinations produce invalid syntax trees.
+- `EndOfLineStyle.OfConfigString "cr"` now raises `FormatException` instead of calling `failwith`.
+
+#### CodeFormatter
+
+All additions, nothing was removed:
+
+- `CodeFormatter.FormatASTAsync(ast, config, source)` was added, next to the existing `FormatASTAsync(ast, source)`.
+- `CodeFormatter.GetWriterEventsAsync` was added for debugging. It returns the writer events produced while formatting.
+
+#### Oak: chains
+
+`Expr.Chain` no longer holds a flat `ChainLink list`. A chain is now a head expression, a list of
+dot-prefixed segments, and a terminal call:
+
+```fsharp
+type ExprChain(head: Expr, segments: ChainSegment list, terminal: ChainTerminal, range)
+
+type ChainCall =
+    | Paren of ExprParenNode
+    | Unit of UnitNode
+
+type ChainSegment =
+    | DotMember of dot: SingleTextNode * expr: Expr
+    | DotApplication of dot: SingleTextNode * expr: Expr * call: ChainCall
+    | DotIndex of dot: SingleTextNode * indexExpr: Expr
+
+type ChainTerminal =
+    | SpaceAllowed of ChainCall
+    | NoSpaceAllowed of ChainCall
+    | NoTerminal
+```
+
+Mapping from the old model:
+
+| Removed | Replacement |
+| --- | --- |
+| `ChainLink.Identifier` | `ExprChain.Head`, when it is the first link |
+| `ChainLink.Dot` | the `dot` field of the segment that follows it |
+| `ChainLink.Expr` | `ChainSegment.DotMember` |
+| `ChainLink.AppParen` | `ChainSegment.DotApplication` with `ChainCall.Paren`, or `ExprChain.Terminal` when last |
+| `ChainLink.AppUnit` | `ChainSegment.DotApplication` with `ChainCall.Unit`, or `ExprChain.Terminal` when last |
+| `ChainLink.IndexExpr` | `ChainSegment.DotIndex` |
+| `LinkSingleAppParen`, `LinkSingleAppUnit` | `ChainCall` |
+
+A dot now always belongs to the step that follows it, so two adjacent dots are unrepresentable and
+you no longer have to pair links up yourself. The final call is `Terminal` rather than the last
+element of the list, and `ChainTerminal.NoSpaceAllowed` records that no space may precede its
+parenthesis. That is a grammar constraint, not a style choice: a space there reparses
+`a.Foo (x).Bar()` as `a.Foo ((x).Bar())`.
+
+#### Oak: expressions absorbed into `Expr.Chain`
+
+These `Expr` cases were removed. Each was a chain in all but name, and all four now arrive as
+`Expr.Chain`:
+
+- `Expr.DotLambda` (`_.Property`), now a chain whose `Head` is the `_`
+- `Expr.DotIndexedGet` (`a.[i]`), now a `ChainSegment.DotIndex`
+- `Expr.AppLongIdentAndSingleParenArg` (`a.Foo(x)`), now a chain with a terminal call
+- `Expr.NestedIndexWithoutDot`, which was already dead: nothing ever constructed it
+
+`Expr.AppWithLambda` is unchanged, but no longer receives calls that have no prefix arguments;
+those are chains now.
+
+A dotted long identifier such as `a.b.c` yields `Expr.Chain` in expression position, where it
+previously yielded `Expr.OptVar`. `Expr.OptVar` still exists, and is still produced for long
+identifiers without dots and for the optional-argument form `?a.b`. A single identifier is
+`Expr.Ident`, as before.
+
+#### Oak: other node changes
+
+- `Expr.DynamicChain` was added for chained `?` operator accesses such as `x?a("")?b(t)`.
+- `ComputationExpressionStatement` collapsed from four cases to two. `LetOrUseStatement`,
+  `LetOrUseBangStatement` and `AndBangStatement` are all `BindingStatement of BindingNode` now,
+  and `ExprLetOrUseNode`, `ExprLetOrUseBangNode` and `ExprAndBang` were removed.
+- `NamePatPair` was renamed to `NamePatPairNode`, and its `ident: SingleTextNode` became
+  `fieldName: IdentListNode`.
+- `PatRecordField` was removed and merged into `NamePatPairNode`. `PatRecordNode.Fields` is now
+  a `NamePatPairNode list`, and the old `Prefix` and `FieldName` fields are together in
+  `fieldName`.
+
 <fantomas-nav previous="{{fsdocs-previous-page-link}}" next="{{fsdocs-next-page-link}}"></fantomas-nav>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }

--- a/scripts/chain.fsx
+++ b/scripts/chain.fsx
@@ -27,14 +27,12 @@ let printChain (chain: ExprChain) =
     chain.Segments
     |> List.iteri (fun i seg ->
         match seg with
-        | ChainSegment.DotMember(_, expr) ->
-            printfn "    [%02d] simple   .%s" i (exprName expr)
+        | ChainSegment.DotMember(_, expr) -> printfn "    [%02d] navigation  .%s" i (exprName expr)
         | ChainSegment.DotApplication(_, expr, ChainCall.Unit _) ->
-            printfn "    [%02d] complex  .%s()" i (exprName expr)
+            printfn "    [%02d] action      .%s()" i (exprName expr)
         | ChainSegment.DotApplication(_, expr, ChainCall.Paren _) ->
-            printfn "    [%02d] complex  .%s(...)" i (exprName expr)
-        | ChainSegment.DotIndex(_, idx) ->
-            printfn "    [%02d] simple   .[%s]" i (exprName idx))
+            printfn "    [%02d] action      .%s(...)" i (exprName expr)
+        | ChainSegment.DotIndex(_, idx) -> printfn "    [%02d] navigation  .[%s]" i (exprName idx))
 
     let terminalStr =
         match chain.Terminal with
@@ -48,13 +46,11 @@ let printChain (chain: ExprChain) =
 
 // Recursively collect all ExprChain nodes in the Oak's Node tree.
 let rec collectChains (node: Node) : ExprChain list =
-    [
-        match node with
-        | :? ExprChain as chain -> yield chain
-        | _ -> ()
-        for child in node.Children do
-            yield! collectChains child
-    ]
+    [ match node with
+      | :? ExprChain as chain -> yield chain
+      | _ -> ()
+      for child in node.Children do
+          yield! collectChains child ]
 
 match Array.tryHead fsi.CommandLineArgs with
 | Some scriptPath ->
@@ -62,9 +58,10 @@ match Array.tryHead fsi.CommandLineArgs with
     let sourceFile = FileInfo(Path.Combine(__SOURCE_DIRECTORY__, __SOURCE_FILE__))
 
     if scriptFile.FullName = sourceFile.FullName then
-        let source, _, _, _ = parseArgs fsi.CommandLineArgs.[1..]
+        let source, isSignature, _, _ = parseArgs fsi.CommandLineArgs.[1..]
+
         let oak =
-            CodeFormatter.ParseOakAsync(false, source)
+            CodeFormatter.ParseOakAsync(isSignature, source)
             |> Async.RunSynchronously
             |> Array.head
             |> fst
@@ -75,9 +72,12 @@ match Array.tryHead fsi.CommandLineArgs with
             printfn "No chain expression found in input."
         else
             printfn "Found %d chain(s):\n" chains.Length
-            chains |> List.iteri (fun i chain ->
+
+            chains
+            |> List.iteri (fun i chain ->
                 printfn "--- Chain #%d ---" (i + 1)
                 printChain chain
                 printfn "")
 | _ ->
-    printfn "Usage: dotnet fsi scripts/chain.fsx <input-file>"
+    printfn "Usage: dotnet fsi chain.fsx [--signature] [<input file>]"
+    printfn "       source code is read from stdin when no input file is given"

--- a/scripts/chain.fsx
+++ b/scripts/chain.fsx
@@ -24,9 +24,20 @@ let printChain (chain: ExprChain) =
 
     printfn "  Segments: %d" chain.Segments.Length
 
+    // When the chain has a terminal call, its method name lives in the LAST segment
+    // (the call itself is the Terminal). Labelling that one "navigation" would be a lie.
+    let hasTerminal =
+        match chain.Terminal with
+        | ChainTerminal.NoTerminal -> false
+        | _ -> true
+
+    let lastIndex = chain.Segments.Length - 1
+
     chain.Segments
     |> List.iteri (fun i seg ->
         match seg with
+        | ChainSegment.DotMember(_, expr) when hasTerminal && i = lastIndex ->
+            printfn "    [%02d] terminal    .%s (called below)" i (exprName expr)
         | ChainSegment.DotMember(_, expr) -> printfn "    [%02d] navigation  .%s" i (exprName expr)
         | ChainSegment.DotApplication(_, expr, ChainCall.Unit _) ->
             printfn "    [%02d] action      .%s()" i (exprName expr)

--- a/scripts/chain.fsx
+++ b/scripts/chain.fsx
@@ -1,0 +1,83 @@
+#load "shared.fsx"
+
+open System.IO
+open Fantomas.Core
+open Fantomas.Core.SyntaxOak
+open Shared
+
+// Best-effort: extract a short display name from the member expression of a segment.
+let rec exprName (e: Expr) : string =
+    match e with
+    | Expr.Ident n -> n.Text
+    | Expr.OptVar n ->
+        n.Identifier.Content
+        |> List.choose (function
+            | IdentifierOrDot.Ident i -> Some i.Text
+            | _ -> None)
+        |> String.concat "."
+    | Expr.TypeApp n -> $"{exprName n.Identifier}<...>"
+    | _ -> e.GetType().Name
+
+let printChain (chain: ExprChain) =
+    printfn "Chain:"
+    printfn "  Head    : %s" (exprName chain.Head)
+
+    printfn "  Segments: %d" chain.Segments.Length
+
+    chain.Segments
+    |> List.iteri (fun i seg ->
+        match seg with
+        | ChainSegment.DotMember(_, expr) ->
+            printfn "    [%02d] simple   .%s" i (exprName expr)
+        | ChainSegment.DotApplication(_, expr, ChainCall.Unit _) ->
+            printfn "    [%02d] complex  .%s()" i (exprName expr)
+        | ChainSegment.DotApplication(_, expr, ChainCall.Paren _) ->
+            printfn "    [%02d] complex  .%s(...)" i (exprName expr)
+        | ChainSegment.DotIndex(_, idx) ->
+            printfn "    [%02d] simple   .[%s]" i (exprName idx))
+
+    let terminalStr =
+        match chain.Terminal with
+        | ChainTerminal.NoTerminal -> "(none)"
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> "SpaceAllowed ()"
+        | ChainTerminal.SpaceAllowed(ChainCall.Paren _) -> "SpaceAllowed (...)"
+        | ChainTerminal.NoSpaceAllowed(ChainCall.Unit _) -> "NoSpaceAllowed ()"
+        | ChainTerminal.NoSpaceAllowed(ChainCall.Paren _) -> "NoSpaceAllowed (...)"
+
+    printfn "  Terminal: %s" terminalStr
+
+// Recursively collect all ExprChain nodes in the Oak's Node tree.
+let rec collectChains (node: Node) : ExprChain list =
+    [
+        match node with
+        | :? ExprChain as chain -> yield chain
+        | _ -> ()
+        for child in node.Children do
+            yield! collectChains child
+    ]
+
+match Array.tryHead fsi.CommandLineArgs with
+| Some scriptPath ->
+    let scriptFile = FileInfo(scriptPath)
+    let sourceFile = FileInfo(Path.Combine(__SOURCE_DIRECTORY__, __SOURCE_FILE__))
+
+    if scriptFile.FullName = sourceFile.FullName then
+        let source, _, _, _ = parseArgs fsi.CommandLineArgs.[1..]
+        let oak =
+            CodeFormatter.ParseOakAsync(false, source)
+            |> Async.RunSynchronously
+            |> Array.head
+            |> fst
+
+        let chains = collectChains oak
+
+        if chains.IsEmpty then
+            printfn "No chain expression found in input."
+        else
+            printfn "Found %d chain(s):\n" chains.Length
+            chains |> List.iteri (fun i chain ->
+                printfn "--- Chain #%d ---" (i + 1)
+                printChain chain
+                printfn "")
+| _ ->
+    printfn "Usage: dotnet fsi scripts/chain.fsx <input-file>"

--- a/src/Fantomas.Client.Tests/EndToEndTests.fs
+++ b/src/Fantomas.Client.Tests/EndToEndTests.fs
@@ -2,6 +2,7 @@ module Fantomas.Client.Tests
 
 open System
 open System.IO
+open System.Text
 open System.Threading.Tasks
 open CliWrap
 open CliWrap.Buffered
@@ -19,43 +20,59 @@ type EndToEndTests() =
 
     let unformattedCode = "let a    =    8"
 
-    let withVersion version (callback: string -> Task) =
-        if Path.Exists(Path.Combine(folder.FullName, version)) then
-            backgroundTask {
-                let file = Path.Combine(folder.FullName, version, "File.fs")
-                do! callback file
-            }
-        else
-            backgroundTask {
-                let subDirectory = folder.CreateSubdirectory(version)
+    /// Every fantomas version the tests below drive. Each one is installed once, before any test
+    /// runs, so that a test never races another one into a half-prepared directory. Add a version
+    /// here when you add a `TestCase` for it.
+    ///
+    /// The point of these tests is that Fantomas.Client can still talk to a released fantomas, so
+    /// the latest stable release of each supported major is enough. Older releases, and the
+    /// prereleases of a major that has since shipped, are not worth holding anyone to.
+    let versions: string list = [ "6.3.16"; "7.0.5" ]
 
-                let dotnet (command: string) =
-                    Cli
-                        .Wrap("dotnet")
-                        .WithWorkingDirectory(subDirectory.FullName)
-                        .WithArguments(command)
-                        .ExecuteBufferedAsync()
-                        .Task
-                    :> Task
+    let installAttempts: int = 3
 
-                // This sdk version must match the version used in this repository.
-                // It will be the version which the CI/CD pipeline has access to.
-                let! dotnetVersionResult =
-                    Cli
-                        .Wrap("dotnet")
-                        .WithWorkingDirectory(__SOURCE_DIRECTORY__)
-                        .WithArguments("--version")
-                        .ExecuteBufferedAsync()
-                        .Task
+    let dotnetIn (workingDirectory: string) (command: string) : Task<BufferedCommandResult> =
+        Cli
+            .Wrap("dotnet")
+            .WithWorkingDirectory(workingDirectory)
+            .WithArguments(command)
+            // Report a failing command as a result, so it can be retried instead of thrown.
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteBufferedAsync()
+            .Task
 
-                let dotnetVersion = dotnetVersionResult.StandardOutput.Trim()
-                do! dotnet $"new globaljson --sdk-version %s{dotnetVersion} --roll-forward latestPatch"
-                do! dotnet "new tool-manifest"
+    /// Install one fantomas version in its own directory, and prove it runs.
+    let install (version: string) : Task<Result<unit, string>> =
+        backgroundTask {
+            let subDirectory = folder.CreateSubdirectory(version)
 
-                do!
-                    dotnet
-                        $"tool install fantomas -v d --version %s{version} --add-source https://api.nuget.org/v3/index.json"
+            // This sdk version must match the version used in this repository.
+            // It will be the version which the CI/CD pipeline has access to.
+            let! dotnetVersionResult = dotnetIn __SOURCE_DIRECTORY__ "--version"
+            let dotnetVersion = dotnetVersionResult.StandardOutput.Trim()
 
+            let commands =
+                [ $"new globaljson --sdk-version %s{dotnetVersion} --roll-forward latestPatch"
+                  "new tool-manifest"
+                  $"tool install fantomas -v d --version %s{version} --add-source https://api.nuget.org/v3/index.json"
+                  // The tool answering here is what the tests below assume. Asking now keeps a
+                  // broken install from surfacing as a puzzling assertion failure inside a test.
+                  "fantomas --version" ]
+
+            let mutable failure: string option = None
+
+            for command in commands do
+                if Option.isNone failure then
+                    let! result = dotnetIn subDirectory.FullName command
+
+                    if result.ExitCode <> 0 then
+                        failure <-
+                            Some
+                                $"`dotnet %s{command}` exited with %i{result.ExitCode}.%s{Environment.NewLine}%s{result.StandardOutput}%s{result.StandardError}"
+
+            match failure with
+            | Some error -> return Error error
+            | None ->
                 let fsharpFile = Path.Combine(subDirectory.FullName, "File.fs")
                 File.Create(fsharpFile).Dispose()
 
@@ -71,12 +88,122 @@ end_of_line = lf
 """
 
                 File.WriteAllText(editorConfigPath, editorConfigContent)
+                return Ok()
+        }
 
-                do! callback fsharpFile
-            }
+    /// Installing from NuGet is the flaky part of these tests, so give it a couple of goes before
+    /// declaring the whole fixture unusable.
+    let rec installWithRetry (version: string) (attemptsLeft: int) : Task =
+        backgroundTask {
+            let! result = install version
+
+            match result with
+            | Ok() -> ()
+            | Error error when attemptsLeft > 1 ->
+                TestContext.Progress.WriteLine $"Installing fantomas %s{version} failed, retrying. %s{error}"
+                Directory.Delete(Path.Combine(folder.FullName, version), true)
+                do! Task.Delay(TimeSpan.FromSeconds 5.)
+                do! installWithRetry version (attemptsLeft - 1)
+            | Error error ->
+                failwith
+                    $"Could not install fantomas %s{version} in %i{installAttempts} attempts. Last failure:%s{Environment.NewLine}%s{error}"
+        }
+
+    /// What the daemon answered, and enough of its surroundings to explain why. These tests fail
+    /// on CI now and then with a response nobody expects, `IgnoredFile` in particular, and the
+    /// bare assertion only reports a number. Everything the daemon consults to reach that answer
+    /// is listed here: the file it was asked about, the `.fantomasignore` and `.editorconfig`
+    /// files it can find by walking up from that file, where the temp directory actually is, and
+    /// which fantomas the manifest resolves to.
+    let report (fsharpFile: string) (expected: FantomasResponseCode) (response: FantomasResponse) : Task<string> =
+        backgroundTask {
+            let sb = StringBuilder()
+            let line (text: string) = sb.AppendLine(text) |> ignore
+
+            line
+                $"Expected %A{expected} (%i{int expected}) but the daemon answered %A{enum<FantomasResponseCode> response.Code} (%i{response.Code})."
+
+            line $"Response file path: %s{response.FilePath}"
+
+            match response.Content with
+            | Some content -> line $"Response content: %s{content}"
+            | None -> line "Response content: <none>"
+
+            line ""
+            line $"Requested file: %s{fsharpFile} (exists: %b{File.Exists fsharpFile})"
+            line $"Path.GetTempPath(): %s{Path.GetTempPath()}"
+
+            let tmpdir =
+                Environment.GetEnvironmentVariable "TMPDIR"
+                |> Option.ofObj
+                |> Option.defaultValue "<unset>"
+
+            line $"TMPDIR: %s{tmpdir}"
+            line $"Working directory of this test host: %s{Directory.GetCurrentDirectory()}"
+
+            line ""
+            line "Configuration files found by walking up from the requested file:"
+            let mutable directory = FileInfo(fsharpFile).Directory
+            let mutable foundAny = false
+
+            while not (isNull directory) do
+                for name in [ ".fantomasignore"; ".editorconfig" ] do
+                    let candidate = Path.Combine(directory.FullName, name)
+
+                    if File.Exists candidate then
+                        foundAny <- true
+                        line $"  %s{candidate}"
+
+                        for content in File.ReadAllLines candidate do
+                            line $"    | %s{content}"
+
+                directory <- directory.Parent
+
+            if not foundAny then
+                line "  <none>"
+
+            let versionDirectory = Path.GetDirectoryName(fsharpFile: string)
+
+            line ""
+            let! toolList = dotnetIn versionDirectory "tool list"
+            line $"dotnet tool list (exit %i{toolList.ExitCode}):"
+            line (toolList.StandardOutput.TrimEnd())
+
+            let! toolVersion = dotnetIn versionDirectory "fantomas --version"
+            line $"dotnet fantomas --version (exit %i{toolVersion.ExitCode}): %s{toolVersion.StandardOutput.Trim()}"
+
+            if not (String.IsNullOrWhiteSpace toolVersion.StandardError) then
+                line $"  stderr: %s{toolVersion.StandardError.Trim()}"
+
+            return sb.ToString()
+        }
+
+    /// Assert on the response code, and say everything we know when it is not the expected one.
+    let expectResponse (expected: FantomasResponseCode) (fsharpFile: string) (response: FantomasResponse) : Task =
+        backgroundTask {
+            if response.Code <> int expected then
+                let! report = report fsharpFile expected response
+                Assert.Fail report
+        }
+
+    let withVersion version (callback: string -> Task) =
+        backgroundTask {
+            let file = Path.Combine(folder.FullName, version, "File.fs")
+
+            if not (File.Exists file) then
+                failwith $"fantomas %s{version} was never installed. Add it to `versions` in this fixture."
+
+            do! callback file
+        }
 
     [<OneTimeSetUp>]
-    member _.Setup() = folder.Create()
+    member _.Setup() : Task =
+        backgroundTask {
+            folder.Create()
+
+            for version in versions do
+                do! installWithRetry version installAttempts
+        }
 
     [<OneTimeTearDown>]
     member _.TearDown() =
@@ -87,21 +214,17 @@ end_of_line = lf
             folder.Delete(true)
         }
 
-    [<TestCase("5.0.6")>]
-    [<TestCase("5.1.5")>]
-    [<TestCase("5.2.2")>]
-    [<TestCase("6.0.0")>]
+    [<TestCase("6.3.16")>]
+    [<TestCase("7.0.5")>]
     member _.Version(version: string) =
         withVersion version (fun fsharpFile ->
             backgroundTask {
-                let! version = service.VersionAsync(fsharpFile)
-                Assert.That(version.Code, Is.EqualTo(int FantomasResponseCode.Version))
+                let! response = service.VersionAsync(fsharpFile)
+                do! expectResponse FantomasResponseCode.Version fsharpFile response
             })
 
-    [<TestCase("5.0.6")>]
-    [<TestCase("5.1.5")>]
-    [<TestCase("5.2.2")>]
-    [<TestCase("6.0.0")>]
+    [<TestCase("6.3.16")>]
+    [<TestCase("7.0.5")>]
     member _.FormatDocument(version: string) =
         withVersion version (fun fsharpFile ->
             backgroundTask {
@@ -111,11 +234,12 @@ end_of_line = lf
                       Config = None
                       Cursor = None }
 
-                let! formatResponse = service.FormatDocumentAsync(request)
-                Assert.That(formatResponse.Code, Is.EqualTo(int FantomasResponseCode.Formatted))
+                let! response = service.FormatDocumentAsync(request)
+                do! expectResponse FantomasResponseCode.Formatted fsharpFile response
             })
 
-    [<TestCase("6.0.0-alpha-004")>]
+    [<TestCase("6.3.16")>]
+    [<TestCase("7.0.5")>]
     member _.``FormatDocument with Cursor``(version: string) =
         withVersion version (fun fsharpFile ->
             backgroundTask {
@@ -125,6 +249,6 @@ end_of_line = lf
                       Config = None
                       Cursor = Some(FormatCursorPosition(1, 12)) }
 
-                let! formatResponse = service.FormatDocumentAsync(request)
-                Assert.That(formatResponse.Code, Is.EqualTo(int FantomasResponseCode.Formatted))
+                let! response = service.FormatDocumentAsync(request)
+                do! expectResponse FantomasResponseCode.Formatted fsharpFile response
             })

--- a/src/Fantomas.Core.Tests/ASTTransformerTests.fs
+++ b/src/Fantomas.Core.Tests/ASTTransformerTests.fs
@@ -105,7 +105,7 @@ let ``avoid stack-overflow in long array/list, 2485`` () =
     Assert.Pass()
 
 // ============================================================
-// Chain transformation tests — worked examples from chain-formatting-rationale.md
+// Chain transformation tests, worked examples from docs/docs/contributors/Chains.md
 // ============================================================
 
 [<Test>]
@@ -567,8 +567,9 @@ let ``repo.Where(fun a -> a.B).Select(f).ToList() — intermediate call carrying
     | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
 
 [<Test>]
-let ``a.Foo()[0].Bar() — new-style index (no dot) as part of the head`` () =
-    // Note: a.Foo()[0] requires dot-index syntax to parse: (a.Foo()).[0].Bar()
+let ``(a.Foo()).[0].Bar(), a dot-index segment after a parenthesised call head`` () =
+    // Note: `a.Foo()[0].Bar()` does not parse (FS0597), so the dot-index spelling is
+    // required here. (`a.Foo()[0]` on its own parses fine.)
     let oak = parseOak "let x = (a.Foo()).[0].Bar()"
     let expr = getExprFromBinding oak
 
@@ -615,10 +616,11 @@ let ``a.Foo()[0].Bar() — new-style index (no dot) as part of the head`` () =
 // Negative routing — expressions that must NOT become chains
 // ============================================================
 //
-// A chain is a sequence of DOT-separated steps. These three shapes have no dot to
-// separate anything, so the transformer must route them to their own nodes. If a
-// future FCS change alters how they are grouped, these tests fail rather than
-// silently widening what a chain is.
+// A chain is a sequence of DOT-separated steps, ending in at most one call. `xs[i]` and
+// `f (args)` have no dot at all, and `List.map f (fun ...)` has a prefix argument the
+// chain terminal model cannot hold, so the transformer must route all three to their own
+// nodes. If a future FCS change alters how they are grouped, these tests fail rather
+// than silently widening what a chain is.
 
 [<Test>]
 let ``List.map f (fun x -> x+1) — prefix args mean AppWithLambda, not a chain`` () =

--- a/src/Fantomas.Core.Tests/ASTTransformerTests.fs
+++ b/src/Fantomas.Core.Tests/ASTTransformerTests.fs
@@ -6,6 +6,50 @@ open Fantomas.FCS.Xml
 open Fantomas.FCS.Syntax
 open Fantomas.FCS.SyntaxTrivia
 open Fantomas.Core
+open Fantomas.Core.SyntaxOak
+
+let private parseOak source =
+    CodeFormatter.ParseOakAsync(false, source)
+    |> Async.RunSynchronously
+    |> Array.head
+    |> fst
+
+let private getExprFromBinding (oak: Oak) =
+    match oak.ModulesOrNamespaces.[0].Declarations.[0] with
+    | ModuleDecl.TopLevelBinding binding -> binding.Expr
+    | _ ->
+        Assert.Fail "Expected TopLevelBinding"
+        raise (System.Exception())
+
+let private assertIdent (text: string) (expr: Expr) =
+    match expr with
+    | Expr.Ident node -> Assert.That(node.Text, Is.EqualTo text)
+    | Expr.OptVar node ->
+        match List.tryLast node.Identifier.Content with
+        | Some(IdentifierOrDot.Ident identNode) -> Assert.That(identNode.Text, Is.EqualTo text)
+        | _ -> Assert.Fail $"Expected OptVar ending with Ident '%s{text}', got %A{expr}"
+    | _ -> Assert.Fail $"Expected Ident or OptVar '%s{text}', got %A{expr}"
+
+let private assertCount (expected: int) (list: 'a list) =
+    Assert.That(List.length list, Is.EqualTo expected)
+
+let private assertText (expected: string) (node: SingleTextNode) =
+    Assert.That(node.Text, Is.EqualTo expected)
+
+let private lastIdentText (expr: Expr) : string =
+    match expr with
+    | Expr.Ident node -> node.Text
+    | Expr.OptVar node ->
+        match List.tryLast node.Identifier.Content with
+        | Some(IdentifierOrDot.Ident identNode) -> identNode.Text
+        | _ -> failwith "no ident"
+    | _ -> failwithf "not an ident or optvar: %A" expr
+
+/// Like lastIdentText, but also looks through a type application (e.g. `OfType<Customer>` -> "OfType").
+let rec private memberName (expr: Expr) : string =
+    match expr with
+    | Expr.TypeApp node -> memberName node.Identifier
+    | _ -> lastIdentText expr
 
 [<Test>]
 let ``avoid stack-overflow in long array/list, 2485`` () =
@@ -59,3 +103,639 @@ let ``avoid stack-overflow in long array/list, 2485`` () =
 
     let _rootNode = ASTTransformer.mkOak None ast
     Assert.Pass()
+
+// ============================================================
+// Chain transformation tests — worked examples from chain-formatting-rationale.md
+// ============================================================
+
+[<Test>]
+let ``a.Foo(x).Bar() — regular chain with intermediate call and terminal unit call`` () =
+    let oak = parseOak "let x = a.Foo(x).Bar()"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        // head = Identifier(a)
+        assertIdent "a" node.Head
+
+        // segments = [DotApplication(., Foo, Paren(x)), DotMember(., Bar)]
+        assertCount 2 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotApplication(dot1, fooExpr, ChainCall.Paren _); ChainSegment.DotMember(dot2, barExpr) ] ->
+            assertText "." dot1
+            Assert.That(lastIdentText fooExpr, Is.EqualTo "Foo")
+            assertText "." dot2
+            Assert.That(lastIdentText barExpr, Is.EqualTo "Bar")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        // terminal = SpaceAllowed(Unit)
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Unit)"
+    | _ -> Assert.Fail "Expected Chain expression"
+
+[<Test>]
+let ``a.b.c — pure property access chain`` () =
+    let oak = parseOak "let x = a.b.c"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        assertIdent "a" node.Head
+        assertCount 2 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotMember(_, b); ChainSegment.DotMember(_, c) ] ->
+            Assert.That(lastIdentText b, Is.EqualTo "b")
+            Assert.That(lastIdentText c, Is.EqualTo "c")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.NoTerminal -> ()
+        | _ -> Assert.Fail "Expected NoTerminal"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``_.Substring(0,16).ToLower() — DotLambda becomes NoSpaceAllowed terminal`` () =
+    let oak = parseOak "let x = arr |> _.Substring(0,16).ToLower()"
+    let expr = getExprFromBinding oak
+
+    // The pipe right side should be a Chain
+    let rec findChain (e: Expr) : ExprChain =
+        match e with
+        | Expr.Chain node -> node
+        | Expr.InfixApp app -> findChain app.RightHandSide
+        | _ ->
+            Assert.Fail "Expected to find Chain in expression"
+            raise (System.Exception())
+
+    let chainNode = findChain expr
+
+    // head = Identifier(_)
+    assertIdent "_" chainNode.Head
+
+    // segments = [DotApplication(., Substring, Paren(...)), DotMember(., ToLower)]
+    assertCount 2 chainNode.Segments
+
+    match chainNode.Segments with
+    | [ ChainSegment.DotApplication(_, sub, ChainCall.Paren _); ChainSegment.DotMember(_, lower) ] ->
+        Assert.That(lastIdentText sub, Is.EqualTo "Substring")
+        Assert.That(lastIdentText lower, Is.EqualTo "ToLower")
+    | _ -> Assert.Fail $"Unexpected segments: %A{chainNode.Segments}"
+
+    // terminal = NoSpaceAllowed(Unit)
+    match chainNode.Terminal with
+    | ChainTerminal.NoSpaceAllowed(ChainCall.Unit _) -> ()
+    | _ -> Assert.Fail "Expected NoSpaceAllowed(Unit)"
+
+[<Test>]
+let ``path.Replace("x","y") — absorbed from AppLongIdentAndSingleParenArg`` () =
+    let oak = parseOak """let x = path.Replace("x","y")"""
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        assertIdent "path" node.Head
+
+        // segments = [DotMember(., Replace)]
+        assertCount 1 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotMember(_, replace) ] -> Assert.That(lastIdentText replace, Is.EqualTo "Replace")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        // terminal = SpaceAllowed(Paren(...))
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Paren paren) ->
+            // paren.Expr should be a tuple of the two string args
+            match paren.Expr with
+            | Expr.Tuple _ -> ()
+            | _ -> Assert.Fail "Expected tuple paren for terminal call"
+        | _ -> Assert.Fail "Expected SpaceAllowed(Paren)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``List.map (fun x -> x+1) — absorbed from AppWithLambda with no prefix args`` () =
+    let oak = parseOak "let x = List.map (fun x -> x+1)"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        assertIdent "List" node.Head
+
+        // segments = [DotMember(., map)]
+        assertCount 1 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotMember(_, map) ] -> Assert.That(lastIdentText map, Is.EqualTo "map")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        // terminal = SpaceAllowed(Paren(lambda))
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Paren paren) ->
+            match paren.Expr with
+            | Expr.Lambda _ -> ()
+            | _ -> Assert.Fail "Expected lambda inside paren"
+        | _ -> Assert.Fail "Expected SpaceAllowed(Paren)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``arr.[0] — standalone dot-indexed becomes single-segment chain`` () =
+    let oak = parseOak "let x = arr.[0]"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        assertIdent "arr" node.Head
+
+        // segments = [DotIndex(., [0])]
+        assertCount 1 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotIndex(dot, idx) ] ->
+            assertText "." dot
+
+            match idx with
+            | Expr.Constant _ -> ()
+            | _ -> Assert.Fail "Expected constant index expression"
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.NoTerminal -> ()
+        | _ -> Assert.Fail "Expected NoTerminal"
+    | _ -> Assert.Fail "Expected Chain expression"
+
+[<Test>]
+let ``arr.[0].Foo() — dot-indexed then chained`` () =
+    let oak = parseOak "let x = arr.[0].Foo()"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        assertIdent "arr" node.Head
+
+        // segments = [DotIndex(., [0]), DotMember(., Foo)]
+        assertCount 2 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotIndex(dot1, _); ChainSegment.DotMember(dot2, foo) ] ->
+            assertText "." dot1
+            assertText "." dot2
+            Assert.That(lastIdentText foo, Is.EqualTo "Foo")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        // terminal = SpaceAllowed(Unit)
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Unit)"
+    | _ -> Assert.Fail "Expected Chain expression"
+
+[<Test>]
+let ``getBuilder().Configure(opts).Build() — chain whose head is itself a call chain`` () =
+    let oak = parseOak "let x = getBuilder().Configure(opts).Build()"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        // head = Chain(getBuilder()) — a tight call receiver
+        match node.Head with
+        | Expr.Chain headChain ->
+            assertIdent "getBuilder" headChain.Head
+            assertCount 0 headChain.Segments
+
+            match headChain.Terminal with
+            | ChainTerminal.NoSpaceAllowed(ChainCall.Unit _) -> ()
+            | _ -> Assert.Fail "Expected NoSpaceAllowed(Unit) for head chain"
+        | _ -> Assert.Fail $"Expected Chain head, got %A{node.Head}"
+
+        // segments = [DotApplication(., Configure, Paren), DotMember(., Build)]
+        assertCount 2 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotApplication(_, configure, ChainCall.Paren _); ChainSegment.DotMember(_, build) ] ->
+            Assert.That(memberName configure, Is.EqualTo "Configure")
+            Assert.That(memberName build, Is.EqualTo "Build")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Unit)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``build(config).Run() — chain whose head is a call with a paren argument`` () =
+    let oak = parseOak "let x = build(config).Run()"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        // head = Chain(build(config)) — a tight call receiver with a paren arg
+        match node.Head with
+        | Expr.Chain headChain ->
+            assertIdent "build" headChain.Head
+            assertCount 0 headChain.Segments
+
+            match headChain.Terminal with
+            | ChainTerminal.NoSpaceAllowed(ChainCall.Paren _) -> ()
+            | _ -> Assert.Fail "Expected NoSpaceAllowed(Paren) for head chain"
+        | _ -> Assert.Fail $"Expected Chain head, got %A{node.Head}"
+
+        assertCount 1 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotMember(_, run) ] -> Assert.That(memberName run, Is.EqualTo "Run")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Unit)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``query.OfType<Customer>().Where(p).Cast<IEntity>() — type-application call segments and terminal`` () =
+    let oak = parseOak "let x = query.OfType<Customer>().Where(p).Cast<IEntity>()"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        assertIdent "query" node.Head
+
+        // segments = [DotApplication(., OfType<_>, Unit), DotApplication(., Where, Paren), DotMember(., Cast<_>)]
+        assertCount 3 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotApplication(_, ofType, ChainCall.Unit _)
+            ChainSegment.DotApplication(_, where, ChainCall.Paren _)
+            ChainSegment.DotMember(_, cast) ] ->
+            Assert.That(memberName ofType, Is.EqualTo "OfType")
+            Assert.That(memberName where, Is.EqualTo "Where")
+            Assert.That(memberName cast, Is.EqualTo "Cast")
+
+            // The type-application segments are genuinely TypeApp expressions.
+            match ofType with
+            | Expr.TypeApp _ -> ()
+            | _ -> Assert.Fail "Expected OfType to be a TypeApp"
+
+            match cast with
+            | Expr.TypeApp _ -> ()
+            | _ -> Assert.Fail "Expected Cast to be a TypeApp"
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Unit)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``a.b<int>.c.Print() — type-application navigation segment (no call)`` () =
+    let oak = parseOak "let x = a.b<int>.c.Print()"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        assertIdent "a" node.Head
+
+        // segments = [DotMember(., b<int>), DotMember(., c), DotMember(., Print)]
+        assertCount 3 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotMember(_, b); ChainSegment.DotMember(_, c); ChainSegment.DotMember(_, print) ] ->
+            Assert.That(memberName b, Is.EqualTo "b")
+            Assert.That(memberName c, Is.EqualTo "c")
+            Assert.That(memberName print, Is.EqualTo "Print")
+
+            // `.b<int>` is a navigation segment that carries a type application.
+            match b with
+            | Expr.TypeApp _ -> ()
+            | _ -> Assert.Fail "Expected b to be a TypeApp"
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Unit)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``x().y[0].Foo() — indexed member becomes a segment whose expr is IndexWithoutDot`` () =
+    let oak = parseOak "let x = x().y[0].Foo()"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        // head = Chain(x())
+        match node.Head with
+        | Expr.Chain headChain ->
+            assertIdent "x" headChain.Head
+            assertCount 0 headChain.Segments
+        | _ -> Assert.Fail $"Expected Chain head, got %A{node.Head}"
+
+        // segments = [DotMember(., IndexWithoutDot(y, [0])), DotMember(., Foo)]
+        assertCount 2 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotMember(_, yIndexed); ChainSegment.DotMember(_, foo) ] ->
+            // `.y[0]` is a DotMember whose expr is an IndexWithoutDot (member with a dotless index suffix).
+            match yIndexed with
+            | Expr.IndexWithoutDot _ -> ()
+            | _ -> Assert.Fail $"Expected IndexWithoutDot expr for .y[0], got %A{yIndexed}"
+
+            Assert.That(memberName foo, Is.EqualTo "Foo")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Unit)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``node.Children[0].Render() — leading indexed member becomes the head`` () =
+    // Contrast with `x().y[0]`: when the indexed member is at the START of the chain,
+    // the whole `node.Children[0]` is the opaque head (an IndexWithoutDot), not a segment.
+    let oak = parseOak "let x = node.Children[0].Render()"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        // head = IndexWithoutDot(Chain(node.Children), [0])
+        match node.Head with
+        | Expr.IndexWithoutDot idx ->
+            match idx.Identifier with
+            | Expr.Chain inner -> assertIdent "node" inner.Head
+            | _ -> Assert.Fail $"Expected Chain inside IndexWithoutDot head, got %A{idx.Identifier}"
+        | _ -> Assert.Fail $"Expected IndexWithoutDot head, got %A{node.Head}"
+
+        // segments = [DotMember(., Render)]
+        assertCount 1 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotMember(_, render) ] -> Assert.That(memberName render, Is.EqualTo "Render")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Unit)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``a.Foo(x).b.c.Bar(y) — multiple navigation segments between two calls`` () =
+    let oak = parseOak "let x = a.Foo(x).b.c.Bar(y)"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        assertIdent "a" node.Head
+
+        // segments = [DotApplication(., Foo, Paren), DotMember(., b), DotMember(., c), DotMember(., Bar)]
+        assertCount 4 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotApplication(_, foo, ChainCall.Paren _)
+            ChainSegment.DotMember(_, b)
+            ChainSegment.DotMember(_, c)
+            ChainSegment.DotMember(_, bar) ] ->
+            Assert.That(memberName foo, Is.EqualTo "Foo")
+            Assert.That(memberName b, Is.EqualTo "b")
+            Assert.That(memberName c, Is.EqualTo "c")
+            Assert.That(memberName bar, Is.EqualTo "Bar")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        // The trailing call `Bar(y)` is the terminal.
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Paren _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Paren)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``a.Foo(x).[2].Bar(y) — dot-index segment between two calls`` () =
+    let oak = parseOak "let x = a.Foo(x).[2].Bar(y)"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        assertIdent "a" node.Head
+
+        // segments = [DotApplication(., Foo, Paren), DotIndex(., [2]), DotMember(., Bar)]
+        assertCount 3 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotApplication(_, foo, ChainCall.Paren _)
+            ChainSegment.DotIndex(_, idx)
+            ChainSegment.DotMember(_, bar) ] ->
+            Assert.That(memberName foo, Is.EqualTo "Foo")
+            Assert.That(memberName bar, Is.EqualTo "Bar")
+
+            match idx with
+            | Expr.Constant _ -> ()
+            | _ -> Assert.Fail "Expected constant index expression"
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Paren _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Paren)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``repo.Where(fun a -> a.B).Select(f).ToList() — intermediate call carrying a lambda`` () =
+    let oak = parseOak "let x = repo.Where(fun a -> a.B).Select(f).ToList()"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        assertIdent "repo" node.Head
+
+        // segments = [DotApplication(., Where, Paren(lambda)), DotApplication(., Select, Paren), DotMember(., ToList)]
+        assertCount 3 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotApplication(_, where, ChainCall.Paren wherePack)
+            ChainSegment.DotApplication(_, select, ChainCall.Paren _)
+            ChainSegment.DotMember(_, toList) ] ->
+            Assert.That(memberName where, Is.EqualTo "Where")
+            Assert.That(memberName select, Is.EqualTo "Select")
+            Assert.That(memberName toList, Is.EqualTo "ToList")
+
+            // The intermediate `.Where(...)` call carries a lambda argument.
+            match wherePack.Expr with
+            | Expr.Lambda _ -> ()
+            | _ -> Assert.Fail $"Expected lambda inside Where paren, got %A{wherePack.Expr}"
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Unit)"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``a.Foo()[0].Bar() — new-style index (no dot) as part of the head`` () =
+    // Note: a.Foo()[0] requires dot-index syntax to parse: (a.Foo()).[0].Bar()
+    let oak = parseOak "let x = (a.Foo()).[0].Bar()"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        // head = Paren(Chain(a.Foo())) — the paren wraps the inner chain
+        match node.Head with
+        | Expr.Paren parenNode ->
+            match parenNode.Expr with
+            | Expr.Chain innerChain ->
+                assertIdent "a" innerChain.Head
+                // inner chain: a.Foo() — Foo is a segment, () is the terminal
+                match innerChain.Segments with
+                | [ ChainSegment.DotMember(_, foo) ] -> Assert.That(lastIdentText foo, Is.EqualTo "Foo")
+                | _ -> Assert.Fail "Expected single Foo segment in head chain"
+
+                match innerChain.Terminal with
+                | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+                | _ -> Assert.Fail "Expected SpaceAllowed(Unit) for inner chain"
+            | _ -> Assert.Fail "Expected chain inside paren"
+        | _ -> Assert.Fail "Expected Paren as head"
+
+        // segments = [DotIndex(., [0]), DotMember(., Bar)]
+        assertCount 2 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotIndex(dot1, idx); ChainSegment.DotMember(dot2, bar) ] ->
+            assertText "." dot1
+            assertText "." dot2
+            Assert.That(lastIdentText bar, Is.EqualTo "Bar")
+
+            match idx with
+            | Expr.Constant _ -> ()
+            | _ -> Assert.Fail "Expected constant index"
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        // terminal = SpaceAllowed(Unit)
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed(ChainCall.Unit _) -> ()
+        | _ -> Assert.Fail "Expected SpaceAllowed(Unit)"
+    | _ -> Assert.Fail "Expected Chain expression"
+
+// ============================================================
+// Negative routing — expressions that must NOT become chains
+// ============================================================
+//
+// A chain is a sequence of DOT-separated steps. These three shapes have no dot to
+// separate anything, so the transformer must route them to their own nodes. If a
+// future FCS change alters how they are grouped, these tests fail rather than
+// silently widening what a chain is.
+
+[<Test>]
+let ``List.map f (fun x -> x+1) — prefix args mean AppWithLambda, not a chain`` () =
+    let oak = parseOak "let x = List.map f (fun y -> y + 1)"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.AppWithLambda node ->
+        // The lambda is the trailing argument; `f` sits in front of it as a prefix arg.
+        // That prefix arg is exactly what disqualifies this from the chain terminal model.
+        assertCount 1 node.Arguments
+    | _ -> Assert.Fail $"Expected AppWithLambda, got %A{expr}"
+
+[<Test>]
+let ``xs[i] — new-style index has no dot, so it is not a chain`` () =
+    let oak = parseOak "let x = xs[i]"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.IndexWithoutDot node -> assertIdent "xs" node.Identifier
+    | _ -> Assert.Fail $"Expected IndexWithoutDot, got %A{expr}"
+
+[<Test>]
+let ``f (args) — an undotted call is AppSingleParenArg, not a chain`` () =
+    let oak = parseOak "let x = f (args)"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.AppSingleParenArg node -> assertIdent "f" node.FunctionExpr
+    | _ -> Assert.Fail $"Expected AppSingleParenArg, got %A{expr}"
+
+// ============================================================
+// Zero-segment chains — the tight-receiver shape
+// ============================================================
+
+[<Test>]
+let ``X().Y — the receiver call is a chain with zero segments and a tight terminal`` () =
+    let oak = parseOak "let x = X().Y"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        // The outer chain is `<head>.Y`.
+        assertCount 1 node.Segments
+
+        match node.Segments with
+        | [ ChainSegment.DotMember(_, y) ] -> Assert.That(lastIdentText y, Is.EqualTo "Y")
+        | _ -> Assert.Fail $"Unexpected segments: %A{node.Segments}"
+
+        match node.Terminal with
+        | ChainTerminal.NoTerminal -> ()
+        | _ -> Assert.Fail "Expected NoTerminal on the outer chain"
+
+        // The head is itself a chain: `X()` with NO segments at all. It exists only to
+        // pair the callee with its argument under a terminal that forbids the space,
+        // because `X ().Y` would parse as `X (().Y)`.
+        match node.Head with
+        | Expr.Chain headChain ->
+            assertIdent "X" headChain.Head
+            assertCount 0 headChain.Segments
+
+            match headChain.Terminal with
+            | ChainTerminal.NoSpaceAllowed(ChainCall.Unit _) -> ()
+            | _ -> Assert.Fail $"Expected NoSpaceAllowed(Unit), got %A{headChain.Terminal}"
+        | _ -> Assert.Fail $"Expected the head to be a zero-segment Chain, got %A{node.Head}"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+[<Test>]
+let ``X(a).Y — a paren receiver call is also a zero-segment tight chain`` () =
+    let oak = parseOak "let x = X(a).Y"
+    let expr = getExprFromBinding oak
+
+    match expr with
+    | Expr.Chain node ->
+        match node.Head with
+        | Expr.Chain headChain ->
+            assertIdent "X" headChain.Head
+            assertCount 0 headChain.Segments
+
+            match headChain.Terminal with
+            | ChainTerminal.NoSpaceAllowed(ChainCall.Paren _) -> ()
+            | _ -> Assert.Fail $"Expected NoSpaceAllowed(Paren), got %A{headChain.Terminal}"
+        | _ -> Assert.Fail $"Expected the head to be a zero-segment Chain, got %A{node.Head}"
+    | _ -> Assert.Fail $"Expected Chain expression, got %A{expr}"
+
+// ============================================================
+// Dot-lambda whose body ends in an indexed member
+// ============================================================
+
+[<Test>]
+let ``_.Values[0] — indexed member arrives as one opaque segment with no terminal`` () =
+    // `Values[0]` has no dot of its own, so it cannot be split into a member plus an
+    // index. It reaches the chain as a single opaque step, and because there is no call
+    // there is nothing to negotiate a space for.
+    let oak = parseOak "let x = xs |> List.map _.Values[0]"
+    let expr = getExprFromBinding oak
+
+    // Walk the whole tree looking for the `_` chain.
+    let rec search (node: Node) : ExprChain option =
+        let isUnderscoreChain (chain: ExprChain) =
+            match chain.Head with
+            | Expr.Ident n -> n.Text = "_"
+            | _ -> false
+
+        match node with
+        | :? ExprChain as chain when isUnderscoreChain chain -> Some chain
+        | _ -> node.Children |> Array.tryPick search
+
+    match search (Expr.Node expr) with
+    | Some chain ->
+        assertCount 1 chain.Segments
+
+        match chain.Segments with
+        | [ ChainSegment.DotMember(dot, _) ] -> assertText "." dot
+        | _ -> Assert.Fail $"Unexpected segments: %A{chain.Segments}"
+
+        match chain.Terminal with
+        | ChainTerminal.NoTerminal -> ()
+        | _ -> Assert.Fail $"Expected NoTerminal, got %A{chain.Terminal}"
+    | None -> Assert.Fail "Expected to find the `_` dot-lambda chain"

--- a/src/Fantomas.Core.Tests/ChainFormattingTests.fs
+++ b/src/Fantomas.Core.Tests/ChainFormattingTests.fs
@@ -166,7 +166,7 @@ lookupTable
 // ── A chain with no calls at all ────────────────────────────────────────────
 
 [<Test>]
-let ``chain with no calls at all fills greedily`` () =
+let ``chain with no calls at all is balanced across its lines`` () =
     formatSourceString
         """
 this.Configuration.Database.PrimaryConnection.Settings.IdleTimeoutInSeconds
@@ -176,8 +176,229 @@ this.Configuration.Database.PrimaryConnection.Settings.IdleTimeoutInSeconds
     |> should
         equal
         """
-this.Configuration.Database.PrimaryConnection.Settings
-    .IdleTimeoutInSeconds
+this.Configuration.Database.PrimaryConnection
+    .Settings.IdleTimeoutInSeconds
+"""
+
+// ── Keeping the chain together needs more than one trailing action ──────────
+//
+// Two further conditions guard the "break the arguments" branch: the starting value
+// must be a plain value, and everything up to the method name must fit on one line.
+
+[<Test>]
+let ``a plain starting value keeps the chain together`` () =
+    formatSourceString
+        """
+config.Settings.GetValue(theConfigurationKeyNameThatIsRatherLong)
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+config.Settings.GetValue(
+    theConfigurationKeyNameThatIsRatherLong
+)
+"""
+
+[<Test>]
+let ``a starting value that is a call leads a pipeline, even with one action`` () =
+    // Same steps and the same single trailing call as the test above; only the starting
+    // value differs, and that alone decides the layout.
+    formatSourceString
+        """
+getConfiguration().Settings.GetValue(theConfigurationKeyNameThatIsRatherLong)
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+getConfiguration()
+    .Settings.GetValue(
+        theConfigurationKeyNameThatIsRatherLong
+    )
+"""
+
+[<Test>]
+let ``a comment between the steps leaves nothing to keep together`` () =
+    formatSourceString
+        """
+config.Settings
+    // the primary one
+    .GetValue(theKeyName)
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+config.Settings
+    // the primary one
+    .GetValue(theKeyName)
+"""
+
+// ── When a line is still too long ───────────────────────────────────────────
+//
+// A run of navigation that does not fit wraps before a dot, chosen so the longest
+// resulting line is as short as possible. Greedy filling would leave one line packed
+// to the margin and a stub behind it.
+
+[<Test>]
+let ``a long navigation run is balanced rather than filled greedily`` () =
+    formatSourceString
+        """
+getConfiguration().Configuration.Database.PrimaryConnection.Settings.Timeouts.IdleTimeout.Duration.Total.Seconds.Value
+"""
+        { config with MaxLineLength = 100 }
+    |> prepend newline
+    |> should
+        equal
+        """
+getConfiguration()
+    .Configuration.Database.PrimaryConnection.Settings
+    .Timeouts.IdleTimeout.Duration.Total.Seconds.Value
+"""
+
+[<Test>]
+let ``when two splits tie, the longer first line wins`` () =
+    formatSourceString
+        """
+builder.Connect(hostName).Configuration.Database.PrimaryConnection.Settings.Timeouts.Idle
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Connect(hostName)
+    .Configuration.Database.PrimaryConnection
+    .Settings.Timeouts.Idle
+"""
+
+[<Test>]
+let ``the receiver keeps a step rather than sitting alone`` () =
+    formatSourceString
+        """
+defineCombinationValue.Value.IsEmpty
+"""
+        { config with MaxLineLength = 30 }
+    |> prepend newline
+    |> should
+        equal
+        """
+defineCombinationValue.Value
+    .IsEmpty
+"""
+
+[<Test>]
+let ``navigation wraps to keep an intermediate call whole`` () =
+    // The run leads a call in the middle of a pipeline. Wrapping the navigation is preferred,
+    // so `spec` is never pushed onto a line of its own to make room for it.
+    formatSourceString
+        """
+builder.Connect(hostName).Configuration.Database.PrimaryConnection.Settings.Apply(spec).Build()
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Connect(hostName)
+    .Configuration.Database
+    .PrimaryConnection.Settings.Apply(spec)
+    .Build()
+"""
+
+[<Test>]
+let ``navigation wraps to keep the terminal call whole`` () =
+    // Wrapping one step earlier than strictly needed keeps `keyName` beside its method.
+    formatSourceString
+        """
+getConfiguration().Configuration.Database.PrimaryConnection.Settings.Timeouts.GetValue(keyName)
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+getConfiguration()
+    .Configuration.Database.PrimaryConnection
+    .Settings.Timeouts.GetValue(keyName)
+"""
+
+[<Test>]
+let ``arguments still break when no wrap can hold the whole call`` () =
+    formatSourceString
+        """
+getConfiguration().Configuration.Database.Settings.GetValue(theConfigurationKeyNameThatIsVeryVeryLongIndeed)
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+getConfiguration()
+    .Configuration.Database.Settings.GetValue(
+        theConfigurationKeyNameThatIsVeryVeryLongIndeed
+    )
+"""
+
+[<Test>]
+let ``a call leaving the receiver's line has its own line to fit in`` () =
+    // The navigation fits on the receiver's line, so the call leaves that line and claims one
+    // of its own. There is nothing for the navigation to make room for, and it stays put.
+    formatSourceString
+        """
+Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<option<option<unit>>>.GetGenericTypeDefinition().MakeGenericType(t)).Assembly
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+Microsoft.FSharp.Reflection.FSharpType
+    .GetUnionCases(typeof<option<option<unit>>>.GetGenericTypeDefinition().MakeGenericType(t))
+    .Assembly
+"""
+
+[<Test>]
+let ``balancing never crosses an action`` () =
+    formatSourceString
+        """
+serviceCollection.AddSingleton<IClock>(systemClock).AddOptions<MyOptions>(configureOptions)
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+serviceCollection
+    .AddSingleton<IClock>(systemClock)
+    .AddOptions<MyOptions>(configureOptions)
+"""
+
+[<Test>]
+let ``a step carrying a comment opens its own line and the rest is balanced from there`` () =
+    // A commented dot renders on lines of its own, so it has no width to balance with.
+    // The run stops there and resumes afterwards, measured from where the comment left off.
+    formatSourceString
+        """
+myConfiguration
+    // pick the primary
+    .Database.PrimaryConnection.Settings.IdleTimeoutInSeconds
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+myConfiguration
+    // pick the primary
+    .Database.PrimaryConnection
+    .Settings.IdleTimeoutInSeconds
 """
 
 // ── A dot-lambda body (_.…) ─────────────────────────────────────────────────
@@ -490,4 +711,193 @@ repository.Cast<IEntity>.GetConnectionString(primaryReplica)
 repository.Cast<IEntity>.GetConnectionString(
     primaryReplica
 )
+"""
+
+// ── Lambda arguments do not depend on the call's position ───────────────────
+//
+// `fun` and `function` are laid out the same way wherever their call sits, as the F#
+// style guide asks ("Treat match lambda's in a similar fashion"). The eight tests below
+// are the full matrix: both lambda forms, both positions, both settings.
+
+[<Test>]
+let ``fun lambda mid-pipeline keeps its opener attached`` () =
+    formatSourceString
+        """
+builder.Configure(fun v -> handleSomeValue v |> andThenSomethingElse v).Build().Result
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Configure(fun v ->
+        handleSomeValue v |> andThenSomethingElse v)
+    .Build()
+    .Result
+"""
+
+[<Test>]
+let ``fun lambda as the last step keeps its opener attached`` () =
+    formatSourceString
+        """
+builder.Build().Configure(fun v -> handleSomeValue v |> andThenSomethingElse v)
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Build()
+    .Configure(fun v ->
+        handleSomeValue v |> andThenSomethingElse v)
+"""
+
+[<Test>]
+let ``match lambda mid-pipeline keeps its opener attached`` () =
+    formatSourceString
+        """
+builder.Configure(function Some v -> handleSome v | None -> handleNone ()).Build().Result
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Configure(function
+        | Some v -> handleSome v
+        | None -> handleNone ())
+    .Build()
+    .Result
+"""
+
+[<Test>]
+let ``match lambda as the last step keeps its opener attached`` () =
+    formatSourceString
+        """
+builder.Build().Configure(function Some v -> handleSome v | None -> handleNone ())
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Build()
+    .Configure(function
+        | Some v -> handleSome v
+        | None -> handleNone ())
+"""
+
+[<Test>]
+let ``fun lambda mid-pipeline, closing newline true`` () =
+    formatSourceString
+        """
+builder.Configure(fun v -> handleSomeValue v |> andThenSomethingElse v).Build().Result
+"""
+        { config with
+            MaxLineLength = 60
+            MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Configure(fun v ->
+        handleSomeValue v |> andThenSomethingElse v
+    )
+    .Build()
+    .Result
+"""
+
+[<Test>]
+let ``fun lambda as the last step, closing newline true`` () =
+    formatSourceString
+        """
+builder.Build().Configure(fun v -> handleSomeValue v |> andThenSomethingElse v)
+"""
+        { config with
+            MaxLineLength = 60
+            MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Build()
+    .Configure(fun v ->
+        handleSomeValue v |> andThenSomethingElse v
+    )
+"""
+
+[<Test>]
+let ``match lambda mid-pipeline, closing newline true`` () =
+    formatSourceString
+        """
+builder.Configure(function Some v -> handleSome v | None -> handleNone ()).Build().Result
+"""
+        { config with
+            MaxLineLength = 60
+            MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Configure(
+        function
+        | Some v -> handleSome v
+        | None -> handleNone ()
+    )
+    .Build()
+    .Result
+"""
+
+[<Test>]
+let ``match lambda as the last step, closing newline true`` () =
+    formatSourceString
+        """
+builder.Build().Configure(function Some v -> handleSome v | None -> handleNone ())
+"""
+        { config with
+            MaxLineLength = 60
+            MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Build()
+    .Configure(
+        function
+        | Some v -> handleSome v
+        | None -> handleNone ()
+    )
+"""
+
+[<Test>]
+let ``breaking after the opening paren yourself moves function down`` () =
+    // The third thing that moves `function` onto its own line, and the only one that is
+    // neither the setting nor the chain: the source already had it there.
+    formatSourceString
+        """
+builder.Build().Configure(
+    function
+    | Some v -> handleSome v
+    | None -> handleNone ())
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .Build()
+    .Configure(
+        function
+        | Some v -> handleSome v
+        | None -> handleNone ()
+    )
 """

--- a/src/Fantomas.Core.Tests/ChainFormattingTests.fs
+++ b/src/Fantomas.Core.Tests/ChainFormattingTests.fs
@@ -964,3 +964,59 @@ let undotted () =
             (aVeryLongParameterName: AnEquallyLongTypeName)
             (anotherLongParameterName: AnotherTypeName) -> body ())
 """
+
+[<Test>]
+let ``lambda that still does not fit after moving down keeps its closing parenthesis on the body`` () =
+    formatSourceString
+        """
+let dotted () =
+    storage.SetConfigurationSettingPublisher(fun configName publisher -> publishTheConfigurationValue configName publisher andThenSomethingElse)
+
+let undotted () =
+    storageSetConfigurationSettingPublisher (fun configName publisher -> publishTheConfigurationValue configName publisher andThenSomethingElse)
+"""
+        { config with MaxLineLength = 70 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let dotted () =
+    storage.SetConfigurationSettingPublisher
+        (fun configName publisher ->
+            publishTheConfigurationValue
+                configName
+                publisher
+                andThenSomethingElse)
+
+let undotted () =
+    storageSetConfigurationSettingPublisher
+        (fun configName publisher ->
+            publishTheConfigurationValue
+                configName
+                publisher
+                andThenSomethingElse)
+"""
+
+[<Test>]
+let ``lambda that fits on one line after moving down keeps its closing parenthesis`` () =
+    formatSourceString
+        """
+let dotted () =
+    storage.SetConfigurationSettingPublisher(fun configName publisher -> publish configName publisher)
+
+let undotted () =
+    storageSetConfigurationSettingPublisher (fun configName publisher -> publish configName publisher)
+"""
+        { config with MaxLineLength = 70 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let dotted () =
+    storage.SetConfigurationSettingPublisher
+        (fun configName publisher -> publish configName publisher)
+
+let undotted () =
+    storageSetConfigurationSettingPublisher
+        (fun configName publisher -> publish configName publisher)
+"""

--- a/src/Fantomas.Core.Tests/ChainFormattingTests.fs
+++ b/src/Fantomas.Core.Tests/ChainFormattingTests.fs
@@ -899,3 +899,68 @@ builder
         | Some v -> handleSome v
         | None -> handleNone ())
 """
+
+// ── A lambda argument that no longer fits ───────────────────────────────────
+//
+// Where the lambda goes is the argument's business, not the chain's, so a call reached through
+// a dot is laid out exactly like the same call without one. The F# style guide asks for
+// everything up to the arrow on one line, and rejects parameters aligned under the opening
+// parenthesis, because that column depends on the length of the name in front of it.
+
+[<Test>]
+let ``lambda moves to its own line when everything up to the arrow does not fit`` () =
+    formatSourceString
+        """
+let dotted ifaces =
+    ifaces
+    |> List.tryPick (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) -> Some(ty, withRange))
+
+let undotted ifaces =
+    ifaces
+    |> pickFromList (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) -> Some(ty, withRange))
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let dotted ifaces =
+    ifaces
+    |> List.tryPick
+        (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) ->
+            Some(ty, withRange))
+
+let undotted ifaces =
+    ifaces
+    |> pickFromList
+        (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) ->
+            Some(ty, withRange))
+"""
+
+[<Test>]
+let ``lambda parameters take a line each when they do not fit after the lambda moved down`` () =
+    formatSourceString
+        """
+let dotted () =
+    Cfg.register (fun (aVeryLongParameterName: AnEquallyLongTypeName) (anotherLongParameterName: AnotherTypeName) -> body ())
+
+let undotted () =
+    registerWith (fun (aVeryLongParameterName: AnEquallyLongTypeName) (anotherLongParameterName: AnotherTypeName) -> body ())
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let dotted () =
+    Cfg.register
+        (fun
+            (aVeryLongParameterName: AnEquallyLongTypeName)
+            (anotherLongParameterName: AnotherTypeName) -> body ())
+
+let undotted () =
+    registerWith
+        (fun
+            (aVeryLongParameterName: AnEquallyLongTypeName)
+            (anotherLongParameterName: AnotherTypeName) -> body ())
+"""

--- a/src/Fantomas.Core.Tests/ChainFormattingTests.fs
+++ b/src/Fantomas.Core.Tests/ChainFormattingTests.fs
@@ -878,9 +878,9 @@ builder
 """
 
 [<Test>]
-let ``breaking after the opening paren yourself moves function down`` () =
-    // The second thing that moves `function` onto its own line, and the only one that is
-    // not the setting: the source already had it there.
+let ``match lambda as the last step, function written below the opening paren`` () =
+    // The setting is the only thing that moves `function` onto its own line. The same call
+    // written across more lines is still the same call, so it formats the same way.
     formatSourceString
         """
 builder.Build().Configure(
@@ -895,9 +895,7 @@ builder.Build().Configure(
         """
 builder
     .Build()
-    .Configure(
-        function
+    .Configure(function
         | Some v -> handleSome v
-        | None -> handleNone ()
-    )
+        | None -> handleNone ())
 """

--- a/src/Fantomas.Core.Tests/ChainFormattingTests.fs
+++ b/src/Fantomas.Core.Tests/ChainFormattingTests.fs
@@ -1,7 +1,7 @@
 module Fantomas.Core.Tests.ChainFormattingTests
 
-// This file encodes the specification in `chain-formatting-rationale.md`.
-// Each test mirrors one before/after example from that document, at a narrow
+// This file encodes the specification in `docs/docs/contributors/Chains.md`.
+// Most tests mirror a before/after example from that document, at a narrow
 // page width so the intended line breaks are visible. Where the spec shows a
 // setting explicitly, the test uses it (default vs. MultiLineLambdaClosingNewline).
 //
@@ -180,7 +180,7 @@ this.Configuration.Database.PrimaryConnection
     .Settings.IdleTimeoutInSeconds
 """
 
-// ── Keeping the chain together needs more than one trailing action ──────────
+// ── A single trailing action is not enough on its own ───────────────────────
 //
 // Two further conditions guard the "break the arguments" branch: the starting value
 // must be a plain value, and everything up to the method name must fit on one line.
@@ -879,8 +879,8 @@ builder
 
 [<Test>]
 let ``breaking after the opening paren yourself moves function down`` () =
-    // The third thing that moves `function` onto its own line, and the only one that is
-    // neither the setting nor the chain: the source already had it there.
+    // The second thing that moves `function` onto its own line, and the only one that is
+    // not the setting: the source already had it there.
     formatSourceString
         """
 builder.Build().Configure(

--- a/src/Fantomas.Core.Tests/ChainFormattingTests.fs
+++ b/src/Fantomas.Core.Tests/ChainFormattingTests.fs
@@ -1,0 +1,493 @@
+module Fantomas.Core.Tests.ChainFormattingTests
+
+// This file encodes the specification in `chain-formatting-rationale.md`.
+// Each test mirrors one before/after example from that document, at a narrow
+// page width so the intended line breaks are visible. Where the spec shows a
+// setting explicitly, the test uses it (default vs. MultiLineLambdaClosingNewline).
+//
+// These tests are the north star for the chain redesign: they describe the
+// output the design must produce.
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Core.Tests.TestHelpers
+
+// ── A single call at the end — break the arguments ──────────────────────────
+
+[<Test>]
+let ``single call at the end breaks the arguments`` () =
+    formatSourceString
+        """
+config.GetConnectionString("primary-database-readonly-replica-connection-string")
+"""
+        { config with MaxLineLength = 70 }
+    |> prepend newline
+    |> should
+        equal
+        """
+config.GetConnectionString(
+    "primary-database-readonly-replica-connection-string"
+)
+"""
+
+// ── Navigation before a single call — still break the arguments ─────────────
+
+[<Test>]
+let ``navigation before a single call still breaks the arguments`` () =
+    formatSourceString
+        """
+response.Content.Headers.GetValues("Content-Type-And-Transfer-Encoding-Header")
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+response.Content.Headers.GetValues(
+    "Content-Type-And-Transfer-Encoding-Header"
+)
+"""
+
+// ── A single call whose argument is a lambda ────────────────────────────────
+
+[<Test>]
+let ``single trailing lambda call, closing newline false`` () =
+    formatSourceString
+        """
+storage.SetConfigurationSettingPublisher(fun configName publisher -> publish configName publisher)
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+storage.SetConfigurationSettingPublisher(fun configName publisher ->
+    publish configName publisher)
+"""
+
+[<Test>]
+let ``single trailing lambda call, closing newline true`` () =
+    formatSourceString
+        """
+storage.SetConfigurationSettingPublisher(fun configName publisher -> publish configName publisher)
+"""
+        { config with
+            MaxLineLength = 80
+            MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+storage.SetConfigurationSettingPublisher(fun configName publisher ->
+    publish configName publisher
+)
+"""
+
+// ── Two or more calls — a pipeline ──────────────────────────────────────────
+
+[<Test>]
+let ``two or more calls form a pipeline`` () =
+    formatSourceString
+        """
+serviceCollection.AddSingleton<IClock>(systemClock).AddOptions<MyOptions>(configureOptions)
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+serviceCollection
+    .AddSingleton<IClock>(systemClock)
+    .AddOptions<MyOptions>(configureOptions)
+"""
+
+// ── Navigation between calls rides at the front of the line ─────────────────
+
+[<Test>]
+let ``navigation between calls rides at the front of the line`` () =
+    formatSourceString
+        """
+document.Body.FirstChild.AppendChild(newNode).ParentElement.RemoveChild(oldNode)
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+document.Body.FirstChild
+    .AppendChild(newNode)
+    .ParentElement.RemoveChild(oldNode)
+"""
+
+// ── A long pipeline with lambdas — MultiLineLambdaClosingNewline = true ──────
+
+[<Test>]
+let ``long pipeline with lambdas, closing newline true`` () =
+    formatSourceString
+        """
+builder.FirstThing<X>(fun lambda -> processFirst lambda).SecondThing<Y>(fun next -> processSecond next).ThirdThing<Z>().Result
+"""
+        { config with
+            MaxLineLength = 40
+            MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+builder
+    .FirstThing<X>(fun lambda ->
+        processFirst lambda
+    )
+    .SecondThing<Y>(fun next ->
+        processSecond next
+    )
+    .ThirdThing<Z>()
+    .Result
+"""
+
+// ── A chain that ends in navigation, not a call ─────────────────────────────
+
+[<Test>]
+let ``chain that ends in navigation, not a call`` () =
+    formatSourceString
+        """
+lookupTable.GetBucketForHash(hashOfTheKeyValue).Entries.[indexWithinTheBucket]
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+lookupTable
+    .GetBucketForHash(hashOfTheKeyValue)
+    .Entries.[indexWithinTheBucket]
+"""
+
+// ── A chain with no calls at all ────────────────────────────────────────────
+
+[<Test>]
+let ``chain with no calls at all fills greedily`` () =
+    formatSourceString
+        """
+this.Configuration.Database.PrimaryConnection.Settings.IdleTimeoutInSeconds
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+this.Configuration.Database.PrimaryConnection.Settings
+    .IdleTimeoutInSeconds
+"""
+
+// ── A dot-lambda body (_.…) ─────────────────────────────────────────────────
+
+[<Test>]
+let ``dot-lambda body stays tight and short`` () =
+    formatSourceString
+        """
+"yow" |> _.Substring(0, 16).ToLower()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+"yow" |> _.Substring(0, 16).ToLower()
+"""
+
+[<Test>]
+let ``dot-lambda body too long follows leading-dot`` () =
+    formatSourceString
+        """
+_.Substring(0, 16).ToLower()
+"""
+        { config with MaxLineLength = 25 }
+    |> prepend newline
+    |> should
+        equal
+        """
+_
+    .Substring(0, 16)
+    .ToLower()
+"""
+
+// ── Exotic and combined shapes ──────────────────────────────────────────────
+
+// A pipeline where one call is multiline and the others are not.
+
+[<Test>]
+let ``pipeline with one multiline call, closing newline false`` () =
+    formatSourceString
+        """
+repo.Where(fun customer -> customer.IsActive && customer.Region = targetRegion).Select(projector).ToList()
+"""
+        { config with MaxLineLength = 70 }
+    |> prepend newline
+    |> should
+        equal
+        """
+repo
+    .Where(fun customer ->
+        customer.IsActive && customer.Region = targetRegion)
+    .Select(projector)
+    .ToList()
+"""
+
+[<Test>]
+let ``pipeline with one multiline call, closing newline true`` () =
+    formatSourceString
+        """
+repo.Where(fun customer -> customer.IsActive && customer.Region = targetRegion).Select(projector).ToList()
+"""
+        { config with
+            MaxLineLength = 70
+            MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+repo
+    .Where(fun customer ->
+        customer.IsActive && customer.Region = targetRegion
+    )
+    .Select(projector)
+    .ToList()
+"""
+
+// An intermediate call whose tuple arguments break.
+
+[<Test>]
+let ``intermediate call whose tuple arguments break`` () =
+    formatSourceString
+        """
+client.Post(endpointUrl, serializedRequestPayload, requestHeaders).EnsureSuccessStatusCode().Content
+"""
+        { config with MaxLineLength = 40 }
+    |> prepend newline
+    |> should
+        equal
+        """
+client
+    .Post(
+        endpointUrl,
+        serializedRequestPayload,
+        requestHeaders
+    )
+    .EnsureSuccessStatusCode()
+    .Content
+"""
+
+// Several navigation steps between two calls.
+
+[<Test>]
+let ``several navigation steps between two calls`` () =
+    formatSourceString
+        """
+store.Items.Active.Filter(predicate).Results.Page.First.Render(renderContext)
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+store.Items.Active
+    .Filter(predicate)
+    .Results.Page.First.Render(renderContext)
+"""
+
+// Generic (type-application) methods.
+
+[<Test>]
+let ``generic type-application methods`` () =
+    formatSourceString
+        """
+query.OfType<Customer>().Where(activePredicate).Cast<IEntityWithTimestamp>()
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+query
+    .OfType<Customer>()
+    .Where(activePredicate)
+    .Cast<IEntityWithTimestamp>()
+"""
+
+// A chain whose receiver is itself a call.
+
+[<Test>]
+let ``chain whose receiver is itself a call`` () =
+    formatSourceString
+        """
+getConfiguredServiceBuilder().AddLogging(loggingOptions).Build()
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+getConfiguredServiceBuilder()
+    .AddLogging(loggingOptions)
+    .Build()
+"""
+
+// An index between two calls.
+
+[<Test>]
+let ``index between two calls`` () =
+    formatSourceString
+        """
+spreadsheet.GetRow(rowIndex).[targetColumnIndex].FormatWith(cultureInfo)
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+spreadsheet
+    .GetRow(rowIndex)
+    .[targetColumnIndex].FormatWith(cultureInfo)
+"""
+
+// ── The receiver has a vote ─────────────────────────────────────────────────
+//
+// Keeping a chain together is only offered when the receiver is a plain value.
+// A compound receiver leads a pipeline even when there is a single trailing call.
+
+[<Test>]
+let ``plain value receiver with a single trailing call breaks the arguments`` () =
+    formatSourceString
+        """
+config.GetConnectionString(primaryDatabaseReadonlyReplica)
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+config.GetConnectionString(
+    primaryDatabaseReadonlyReplica
+)
+"""
+
+[<Test>]
+let ``call receiver with a single trailing call leads a pipeline`` () =
+    formatSourceString
+        """
+getBuilder().GetConnectionString(primaryDatabaseReplica)
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+getBuilder()
+    .GetConnectionString(primaryDatabaseReplica)
+"""
+
+[<Test>]
+let ``parenthesised receiver with a single trailing call leads a pipeline`` () =
+    formatSourceString
+        """
+(thing :> IProvider).GetConnectionString(primaryDbReplica)
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+(thing :> IProvider)
+    .GetConnectionString(primaryDbReplica)
+"""
+
+[<Test>]
+let ``generic receiver with a single trailing call leads a pipeline`` () =
+    formatSourceString
+        """
+Animal<Identifier>.GetConnectionString(primaryDbReplica)
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+Animal<Identifier>
+    .GetConnectionString(primaryDbReplica)
+"""
+
+// ── Exception: a parenthesised value that is only indexed ───────────────────
+
+[<Test>]
+let ``multiline parenthesised receiver keeps a lone dot-index welded`` () =
+    formatSourceString
+        """
+let first =
+    (line.Split([| ":" |], StringSplitOptions.RemoveEmptyEntries)).[0]
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let first =
+    (line.Split(
+        [| ":" |],
+        StringSplitOptions.RemoveEmptyEntries
+    )).[0]
+"""
+
+[<Test>]
+let ``multiline parenthesised receiver followed by a member does break`` () =
+    formatSourceString
+        """
+let first =
+    (line.Split([| ":" |], StringSplitOptions.RemoveEmptyEntries)).Length
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let first =
+    (line.Split(
+        [| ":" |],
+        StringSplitOptions.RemoveEmptyEntries
+    ))
+        .Length
+"""
+
+// ── A generic call is still a call ──────────────────────────────────────────
+
+[<Test>]
+let ``generic call is an action, so a lone trailing one breaks its arguments`` () =
+    formatSourceString
+        """
+repository.Cast<IEntityWithTimestampAndAudit>(someArgument)
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+repository.Cast<IEntityWithTimestampAndAudit>(
+    someArgument
+)
+"""
+
+[<Test>]
+let ``bare generic member is navigation and rides with the receiver`` () =
+    formatSourceString
+        """
+repository.Cast<IEntity>.GetConnectionString(primaryReplica)
+"""
+        { config with MaxLineLength = 50 }
+    |> prepend newline
+    |> should
+        equal
+        """
+repository.Cast<IEntity>.GetConnectionString(
+    primaryReplica
+)
+"""

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -450,8 +450,9 @@ Animal<
 // ── Tight receivers ─────────────────────────────────────────────────────────
 //
 // `mkAtomicExpr` in the ASTTransformer marks a chain that has to stay one indivisible unit,
-// because a prefix operator, an index or a `?member` binds directly to it. Each test below
-// covers one call site of it. They all run with `SpaceBeforeUppercaseInvocation = true`,
+// because a prefix operator, an index or a `?member` binds directly to it. The tests below
+// cover the prefix-operator, index and `?`-chain call sites. They all run with
+// `SpaceBeforeUppercaseInvocation = true`,
 // because that is the setting that would otherwise introduce the space: compare with
 // `obj.Bar()` on its own, which correctly becomes `obj.Bar ()` under the same config.
 
@@ -650,6 +651,11 @@ a.Foo(x).bar(y)
         """
 a.Foo(x).bar(y)
 """
+
+// ── A match lambda as the terminal call's argument ──────────────────────────
+//
+// Only `MultiLineLambdaClosingNewline` or a break the user already made after the `(`
+// moves `function` onto its own line. Where the call sits in the chain has no say.
 
 [<Test>]
 let ``match lambda as a terminal call argument breaks when closing newline is set`` () =

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -352,8 +352,8 @@ Universe.Galaxy.SolarSystem.Planet.[3].Countries.[9].People.Count
     |> should
         equal
         """
-Universe.Galaxy.SolarSystem.Planet.[3].Countries
-    .[9].People.Count
+Universe.Galaxy.SolarSystem.Planet
+    .[3].Countries.[9].People.Count
 """
 
 [<Test>]
@@ -568,7 +568,9 @@ let x =
 """
 
 [<Test>]
-let ``match lambda as an intermediate call argument breaks after the opening paren`` () =
+let ``match lambda as an intermediate call argument keeps the function keyword attached`` () =
+    // Identical in shape to the terminal case below: where the call sits in the chain has no
+    // say over a lambda argument, for `function` just as for `fun`.
     formatSourceString
         """
 let x =
@@ -583,11 +585,9 @@ let x =
         """
 let x =
     builder
-        .Configure(
-            function
+        .Configure(function
             | Some v -> handleSome v
-            | None -> handleNone ()
-        )
+            | None -> handleNone ())
         .Build()
         .Result
 """

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -706,3 +706,114 @@ let x =
             | None -> handleNone ()
         )
 """
+
+[<Test>]
+let ``a comment before the argument of a terminal call keeps the parenthesis with the method name`` () =
+    formatSourceString
+        """
+let host =
+    builder.UseUrls(
+        // the public endpoint
+        url
+    )
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let host =
+    builder.UseUrls(
+        // the public endpoint
+        url
+    )
+"""
+
+[<Test>]
+let ``a comment before the argument keeps the parenthesis with the method name, however the source was laid out`` () =
+    formatSourceString
+        """
+let host = builder.UseUrls(
+    // the public endpoint
+    url)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let host =
+    builder.UseUrls(
+        // the public endpoint
+        url
+    )
+"""
+
+[<Test>]
+let ``a comment before the argument of an intermediate call keeps the parenthesis welded`` () =
+    formatSourceString
+        """
+let host =
+    builder
+        .UseUrls(
+            // the public endpoint
+            url
+        )
+        .Build()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let host =
+    builder
+        .UseUrls(
+            // the public endpoint
+            url
+        )
+        .Build()
+"""
+
+[<Test>]
+let ``a comment between the method name and the parenthesis takes the call down with it`` () =
+    formatSourceString
+        """
+let host =
+    builder.UseUrls
+        // pick the endpoint
+        (url)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let host =
+    builder.UseUrls
+        // pick the endpoint
+        (url)
+"""
+
+[<Test>]
+let ``a comment between the method name and the parenthesis leaves the argument rules alone`` () =
+    formatSourceString
+        """
+let host =
+    builder.UseUrls
+        // pick the endpoint
+        (theConfigurationValueForThePublicEndpoint, theFallbackEndpointValue)
+"""
+        { config with MaxLineLength = 60 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let host =
+    builder.UseUrls
+        // pick the endpoint
+        (
+            theConfigurationValueForThePublicEndpoint,
+            theFallbackEndpointValue
+        )
+"""

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -815,3 +815,66 @@ let host =
             theFallbackEndpointValue
         )
 """
+
+// A comment written after the receiver ends its line before the chain has decided anything.
+// The steps behind it have to open an indented line, or they land level with the receiver and
+// the result no longer parses. Where the comment attaches depends on how it was written, so
+// the three spellings below are the same chain and have to reach the same output.
+
+[<Test>]
+let ``a comment on its own line after the receiver indents the steps behind it`` () =
+    formatSourceString
+        """
+let a =
+    config
+    // note
+        .Settings.GetValue(key)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a =
+    config
+        // note
+        .Settings.GetValue(key)
+"""
+
+[<Test>]
+let ``the column the comment after a receiver was written at makes no difference`` () =
+    formatSourceString
+        """
+let a =
+    config
+        // note
+        .Settings.GetValue(key)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a =
+    config
+        // note
+        .Settings.GetValue(key)
+"""
+
+[<Test>]
+let ``a trailing comment after the receiver indents the steps behind it`` () =
+    formatSourceString
+        """
+let a =
+    config // note
+        .Settings.GetValue(key)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a =
+    config // note
+        .Settings.GetValue(key)
+"""

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -289,8 +289,25 @@ Map
     |> should
         equal
         """
-Map.empty<_, obj>
-    .Add("headerAction", modifyHeader.Action.ArmValue)
+Map.empty<_, obj>.Add(
+    "headerAction",
+    modifyHeader.Action.ArmValue
+)
+"""
+
+[<Test>]
+let ``dotlambda chain with simple segments`` () =
+    formatSourceString
+        """
+_.Name.Length
+"""
+        { config with MaxLineLength = 12 }
+    |> prepend newline
+    |> should
+        equal
+        """
+_.Name
+    .Length
 """
 
 [<Test>]
@@ -428,4 +445,258 @@ Animal<
     .Dog(
         "Spot"
     )
+"""
+
+// ── Tight receivers ─────────────────────────────────────────────────────────
+//
+// `mkAtomicExpr` in the ASTTransformer marks a chain that has to stay one indivisible unit,
+// because a prefix operator, an index or a `?member` binds directly to it. Each test below
+// covers one call site of it. They all run with `SpaceBeforeUppercaseInvocation = true`,
+// because that is the setting that would otherwise introduce the space: compare with
+// `obj.Bar()` on its own, which correctly becomes `obj.Bar ()` under the same config.
+
+[<Test>]
+let ``tight receiver control case, a plain terminal call does take the space`` () =
+    formatSourceString
+        """
+obj.Bar()
+"""
+        { config with
+            SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+obj.Bar ()
+"""
+
+[<Test>]
+let ``tight receiver, leading expression of a dynamic chain`` () =
+    formatSourceString
+        """
+obj?A()?B()
+"""
+        { config with
+            SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+obj?A()?B()
+"""
+
+[<Test>]
+let ``tight receiver, prefix operator applied to a unit call`` () =
+    formatSourceString
+        """
+-obj.Bar()
+"""
+        { config with
+            SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+-obj.Bar()
+"""
+
+[<Test>]
+let ``tight receiver, prefix operator applied to a paren call`` () =
+    formatSourceString
+        """
+-obj.Bar(a)
+"""
+        { config with
+            SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+-obj.Bar(a)
+"""
+
+[<Test>]
+let ``tight receiver, identifier of a new-style index`` () =
+    formatSourceString
+        """
+a.Foo()[0]
+"""
+        { config with
+            SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+a.Foo()[0]
+"""
+
+// ── Intermediate calls stay welded to their opening paren ───────────────────
+//
+// An intermediate call may never be separated from its `(`: `a.Foo (x).Bar()` parses as
+// `a.Foo ((x).Bar())`. A conditional directive attached to the argument pushes that
+// argument onto its own lines, and the break has to land AFTER the `(`, not before it.
+
+[<Test>]
+let ``directive inside an intermediate call argument keeps the opening paren tight`` () =
+    formatSourceString
+        """
+let x =
+    builder.Configure(
+#if DEBUG
+        debugOptions
+#else
+        releaseOptions
+#endif
+    ).Build().Result
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x =
+    builder
+        .Configure(
+#if DEBUG
+            debugOptions
+#else
+            releaseOptions
+#endif
+        )
+        .Build()
+        .Result
+"""
+
+[<Test>]
+let ``match lambda as an intermediate call argument breaks after the opening paren`` () =
+    formatSourceString
+        """
+let x =
+    builder.Configure(function
+        | Some v -> handleSome v
+        | None -> handleNone ()).Build().Result
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x =
+    builder
+        .Configure(
+            function
+            | Some v -> handleSome v
+            | None -> handleNone ()
+        )
+        .Build()
+        .Result
+"""
+
+[<Test>]
+let ``match lambda as a terminal call argument keeps the function keyword attached`` () =
+    formatSourceString
+        """
+let x =
+    builder.Build().Configure(function
+        | Some v -> handleSome v
+        | None -> handleNone ())
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x =
+    builder
+        .Build()
+        .Configure(function
+            | Some v -> handleSome v
+            | None -> handleNone ())
+"""
+
+// ── Casing of the terminal is decided by the LAST segment ───────────────────
+//
+// `SpaceBeforeUppercaseInvocation` looks at the name the terminal call is made on,
+// which is always the final segment. Intermediate calls earlier in the chain have no
+// say — and stay tight regardless of their own casing.
+
+[<Test>]
+let ``uppercase terminal after an uppercase intermediate call takes the space`` () =
+    formatSourceString
+        """
+a.Foo(x).Bar(y)
+"""
+        { config with
+            SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+a.Foo(x).Bar (y)
+"""
+
+[<Test>]
+let ``lowercase terminal after an uppercase intermediate call does not take the space`` () =
+    formatSourceString
+        """
+a.Foo(x).bar(y)
+"""
+        { config with
+            SpaceBeforeUppercaseInvocation = true
+            SpaceBeforeLowercaseInvocation = false }
+    |> prepend newline
+    |> should
+        equal
+        """
+a.Foo(x).bar(y)
+"""
+
+[<Test>]
+let ``match lambda as a terminal call argument breaks when closing newline is set`` () =
+    formatSourceString
+        """
+let x =
+    builder.Build().Configure(function
+        | Some v -> handleSome v
+        | None -> handleNone ())
+"""
+        { config with
+            MultiLineLambdaClosingNewline = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+let x =
+    builder
+        .Build()
+        .Configure(
+            function
+            | Some v -> handleSome v
+            | None -> handleNone ()
+        )
+"""
+
+[<Test>]
+let ``match lambda as a terminal call argument honours a user break after the paren`` () =
+    formatSourceString
+        """
+let x =
+    builder.Build().Configure(
+        function
+        | Some v -> handleSome v
+        | None -> handleNone ())
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x =
+    builder
+        .Build()
+        .Configure(
+            function
+            | Some v -> handleSome v
+            | None -> handleNone ()
+        )
 """

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -683,7 +683,7 @@ let x =
 """
 
 [<Test>]
-let ``match lambda as a terminal call argument honours a user break after the paren`` () =
+let ``match lambda as a terminal call argument with the function keyword written below the paren`` () =
     formatSourceString
         """
 let x =
@@ -700,11 +700,9 @@ let x =
 let x =
     builder
         .Build()
-        .Configure(
-            function
+        .Configure(function
             | Some v -> handleSome v
-            | None -> handleNone ()
-        )
+            | None -> handleNone ())
 """
 
 [<Test>]
@@ -730,7 +728,7 @@ let host =
 """
 
 [<Test>]
-let ``a comment before the argument keeps the parenthesis with the method name, however the source was laid out`` () =
+let ``a comment before the argument of a terminal call written on one line`` () =
     formatSourceString
         """
 let host = builder.UseUrls(

--- a/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
+++ b/src/Fantomas.Core.Tests/CompilerDirectivesTests.fs
@@ -3272,8 +3272,7 @@ Program.statefulWithCmdMsg
         CanReuseView = ViewHelper.canReuseView
         SyncAction =
             (fun fn ->
-                program.SyncAction
-                    (
+                program.SyncAction(
 #if IOS
                     // iOS animates by default layout changes, we don't want that
                     fun () -> UIKit.UIView.PerformWithoutAnimation(fn)

--- a/src/Fantomas.Core.Tests/DotGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotGetTests.fs
@@ -1164,11 +1164,9 @@ db.Schema.Users.Query
         """
 db.Schema.Users.Query
     .Where(fun x -> x.Role)
-    .Matches(
-        function
+    .Matches(function
         | Role.User companyId -> companyId
-        | _ -> __
-    )
+        | _ -> __)
     .In(db.Schema.Companies.Query.Where(fun x -> x.LicenceId).Equals(licenceId).Select(fun x -> x.Id))
 """
 

--- a/src/Fantomas.Core.Tests/DotIndexedGetTests.fs
+++ b/src/Fantomas.Core.Tests/DotIndexedGetTests.fs
@@ -20,11 +20,13 @@ foo.Bar(
     |> should
         equal
         """
-foo.Bar(
-    ziggy,
-    jiggy,
-    "looooooooooooooooooooooooooooooooonStringValue"
-).[5]
+foo
+    .Bar(
+        ziggy,
+        jiggy,
+        "looooooooooooooooooooooooooooooooonStringValue"
+    )
+    .[5]
 """
 
 [<Test>]
@@ -38,14 +40,13 @@ myList.[7].SomeFunctionCallOnSeven("looooooooooooooooooooooooooooooooonnggggStri
     |> should
         equal
         """
-myList.[7]
-    .SomeFunctionCallOnSeven(
-        "looooooooooooooooooooooooooooooooonnggggStringArgument",
-        otherArg1,
-        otherArg2,
-        otherArg3,
-        otherArgument4
-    )
+myList.[7].SomeFunctionCallOnSeven(
+    "looooooooooooooooooooooooooooooooonnggggStringArgument",
+    otherArg1,
+    otherArg2,
+    otherArg3,
+    otherArgument4
+)
 """
 
 [<Test>]
@@ -59,14 +60,13 @@ myList.[7].lowerSomeFunctionCallOnSeven("looooooooooooooooooooooooooooooooonnggg
     |> should
         equal
         """
-myList.[7]
-    .lowerSomeFunctionCallOnSeven (
-        "looooooooooooooooooooooooooooooooonnggggStringArgument",
-        otherArg1,
-        otherArg2,
-        otherArg3,
-        otherArgument4
-    )
+myList.[7].lowerSomeFunctionCallOnSeven (
+    "looooooooooooooooooooooooooooooooonnggggStringArgument",
+    otherArg1,
+    otherArg2,
+    otherArg3,
+    otherArgument4
+)
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/DotLambdaTests.fs
+++ b/src/Fantomas.Core.Tests/DotLambdaTests.fs
@@ -174,3 +174,18 @@ workstations
         category
     )
 """
+
+[<Test>]
+let ``no space before unit invocation in chained dot lambda body, 3364`` () =
+    formatSourceString
+        """
+"yow" |> _.Substring(0, 16).ToLower()
+"""
+        { config with
+            SpaceBeforeUppercaseInvocation = true }
+    |> prepend newline
+    |> should
+        equal
+        """
+"yow" |> _.Substring(0, 16).ToLower()
+"""

--- a/src/Fantomas.Core.Tests/DynamicOperatorTests.fs
+++ b/src/Fantomas.Core.Tests/DynamicOperatorTests.fs
@@ -155,8 +155,8 @@ Jest.expect(json)?oMatchSnapshot ()
 """
 
 // A lambda or match-lambda argument is NOT fused into the `?` chain: unlike a plain
-// argument (`x?y (a)`), it stays a normal application so the argument can use the
-// ordinary multiline lambda layout.
+// argument (`obj?y?z (a)`, where the argument ends up inside the chain item), it stays a
+// normal application so the argument can use the ordinary multiline lambda layout.
 
 [<Test>]
 let ``dynamic operator with a lambda argument`` () =

--- a/src/Fantomas.Core.Tests/DynamicOperatorTests.fs
+++ b/src/Fantomas.Core.Tests/DynamicOperatorTests.fs
@@ -153,3 +153,54 @@ Jest.expect(json)?oMatchSnapshot ()
         """
 Jest.expect(json)?oMatchSnapshot ()
 """
+
+// A lambda or match-lambda argument is NOT fused into the `?` chain: unlike a plain
+// argument (`x?y (a)`), it stays a normal application so the argument can use the
+// ordinary multiline lambda layout.
+
+[<Test>]
+let ``dynamic operator with a lambda argument`` () =
+    formatSourceString
+        """
+let a = x?y (fun a -> a)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let a = x?y (fun a -> a)
+"""
+
+[<Test>]
+let ``dynamic operator with a match lambda argument`` () =
+    formatSourceString
+        """
+let b = x?y (function
+             | Some v -> v
+             | None -> 0)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let b =
+    x?y (function
+        | Some v -> v
+        | None -> 0)
+"""
+
+[<Test>]
+let ``dynamic chain with a lambda argument`` () =
+    formatSourceString
+        """
+let c = obj?y?z (fun a -> a)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let c = obj?y?z (fun a -> a)
+"""

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -126,6 +126,7 @@
     <Compile Include="DallasTests.fs" />
     <Compile Include="InlineTests.fs" />
     <Compile Include="ChainTests.fs" />
+    <Compile Include="ChainFormattingTests.fs" />
     <Compile Include="TryWithTests.fs" />
     <Compile Include="CursorTests.fs" />
     <Compile Include="MultipleDefineCombinationsTests.fs" />
@@ -149,5 +150,6 @@
     <PackageReference Include="FsCheck" />
     <PackageReference Include="FsUnit" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
+    <PackageReference Include="AltCover" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Fantomas.Core.Tests/LetBindingTests.fs
+++ b/src/Fantomas.Core.Tests/LetBindingTests.fs
@@ -1321,9 +1321,7 @@ let ``app tuple inside dotget expression`` () =
         """
 (st :> IProvidedCustomAttributeProvider)
     .GetHasTypeProviderEditorHideMethodsAttribute(
-        info
-            .ProvidedType
-            .TypeProvider
+        info.ProvidedType.TypeProvider
             .PUntaintNoFailure(id)
     )
 """

--- a/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -1201,3 +1201,61 @@ let undotted () =
             (anotherLongParameterName: AnotherTypeName) -> body ()
         )
 """
+
+[<Test>]
+let ``lambda that fits on one line after moving down keeps its closing parenthesis`` () =
+    formatSourceString
+        """
+let dotted () =
+    storage.SetConfigurationSettingPublisher(fun configName publisher -> publish configName publisher)
+
+let undotted () =
+    storageSetConfigurationSettingPublisher (fun configName publisher -> publish configName publisher)
+"""
+        { config with MaxLineLength = 70 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let dotted () =
+    storage.SetConfigurationSettingPublisher
+        (fun configName publisher -> publish configName publisher)
+
+let undotted () =
+    storageSetConfigurationSettingPublisher
+        (fun configName publisher -> publish configName publisher)
+"""
+
+[<Test>]
+let ``lambda that still does not fit after moving down puts its closing parenthesis on its own line`` () =
+    formatSourceString
+        """
+let dotted () =
+    storage.SetConfigurationSettingPublisher(fun configName publisher -> publishTheConfigurationValue configName publisher andThenSomethingElse)
+
+let undotted () =
+    storageSetConfigurationSettingPublisher (fun configName publisher -> publishTheConfigurationValue configName publisher andThenSomethingElse)
+"""
+        { config with MaxLineLength = 70 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let dotted () =
+    storage.SetConfigurationSettingPublisher
+        (fun configName publisher ->
+            publishTheConfigurationValue
+                configName
+                publisher
+                andThenSomethingElse
+        )
+
+let undotted () =
+    storageSetConfigurationSettingPublisher
+        (fun configName publisher ->
+            publishTheConfigurationValue
+                configName
+                publisher
+                andThenSomethingElse
+        )
+"""

--- a/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -977,22 +977,23 @@ configuration
         """
 configuration.MinimumLevel
     .Debug()
-    .WriteTo.Logger(fun
-                        (a0: int)
-                        (a1: int)
-                        (a2: int)
-                        (a3: int)
-                        (a4: int)
-                        (a5: int)
-                        (a6: int)
-                        (a7: int)
-                        (a8: int)
-                        (a9: int)
-                        (a10: int)
-                        (a11: int) ->
-        //
-        ()
-    )
+    .WriteTo.Logger
+        (fun
+            (a0: int)
+            (a1: int)
+            (a2: int)
+            (a3: int)
+            (a4: int)
+            (a5: int)
+            (a6: int)
+            (a7: int)
+            (a8: int)
+            (a9: int)
+            (a10: int)
+            (a11: int) ->
+            //
+            ()
+        )
 """
 
 [<Test>]
@@ -1133,4 +1134,72 @@ module Foo =
                 .Create()
 
         ()
+"""
+
+// The two tests below repeat the chain cases from ChainFormattingTests with this setting on.
+// A call reached through a dot is laid out like the same call without one, whatever the setting
+// says about the closing parenthesis.
+
+[<Test>]
+[<Ignore("A call without a dot does not ask whether the lambda opener fits when this setting is on; fixed in the next commit")>]
+let ``lambda moves to its own line when everything up to the arrow does not fit`` () =
+    formatSourceString
+        """
+let dotted ifaces =
+    ifaces
+    |> List.tryPick (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) -> Some(ty, withRange))
+
+let undotted ifaces =
+    ifaces
+    |> pickFromList (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) -> Some(ty, withRange))
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let dotted ifaces =
+    ifaces
+    |> List.tryPick
+        (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) ->
+            Some(ty, withRange)
+        )
+
+let undotted ifaces =
+    ifaces
+    |> pickFromList
+        (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) ->
+            Some(ty, withRange)
+        )
+"""
+
+[<Test>]
+[<Ignore("A call without a dot does not ask whether the lambda opener fits when this setting is on; fixed in the next commit")>]
+let ``lambda parameters take a line each when they do not fit after the lambda moved down`` () =
+    formatSourceString
+        """
+let dotted () =
+    Cfg.register (fun (aVeryLongParameterName: AnEquallyLongTypeName) (anotherLongParameterName: AnotherTypeName) -> body ())
+
+let undotted () =
+    registerWith (fun (aVeryLongParameterName: AnEquallyLongTypeName) (anotherLongParameterName: AnotherTypeName) -> body ())
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let dotted () =
+    Cfg.register
+        (fun
+            (aVeryLongParameterName: AnEquallyLongTypeName)
+            (anotherLongParameterName: AnotherTypeName) -> body ()
+        )
+
+let undotted () =
+    registerWith
+        (fun
+            (aVeryLongParameterName: AnEquallyLongTypeName)
+            (anotherLongParameterName: AnotherTypeName) -> body ()
+        )
 """

--- a/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
+++ b/src/Fantomas.Core.Tests/MultiLineLambdaClosingNewlineTests.fs
@@ -1141,7 +1141,6 @@ module Foo =
 // says about the closing parenthesis.
 
 [<Test>]
-[<Ignore("A call without a dot does not ask whether the lambda opener fits when this setting is on; fixed in the next commit")>]
 let ``lambda moves to its own line when everything up to the arrow does not fit`` () =
     formatSourceString
         """
@@ -1174,7 +1173,6 @@ let undotted ifaces =
 """
 
 [<Test>]
-[<Ignore("A call without a dot does not ask whether the lambda opener fits when this setting is on; fixed in the next commit")>]
 let ``lambda parameters take a line each when they do not fit after the lambda moved down`` () =
     formatSourceString
         """

--- a/src/Fantomas.Core.Tests/SynLongIdentTests.fs
+++ b/src/Fantomas.Core.Tests/SynLongIdentTests.fs
@@ -312,9 +312,7 @@ Rollbar
     |> should
         equal
         """
-Rollbar
-    .RollbarLocator
-    .RollbarInstance
+Rollbar.RollbarLocator.RollbarInstance
     // .AsBlockingLogger(System.TimeSpan.FromSeconds 5)
     .Error(package, custom)
 """

--- a/src/Fantomas.Core.Tests/TypeAnnotationTests.fs
+++ b/src/Fantomas.Core.Tests/TypeAnnotationTests.fs
@@ -574,15 +574,17 @@ XYZ.app<int -> int -> int -> string>.[tellMeWhy { return wouldSomeoneWriteThisCo
     |> should
         equal
         """
-XYZ.app<
-    int
-        -> int
-        -> int
-        -> string
- >.[tellMeWhy {
-    return
-        wouldSomeoneWriteThisCode
-}]
+XYZ
+    .app<
+        int
+            -> int
+            -> int
+            -> string
+      >
+    .[tellMeWhy {
+        return
+            wouldSomeoneWriteThisCode
+    }]
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/TypeAppTests.fs
+++ b/src/Fantomas.Core.Tests/TypeAppTests.fs
@@ -460,15 +460,17 @@ XYZ.app<int -> int -> int -> string>.[tellMeWhy { return wouldSomeoneWriteThisCo
     |> should
         equal
         """
-XYZ.app<
-    int
-        -> int
-        -> int
-        -> string
- >.[tellMeWhy {
-    return
-        wouldSomeoneWriteThisCode
-}]
+XYZ
+    .app<
+        int
+            -> int
+            -> int
+            -> string
+      >
+    .[tellMeWhy {
+        return
+            wouldSomeoneWriteThisCode
+    }]
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/ValidationTests.fs
+++ b/src/Fantomas.Core.Tests/ValidationTests.fs
@@ -33,3 +33,34 @@ let ``should fail on uncompilable extern functions`` () =
 [<System.Runtime.InteropServices.DllImport("user32.dll")>]
 let GetWindowLong hwnd : System.IntPtr, index : int : int = failwith )"""
     |> should equal false
+
+// InvariantViolationException marks a state the transformer's own model says is impossible.
+// It must derive from FormatException: the CLI matches on that type to decide what to print,
+// and anything else falls through to an empty message at normal verbosity.
+
+let private sampleRange =
+    Fantomas.FCS.Text.Range.mkRange
+        "Sample.fs"
+        (Fantomas.FCS.Text.Position.mkPos 7 4)
+        (Fantomas.FCS.Text.Position.mkPos 7 20)
+
+[<Test>]
+let ``InvariantViolationException is reported as a FormatException`` () =
+    let ex = Fantomas.Core.InvariantViolationException("chain head is Foo", sampleRange)
+    ex |> should be instanceOfType<Fantomas.Core.FormatException>
+
+[<Test>]
+let ``InvariantViolationException keeps the bare invariant and points at the issue tracker`` () =
+    let ex = Fantomas.Core.InvariantViolationException("chain head is Foo", sampleRange)
+    ex.Invariant |> should equal "chain head is Foo"
+    ex.Message |> should haveSubstring "chain head is Foo"
+    ex.Message |> should haveSubstring "fsprojects.github.io/fantomas-tools"
+
+[<Test>]
+let ``InvariantViolationException reports where in the source the violation happened`` () =
+    let ex = Fantomas.Core.InvariantViolationException("chain head is Foo", sampleRange)
+    ex.Range |> should equal sampleRange
+    // The location has to survive into the message, because that is all the CLI prints.
+    ex.Message |> should haveSubstring "line 7"
+    ex.Message |> should haveSubstring "column 4"
+    ex.Message |> should haveSubstring "Sample.fs"

--- a/src/Fantomas.Core.Tests/packages.lock.json
+++ b/src/Fantomas.Core.Tests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "altcover": {
+        "type": "Direct",
+        "requested": "[9.0.102, )",
+        "resolved": "9.0.102",
+        "contentHash": "q3Rf5t0M9kXlcO5qhsaAe6NrFSNd5enrhKmF/Ezgmomqw34PbUTbRSYjSDNhS3YGDyUrPTkyPn14EfLDJWztcA=="
+      },
       "FsCheck": {
         "type": "Direct",
         "requested": "[3.3.2, )",

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -291,7 +291,7 @@ let mkInheritConstructor (creationAide: CreationAide) (t: SynType) (e: SynExpr) 
 
 let mkTuple (creationAide: CreationAide) (exprs: SynExpr list) (commas: range list) (m: range) =
     match exprs with
-    | [] -> failwith "SynExpr.Tuple with no elements"
+    | [] -> invariantViolation m "a tuple expression has no elements"
     | head :: tail ->
         let rest =
             assert (tail.Length = commas.Length)
@@ -393,7 +393,7 @@ let mkSynMatchClause creationAide (SynMatchClause(p, eo, e, range, _, trivia)) :
     let arrowRange =
         match trivia.ArrowRange with
         | Some r -> r
-        | None -> failwith $"unable to get the arrow range from trivia in %s{nameof mkSynMatchClause}"
+        | None -> invariantViolation range $"unable to get the arrow range from trivia in %s{nameof mkSynMatchClause}"
 
     MatchClauseNode(
         Option.map (stn "|") trivia.BarRange,
@@ -604,7 +604,10 @@ let (|ElIf|_|) expr =
                         | Some mElse ->
                             match ifNode with
                             | Choice1Of2 ifNode -> Choice2Of2(mElse, ifNode.Range)
-                            | Choice2Of2 _ -> failwith "Cannot merge a second else keyword into existing else if"
+                            | Choice2Of2 _ ->
+                                invariantViolation
+                                    expr.Range
+                                    "cannot merge a second else keyword into existing else if"
                         | None -> ifNode
 
                 (node, e1, thenKw, e2))
@@ -1260,7 +1263,7 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
         let mTuple =
             match List.tryHead exprs, List.tryLast exprs with
             | Some e1, Some e2 -> unionRanges e1.Range e2.Range
-            | _ -> failwith "SynExpr.Tuple with no elements"
+            | _ -> invariantViolation exprRange "a struct tuple expression has no elements"
 
         ExprStructTupleNode(stn "struct" mStruct, mkTuple creationAide exprs commas mTuple, stn ")" mClosing, exprRange)
         |> Expr.StructTuple
@@ -1286,7 +1289,8 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
                 | _ -> None)
 
         match baseInfo, copyInfo with
-        | Some _, Some _ -> failwith "Unexpected that both baseInfo and copyInfo are present in SynExpr.Record"
+        | Some _, Some _ ->
+            invariantViolation exprRange "a record expression has both an inherit and a copy-from source"
         | Some(t, e, m, _, mInherit), None ->
             let inheritCtor = mkInheritConstructor creationAide t e mInherit m
 
@@ -1875,7 +1879,7 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
             [ LinkExpr.Identifier underscore; LinkExpr.Dot mDot; yield! bodyLinks ]
 
         mkChainFromLinks creationAide allLinks ChainTerminal.NoSpaceAllowed exprRange
-    | _ -> failwithf "todo for %A" e
+    | _ -> invariantViolation exprRange "no Oak node is defined for this expression: %A" e
 
 let mkExprQuote creationAide isRaw e range : ExprQuoteNode =
     let startToken, endToken =
@@ -1909,11 +1913,12 @@ let mkUnit (StartEndRange 1 (lpr, m, rpr)) = UnitNode(stn "(" lpr, stn ")" rpr, 
 
 let mkTuplePat (creationAide: CreationAide) (pats: SynPat list) (commas: range list) (m: range) =
     match pats with
-    | [] -> failwith "SynPat.Tuple with no elements"
+    | [] -> invariantViolation m "a tuple pattern has no elements"
     | head :: tail ->
         let rest =
             if tail.Length <> commas.Length then
-                failwith
+                invariantViolation
+                    m
                     $"Number of elements in tail of tuple (%i{tail.Length}) was not equal to number of commas (%i{commas.Length}), at range %O{m}."
 
             List.zip commas tail
@@ -2032,7 +2037,7 @@ let mkPat (creationAide: CreationAide) (p: SynPat) =
         |> Pattern.IsInst
     | SynPat.QuoteExpr(SynExpr.Quote(_, isRaw, e, _, _), _) ->
         mkExprQuote creationAide isRaw e patternRange |> Pattern.QuoteExpr
-    | pat -> failwith $"unexpected pattern: %A{pat}"
+    | pat -> invariantViolation pat.Range $"no Oak node is defined for this pattern: %A{pat}"
 
 let mkBindingReturnInfo creationAide (returnInfo: SynBindingReturnInfo option) =
     Option.bind
@@ -2091,7 +2096,7 @@ let mkBinding
         let equalsRange =
             match trivia.EqualsRange with
             | Some r -> r
-            | None -> failwith $"failed to get equals range in %s{nameof mkBinding}"
+            | None -> invariantViolation pat.Range $"failed to get equals range in %s{nameof mkBinding}"
 
         stn "=" equalsRange
 
@@ -2155,11 +2160,11 @@ let mkExternBinding
     let externNode =
         match trivia.LeadingKeyword with
         | SynLeadingKeyword.Extern mExtern -> stn "extern" mExtern
-        | _ -> failwith "Leading keyword should be extern"
+        | _ -> invariantViolation range "an extern binding has a leading keyword other than `extern`"
 
     let attributesOfReturnType, returnType =
         match returnInfo with
-        | None -> failwith "return info in extern binding should be present"
+        | None -> invariantViolation range "an extern binding has no return type"
         | Some(SynBindingReturnInfo(typeName = t; attributes = a)) ->
             let attrs = mkAttributes creationAide a
 
@@ -2231,7 +2236,7 @@ let mkExternBinding
             longDotId = longDotId
             argPats = SynArgPats.Pats [ SynPat.Tuple(_, ps, _, StartEndRange 1 (mOpen, _, mClose)) ]) ->
             mkSynLongIdent creationAide longDotId, stn "(" mOpen, List.map mkExternPat ps, stn ")" mClose
-        | _ -> failwith "expecting a SynPat.LongIdent for extern binding"
+        | _ -> invariantViolation pat.Range "an extern binding has a head pattern that is not a long identifier"
 
     ExternBindingNode(
         mkXmlDoc xmlDoc,
@@ -2302,7 +2307,7 @@ let mkModuleDecl (creationAide: CreationAide) (decl: SynModuleDecl) =
             declRange
         )
         |> ModuleDecl.NestedModule
-    | decl -> failwithf $"Failed to create ModuleDecl for %A{decl}"
+    | decl -> invariantViolation decl.Range $"no Oak node is defined for this module declaration: %A{decl}"
 
 let mkSynTyparDecl
     (creationAide: CreationAide)
@@ -2315,7 +2320,9 @@ let mkSynTyparDecl
 
     let intersectionConstraintNodes =
         if intersectionConstraints.Length <> trivia.AmpersandRanges.Length then
-            failwith "Unexpected mismatch in SynTyparDecl between intersectionConstraints and AmpersandRanges"
+            invariantViolation
+                typar.Range
+                "a typar declaration has a different number of intersection constraints than ampersands"
         else
             (trivia.AmpersandRanges, intersectionConstraints)
             ||> List.zip
@@ -2381,7 +2388,8 @@ let mkSynRationalConst (creationAide: CreationAide) rc =
         | SynRationalConst.Paren(innerRc, _) -> visit innerRc
         | SynRationalConst.Negate(innerRc, range) ->
             RationalConstNode.Negate(NegateRationalNode(stn "-" range.StartRange, visit innerRc, range))
-        | SynRationalConst.Rational _ -> failwith "SynRationalConst.Rational not wrapped in SynRationalConst.Paren"
+        | SynRationalConst.Rational(range = m) ->
+            invariantViolation m "a rational constant is not wrapped in parentheses"
 
     visit rc
 
@@ -2579,7 +2587,8 @@ let mkType (creationAide: CreationAide) (t: SynType) : Type =
                     Type.Var(mkSynTypar typar), ts
                 | None ->
                     match ts with
-                    | [] -> failwith "SynType.Intersection does not contain typar or any intersectionConstraints"
+                    | [] ->
+                        invariantViolation t.Range "a type intersection contains neither a typar nor any constraints"
                     | head :: tail -> mkType creationAide head, tail
 
             assert (ts.Length = trivia.AmpersandRanges.Length)
@@ -2596,7 +2605,7 @@ let mkType (creationAide: CreationAide) (t: SynType) : Type =
         let nullType = stn "null" mNull |> Type.Var
 
         TypeOrNode(mkType creationAide innerType, stn "|" mBar, nullType, m) |> Type.Or
-    | t -> failwith $"unexpected type: %A{t}"
+    | t -> invariantViolation t.Range $"no Oak node is defined for this type: %A{t}"
 
 [<TailCall>]
 let rec visitOpenL acc decls =
@@ -2670,7 +2679,7 @@ let mkSynLeadingKeyword (lk: SynLeadingKeyword) =
     | SynLeadingKeyword.Val valRange -> mtn [ "val", valRange ]
     | SynLeadingKeyword.New newRange -> mtn [ "new", newRange ]
     | SynLeadingKeyword.Do doRange -> mtn [ "do", doRange ]
-    | SynLeadingKeyword.Synthetic -> failwith "Unexpected SynLeadingKeyword.Synthetic"
+    | SynLeadingKeyword.Synthetic -> invariantViolation lk.Range "a synthetic leading keyword reached the transformer"
 
 let mkSynField
     (creationAide: CreationAide)
@@ -2774,7 +2783,8 @@ let mkTypeDefn
                 | SynTypeDefnLeadingKeyword.Type mType -> stn "type" mType
                 | SynTypeDefnLeadingKeyword.And mAnd -> stn "and" mAnd
                 | SynTypeDefnLeadingKeyword.StaticType _
-                | SynTypeDefnLeadingKeyword.Synthetic -> failwithf "unexpected %A" trivia.LeadingKeyword
+                | SynTypeDefnLeadingKeyword.Synthetic ->
+                    invariantViolation range "unexpected leading keyword %A" trivia.LeadingKeyword
 
             let implicitConstructorNode =
                 match implicitConstructor with
@@ -2875,7 +2885,7 @@ let mkTypeDefn
             | SynTypeDefnKind.Class, StartRange 5 (mClass, _) -> stn "class" mClass
             | SynTypeDefnKind.Interface, StartRange 9 (mInterface, _) -> stn "interface" mInterface
             | SynTypeDefnKind.Struct, StartRange 6 (mStruct, _) -> stn "struct" mStruct
-            | _ -> failwith "unexpected kind"
+            | _ -> invariantViolation range "unexpected type definition kind"
 
         let objectMembers =
             objectMembers
@@ -2932,7 +2942,7 @@ let mkTypeDefn
             [ yield! objectMembers; yield! members ]
 
         TypeDefnRegularNode(typeNameNode, allMembers, typeDefnRange) |> TypeDefn.Regular
-    | _ -> failwithf $"Could not create a TypeDefn for %A{typeRepr}"
+    | _ -> invariantViolation range $"no Oak node is defined for this type definition: %A{typeRepr}"
 
 let mkWithGetSet
     (withKeyword: range option)
@@ -3024,7 +3034,10 @@ let mkPropertyGetSetBinding
 
                 [ tuplePat
                   match List.tryLast ps with
-                  | None -> failwith ""
+                  | None ->
+                      invariantViolation
+                          binding.RangeOfBindingWithRhs
+                          "an indexed property setter has no indexer pattern"
                   | Some indexerPat -> mkPat creationAide indexerPat ]
             | [ SynPat.Tuple(false, [ p1; p2 ], _, _) ] -> [ mkPat creationAide p1; mkPat creationAide p2 ]
             | ps -> List.map (mkPat creationAide) ps
@@ -3042,7 +3055,10 @@ let mkPropertyGetSetBinding
             mkExpr creationAide e,
             range
         )
-    | _ -> failwith "SynBinding does not expected information for PropertyGetSetBinding"
+    | _ ->
+        invariantViolation
+            binding.RangeOfBindingWithRhs
+            "a property get/set binding is missing the information the printer needs"
 
 let mkMemberDefn (creationAide: CreationAide) (md: SynMemberDefn) =
     let memberDefinitionRange = md.Range
@@ -3117,7 +3133,7 @@ let mkMemberDefn (creationAide: CreationAide) (md: SynMemberDefn) =
                 memberDefinitionRange
             )
             |> MemberDefn.Inherit
-        | None -> failwith "successful parse shouldn't have any unfinished inherit"
+        | None -> invariantViolation md.Range "a successful parse produced an unfinished inherit member"
     | SynMemberDefn.ValField(f, _) -> mkSynField creationAide f |> MemberDefn.ValField
     | SynMemberDefn.LetBindings(
         bindings = [ SynBinding(trivia = { LeadingKeyword = SynLeadingKeyword.Extern _ }) as binding ]) ->
@@ -3354,8 +3370,8 @@ let mkMemberDefn (creationAide: CreationAide) (md: SynMemberDefn) =
                 memberDefinitionRange
             )
             |> MemberDefn.PropertyGetSet
-        | _ -> failwith "SynMemberDefn.GetSetMember cannot exist with get and without set"
-    | _ -> failwithf "Unexpected SynMemberDefn: %A" md
+        | _ -> invariantViolation md.Range "a get/set member has a getter but no setter"
+    | _ -> invariantViolation md.Range "no Oak node is defined for this member definition: %A" md
 
 let mkVal
     (creationAide: CreationAide)
@@ -3403,7 +3419,7 @@ let mkMemberSig (creationAide: CreationAide) (ms: SynMemberSig) =
         MemberDefnInheritNode(stn "inherit" mInherit, mkType creationAide t, memberSigRange)
         |> MemberDefn.Inherit
     | SynMemberSig.ValField(f, _) -> mkSynField creationAide f |> MemberDefn.ValField
-    | _ -> failwithf "Cannot construct node for %A" ms
+    | _ -> invariantViolation ms.Range "no Oak node is defined for this member signature: %A" ms
 
 [<TailCall>]
 let rec mkModuleDecls
@@ -3599,7 +3615,7 @@ let mkModuleSigDecl (creationAide: CreationAide) (decl: SynModuleSigDecl) =
         )
         |> ModuleDecl.NestedModule
     | SynModuleSigDecl.Val(valSig, _) -> mkVal creationAide valSig |> ModuleDecl.Val
-    | decl -> failwithf $"Failed to create ModuleDecl for %A{decl}"
+    | decl -> invariantViolation decl.Range $"no Oak node is defined for this signature declaration: %A{decl}"
 
 let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRepr, members, range, trivia)) : TypeDefn =
     let typeNameNode =
@@ -3613,7 +3629,8 @@ let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRep
                 | SynTypeDefnLeadingKeyword.Type mType -> stn "type" mType
                 | SynTypeDefnLeadingKeyword.And mAnd -> stn "and" mAnd
                 | SynTypeDefnLeadingKeyword.StaticType _
-                | SynTypeDefnLeadingKeyword.Synthetic -> failwithf "unexpected %A" trivia.LeadingKeyword
+                | SynTypeDefnLeadingKeyword.Synthetic ->
+                    invariantViolation range "unexpected leading keyword %A" trivia.LeadingKeyword
 
             let m =
                 if not px.IsEmpty then
@@ -3713,7 +3730,7 @@ let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRep
             | SynTypeDefnKind.Class, StartRange 5 (mClass, _) -> stn "class" mClass
             | SynTypeDefnKind.Interface, StartRange 9 (mInterface, _) -> stn "interface" mInterface
             | SynTypeDefnKind.Struct, StartRange 6 (mStruct, _) -> stn "struct" mStruct
-            | _ -> failwith "unexpected kind"
+            | _ -> invariantViolation range "unexpected type definition kind"
 
         let objectMembers = objectMembers |> List.map (mkMemberSig creationAide)
 
@@ -3759,7 +3776,7 @@ let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRep
             [ yield! objectMembers; yield! members ]
 
         TypeDefnRegularNode(typeNameNode, allMembers, typeDefnRange) |> TypeDefn.Regular
-    | _ -> failwithf "Could not create a TypeDefn for %A" typeRepr
+    | _ -> invariantViolation range "no Oak node is defined for this type definition: %A" typeRepr
 
 [<TailCall>]
 let rec mkModuleSigDecls

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -992,7 +992,8 @@ let rec visitChainLinks (e: SynExpr) (continuation: LinkExpr list -> LinkExpr li
 
 /// Convert a LinkExpr list (produced by visitChainLinks) into an ExprChain.
 /// mkTerminal maps a ChainCall to the appropriate ChainTerminal case —
-/// use ChainTerminal.SpaceAllowed for regular chains, ChainTerminal.NoSpaceAllowed for DotLambda bodies.
+/// use ChainTerminal.SpaceAllowed for regular chains, ChainTerminal.NoSpaceAllowed wherever the chain
+/// must stay atomic: DotLambda bodies and the positions handled by `mkAtomicExpr`.
 ///
 /// This is the ONLY place an ExprChain with segments is built, so it is also the only place
 /// that has to uphold the chain invariant: **the head contains no dotted content**. Every dot
@@ -1009,7 +1010,8 @@ let mkChainFromLinks
 
     // The first link is the receiver; everything after it is dotted content. Because
     // visitChainLinks has already peeled every dot out into its own `Dot` link, whatever
-    // lands here is dot-free and can be used as the head as-is.
+    // lands here is dot-free: a plain receiver becomes the head directly, while a call
+    // receiver is wrapped in a zero-segment chain (see the AppUnit / AppParen arms below).
     let head, rest =
         match links with
         | LinkExpr.Identifier e :: rest -> mkExpr creationAide e, rest
@@ -1054,10 +1056,6 @@ let mkChainFromLinks
     // rather than silently dropping links.
     let rec processLinks (remainingLinks: LinkExpr list) : ChainSegment list * ChainTerminal =
         match remainingLinks with
-        // Only reachable for a chain with no segments at all. `visitChainLinks` never
-        // produces this (every chain it matches has at least one dot) and the recursion
-        // below always stops at a two-element arm, so this is the base case for
-        // completeness rather than a path exercised by real source.
         // Unreachable: every chain has at least one dot, and the recursion below always stops
         // at one of the two-element arms, so an empty remainder is never passed in.
         | [] -> invariantViolation range "a chain was built with no dotted content at all"
@@ -1125,12 +1123,22 @@ let mkChainFromLinks
     ExprChain(head, segments, terminal, range) |> Expr.Chain
 
 [<return: Struct>]
-let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list voption =
-    let (|DottedLongIdent|_|) (sli: SynLongIdent) =
-        match sli.IdentsWithTrivia with
-        | _ :: _ :: _ when sli.Dots.Length > 0 -> ValueSome()
-        | _ -> ValueNone
+let (|DottedLongIdent|_|) (sli: SynLongIdent) =
+    match sli.IdentsWithTrivia with
+    | _ :: _ :: _ when sli.Dots.Length > 0 -> ValueSome()
+    | _ -> ValueNone
 
+/// A function expression that carries dotted content, so the application around it is a chain.
+[<return: Struct>]
+let (|DottedFunctionExpr|_|) (e: SynExpr) : unit voption =
+    match e with
+    | SynExpr.LongIdent(isOptional = false; longDotId = DottedLongIdent)
+    | SynExpr.DotGet _
+    | SynExpr.TypeApp(expr = SynExpr.DotGet _) -> ValueSome()
+    | _ -> ValueNone
+
+[<return: Struct>]
+let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list voption =
     match e with
     // A plain LongIdent with dots (e.g. `a.b.c`) is a chain of property accesses.
     // An *optional* one (`?a.b`) is not: the `?` belongs to the whole path and the chain
@@ -1163,11 +1171,13 @@ let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list voption =
     | _ -> ValueNone
 
 [<return: Struct>]
-// Note: no guard is needed against a dotted function expression (`a.Foo(x, y)`). The only
-// use site sits directly after the `ChainExpr` arm in `mkExpr`, and a chain claims every
-// `App(DotGet, Paren _)` before this pattern is ever tried.
+// A dotted function expression (`a.Foo(x, y)`) belongs to `ChainExpr`, and this pattern
+// declines it here rather than relying on `mkExpr` trying `ChainExpr` first. The result is
+// the same either way, but the pattern then holds on its own instead of depending on where
+// it is used.
 let (|AppSingleParenArg|_|) =
     function
+    | App(DottedFunctionExpr, _) -> ValueNone
     | App(e, [ UnitExpr _ as px ]) -> ValueSome(e, px)
     | App(e, [ SynExpr.Paren(expr = singleExpr) as px ]) ->
         match singleExpr with

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -1143,8 +1143,12 @@ let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list voption =
     | SynExpr.App(
         isInfix = false; funcExpr = SynExpr.LongIdent(longDotId = DottedLongIdent); argExpr = (ParenExpr _ | UnitExpr _)) ->
         ValueSome(visitChainLinks e id)
-    // An identifier-only application with a paren lambda (e.g. `List.map (fun n -> n)`)
-    // is NOT considered a chain because the identifier is not complex.
+    // An application with a paren lambda and a dot-less function expression (e.g. `map (fun n -> n)`)
+    // is NOT considered a chain: there is nothing to chain. The dotted `List.map (fun n -> n)`
+    // never reaches here — the arm above already claimed it.
+    // The one dotted shape that does land here is `DotGet(TypeApp(Ident))`
+    // (`MailboxProcessor<string>.Start (fun ...)`): it deliberately stays an `AppWithLambda`
+    // rather than becoming a chain, so it keeps the space before its argument.
     | SynExpr.App(
         isInfix = false
         funcExpr = SynExpr.LongIdent _ | SynExpr.Ident _ | SynExpr.DotGet(expr = SynExpr.TypeApp(expr = SynExpr.Ident _))

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -11,6 +11,12 @@ open Fantomas.Core.RangePatterns
 open Fantomas.Core.SyntaxOak
 open Microsoft.FSharp.Core
 
+/// Raise an <see cref="T:Fantomas.Core.InvariantViolationException"/> with a printf-style
+/// message. Use this instead of `failwith` when a branch is unreachable by construction, so
+/// that the CLI reports something actionable rather than an empty message.
+let invariantViolation (range: range) format =
+    Printf.kprintf (fun msg -> raise (InvariantViolationException(msg, range))) format
+
 [<NoComparison>]
 type CreationAide =
     { SourceText: ISourceText option }
@@ -669,7 +675,6 @@ type LinkExpr =
         SynExpr
     | Dot of range
     | Expr of SynExpr
-    | AppParenLambda of functionName: SynExpr * parenLambda: SynExpr
     | AppParen of functionName: SynExpr * lpr: range * e: SynExpr * rpr: range * pr: range
     | AppUnit of functionName: SynExpr * unit: range
     | IndexExpr of indexExpr: SynExpr
@@ -685,10 +690,14 @@ let mkLinksFromSynLongIdent (sli: SynLongIdent) : LinkExpr list =
         | LinkExpr.Identifier identifierExpr -> identifierExpr.Range.StartLine, identifierExpr.Range.StartColumn
         | LinkExpr.Dot m -> m.StartLine, m.StartColumn
         | LinkExpr.Expr _
-        | LinkExpr.AppParenLambda _
         | LinkExpr.AppParen _
         | LinkExpr.AppUnit _
-        | LinkExpr.IndexExpr _ -> -1, -1)
+        // mkLinksFromSynLongIdent only ever builds Identifier and Dot links, so no other
+        // case can reach the sort key.
+        | LinkExpr.IndexExpr _ ->
+            invariantViolation
+                sli.Range
+                "mkLinksFromSynLongIdent produced a link that is neither an Identifier nor a Dot")
 
 [<return: Struct>]
 let (|UnitExpr|_|) e =
@@ -704,6 +713,8 @@ let (|DynamicChainArg|_|) (e: SynExpr) =
     | SynExpr.Const(constant = SynConst.Unit) -> ValueSome e
     | SynExpr.Paren(expr = inner) ->
         match inner with
+        // A lambda argument (`x?y (fun a -> a)`) is not fused into the `?` chain: it is a
+        // normal application whose argument needs the ordinary multiline lambda layout.
         | SynExpr.Lambda _
         | SynExpr.MatchLambda _ -> ValueNone
         | _ -> ValueSome e
@@ -750,8 +761,10 @@ let mkLinksFromFunctionName (mkLinkFromExpr: SynExpr -> LinkExpr) (functionName:
                       typeArgsRange,
                       _) ->
         match sli.IdentsWithTrivia with
+        // A generic function name only reaches here from a dotted chain, so it always has
+        // at least two identifiers (`a.Foo<T>`); `Foo<T>` on its own is not a chain.
         | []
-        | [ _ ] -> [ mkLinkFromExpr functionName ]
+        | [ _ ] -> invariantViolation functionName.Range "generic function name %A has fewer than two identifiers" sli
         | synIdents ->
             let leftLinks = mkLinksFromSynLongIdent sli
             let lastSynIdent = List.last synIdents
@@ -775,8 +788,10 @@ let mkLinksFromFunctionName (mkLinkFromExpr: SynExpr -> LinkExpr) (functionName:
 
     | SynExpr.LongIdent(longDotId = sli) ->
         match sli.IdentsWithTrivia with
+        // Likewise a plain function name: an undotted `f(x)` never becomes a chain, so by the
+        // time we are building links there are always at least two identifiers.
         | []
-        | [ _ ] -> [ mkLinkFromExpr functionName ]
+        | [ _ ] -> invariantViolation functionName.Range "function name %A has fewer than two identifiers" sli
         | synIdents ->
             let leftLinks = mkLinksFromSynLongIdent sli
             let lastSynIdent = List.last synIdents
@@ -785,188 +800,348 @@ let mkLinksFromFunctionName (mkLinkFromExpr: SynExpr -> LinkExpr) (functionName:
               yield (mkLongIdentExprFromSynIdent lastSynIdent |> mkLinkFromExpr) ]
     | e -> [ mkLinkFromExpr e ]
 
-[<return: Struct>]
-let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list voption =
-    let rec visit (e: SynExpr) (continuation: LinkExpr list -> LinkExpr list) =
-        match e with
-        | SynExpr.App(
-            isInfix = false
-            funcExpr = SynExpr.TypeApp(SynExpr.DotGet _ as funcExpr,
-                                       lessRange,
-                                       typeArgs,
-                                       commaRanges,
-                                       Some greaterRange,
-                                       typeArgsRange,
-                                       _)
-            argExpr = ParenExpr _ | UnitExpr _ as argExpr) ->
-            visit funcExpr (fun leftLinks ->
-                let lastLink =
-                    match List.tryLast leftLinks with
-                    | Some(LinkExpr.Identifier identifierExpr) ->
-                        let typeApp =
-                            SynExpr.TypeApp(
-                                identifierExpr,
-                                lessRange,
-                                typeArgs,
-                                commaRanges,
-                                Some greaterRange,
-                                typeArgsRange,
-                                unionRanges identifierExpr.Range greaterRange
-                            )
+/// Visits a SynExpr and produces a flat LinkExpr list representing the chain links.
+/// Exposed at module level so that SynExpr.DotLambda handling can reuse the same logic.
+let rec visitChainLinks (e: SynExpr) (continuation: LinkExpr list -> LinkExpr list) =
+    match e with
+    | SynExpr.App(
+        isInfix = false
+        funcExpr = SynExpr.TypeApp(SynExpr.DotGet _ as funcExpr,
+                                   lessRange,
+                                   typeArgs,
+                                   commaRanges,
+                                   Some greaterRange,
+                                   typeArgsRange,
+                                   _)
+        argExpr = ParenExpr _ | UnitExpr _ as argExpr) ->
+        visitChainLinks funcExpr (fun leftLinks ->
+            let lastLink =
+                match List.tryLast leftLinks with
+                | Some(LinkExpr.Identifier identifierExpr) ->
+                    let typeApp =
+                        SynExpr.TypeApp(
+                            identifierExpr,
+                            lessRange,
+                            typeArgs,
+                            commaRanges,
+                            Some greaterRange,
+                            typeArgsRange,
+                            unionRanges identifierExpr.Range greaterRange
+                        )
 
-                        match argExpr with
-                        | UnitExpr mUnit -> [ LinkExpr.AppUnit(typeApp, mUnit) ]
-                        | ParenExpr(lpr, innerExpr, rpr, pr) -> [ LinkExpr.AppParen(typeApp, lpr, innerExpr, rpr, pr) ]
-                        | _ -> []
-                    | _ -> []
+                    match argExpr with
+                    | UnitExpr mUnit -> [ LinkExpr.AppUnit(typeApp, mUnit) ]
+                    | ParenExpr(lpr, innerExpr, rpr, pr) -> [ LinkExpr.AppParen(typeApp, lpr, innerExpr, rpr, pr) ]
+                    // Unreachable: the outer pattern already constrained argExpr to Paren or Unit.
+                    | _ ->
+                        invariantViolation
+                            e.Range
+                            "generic call argument %A is neither a unit nor a parenthesised expression"
+                            argExpr
+                // Unreachable: visiting a DotGet always ends the link list with an Identifier.
+                | _ ->
+                    invariantViolation
+                        e.Range
+                        "generic call has no identifier to attach its type arguments to (links: %A)"
+                        leftLinks
 
-                let leftLinks = List.cutOffLast leftLinks
+            let leftLinks = List.cutOffLast leftLinks
+            continuation [ yield! leftLinks; yield! lastLink ])
 
-                continuation [ yield! leftLinks; yield! lastLink ])
-
-        | SynExpr.TypeApp(SynExpr.DotGet _ as dotGet,
+    | SynExpr.TypeApp(SynExpr.DotGet _ as dotGet, lessRange, typeArgs, commaRanges, Some greaterRange, typeArgsRange, _) ->
+        visitChainLinks dotGet (fun leftLinks ->
+            let lastLink =
+                match List.tryLast leftLinks with
+                | Some(LinkExpr.Identifier property) ->
+                    [ SynExpr.TypeApp(
+                          property,
                           lessRange,
                           typeArgs,
                           commaRanges,
                           Some greaterRange,
                           typeArgsRange,
-                          _) ->
-            visit dotGet (fun leftLinks ->
-                let lastLink =
-                    match List.tryLast leftLinks with
-                    | Some(LinkExpr.Identifier property) ->
-                        [ SynExpr.TypeApp(
-                              property,
-                              lessRange,
-                              typeArgs,
-                              commaRanges,
-                              Some greaterRange,
-                              typeArgsRange,
-                              unionRanges property.Range greaterRange
-                          )
-                          |> LinkExpr.Identifier ]
-                    | _ -> []
+                          unionRanges property.Range greaterRange
+                      )
+                      |> LinkExpr.Identifier ]
+                // Unreachable: visiting a DotGet always ends the link list with an Identifier.
+                | _ ->
+                    invariantViolation e.Range "type application has no identifier to attach to (links: %A)" leftLinks
 
-                let leftLinks = List.cutOffLast leftLinks
-                continuation [ yield! leftLinks; yield! lastLink ])
+            let leftLinks = List.cutOffLast leftLinks
+            continuation [ yield! leftLinks; yield! lastLink ])
 
-        // Transform `x().y[0]` into `x()` , `dot`, `y[0]`
-        | IndexWithoutDot(SynExpr.DotGet(expr, mDot, sli, _), indexExpr) ->
-            visit expr (fun leftLinks ->
-                let middleLinks, lastExpr =
-                    match List.tryLast sli.IdentsWithTrivia with
-                    | None -> [], indexExpr
-                    | Some lastMiddleLink ->
-                        let middleLinks = mkLinksFromSynLongIdent sli |> List.cutOffLast
+    // Transform `x().y[0]` into `x()` , `dot`, `y[0]`
+    | IndexWithoutDot(SynExpr.DotGet(expr, mDot, sli, _), indexExpr) ->
+        visitChainLinks expr (fun leftLinks ->
+            let middleLinks, lastExpr =
+                match List.tryLast sli.IdentsWithTrivia with
+                // Unreachable: a DotGet always carries at least one identifier after its dot.
+                | None -> invariantViolation e.Range "indexed member access has no identifier after the dot (%A)" sli
+                | Some lastMiddleLink ->
+                    let middleLinks = mkLinksFromSynLongIdent sli |> List.cutOffLast
 
-                        let indexWithDotExpr =
-                            let identifierExpr = mkLongIdentExprFromSynIdent lastMiddleLink
+                    let indexWithDotExpr =
+                        let identifierExpr = mkLongIdentExprFromSynIdent lastMiddleLink
 
-                            // Create an adjacent range for the `[`,`]` in the index expression.
-                            let adjacentRange =
-                                mkRange
-                                    indexExpr.Range.FileName
-                                    (Position.mkPos
-                                        identifierExpr.Range.StartLine
-                                        (identifierExpr.Range.StartColumn + 1))
-                                    (Position.mkPos indexExpr.Range.EndLine (indexExpr.Range.EndColumn - 1))
+                        // Create an adjacent range for the `[`,`]` in the index expression.
+                        let adjacentRange =
+                            mkRange
+                                indexExpr.Range.FileName
+                                (Position.mkPos identifierExpr.Range.StartLine (identifierExpr.Range.StartColumn + 1))
+                                (Position.mkPos indexExpr.Range.EndLine (indexExpr.Range.EndColumn - 1))
 
-                            SynExpr.App(
-                                ExprAtomicFlag.Atomic,
-                                false,
-                                identifierExpr,
-                                SynExpr.ArrayOrListComputed(false, indexExpr, adjacentRange),
-                                unionRanges identifierExpr.Range indexExpr.Range
-                            )
+                        SynExpr.App(
+                            ExprAtomicFlag.Atomic,
+                            false,
+                            identifierExpr,
+                            SynExpr.ArrayOrListComputed(false, indexExpr, adjacentRange),
+                            unionRanges identifierExpr.Range indexExpr.Range
+                        )
 
-                        middleLinks, indexWithDotExpr
+                    middleLinks, indexWithDotExpr
 
-                continuation
-                    [ yield! leftLinks
-                      yield LinkExpr.Dot mDot
-                      yield! middleLinks
-                      yield LinkExpr.Expr lastExpr ])
+            continuation
+                [ yield! leftLinks
+                  yield LinkExpr.Dot mDot
+                  yield! middleLinks
+                  yield LinkExpr.Expr lastExpr ])
 
-        | SynExpr.App(isInfix = false; funcExpr = SynExpr.DotGet _ as funcExpr; argExpr = argExpr) ->
-            visit funcExpr (fun leftLinks ->
+    | SynExpr.App(isInfix = false; funcExpr = SynExpr.DotGet _ as funcExpr; argExpr = argExpr) ->
+        visitChainLinks funcExpr (fun leftLinks ->
+            match List.tryLast leftLinks with
+            | Some(LinkExpr.Identifier(identifierExpr)) ->
+                match argExpr with
+                | UnitExpr mUnit ->
+                    let leftLinks = List.cutOffLast leftLinks
+
+                    // Compose a function application by taking the last identifier of the SynExpr.DotGet
+                    // and the following argument expression.
+                    // Example: X().Y() -> Take `Y` as function name and `()` as argument.
+                    let rightLink = LinkExpr.AppUnit(identifierExpr, mUnit)
+
+                    continuation [ yield! leftLinks; yield rightLink ]
+
+                | ParenExpr(lpr, e, rpr, pr) ->
+                    let leftLinks = List.cutOffLast leftLinks
+                    // Example: A().B(fun b -> b)
+                    let rightLink = LinkExpr.AppParen(identifierExpr, lpr, e, rpr, pr)
+                    continuation [ yield! leftLinks; yield rightLink ]
+
+                // Unreachable: `(|ChainExpr|_|)` only routes Unit/Paren arguments here, and a
+                // dot-lambda body cannot be a space-separated application.
+                | _ ->
+                    invariantViolation
+                        e.Range
+                        "call argument %A is neither a unit nor a parenthesised expression"
+                        argExpr
+            // Unreachable: visiting a DotGet always ends the link list with an Identifier.
+            | _ -> invariantViolation e.Range "call has no identifier to apply its argument to (links: %A)" leftLinks)
+
+    | SynExpr.DotGet(expr, rangeOfDot, longDotId, _) ->
+        visitChainLinks expr (fun links ->
+            continuation
+                [ yield! links
+                  yield LinkExpr.Dot rangeOfDot
+                  yield! mkLinksFromSynLongIdent longDotId ])
+
+    | SynExpr.App(isInfix = false; funcExpr = funcExpr; argExpr = UnitExpr mUnit) ->
+        mkLinksFromFunctionName (fun e -> LinkExpr.AppUnit(e, mUnit)) funcExpr
+        |> continuation
+
+    | SynExpr.App(isInfix = false; funcExpr = funcExpr; argExpr = ParenExpr(lpr, e, rpr, pr)) ->
+        mkLinksFromFunctionName (fun f -> LinkExpr.AppParen(f, lpr, e, rpr, pr)) funcExpr
+        |> continuation
+
+    | SynExpr.App(ExprAtomicFlag.Atomic, false, (SynExpr.LongIdent _ as funcExpr), (SynExpr.ArrayOrList _ as argExpr), _) ->
+        visitChainLinks funcExpr (fun leftLinks ->
+            let app =
                 match List.tryLast leftLinks with
-                | Some(LinkExpr.Identifier(identifierExpr)) ->
-                    match argExpr with
-                    | UnitExpr mUnit ->
-                        let leftLinks = List.cutOffLast leftLinks
+                | Some(LinkExpr.Identifier identifier) ->
+                    [ SynExpr.App(
+                          ExprAtomicFlag.Atomic,
+                          false,
+                          identifier,
+                          argExpr,
+                          unionRanges identifier.Range argExpr.Range
+                      )
+                      |> LinkExpr.Expr ]
+                // Unreachable: visiting a LongIdent always ends the link list with an Identifier.
+                | _ ->
+                    invariantViolation e.Range "indexed application has no identifier to index (links: %A)" leftLinks
 
-                        // Compose a function application by taking the last identifier of the SynExpr.DotGet
-                        // and the following argument expression.
-                        // Example: X().Y() -> Take `Y` as function name and `()` as argument.
-                        let rightLink = LinkExpr.AppUnit(identifierExpr, mUnit)
+            let leftLinks = List.cutOffLast leftLinks
+            continuation [ yield! leftLinks; yield! app ])
 
-                        continuation [ yield! leftLinks; yield rightLink ]
+    | SynExpr.TypeApp _ as typeApp -> mkLinksFromFunctionName LinkExpr.Identifier typeApp |> continuation
 
-                    | ParenExpr(lpr, e, rpr, pr) ->
-                        let leftLinks = List.cutOffLast leftLinks
-                        // Example: A().B(fun b -> b)
-                        let rightLink = LinkExpr.AppParen(identifierExpr, lpr, e, rpr, pr)
-                        continuation [ yield! leftLinks; yield rightLink ]
+    | SynExpr.LongIdent(longDotId = sli) -> continuation (mkLinksFromSynLongIdent sli)
 
-                    | _ -> visit argExpr (fun rightLinks -> continuation [ yield! leftLinks; yield! rightLinks ])
-                | _ -> visit argExpr (fun rightLinks -> continuation [ yield! leftLinks; yield! rightLinks ]))
+    | SynExpr.Ident _ -> continuation [ LinkExpr.Identifier e ]
 
-        | SynExpr.DotGet(expr, rangeOfDot, longDotId, _) ->
-            visit expr (fun links ->
-                continuation
-                    [ yield! links
-                      yield LinkExpr.Dot rangeOfDot
-                      yield! mkLinksFromSynLongIdent longDotId ])
+    | SynExpr.DotIndexedGet(objectExpr, indexArgs, dotRange, _) ->
+        visitChainLinks objectExpr (fun leftLinks ->
+            continuation
+                [ yield! leftLinks
+                  yield LinkExpr.Dot dotRange
+                  yield LinkExpr.IndexExpr indexArgs ])
 
-        | SynExpr.App(isInfix = false; funcExpr = funcExpr; argExpr = UnitExpr mUnit) ->
-            mkLinksFromFunctionName (fun e -> LinkExpr.AppUnit(e, mUnit)) funcExpr
-            |> continuation
+    | other -> continuation [ LinkExpr.Expr other ]
 
-        | SynExpr.App(isInfix = false; funcExpr = funcExpr; argExpr = ParenExpr(lpr, e, rpr, pr)) ->
-            mkLinksFromFunctionName (fun f -> LinkExpr.AppParen(f, lpr, e, rpr, pr)) funcExpr
-            |> continuation
+/// Convert a LinkExpr list (produced by visitChainLinks) into an ExprChain.
+/// mkTerminal maps a ChainCall to the appropriate ChainTerminal case —
+/// use ChainTerminal.SpaceAllowed for regular chains, ChainTerminal.NoSpaceAllowed for DotLambda bodies.
+///
+/// This is the ONLY place an ExprChain with segments is built, so it is also the only place
+/// that has to uphold the chain invariant: **the head contains no dotted content**. Every dot
+/// in the source becomes a ChainSegment, so a receiver like `List.map` is split into
+/// `head = List` plus `DotMember(., map)` rather than being kept as one opaque LongIdent.
+/// The CodePrinter relies on this — it decides where to break by counting segments, and a
+/// dot hidden inside the head would be invisible to that count.
+let mkChainFromLinks
+    (creationAide: CreationAide)
+    (links: LinkExpr list)
+    (mkTerminal: ChainCall -> ChainTerminal)
+    (range: range)
+    : Expr =
 
-        | SynExpr.App(ExprAtomicFlag.Atomic,
-                      false,
-                      (SynExpr.LongIdent _ as funcExpr),
-                      (SynExpr.ArrayOrList _ as argExpr),
-                      _) ->
-            visit funcExpr (fun leftLinks ->
-                let app =
-                    match List.tryLast leftLinks with
-                    | Some(LinkExpr.Identifier identifier) ->
-                        [ SynExpr.App(
-                              ExprAtomicFlag.Atomic,
-                              false,
-                              identifier,
-                              argExpr,
-                              unionRanges identifier.Range argExpr.Range
-                          )
-                          |> LinkExpr.Expr ]
-                    | _ -> []
+    // The first link is the receiver; everything after it is dotted content. Because
+    // visitChainLinks has already peeled every dot out into its own `Dot` link, whatever
+    // lands here is dot-free and can be used as the head as-is.
+    let head, rest =
+        match links with
+        | LinkExpr.Identifier e :: rest -> mkExpr creationAide e, rest
+        | LinkExpr.Expr e :: rest -> mkExpr creationAide e, rest
+        | LinkExpr.AppUnit(f, mUnit) :: rest ->
+            // A function call like X() is the receiver of a dotted chain (e.g. X().Y).
+            // Use NoSpaceAllowed so the head always prints tight — a space before () would
+            // change the parse (X ().Y parses as X (().Y), not (X ()).Y).
+            // The result is a chain with ZERO segments: it exists only to pair a callee with
+            // its argument under a terminal that forbids the space.
+            let headChain =
+                ExprChain(
+                    mkExpr creationAide f,
+                    [],
+                    ChainTerminal.NoSpaceAllowed(ChainCall.Unit(mkUnit mUnit)),
+                    unionRanges f.Range mUnit
+                )
 
-                let leftLinks = List.cutOffLast leftLinks
-                continuation [ yield! leftLinks; yield! app ])
+            Expr.Chain headChain, rest
+        | LinkExpr.AppParen(f, lpr, e, rpr, pr) :: rest ->
+            // Similarly, X(args) as the chain receiver must be tight.
+            let headChain =
+                ExprChain(
+                    mkExpr creationAide f,
+                    [],
+                    ChainTerminal.NoSpaceAllowed(ChainCall.Paren(mkParenExpr creationAide lpr e rpr pr)),
+                    unionRanges f.Range pr
+                )
 
-        | SynExpr.TypeApp _ as typeApp -> mkLinksFromFunctionName LinkExpr.Identifier typeApp |> continuation
+            Expr.Chain headChain, rest
+        | other -> invariantViolation range "chain head is %A, which is not a receiver the model allows" other
 
-        | SynExpr.LongIdent(longDotId = sli) -> continuation (mkLinksFromSynLongIdent sli)
+    // Expected input: the links *after* the head, which `visitChainLinks` always emits as a
+    // repeating `Dot` + one content link (`Identifier` / `AppUnit` / `AppParen` / `IndexExpr` /
+    // `Expr`). Two dots never follow each other and two content links never sit adjacent — a
+    // dot always introduces exactly one thing. `processLinks` consumes that pairing two links
+    // at a time; the two-element arms come first because the *last* pair is what decides the
+    // terminal, and only there may a call negotiate a space before its `(`.
+    //
+    // A malformed list (e.g. `[Identifier; Identifier]`, no dot between them) means
+    // `visitChainLinks` produced something this function does not model, so it fails loudly
+    // rather than silently dropping links.
+    let rec processLinks (remainingLinks: LinkExpr list) : ChainSegment list * ChainTerminal =
+        match remainingLinks with
+        // Only reachable for a chain with no segments at all. `visitChainLinks` never
+        // produces this (every chain it matches has at least one dot) and the recursion
+        // below always stops at a two-element arm, so this is the base case for
+        // completeness rather than a path exercised by real source.
+        // Unreachable: every chain has at least one dot, and the recursion below always stops
+        // at one of the two-element arms, so an empty remainder is never passed in.
+        | [] -> invariantViolation range "a chain was built with no dotted content at all"
 
-        | SynExpr.Ident _ -> continuation [ LinkExpr.Identifier e ]
+        | [ LinkExpr.Dot mDot; LinkExpr.Identifier f ] ->
+            [ ChainSegment.DotMember(stn "." mDot, mkExpr creationAide f) ], ChainTerminal.NoTerminal
 
-        | SynExpr.DotIndexedGet(objectExpr, indexArgs, dotRange, _) ->
-            visit objectExpr (fun leftLinks ->
-                continuation
-                    [ yield! leftLinks
-                      yield LinkExpr.Dot dotRange
-                      yield LinkExpr.IndexExpr indexArgs ])
+        | [ LinkExpr.Dot mDot; LinkExpr.AppUnit(f, mUnit) ] ->
+            [ ChainSegment.DotMember(stn "." mDot, mkExpr creationAide f) ], mkTerminal (ChainCall.Unit(mkUnit mUnit))
 
-        | other -> continuation [ LinkExpr.Expr other ]
+        | [ LinkExpr.Dot mDot; LinkExpr.AppParen(f, lpr, e, rpr, pr) ] ->
+            [ ChainSegment.DotMember(stn "." mDot, mkExpr creationAide f) ],
+            mkTerminal (ChainCall.Paren(mkParenExpr creationAide lpr e rpr pr))
+
+        | [ LinkExpr.Dot mDot; LinkExpr.IndexExpr idx ] ->
+            [ ChainSegment.DotIndex(stn "." mDot, mkExpr creationAide idx) ], ChainTerminal.NoTerminal
+
+        // A chain ending in an opaque expression. Reached when a dot-lambda body is an indexed
+        // member access (`_.Values[0]`): the `[0]` has no dot of its own, so `Values[0]` arrives
+        // as a single `Expr` link. There is no call to negotiate, hence no terminal.
+        | [ LinkExpr.Dot mDot; LinkExpr.Expr e ] ->
+            [ ChainSegment.DotMember(stn "." mDot, mkExpr creationAide e) ], ChainTerminal.NoTerminal
+
+        | LinkExpr.Dot mDot :: LinkExpr.AppUnit(f, mUnit) :: rest ->
+            let seg =
+                ChainSegment.DotApplication(stn "." mDot, mkExpr creationAide f, ChainCall.Unit(mkUnit mUnit))
+
+            let segs, terminal = processLinks rest
+            seg :: segs, terminal
+
+        | LinkExpr.Dot mDot :: LinkExpr.AppParen(f, lpr, e, rpr, pr) :: rest ->
+            let seg =
+                ChainSegment.DotApplication(
+                    stn "." mDot,
+                    mkExpr creationAide f,
+                    ChainCall.Paren(mkParenExpr creationAide lpr e rpr pr)
+                )
+
+            let segs, terminal = processLinks rest
+            seg :: segs, terminal
+
+        | LinkExpr.Dot mDot :: LinkExpr.Identifier f :: rest ->
+            let seg = ChainSegment.DotMember(stn "." mDot, mkExpr creationAide f)
+            let segs, terminal = processLinks rest
+            seg :: segs, terminal
+
+        | LinkExpr.Dot mDot :: LinkExpr.IndexExpr idx :: rest ->
+            let seg = ChainSegment.DotIndex(stn "." mDot, mkExpr creationAide idx)
+            let segs, terminal = processLinks rest
+            seg :: segs, terminal
+
+        | LinkExpr.Dot mDot :: LinkExpr.Expr e :: rest ->
+            let seg = ChainSegment.DotMember(stn "." mDot, mkExpr creationAide e)
+            let segs, terminal = processLinks rest
+            seg :: segs, terminal
+
+        | other ->
+            invariantViolation
+                range
+                "unexpected link pattern in chain.\nExpected a `Dot` followed by exactly one content link, but got:\n%A\nFull link list for this chain:\n%A"
+                other
+                links
+
+    let segments, terminal = processLinks rest
+    ExprChain(head, segments, terminal, range) |> Expr.Chain
+
+[<return: Struct>]
+let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list voption =
+    let (|DottedLongIdent|_|) (sli: SynLongIdent) =
+        match sli.IdentsWithTrivia with
+        | _ :: _ :: _ when sli.Dots.Length > 0 -> ValueSome()
+        | _ -> ValueNone
 
     match e with
-    // An identifier only application with a parenthesis lambda expression.
-    // ex: `List.map (fun n -> n)` or `MailboxProcessor<string>.Start (fun n -> n)
-    // Because the identifier is not complex we don't consider it a chain.
+    // A plain LongIdent with dots (e.g. `a.b.c`) is a chain of property accesses.
+    // An *optional* one (`?a.b`) is not: the `?` belongs to the whole path and the chain
+    // links would drop it, so leave it as a single (OptVar) expression.
+    | SynExpr.LongIdent(isOptional = false; longDotId = DottedLongIdent) -> ValueSome(visitChainLinks e id)
+    // An App(LongIdent, Paren _ | Unit) where the LongIdent has dots (e.g. `path.Replace("x","y")`)
+    // is a chain with a terminal call. `ParenExpr _` is deliberately unrestricted, so this also
+    // covers a paren carrying a lambda (`List.map (fun x -> x+1)`) — the lambda is just another
+    // argument shape and needs no arm of its own.
+    | SynExpr.App(
+        isInfix = false; funcExpr = SynExpr.LongIdent(longDotId = DottedLongIdent); argExpr = (ParenExpr _ | UnitExpr _)) ->
+        ValueSome(visitChainLinks e id)
+    // An identifier-only application with a paren lambda (e.g. `List.map (fun n -> n)`)
+    // is NOT considered a chain because the identifier is not complex.
     | SynExpr.App(
         isInfix = false
         funcExpr = SynExpr.LongIdent _ | SynExpr.Ident _ | SynExpr.DotGet(expr = SynExpr.TypeApp(expr = SynExpr.Ident _))
@@ -977,14 +1152,15 @@ let (|ChainExpr|_|) (e: SynExpr) : LinkExpr list voption =
         argExpr = UnitExpr _ | ParenExpr _)
     | SynExpr.DotGet _
     | SynExpr.TypeApp(expr = SynExpr.DotGet _)
-    | SynExpr.DotIndexedGet(objectExpr = SynExpr.App(funcExpr = SynExpr.DotGet _) | SynExpr.DotGet _) ->
-        ValueSome(visit e id)
+    | SynExpr.DotIndexedGet _ -> ValueSome(visitChainLinks e id)
     | _ -> ValueNone
 
 [<return: Struct>]
+// Note: no guard is needed against a dotted function expression (`a.Foo(x, y)`). The only
+// use site sits directly after the `ChainExpr` arm in `mkExpr`, and a chain claims every
+// `App(DotGet, Paren _)` before this pattern is ever tried.
 let (|AppSingleParenArg|_|) =
     function
-    | App(SynExpr.DotGet _, [ (SynExpr.Paren(expr = SynExpr.Tuple _)) ]) -> ValueNone
     | App(e, [ UnitExpr _ as px ]) -> ValueSome(e, px)
     | App(e, [ SynExpr.Paren(expr = singleExpr) as px ]) ->
         match singleExpr with
@@ -995,6 +1171,28 @@ let (|AppSingleParenArg|_|) =
 
 let mkParenExpr creationAide lpr e rpr m =
     ExprParenNode(stn "(" lpr, mkExpr creationAide e, stn ")" rpr, m)
+
+/// Build `expr` for a position where it has to stay one indivisible unit, because something
+/// binds directly to it with no whitespace allowed in between:
+///
+///   * a prefix operator in front of it   — `-x.Foo(a)`
+///   * an index behind it                 — `x.Foo()[0]`, `x.Foo().[0] <- v`
+///   * a `?member` behind it              — `x.Foo()?Bar`, `x?a()?b()`
+///
+/// The F# parser calls such an expression *atomic*, and it only stays atomic while its final
+/// call is written tight: `x.Foo()[0]` parses the call as `App(Atomic, ...)`, whereas
+/// `x.Foo ()[0]` parses it as `App(NonAtomic, ...)` and the index no longer binds to the call.
+///
+/// The one thing that could introduce that space is a `SpaceBefore*Invocation` setting acting
+/// on a chain's final call, so a chain built here is marked `NoSpaceAllowed`. Every other
+/// expression is already indivisible and is built normally.
+///
+/// Note this does not *make* an expression atomic (it adds no parentheses); it only avoids the
+/// one formatting choice that would stop it being atomic.
+let mkAtomicExpr (creationAide: CreationAide) (expr: SynExpr) : Expr =
+    match expr with
+    | ChainExpr links -> mkChainFromLinks creationAide links ChainTerminal.NoSpaceAllowed expr.Range
+    | _ -> mkExpr creationAide expr
 
 let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
     let exprRange = e.Range
@@ -1304,10 +1502,10 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
 
                 ExprDynamicChainItemNode(memberExpr', parenArg', itemRange))
 
-        ExprDynamicChainNode(mkExpr creationAide leading, chainItems, exprRange)
+        ExprDynamicChainNode(mkAtomicExpr creationAide leading, chainItems, exprRange)
         |> Expr.DynamicChain
     | SynExpr.Dynamic(funcExpr, _, argExpr, _) ->
-        ExprDynamicNode(mkExpr creationAide funcExpr, mkExpr creationAide argExpr, exprRange)
+        ExprDynamicNode(mkAtomicExpr creationAide funcExpr, mkExpr creationAide argExpr, exprRange)
         |> Expr.Dynamic
     | SynExpr.App(_,
                   false,
@@ -1321,7 +1519,9 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
             PrettyNaming.ConvertValLogicalNameToDisplayNameCore ident.idText
         )
         ->
-        ExprPrefixAppNode(stn operatorName ident.idRange, mkExpr creationAide e2, exprRange)
+        // A prefix operator needs an atomic operand (`!-foo.bar(x)`), so a chain argument keeps
+        // its final call tight regardless of the space-before-invocation settings.
+        ExprPrefixAppNode(stn operatorName ident.idRange, mkAtomicExpr creationAide e2, exprRange)
         |> Expr.PrefixApp
 
     | NewlineInfixApps(head, xs)
@@ -1337,7 +1537,7 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
         |> Expr.InfixApp
 
     | IndexWithoutDot(identifierExpr, indexExpr) ->
-        ExprIndexWithoutDotNode(mkExpr creationAide identifierExpr, mkExpr creationAide indexExpr, exprRange)
+        ExprIndexWithoutDotNode(mkAtomicExpr creationAide identifierExpr, mkExpr creationAide indexExpr, exprRange)
         |> Expr.IndexWithoutDot
 
     | EmptyComputationExpr(expr, mOpen, mClose, m) ->
@@ -1350,31 +1550,8 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
         )
         |> Expr.NamedComputation
 
-    | ChainExpr links ->
-        let chainLinks =
-            links
-            |> List.map (function
-                | LinkExpr.Identifier identifierExpr -> mkExpr creationAide identifierExpr |> ChainLink.Identifier
-                | LinkExpr.Dot mDot -> stn "." mDot |> ChainLink.Dot
-                | LinkExpr.Expr e -> mkExpr creationAide e |> ChainLink.Expr
-                | LinkExpr.AppUnit(f, mUnit) ->
-                    LinkSingleAppUnit(mkExpr creationAide f, mkUnit mUnit, unionRanges f.Range mUnit)
-                    |> ChainLink.AppUnit
-                | LinkExpr.AppParen(f, lpr, e, rpr, pr) ->
-                    LinkSingleAppParen(
-                        mkExpr creationAide f,
-                        mkParenExpr creationAide lpr e rpr pr,
-                        unionRanges f.Range pr
-                    )
-                    |> ChainLink.AppParen
-                | LinkExpr.IndexExpr e -> mkExpr creationAide e |> ChainLink.IndexExpr
-                | link -> failwithf "cannot map %A" link)
+    | ChainExpr links -> mkChainFromLinks creationAide links ChainTerminal.SpaceAllowed exprRange
 
-        ExprChain(chainLinks, exprRange) |> Expr.Chain
-
-    | AppSingleParenArg(SynExpr.LongIdent(longDotId = longDotId), px) ->
-        ExprAppLongIdentAndSingleParenArgNode(mkSynLongIdent creationAide longDotId, mkExpr creationAide px, exprRange)
-        |> Expr.AppLongIdentAndSingleParenArg
     | AppSingleParenArg(e, px) ->
         ExprAppSingleParenArgNode(mkExpr creationAide e, mkExpr creationAide px, exprRange)
         |> Expr.AppSingleParenArg
@@ -1531,13 +1708,9 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
     | SynExpr.LongIdentSet(synLongIdent, e, _) ->
         ExprLongIdentSetNode(mkSynLongIdent creationAide synLongIdent, mkExpr creationAide e, exprRange)
         |> Expr.LongIdentSet
-    | SynExpr.DotIndexedGet(objectExpr, indexArgs, _, _) ->
-        ExprDotIndexedGetNode(mkExpr creationAide objectExpr, mkExpr creationAide indexArgs, exprRange)
-        |> Expr.DotIndexedGet
-
     | SynExpr.DotIndexedSet(objectExpr, indexExpr, valueExpr, _, _, _) ->
         ExprDotIndexedSetNode(
-            mkExpr creationAide objectExpr,
+            mkAtomicExpr creationAide objectExpr,
             mkExpr creationAide indexExpr,
             mkExpr creationAide valueExpr,
             exprRange
@@ -1693,8 +1866,15 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
         expr = e
         trivia = { DotRange = mDot
                    UnderscoreRange = mUnderscore }) ->
-        ExprDotLambda(stn "_" mUnderscore, stn "." mDot, mkExpr creationAide e, exprRange)
-        |> Expr.DotLambda
+        // Build the chain with `_` as head and the body links as segments.
+        // Terminal uses NoSpaceAllowed — the F# compiler requires DotLambda bodies to be atomic.
+        let bodyLinks = visitChainLinks e id
+        let underscore = SynExpr.Ident(Ident("_", mUnderscore))
+
+        let allLinks =
+            [ LinkExpr.Identifier underscore; LinkExpr.Dot mDot; yield! bodyLinks ]
+
+        mkChainFromLinks creationAide allLinks ChainTerminal.NoSpaceAllowed exprRange
     | _ -> failwithf "todo for %A" e
 
 let mkExprQuote creationAide isRaw e range : ExprQuoteNode =

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -457,25 +457,6 @@ type ChainCallPosition =
     /// The last call of the chain, with nothing following it.
     | Terminal
 
-/// Layout for an argument carrying a directive or comment before it (e.g. `(` on its own line
-/// above a `#if`): the argument is pushed onto its own indented lines and the closing `)`
-/// returns to the method's column.
-let genParenArgWithContentBefore (position: ChainCallPosition) (parenNode: ExprParenNode) : Context -> Context =
-    // An INTERMEDIATE call may not be separated from its `(` — `a.Foo (x).Bar()` parses as
-    // `a.Foo ((x).Bar())` — so there the paren stays welded to the member name and the break
-    // happens after it. Only a terminal call may put the `(` on the indented line.
-    let genOpeningParen: Context -> Context =
-        match position with
-        | ChainCallPosition.Intermediate -> genSingleTextNode parenNode.OpeningParen +> indent +> sepNln
-        | ChainCallPosition.Terminal -> indent +> sepNln +> genSingleTextNode parenNode.OpeningParen +> sepNln
-
-    genOpeningParen
-    +> genExpr parenNode.Expr
-    +> unindent
-    +> sepNlnUnlessLastEventIsNewline
-    +> genSingleTextNode parenNode.ClosingParen
-    |> genNode parenNode
-
 /// Layout for `(fun params -> body)`. Identical wherever the call sits: `MultiLineLambdaClosingNewline`
 /// decides where the closing `)` lands, exactly as it would for a call with no receiver.
 let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : Context -> Context =
@@ -559,15 +540,76 @@ let genMatchLambdaParenArg (parenNode: ExprParenNode) (matchLambdaNode: ExprMatc
 /// by the ordinary argument rules; the chain only gets a say in the one place named on
 /// `ChainCallPosition`.
 let genMultilineParenArg (position: ChainCallPosition) (parenNode: ExprParenNode) : Context -> Context =
-    // Content attached before the argument is decided ahead of the argument's shape, so this is
-    // an `if` rather than another match arm.
-    if parenNode.HasContentBefore || (Expr.Node parenNode.Expr).HasContentBefore then
-        genParenArgWithContentBefore position parenNode
-    else
+    // How the argument breaks, once it is settled where the call starts. Whatever sits between
+    // the parentheses is the argument's business, so this is the ordinary layout for one.
+    let genByArgumentShape: Context -> Context =
         match parenNode.Expr with
         | Expr.Lambda lambdaNode -> genLambdaParenArg parenNode lambdaNode
         | Expr.MatchLambda matchLambdaNode -> genMatchLambdaParenArg parenNode matchLambdaNode
         | _ -> genMultilineFunctionApplicationArguments (Expr.Paren parenNode)
+
+    // The argument on its own indented lines, with the closing `)` back at the method's column.
+    let genArgumentBelow: Context -> Context =
+        genExpr parenNode.Expr
+        +> unindent
+        +> sepNlnUnlessLastEventIsNewline
+        +> genSingleTextNode parenNode.ClosingParen
+
+    // Trivia attached before the parenthesis or before the argument is decided ahead of the
+    // argument's shape, so this is an `if` rather than another match arm. Which of the two nodes
+    // carries the trivia is what decides where the `(` may sit.
+    if parenNode.HasContentBefore then
+        // The trivia sits between the member name and the `(`:
+        //
+        //     builder.UseUrls
+        //         // pick the endpoint
+        //         (url)
+        //
+        // The comment is written first and ends its line, so the `(` cannot follow `UseUrls`
+        // and drops to the indented line below.
+        //
+        // An intermediate call cannot afford to let the `(` go: a space between a member name
+        // and its parenthesis changes what the code means. `a.Foo(x).Bar()` calls `Foo` and then
+        // `Bar`, while `a.Foo (x).Bar()` passes `(x).Bar()` to `Foo`. A line break in front of
+        // the `(` reads the same way to the parser, so there the paren stays welded to the name
+        // and the argument breaks after it instead.
+        match position with
+        | ChainCallPosition.Terminal ->
+            // `genNode` writes the trivia on entering the node, so the indent has to be in place
+            // before then. Without it the comment lands back at the receiver's column and the
+            // `sepNln` behind it adds a blank line, one more on every format run.
+            //
+            // Only the position of the call moves. Whether the argument then has to break is
+            // asked of a copy of the parenthesis without the trivia, since the comment takes a
+            // line of its own either way and would otherwise answer the question by itself.
+            let parenWithoutTrivia: Expr =
+                mkExprParenNode parenNode.OpeningParen parenNode.Expr parenNode.ClosingParen parenNode.Range
+
+            indent
+            +> sepNln
+            +> ifElseCtx
+                (futureNlnCheck (genExpr parenWithoutTrivia))
+                genByArgumentShape
+                (genExpr (Expr.Paren parenNode))
+            +> unindent
+        | ChainCallPosition.Intermediate ->
+            genSingleTextNode parenNode.OpeningParen +> indent +> sepNln +> genArgumentBelow
+            |> genNode parenNode
+    elif (Expr.Node parenNode.Expr).HasContentBefore then
+        // The trivia sits between the `(` and the argument:
+        //
+        //     builder.UseUrls(
+        //         // the public endpoint
+        //         url
+        //     )
+        //
+        // It is written after the parenthesis, which leaves the parenthesis free to stay with
+        // the method name. Only the argument moves down, and it does so wherever the call sits
+        // in the chain, so an intermediate call is laid out no differently from a terminal one.
+        genSingleTextNode parenNode.OpeningParen +> indent +> sepNln +> genArgumentBelow
+        |> genNode parenNode
+    else
+        genByArgumentShape
 
 let genSegment (segment: ChainSegment) : Context -> Context =
     match segment with

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -443,20 +443,6 @@ type ChainStepPlacement =
     /// The step opens a fresh line, indented to the run's own column.
     | OpensNewLine
 
-/// Where a call sits in its chain. This governs exactly one thing about the layout of the
-/// call's parenthesised argument, and nothing else: whether the opening `(` is allowed to leave
-/// the member name, which is a grammar constraint rather than a style choice.
-///
-/// Nothing about a lambda argument depends on it. `fun` and `function` are laid out the same
-/// way wherever their call sits, as the F# style guide asks ("Treat match lambda's in a similar
-/// fashion").
-[<RequireQualifiedAccess; Struct>]
-type ChainCallPosition =
-    /// A call with more chain after it, e.g. `.Foo(x)` in `a.Foo(x).Bar()`.
-    | Intermediate
-    /// The last call of the chain, with nothing following it.
-    | Terminal
-
 /// Layout for `(fun params -> body)`. Identical wherever the call sits: `MultiLineLambdaClosingNewline`
 /// decides where the closing `)` lands, exactly as it would for a call with no receiver.
 let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : Context -> Context =
@@ -526,10 +512,10 @@ let genMatchLambdaParenArg (parenNode: ExprParenNode) (matchLambdaNode: ExprMatc
     ifElseCtx (fun ctx -> ctx.Config.MultiLineLambdaClosingNewline) breakAfterParen keepFunctionWithParen
 
 /// Multiline layout of a call's parenthesised argument `( ... )`, shared by intermediate calls
-/// (genSegment) and the terminal call (genTerminal). Everything between `(` and `)` is laid out
-/// by the ordinary argument rules; the chain only gets a say in the one place named on
-/// `ChainCallPosition`.
-let genMultilineParenArg (position: ChainCallPosition) (parenNode: ExprParenNode) : Context -> Context =
+/// (genSegment) and the terminal call (genTerminal). Where the call sits in its chain makes no
+/// difference: everything between `(` and `)` is laid out by the ordinary argument rules, and the
+/// chain only decides whether the call itself has to move down.
+let genMultilineParenArg (parenNode: ExprParenNode) : Context -> Context =
     // How the argument breaks, once it is settled where the call starts. Whatever sits between
     // the parentheses is the argument's business, so this is the ordinary layout for one.
     let genByArgumentShape: Context -> Context =
@@ -558,33 +544,26 @@ let genMultilineParenArg (position: ChainCallPosition) (parenNode: ExprParenNode
         // The comment is written first and ends its line, so the `(` cannot follow `UseUrls`
         // and drops to the indented line below.
         //
-        // An intermediate call cannot afford to let the `(` go: a space between a member name
-        // and its parenthesis changes what the code means. `a.Foo(x).Bar()` calls `Foo` and then
-        // `Bar`, while `a.Foo (x).Bar()` passes `(x).Bar()` to `Foo`. A line break in front of
-        // the `(` reads the same way to the parser, so there the paren stays welded to the name
-        // and the argument breaks after it instead.
-        match position with
-        | ChainCallPosition.Terminal ->
-            // `genNode` writes the trivia on entering the node, so the indent has to be in place
-            // before then. Without it the comment lands back at the receiver's column and the
-            // `sepNln` behind it adds a blank line, one more on every format run.
-            //
-            // Only the position of the call moves. Whether the argument then has to break is
-            // asked of a copy of the parenthesis without the trivia, since the comment takes a
-            // line of its own either way and would otherwise answer the question by itself.
-            let parenWithoutTrivia: Expr =
-                mkExprParenNode parenNode.OpeningParen parenNode.Expr parenNode.ClosingParen parenNode.Range
+        // Only the last call of a chain can end up here. An earlier call keeps its `(` glued to
+        // the member name, because a gap there changes what the code means: `a.Foo(x).Bar()`
+        // calls `Foo` and then `Bar`, while `a.Foo (x).Bar()` passes `(x).Bar()` to `Foo`. A
+        // comment makes the same gap a line break would, so a call in the middle of a chain
+        // cannot carry one in front of its parenthesis and still be the same program.
+        //
+        // `genNode` writes the trivia on entering the node, so the indent has to be in place
+        // before then. Without it the comment lands back at the receiver's column and the
+        // `sepNln` behind it adds a blank line, one more on every format run.
+        //
+        // Only the position of the call moves. Whether the argument then has to break is asked
+        // of a copy of the parenthesis without the trivia, since the comment takes a line of its
+        // own either way and would otherwise answer the question by itself.
+        let parenWithoutTrivia: Expr =
+            mkExprParenNode parenNode.OpeningParen parenNode.Expr parenNode.ClosingParen parenNode.Range
 
-            indent
-            +> sepNln
-            +> ifElseCtx
-                (futureNlnCheck (genExpr parenWithoutTrivia))
-                genByArgumentShape
-                (genExpr (Expr.Paren parenNode))
-            +> unindent
-        | ChainCallPosition.Intermediate ->
-            genSingleTextNode parenNode.OpeningParen +> indent +> sepNln +> genArgumentBelow
-            |> genNode parenNode
+        indent
+        +> sepNln
+        +> ifElseCtx (futureNlnCheck (genExpr parenWithoutTrivia)) genByArgumentShape (genExpr (Expr.Paren parenNode))
+        +> unindent
     elif (Expr.Node parenNode.Expr).HasContentBefore then
         // The trivia sits between the `(` and the argument:
         //
@@ -611,9 +590,7 @@ let genSegment (segment: ChainSegment) : Context -> Context =
            | ChainCall.Unit u -> genUnit u
            | ChainCall.Paren parenNode ->
                // Intermediate paren calls are always tight — space would change the parse tree.
-               expressionFitsOnRestOfLine
-                   (genExpr (Expr.Paren parenNode))
-                   (genMultilineParenArg ChainCallPosition.Intermediate parenNode)
+               expressionFitsOnRestOfLine (genExpr (Expr.Paren parenNode)) (genMultilineParenArg parenNode)
     | ChainSegment.DotIndex(dot, index) ->
         // DotIndex (.[i]) is structurally like DotMember with no call: the dot is explicit
         // for trivia, but the [ ] brackets are not part of the index expression and must
@@ -698,8 +675,7 @@ let genTerminal (node: ExprChain) : Context -> Context =
         | ChainCall.Paren parenNode ->
             let short: Context -> Context = addSpace +> genExpr (Expr.Paren parenNode)
 
-            let long: Context -> Context =
-                addSpace +> genMultilineParenArg ChainCallPosition.Terminal parenNode
+            let long: Context -> Context = addSpace +> genMultilineParenArg parenNode
 
             expressionFitsOnRestOfLine short long
 

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -452,15 +452,21 @@ let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : 
     let genParenLambda (ctx: Context) : Context =
         let startColumn: int = ctx.WriterModel.Indent
 
-        (genSingleTextNode parenNode.OpeningParen
-         +> genLambdaWithParen lambdaNode
-         +> ifElseCtx
-             (fun ctx ->
-                 ctx.Config.MultiLineLambdaClosingNewline
-                 && not (isStroustrupStyleExpr ctx.Config lambdaNode.Expr))
-             sepNln
-             (sepNlnWhenWriteBeforeNewlineNotEmpty +> addFixedSpaces startColumn)
-         +> genSingleTextNode parenNode.ClosingParen)
+        // The closing parenthesis takes a line of its own when the setting asks for it and the
+        // lambda spans several lines, which is the case the setting is about. Asking whether it
+        // did, rather than assuming it will, matters once the argument can move down: from its own
+        // line the lambda may well fit, and a `)` below a single line would be left dangling.
+        (leadingExpressionIsMultiline
+            (genSingleTextNode parenNode.OpeningParen +> genLambdaWithParen lambdaNode)
+            (fun isMultiline ->
+                ifElseCtx
+                    (fun ctx ->
+                        isMultiline
+                        && ctx.Config.MultiLineLambdaClosingNewline
+                        && not (isStroustrupStyleExpr ctx.Config lambdaNode.Expr))
+                    sepNln
+                    (sepNlnWhenWriteBeforeNewlineNotEmpty +> addFixedSpaces startColumn)
+                +> genSingleTextNode parenNode.ClosingParen))
             ctx
 
     // Move the whole lambda argument onto its own indented line when leaving it where it is
@@ -2884,10 +2890,17 @@ let genAppWithLambda sep (node: ExprAppWithLambdaNode) =
                 | [] ->
                     match node.Lambda with
                     | Choice1Of2 lambdaNode ->
-                        genSingleTextNode node.OpeningParen
-                        +> genLambdaWithParen lambdaNode
-                        +> onlyIf (not (isStroustrupStyleExpr ctx.Config lambdaNode.Expr)) sepNln
-                        +> genSingleTextNode node.ClosingParen
+                        // The closing parenthesis takes a line of its own when the lambda spans
+                        // several lines, which is what the setting is for. Asking afterwards
+                        // rather than assuming matters once the argument can move down: from its
+                        // own line the lambda may well fit, and then a `)` below it would be
+                        // dangling under a single line. The branch for leading arguments below
+                        // asks the same way.
+                        leadingExpressionIsMultiline
+                            (genSingleTextNode node.OpeningParen +> genLambdaWithParen lambdaNode)
+                            (fun isMultiline ->
+                                onlyIf (isMultiline && not (isStroustrupStyleExpr ctx.Config lambdaNode.Expr)) sepNln
+                                +> genSingleTextNode node.ClosingParen)
                     | Choice2Of2 matchLambdaNode ->
                         genSingleTextNode node.OpeningParen
                         +> indentSepNlnUnindent (

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -463,12 +463,13 @@ let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : 
          +> genSingleTextNode parenNode.ClosingParen)
             ctx
 
-    // Move the whole lambda argument onto its own indented line when leaving `(fun` at the
-    // margin would read badly:
+    // Move the whole lambda argument onto its own indented line when leaving it where it is
+    // would read badly:
     //   * a single parameter that is itself multiline (a record pattern), or
-    //   * even the bare `(fun` no longer fits, because the method name in front of it is
-    //     already too long. (A long *list* of simple parameters is NOT a reason — those align
-    //     under `fun` on the same line — so we probe only up to `fun`.)
+    //   * the opener does not fit, meaning `(fun` plus the parameters up to the arrow. The F#
+    //     style guide asks for all arguments up to the arrow to sit on one line, and rejects
+    //     parameters aligned under the opening parenthesis, since that column depends on the
+    //     length of the identifier in front of it.
     fun (ctx: Context) ->
         let singleMultilineParameter: bool =
             match lambdaNode.Parameters with
@@ -476,7 +477,14 @@ let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : 
             | _ -> false
 
         let openerDoesNotFit: bool =
-            futureNlnCheck (genSingleTextNode parenNode.OpeningParen +> genSingleTextNode lambdaNode.Fun) ctx
+            futureNlnCheck
+                (genSingleTextNode parenNode.OpeningParen
+                 +> genSingleTextNode lambdaNode.Fun
+                 +> sepSpace
+                 +> col sepSpace lambdaNode.Parameters genPat
+                 +> sepSpace
+                 +> genSingleTextNode lambdaNode.Arrow)
+                ctx
 
         if singleMultilineParameter || openerDoesNotFit then
             indentSepNlnUnindent genParenLambda ctx

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -35,7 +35,13 @@ let rec (|UppercaseType|LowercaseType|) (t: Type) : Choice<unit, unit> =
     | Type.Var node -> upperOrLower (node.Text.Substring(1))
     | Type.AppPostfix node -> (|UppercaseType|LowercaseType|) node.First
     | Type.AppPrefix node -> (|UppercaseType|LowercaseType|) node.Identifier
-    | _ -> failwithf $"Cannot determine if synType %A{t} is uppercase or lowercase"
+    | _ ->
+        raise (
+            InvariantViolationException(
+                $"cannot tell whether this type is uppercase or lowercase: %A{t}",
+                (Type.Node t).Range
+            )
+        )
 
 let rec (|UppercaseExpr|LowercaseExpr|) (expr: Expr) =
     let upperOrLower (v: string) =
@@ -76,7 +82,13 @@ let rec (|UppercaseExpr|LowercaseExpr|) (expr: Expr) =
     | Expr.Paren node -> (|UppercaseExpr|LowercaseExpr|) node.Expr
     | Expr.App node -> (|UppercaseExpr|LowercaseExpr|) node.FunctionExpr
     | Expr.IndexWithoutDot node -> (|UppercaseExpr|LowercaseExpr|) node.Identifier
-    | _ -> failwithf "cannot determine if Expr %A is uppercase or lowercase" expr
+    | _ ->
+        raise (
+            InvariantViolationException(
+                $"cannot tell whether this expression is uppercase or lowercase: %A{expr}",
+                (Expr.Node expr).Range
+            )
+        )
 
 let (|ParenExpr|_|) (e: Expr) =
     match e with

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -498,8 +498,7 @@ let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : 
             genParenLambda ctx
 
 /// Layout for `(function | ... -> ...)`. Identical wherever the call sits in its chain:
-/// `MultiLineLambdaClosingNewline`, or a break the user already made after the `(`, decides
-/// whether `function` goes on its own line.
+/// `MultiLineLambdaClosingNewline` decides whether `function` goes on its own line.
 let genMatchLambdaParenArg (parenNode: ExprParenNode) (matchLambdaNode: ExprMatchLambdaNode) : Context -> Context =
     let keepFunctionWithParen: Context -> Context =
         genSingleTextNode parenNode.OpeningParen
@@ -520,20 +519,11 @@ let genMatchLambdaParenArg (parenNode: ExprParenNode) (matchLambdaNode: ExprMatc
         +> sepNln
         +> genSingleTextNode parenNode.ClosingParen
 
-    // The user already broke after the `(` themselves — `function` starts on a line below it.
-    let userBrokeAfterParen: bool =
-        matchLambdaNode.Range.StartLine > parenNode.OpeningParen.Range.EndLine
-
-    fun (ctx: Context) ->
-        // Where the call sits in its chain has no say here: a match lambda is laid out the same
-        // way as a `fun` lambda, whether its call is the last step or the first.
-        let breakOpener: bool =
-            ctx.Config.MultiLineLambdaClosingNewline || userBrokeAfterParen
-
-        if breakOpener then
-            breakAfterParen ctx
-        else
-            keepFunctionWithParen ctx
+    // Where the call sits in its chain has no say here: a match lambda is laid out the same way as
+    // a `fun` lambda, whether its call is the last step or the first. Neither has the line the
+    // author happened to start `function` on: the same call written two ways is one call, and
+    // formatting both has to land on the same answer.
+    ifElseCtx (fun ctx -> ctx.Config.MultiLineLambdaClosingNewline) breakAfterParen keepFunctionWithParen
 
 /// Multiline layout of a call's parenthesised argument `( ... )`, shared by intermediate calls
 /// (genSegment) and the terminal call (genTerminal). Everything between `(` and `)` is laid out

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -54,20 +54,24 @@ let rec (|UppercaseExpr|LowercaseExpr|) (expr: Expr) =
     | Expr.Ident ident -> upperOrLower ident.Text
     | Expr.OptVar node -> lastFragmentInList node.Identifier
     | Expr.Chain node ->
-        match List.tryLast node.Links with
-        | None
-        | Some(ChainLink.Dot _) -> LowercaseExpr
-        | Some(ChainLink.Identifier e)
-        | Some(ChainLink.Expr e) -> (|UppercaseExpr|LowercaseExpr|) e
-        | Some(ChainLink.AppParen appParen) -> (|UppercaseExpr|LowercaseExpr|) appParen.FunctionName
-        | Some(ChainLink.AppUnit appUnit) -> (|UppercaseExpr|LowercaseExpr|) appUnit.FunctionName
-        // Questionable
-        | Some(ChainLink.IndexExpr _) -> LowercaseExpr
-    | Expr.DotIndexedGet node -> (|UppercaseExpr|LowercaseExpr|) node.ObjectExpr
+        // The casing that governs `SpaceBefore*Invocation` is the casing of the name the call
+        // is made on, which is always the LAST segment — `a.foo(x).Bar` is uppercase because of
+        // `Bar`, not `a` or `foo`. The terminal itself carries no name, so it does not take part.
+        //
+        // In practice only the DotMember arm is ever reached: a chain that has a terminal call
+        // always ends in a DotMember (the member being called), and the other shapes are either
+        // impossible or answered before we get here — a chain ending in an index is short-
+        // circuited by `chainEndsInIndex` in `sepSpaceBeforeParenInFuncInvocation`, and a
+        // zero-segment chain only ever exists as the head of another chain. They are kept so
+        // the active pattern stays total, and each returns the answer its shape deserves.
+        match List.tryLast node.Segments with
+        | Some(ChainSegment.DotMember(_, e))
+        | Some(ChainSegment.DotApplication(_, e, _)) -> (|UppercaseExpr|LowercaseExpr|) e
+        | Some(ChainSegment.DotIndex _) -> LowercaseExpr
+        | None -> (|UppercaseExpr|LowercaseExpr|) node.Head
     | Expr.TypeApp node -> (|UppercaseExpr|LowercaseExpr|) node.Identifier
     | Expr.Dynamic node -> (|UppercaseExpr|LowercaseExpr|) node.FuncExpr
     | Expr.DynamicChain node -> (|UppercaseExpr|LowercaseExpr|) node.LeadingExpr
-    | Expr.AppLongIdentAndSingleParenArg node -> lastFragmentInList node.FunctionName
     | Expr.AppSingleParenArg node -> (|UppercaseExpr|LowercaseExpr|) node.FunctionExpr
     | Expr.Paren node -> (|UppercaseExpr|LowercaseExpr|) node.Expr
     | Expr.App node -> (|UppercaseExpr|LowercaseExpr|) node.FunctionExpr
@@ -395,6 +399,347 @@ let requiresMultilineToPreserveSemantics (exprs: Expr list) =
         exprs
         |> List.take (exprs.Length - 1) // skip the last item: it can't swallow anything to its right
         |> List.exists isOpenEndedExpression
+
+// Chain printing helpers
+
+/// Where a call sits in its chain. This governs exactly two things about the layout of the
+/// call's parenthesised argument, and nothing else:
+///   * whether the opening `(` is allowed to leave the member name, which is a grammar
+///     constraint rather than a style choice, and
+///   * whether a `(function` argument is forced onto its own line, which is a readability call.
+[<RequireQualifiedAccess>]
+type ChainCallPosition =
+    /// A call with more chain after it, e.g. `.Foo(x)` in `a.Foo(x).Bar()`.
+    | Intermediate
+    /// The last call of the chain, with nothing following it.
+    | Terminal
+
+/// Layout for an argument carrying a directive or comment before it (e.g. `(` on its own line
+/// above a `#if`): the argument is pushed onto its own indented lines and the closing `)`
+/// returns to the method's column.
+let genParenArgWithContentBefore (position: ChainCallPosition) (p: ExprParenNode) : Context -> Context =
+    // An INTERMEDIATE call may not be separated from its `(` — `a.Foo (x).Bar()` parses as
+    // `a.Foo ((x).Bar())` — so there the paren stays welded to the member name and the break
+    // happens after it. Only a terminal call may put the `(` on the indented line.
+    let genOpeningParen: Context -> Context =
+        match position with
+        | ChainCallPosition.Intermediate -> genSingleTextNode p.OpeningParen +> indent +> sepNln
+        | ChainCallPosition.Terminal -> indent +> sepNln +> genSingleTextNode p.OpeningParen +> sepNln
+
+    genOpeningParen
+    +> genExpr p.Expr
+    +> unindent
+    +> sepNlnUnlessLastEventIsNewline
+    +> genSingleTextNode p.ClosingParen
+    |> genNode p
+
+/// Layout for `(fun params -> body)`. Identical wherever the call sits: `MultiLineLambdaClosingNewline`
+/// decides where the closing `)` lands, exactly as it would for a call with no receiver.
+let genLambdaParenArg (p: ExprParenNode) (lambdaNode: ExprLambdaNode) : Context -> Context =
+    // `startColumn` is remembered so the closing `)` can be indented back to it — important
+    // when the body ends at a shallow column (e.g. a verbatim string in column 0), where a `)`
+    // left there breaks the offside rule and produces invalid F#.
+    let genParenLambda (ctx: Context) : Context =
+        let startColumn: int = ctx.WriterModel.Indent
+
+        (genSingleTextNode p.OpeningParen
+         +> genLambdaWithParen lambdaNode
+         +> ifElseCtx
+             (fun ctx ->
+                 ctx.Config.MultiLineLambdaClosingNewline
+                 && not (isStroustrupStyleExpr ctx.Config lambdaNode.Expr))
+             sepNln
+             (sepNlnWhenWriteBeforeNewlineNotEmpty +> addFixedSpaces startColumn)
+         +> genSingleTextNode p.ClosingParen)
+            ctx
+
+    // Move the whole lambda argument onto its own indented line when leaving `(fun` at the
+    // margin would read badly:
+    //   * a single parameter that is itself multiline (a record pattern), or
+    //   * even the bare `(fun` no longer fits, because the method name in front of it is
+    //     already too long. (A long *list* of simple parameters is NOT a reason — those align
+    //     under `fun` on the same line — so we probe only up to `fun`.)
+    fun (ctx: Context) ->
+        let singleMultilineParameter: bool =
+            match lambdaNode.Parameters with
+            | [ singleParam ] -> fst (futureNlnCheckMem (genPat singleParam, ctx))
+            | _ -> false
+
+        let openerDoesNotFit: bool =
+            futureNlnCheck (genSingleTextNode p.OpeningParen +> genSingleTextNode lambdaNode.Fun) ctx
+
+        if singleMultilineParameter || openerDoesNotFit then
+            indentSepNlnUnindent genParenLambda ctx
+        else
+            genParenLambda ctx
+
+/// Layout for `(function | ... -> ...)`. This is the one argument shape whose layout depends on
+/// where the call sits: mid-chain the clauses would run on underneath a line that still
+/// continues with further steps, so `function` is given its own line.
+let genMatchLambdaParenArg
+    (position: ChainCallPosition)
+    (p: ExprParenNode)
+    (matchLambdaNode: ExprMatchLambdaNode)
+    : Context -> Context =
+    let keepFunctionWithParen: Context -> Context =
+        genSingleTextNode p.OpeningParen
+        +> (genSingleTextNode matchLambdaNode.Function
+            +> indentSepNlnUnindent (genClauses matchLambdaNode.Clauses)
+            |> genNode matchLambdaNode)
+        +> sepNlnWhenWriteBeforeNewlineNotEmpty
+        +> genSingleTextNode p.ClosingParen
+
+    let breakAfterParen: Context -> Context =
+        genSingleTextNode p.OpeningParen
+        +> indentSepNlnUnindent (
+            genSingleTextNode matchLambdaNode.Function
+            +> sepNln
+            +> genClauses matchLambdaNode.Clauses
+            |> genNode matchLambdaNode
+        )
+        +> sepNln
+        +> genSingleTextNode p.ClosingParen
+
+    // The user already broke after the `(` themselves — `function` starts on a line below it.
+    let userBrokeAfterParen: bool =
+        matchLambdaNode.Range.StartLine > p.OpeningParen.Range.EndLine
+
+    fun (ctx: Context) ->
+        let breakOpener: bool =
+            match position with
+            // Mid-chain the other considerations do not get a say.
+            | ChainCallPosition.Intermediate -> true
+            | ChainCallPosition.Terminal -> ctx.Config.MultiLineLambdaClosingNewline || userBrokeAfterParen
+
+        if breakOpener then
+            breakAfterParen ctx
+        else
+            keepFunctionWithParen ctx
+
+/// Multiline layout of a call's parenthesised argument `( ... )`, shared by intermediate calls
+/// (genSegment) and the terminal call (genTerminal). Everything between `(` and `)` is laid out
+/// by the ordinary argument rules; the chain only gets a say in the two places named on
+/// `ChainCallPosition`.
+let genMultilineParenArg (position: ChainCallPosition) (p: ExprParenNode) : Context -> Context =
+    // Content attached before the argument is decided ahead of the argument's shape, so this is
+    // an `if` rather than another match arm.
+    if p.HasContentBefore || (Expr.Node p.Expr).HasContentBefore then
+        genParenArgWithContentBefore position p
+    else
+        match p.Expr with
+        | Expr.Lambda lambdaNode -> genLambdaParenArg p lambdaNode
+        | Expr.MatchLambda matchLambdaNode -> genMatchLambdaParenArg position p matchLambdaNode
+        | _ -> genMultilineFunctionApplicationArguments (Expr.Paren p)
+
+let genSegment (segment: ChainSegment) : Context -> Context =
+    match segment with
+    | ChainSegment.DotMember(dot, expr) -> genSingleTextNode dot +> genExpr expr
+    | ChainSegment.DotApplication(dot, expr, call) ->
+        genSingleTextNode dot
+        +> genExpr expr
+        +> match call with
+           | ChainCall.Unit u -> genUnit u
+           | ChainCall.Paren p ->
+               // Intermediate paren calls are always tight — space would change the parse tree.
+               expressionFitsOnRestOfLine
+                   (genExpr (Expr.Paren p))
+                   (genMultilineParenArg ChainCallPosition.Intermediate p)
+    | ChainSegment.DotIndex(dot, idx) ->
+        // DotIndex (.[i]) is structurally like DotMember with no call: the dot is explicit
+        // for trivia, but the [ ] brackets are not part of the index expression and must
+        // be added here rather than delegated to genExpr.
+        genSingleTextNode dot +> sepOpenLFixed +> genExpr idx +> sepCloseLFixed
+
+let genTerminal (node: ExprChain) : Context -> Context =
+    match node.Terminal with
+    | ChainTerminal.NoTerminal -> sepNone
+    | ChainTerminal.SpaceAllowed call
+    | ChainTerminal.NoSpaceAllowed call ->
+        let addSpace: Context -> Context =
+            match node.Terminal with
+            | ChainTerminal.NoSpaceAllowed _ -> sepNone
+            | _ ->
+                match List.tryLast node.Segments with
+                | Some(ChainSegment.DotMember(_, funcExpr)) ->
+                    match call with
+                    | ChainCall.Unit u -> sepSpaceBeforeParenInFuncInvocation funcExpr (Expr.Constant(Constant.Unit u))
+                    | ChainCall.Paren p -> sepSpaceBeforeParenInFuncInvocation funcExpr (Expr.Paren p)
+                | _ -> sepNone
+
+        match call with
+        | ChainCall.Unit u -> addSpace +> genUnit u
+        | ChainCall.Paren p ->
+            let short: Context -> Context = addSpace +> genExpr (Expr.Paren p)
+
+            let long: Context -> Context =
+                addSpace +> genMultilineParenArg ChainCallPosition.Terminal p
+
+            expressionFitsOnRestOfLine short long
+
+let genChain (node: ExprChain) : Context -> Context =
+    // The receiver, every navigation step and the method name are rendered together in
+    // source order with no line breaks between them; only the terminal call's arguments may
+    // wrap (`genTerminal` breaks them like an ordinary `f(args)`). This same rendering
+    // doubles as the "does the whole chain fit on one line?" candidate — when it fits, it
+    // *is* the one-liner. (The design notes in `chain-formatting-rationale.md` call this
+    // layout "Option A".)
+    let genChainKeptTogether: Context -> Context =
+        genExpr node.Head +> col sepNone node.Segments genSegment +> genTerminal node
+
+    // A segment is HEAVY — it earns its own line in a pipeline — when it is an
+    // intermediate call (`.Foo(x)`), or a member / index whose bracket payload is
+    // large enough to render on multiple lines (a long `.Cast<..>`, a big `.[expr]`).
+    // Everything else is light NAVIGATION (`.Name`, a short `.[0]`) and rides at the
+    // front of the next line instead of taking one of its own.
+    let isHeavy (seg: ChainSegment) (ctx: Context) : bool =
+        // Heavy only when the member's own bracket payload renders on multiple lines.
+        // We probe the payload alone (not the whole segment) so a comment attached to a
+        // plain `.Name` does not masquerade as a multiline type application, and so mere
+        // right-margin overflow does not count either.
+        let payloadIsMultiline (payload: Context -> Context) = fst (futureNlnCheckMem (payload, ctx))
+
+        match seg with
+        | ChainSegment.DotApplication _ -> true
+        | ChainSegment.DotMember(_, expr) ->
+            match expr with
+            | Expr.TypeApp _ -> payloadIsMultiline (genExpr expr)
+            | _ -> false
+        | ChainSegment.DotIndex(_, idx) -> payloadIsMultiline (genExpr idx)
+
+    // A `#if`/`#else` directive before a segment's dot pins that segment to its own line.
+    // Directly after the receiver this makes the navigation split from the call it would
+    // otherwise lead; deeper in the chain the segment already starts a fresh line, so the
+    // directive changes nothing and the following call still rides with it.
+    let segmentBeginsWithDirective (seg: ChainSegment) : bool =
+        let dot =
+            match seg with
+            | ChainSegment.DotMember(dot, _)
+            | ChainSegment.DotApplication(dot, _, _)
+            | ChainSegment.DotIndex(dot, _) -> dot
+
+        dot.ContentBefore
+        |> Seq.exists (fun trivia ->
+            match trivia.Content with
+            | TriviaContent.Directive _ -> true
+            | _ -> false)
+
+    let terminalIsCall: bool =
+        match node.Terminal with
+        | ChainTerminal.SpaceAllowed _
+        | ChainTerminal.NoSpaceAllowed _ -> true
+        | ChainTerminal.NoTerminal -> false
+
+    // Is the receiver a plain value — a bare identifier or dotted path (`config`,
+    // `this`, the dot-lambda `_`)? Only then may it share its line with the navigation
+    // and method name of a single trailing call. A compound receiver — a call `Mock()`,
+    // a parenthesised expression `(x :> T)`, a generic `Animal<Id>` — is not eligible to
+    // be kept together and leads a pipeline instead.
+    let headIsSimple: bool =
+        match node.Head with
+        | Expr.Ident _
+        | Expr.OptVar _ -> true
+        | _ -> false
+
+    // Leading-dot pipeline: two or more actions, or a chain that ends in
+    // navigation. Walk the segments and place each one:
+    //   * every ACTION starts its own line, led by its dot;
+    //   * light NAVIGATION rides at the front of the line of the action it
+    //     introduces — or, directly after the receiver, on the receiver's line;
+    //   * a run of navigation with no action fills the line greedily, breaking
+    //     before a dot when the current line is full.
+    let genLeadingDotPipeline (ctx: Context) : Context =
+        // onHeadLine — still on the receiver's line; no break has been emitted
+        //              yet, so the first break must also `indent`.
+        // mustBreak  — the previous segment was an action, so whatever comes
+        //              next has to start on a fresh line.
+        let rec place (onHeadLine: bool) (mustBreak: bool) (segs: ChainSegment list) (ctx: Context) : Context =
+            match segs with
+            | [] -> (genTerminal node +> onlyIfNot onHeadLine unindent) ctx
+            | seg :: rest ->
+                if isHeavy seg ctx || (onHeadLine && segmentBeginsWithDirective seg) then
+                    // An action starts a new line when it opens the pipeline
+                    // (leaving the receiver's line) or follows another action;
+                    // otherwise it rides after the navigation that introduced it.
+                    let placeAction: Context -> Context =
+                        if onHeadLine then indent +> sepNln +> genSegment seg
+                        elif mustBreak then sepNln +> genSegment seg
+                        else genSegment seg
+
+                    place false true rest (placeAction ctx)
+                elif mustBreak then
+                    // Navigation that introduces the next action: give it a fresh line.
+                    place false false rest ((onlyIf onHeadLine indent +> sepNln +> genSegment seg) ctx)
+                elif not (futureNlnCheck (genSegment seg) ctx) then
+                    // Navigation that still fits: ride on the current line.
+                    place onHeadLine false rest (genSegment seg ctx)
+                else
+                    // Navigation that no longer fits: break before its dot.
+                    place false false rest ((onlyIf onHeadLine indent +> sepNln +> genSegment seg) ctx)
+
+        // Indexing a parenthesised value — `(expr).[0]` — is a plain access, not a
+        // pipeline: the index rides tight onto the closing paren instead of breaking.
+        let isParenThenIndex: bool =
+            (match node.Head with
+             | Expr.Paren _ -> true
+             | _ -> false)
+            && (match node.Segments with
+                | [ ChainSegment.DotIndex _ ] -> true
+                | _ -> false)
+            && not terminalIsCall
+
+        // Otherwise the first segment starts a fresh line when the receiver is compound
+        // (it leads a pipeline), or when the receiver carries a trailing comment — else
+        // that comment would be stranded in the middle of the first call.
+        let receiverForcesBreak: bool =
+            (Expr.Node node.Head).HasContentAfter
+            || (not headIsSimple && not isParenThenIndex)
+
+        place true receiverForcesBreak node.Segments (genExpr node.Head ctx)
+
+    // Chosen when the whole chain does not fit on one line: either keep the chain together
+    // (and let the terminal's arguments wrap) or fall back to the leading-dot pipeline.
+    let long (ctx: Context) : Context =
+        // Keeping the chain together is only allowed for a single call at the very end:
+        // every segment is light navigation and the terminal is the one and only action.
+        let everySegmentIsLight: bool =
+            node.Segments |> List.forall (fun seg -> not (isHeavy seg ctx))
+
+        // Keeping the chain together holds the receiver, navigation and method name on one
+        // line. It gives way to the leading-dot pipeline when a comment between the steps
+        // forces a break, or when breaking actually *helps* the width. With several segments,
+        // spreading them across lines always helps. With a single method, breaking only helps
+        // when that method would fit on its own line — if the method itself is the overflow (a
+        // very long name), there is nothing to gain, so it stays together and the arguments wrap.
+        //
+        // Hence the two arms below ask genuinely different questions, and it is worth being
+        // explicit about why:
+        //   * ONE segment  — `receiver.Method(args)`. The pipeline has exactly one line to
+        //     offer (`.Method(args)` under the receiver), so it is only an improvement if
+        //     `.Method` actually fits there. `methodOverflowsOnItsOwn` asks that. When the
+        //     method name alone already overruns the margin, moving it down changes nothing
+        //     and we would have traded a readable `receiver.Method(` opener for a lone dotted
+        //     line that still overflows.
+        //   * MANY segments — the pipeline can spread the segments over several lines, so it
+        //     always reduces width. There is no "would it even help?" question to ask; we only
+        //     need to know whether the combined head + segments overflow in the first place.
+        let headAndSegmentsFit: bool =
+            match node.Segments with
+            | [ single ] ->
+                let combinedForcesBreak: bool =
+                    futureNlnCheck (genExpr node.Head +> genSegment single) ctx
+
+                let methodOverflowsOnItsOwn: bool = snd (futureNlnCheckMem (genSegment single, ctx))
+                not (combinedForcesBreak && not methodOverflowsOnItsOwn)
+            | _ -> not (futureNlnCheck (genExpr node.Head +> col sepNone node.Segments genSegment) ctx)
+
+        if terminalIsCall && everySegmentIsLight && headIsSimple && headAndSegmentsFit then
+            genChainKeptTogether ctx
+        else
+            genLeadingDotPipeline ctx
+
+    // Try the whole chain on one line first; otherwise `long` decides between keeping the
+    // chain together (with wrapped arguments) and the leading-dot pipeline.
+    expressionFitsOnRestOfLine genChainKeptTogether long
 
 let genExpr (e: Expr) =
     match e with
@@ -765,14 +1110,10 @@ let genExpr (e: Expr) =
             +> genSingleTextNode node.ClosingParen
         |> genNode node
     | Expr.Dynamic node ->
-        // Use sepNone for AppLongIdentAndSingleParenArg to preserve atomic application (no space before paren).
-        // Adding a space would change the AST from `(Jest.expect(json))?oMatchSnapshot` to `Jest.expect ((json)?oMatchSnapshot)`. See #3135.
-        let genFuncExpr =
-            match node.FuncExpr with
-            | Expr.AppLongIdentAndSingleParenArg appNode -> genAppLongIdentAndSingleParenArgExpr sepNone appNode
-            | _ -> genExpr node.FuncExpr
-
-        genFuncExpr +> !-"?" +> genExpr node.ArgExpr |> genNode node
+        // Chain expressions that serve as the function expression (e.g. Jest.expect(json)) are
+        // already printed tight — no space before their terminal paren — so genExpr is sufficient.
+        // See #3135.
+        genExpr node.FuncExpr +> !-"?" +> genExpr node.ArgExpr |> genNode node
     | Expr.DynamicChain node ->
         // A chain of `?` accesses is printed tight (no space before paren args).
         // Adding a space changes the parsing of the next `?member`. See #3159.
@@ -812,13 +1153,6 @@ let genExpr (e: Expr) =
         | Expr.AppSingleParenArg appNode ->
             genSingleTextNode node.Operator
             +> genExpr appNode.FunctionExpr
-            +> genExpr appNode.ArgExpr
-        // E.g. !-Foo.Meh(a)
-        | Expr.AppLongIdentAndSingleParenArg appNode ->
-            let mOptVarNode = appNode.FunctionName.Range
-
-            genSingleTextNode node.Operator
-            +> genExpr (Expr.OptVar(ExprOptVarNode(false, appNode.FunctionName, mOptVarNode)))
             +> genExpr appNode.ArgExpr
         | _ -> genWithoutSpace
         |> genNode node
@@ -916,7 +1250,6 @@ let genExpr (e: Expr) =
     | Expr.IndexWithoutDot node ->
         let genIdentifierExpr =
             match node.Identifier with
-            | Expr.AppLongIdentAndSingleParenArg appNode -> genAppLongIdentAndSingleParenArgExpr sepNone appNode
             | Expr.AppSingleParenArg appNode -> genAppSingleParenArgExpr sepNone appNode
             | _ -> genExpr node.Identifier
 
@@ -928,161 +1261,8 @@ let genExpr (e: Expr) =
         +> sepCloseLFixed
         |> genNode node
 
-    | Expr.Chain node ->
-        let genLink (isLastLink: bool) (link: ChainLink) =
-            match link with
-            | ChainLink.Identifier expr -> genExpr expr
-            | ChainLink.Dot stn -> genSingleTextNode stn
-            | ChainLink.Expr expr ->
-                match expr with
-                | Expr.App appNode ->
-                    match appNode.Arguments with
-                    | [ Expr.ArrayOrList _ as arrayOrList ] ->
-                        // Edge case for something like .G[].
-                        genExpr appNode.FunctionExpr +> genExpr arrayOrList
-                    | _ -> genExpr expr
-                | _ -> genExpr expr
-            | ChainLink.AppUnit appUnitNode ->
-                genExpr appUnitNode.FunctionName
-                +> onlyIf
-                    isLastLink
-                    (sepSpaceBeforeParenInFuncInvocation
-                        appUnitNode.FunctionName
-                        (Expr.Constant(Constant.Unit appUnitNode.Unit)))
-                +> genUnit appUnitNode.Unit
-                |> genNode appUnitNode
-            | ChainLink.AppParen appParen ->
-                let short =
-                    genExpr appParen.FunctionName
-                    +> onlyIf
-                        isLastLink
-                        (sepSpaceBeforeParenInFuncInvocation appParen.FunctionName (Expr.Paren appParen.Paren))
-                    +> genExpr (Expr.Paren appParen.Paren)
+    | Expr.Chain node -> genChain node |> genNode node
 
-                let long =
-                    match appParen.Paren.Expr with
-                    | Expr.Lambda lambdaNode ->
-                        genExpr appParen.FunctionName
-                        +> onlyIf
-                            isLastLink
-                            (sepSpaceBeforeParenInFuncInvocation appParen.FunctionName (Expr.Paren appParen.Paren))
-                        +> genSingleTextNode appParen.Paren.OpeningParen
-                        +> genLambdaWithParen lambdaNode
-                        +> onlyIfCtx
-                            (fun ctx ->
-                                ctx.Config.MultiLineLambdaClosingNewline
-                                && (not (isStroustrupStyleExpr ctx.Config lambdaNode.Expr)))
-                            sepNln
-                        +> genSingleTextNode appParen.Paren.ClosingParen
-                    | _ ->
-                        genExpr appParen.FunctionName
-                        +> onlyIf
-                            isLastLink
-                            (sepSpaceBeforeParenInFuncInvocation appParen.FunctionName (Expr.Paren appParen.Paren))
-                        +> genMultilineFunctionApplicationArguments (Expr.Paren appParen.Paren)
-
-                expressionFitsOnRestOfLine short long |> genNode appParen
-            | ChainLink.IndexExpr e -> sepOpenLFixed +> genExpr e +> sepCloseLFixed
-
-        let lastIndex = node.Links.Length - 1
-        let short = coli sepNone node.Links (fun idx -> genLink (idx = lastIndex))
-
-        let long =
-            let (|SimpleChain|_|) (link: ChainLink) =
-                match link with
-                | ChainLink.Identifier _
-                | ChainLink.IndexExpr _ -> Some link
-                | _ -> None
-
-            let (|LeadingSimpleChain|_|) (links: ChainLink list) =
-                let leading = System.Collections.Generic.Queue(links.Length)
-                let rest = System.Collections.Generic.Queue(links.Length)
-
-                (None, links)
-                ||> List.fold (fun lastDot link ->
-                    if not (Seq.isEmpty rest) then
-                        rest.Enqueue link
-                        None
-                    else
-                        match link with
-                        | SimpleChain _ ->
-                            Option.iter leading.Enqueue lastDot
-                            leading.Enqueue link
-                            None
-                        | ChainLink.Dot _ as dot -> Some dot
-                        | _ ->
-                            Option.iter rest.Enqueue lastDot
-                            rest.Enqueue link
-                            None)
-                |> (fun _ ->
-                    if Seq.isEmpty leading then
-                        None
-                    else
-                        Some(Seq.toList leading, Seq.toList rest))
-
-            let rec genIndentedLinks (lastLinkWasSimple: bool) (links: ChainLink list) (ctx: Context) : Context =
-                match links with
-                | [] -> ctx
-                | ChainLink.Dot dot :: link :: rest ->
-                    let isLast = List.isEmpty rest
-                    let genDotAndLink = genSingleTextNode dot +> genLink isLast link
-                    let currentIsSimple = ((|SimpleChain|_|) >> Option.isSome) link
-                    let currentLinkFitsOnRestOfLine = not (futureNlnCheck genDotAndLink ctx)
-
-                    if lastLinkWasSimple && currentLinkFitsOnRestOfLine then
-                        // The last link was an identifier and the current link fits on the remainder of the current line.
-                        genIndentedLinks currentIsSimple rest (genDotAndLink ctx)
-                    else
-                        let ctx' =
-                            onlyIf
-                                (not // Last link was `.Foo()`
-                                    lastLinkWasSimple
-                                 // `.Foo.Bar` but `Bar` crossed the max_line_length
-                                 || (lastLinkWasSimple && currentIsSimple && not currentLinkFitsOnRestOfLine))
-                                sepNlnUnlessLastEventIsNewline
-                                ctx
-
-                        genIndentedLinks
-                            currentIsSimple
-                            rest
-                            // Print the current link
-                            (genDotAndLink ctx')
-                | _ -> failwith "Expected dot in chain at this point"
-
-            let genFirstLinkAndIndentOther (firstLink: ChainLink) (others: ChainLink list) =
-                genLink false firstLink +> indentSepNlnUnindent (genIndentedLinks false others)
-
-            match node.Links with
-            | [] -> sepNone
-            | LeadingSimpleChain(leadingChain, links) ->
-                match links with
-                | [] ->
-                    expressionFitsOnRestOfLine
-                        short
-                        (match leadingChain with
-                         | [] -> sepNone
-                         | head :: links -> genLink false head +> indent +> genIndentedLinks true links +> unindent)
-                | _ ->
-                    expressionFitsOnRestOfLine
-                        (coli sepNone leadingChain (fun idx -> genLink (idx = lastIndex)))
-                        (match leadingChain with
-                         | [] -> sepNone
-                         | [ head ] -> genLink false head
-                         | head :: rest -> genLink false head +> indentSepNlnUnindent (genIndentedLinks true rest))
-                    +> indentSepNlnUnindent (genIndentedLinks true links)
-
-            | head :: links -> genFirstLinkAndIndentOther head links
-
-        expressionFitsOnRestOfLine short long |> genNode node
-
-    // path.Replace("../../../", "....")
-    | Expr.AppLongIdentAndSingleParenArg node ->
-        let addSpace =
-            sepSpaceBeforeParenInFuncInvocation
-                (Expr.OptVar(ExprOptVarNode(false, node.FunctionName, node.FunctionName.Range)))
-                node.ArgExpr
-
-        genAppLongIdentAndSingleParenArgExpr addSpace node
     // fn (a, b, c)
     | Expr.AppSingleParenArg node when
         (match node.FunctionExpr with
@@ -1111,13 +1291,6 @@ let genExpr (e: Expr) =
             | _ -> sepSpace
 
         genAppWithLambda sepSpaceAfterFunctionName node
-    | Expr.NestedIndexWithoutDot node ->
-        genExpr node.Identifier
-        +> sepOpenLFixed
-        +> genExpr node.Index
-        +> sepCloseLFixed
-        +> genExpr node.Argument
-        |> genNode node
 
     | Expr.App node ->
         fun ctx ->
@@ -1451,41 +1624,6 @@ let genExpr (e: Expr) =
         +> sepArrowRev
         +> autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup genExpr node.Expr
         |> genNode node
-    | Expr.DotIndexedGet node ->
-        let genDotIndexedGet =
-            let isParen =
-                match node.ObjectExpr with
-                | Expr.Paren _ -> true
-                | _ -> false
-
-            ifElse isParen (genExpr node.ObjectExpr) (addParenIfAutoNln node.ObjectExpr genExpr)
-            +> !-"."
-            +> sepOpenLFixed
-            +> genExpr node.IndexExpr
-            +> sepCloseLFixed
-
-        let genDotIndexedGetWithApp funcExpr argExpr (appNode: Node) =
-            let short = funcExpr +> genExpr argExpr |> genNode appNode
-
-            let long =
-                funcExpr +> genMultilineFunctionApplicationArguments argExpr |> genNode appNode
-
-            let idx = !-"." +> sepOpenLFixed +> genExpr node.IndexExpr +> sepCloseLFixed
-            expressionFitsOnRestOfLine (short +> idx) (long +> idx)
-
-        match node.ObjectExpr with
-        | Expr.App appNode ->
-            match appNode.Arguments with
-            | [ Expr.Constant(Constant.Unit _) as ux ] ->
-                genDotIndexedGetWithApp (genExpr appNode.FunctionExpr) ux appNode
-            | _ -> genDotIndexedGet
-        | Expr.AppSingleParenArg appNode ->
-            genDotIndexedGetWithApp (genExpr appNode.FunctionExpr) appNode.ArgExpr appNode
-
-        | Expr.AppLongIdentAndSingleParenArg appNode ->
-            genDotIndexedGetWithApp (genIdentListNode appNode.FunctionName) appNode.ArgExpr appNode
-        | _ -> genDotIndexedGet
-        |> genNode node
     | Expr.DotIndexedSet node ->
         let genDotIndexedSet =
             addParenIfAutoNln node.ObjectExpr genExpr
@@ -1525,8 +1663,16 @@ let genExpr (e: Expr) =
         | Expr.AppSingleParenArg appNode ->
             genDotIndexedSetWithApp (genExpr appNode.FunctionExpr) appNode.ArgExpr appNode
 
-        | Expr.AppLongIdentAndSingleParenArg appNode ->
-            genDotIndexedSetWithApp (genIdentListNode appNode.FunctionName) appNode.ArgExpr appNode
+        // An indexed set on a chain ending in a paren call (`foo.Bar(args).[i] <- v`):
+        // treat the receiver + method as the function and the terminal parens as the
+        // argument, so the arguments can break when the whole statement is too long.
+        | Expr.Chain chainNode ->
+            match chainNode.Terminal with
+            | ChainTerminal.SpaceAllowed(ChainCall.Paren p)
+            | ChainTerminal.NoSpaceAllowed(ChainCall.Paren p) ->
+                let funcExpr = genExpr chainNode.Head +> col sepNone chainNode.Segments genSegment
+                genDotIndexedSetWithApp funcExpr (Expr.Paren p) chainNode
+            | _ -> genDotIndexedSet
 
         | _ -> genDotIndexedSet
         |> genNode node
@@ -1544,7 +1690,10 @@ let genExpr (e: Expr) =
                 match node.Index with
                 | Expr.Constant _
                 | Expr.Ident _
-                | Expr.OptVar _ -> sepSpace
+                | Expr.OptVar _
+                // A dotted access index (`a.B c.DE`) is now a chain; it still needs the
+                // separating space, since a chain never opens with a bracket.
+                | Expr.Chain _ -> sepSpace
                 | _ -> sepNone
 
             genIdentListNode node.Identifier
@@ -1638,17 +1787,6 @@ let genExpr (e: Expr) =
         |> genNode node
     | Expr.IndexFromEnd node -> !-"^" +> genExpr node.Expr |> genNode node
     | Expr.Typar node -> genSingleTextNode node
-    | Expr.DotLambda node ->
-        let genDotLambdaExpr expr =
-            match expr with
-            | Expr.AppSingleParenArg p -> genAppSingleParenArgExpr sepNone p // be always atomic, see 3050
-            | Expr.AppLongIdentAndSingleParenArg p -> genAppLongIdentAndSingleParenArgExpr sepNone p // see 3120
-            | _ -> genExpr expr
-
-        genSingleTextNode node.Underscore
-        +> genSingleTextNode node.Dot
-        +> genDotLambdaExpr node.Expr
-        |> genNode node
     | Expr.BeginEnd node ->
         let short =
             genSingleTextNode node.Begin
@@ -2050,22 +2188,6 @@ let genLambdaAux (includeClosingParen: bool) (node: ExprLambdaNode) =
 let genLambda = genLambdaAux false
 let genLambdaWithParen = genLambdaAux true
 
-let genAppLongIdentAndSingleParenArgExpr (addSpace: Context -> Context) (node: ExprAppLongIdentAndSingleParenArgNode) =
-    let shortLids = genIdentListNode node.FunctionName
-    let short = shortLids +> addSpace +> genExpr node.ArgExpr
-
-    let long =
-        let args =
-            addSpace
-            +> expressionFitsOnRestOfLine (genExpr node.ArgExpr) (genMultilineFunctionApplicationArguments node.ArgExpr)
-
-        ifElseCtx
-            (futureNlnCheck shortLids)
-            (genFunctionNameWithMultilineLids args node.FunctionName)
-            (shortLids +> args)
-
-    expressionFitsOnRestOfLine short long |> genNode node
-
 let genAppSingleParenArgExpr (addSpace: Context -> Context) (node: ExprAppSingleParenArgNode) =
     let short = genExpr node.FunctionExpr +> addSpace +> genExpr node.ArgExpr
 
@@ -2383,25 +2505,6 @@ let genPrefixApp
      +> genSingleTextNode greaterThan)
         ctx
 
-let genFunctionNameWithMultilineLids (trailing: Context -> Context) (longIdent: IdentListNode) =
-    match longIdent.Content with
-    | IdentifierOrDot.Ident identNode :: t ->
-        genSingleTextNode identNode
-        +> indentSepNlnUnindent (
-            colEx
-                (function
-                | IdentifierOrDot.Ident _ -> sepNone
-                | IdentifierOrDot.KnownDot _
-                | IdentifierOrDot.UnknownDot -> sepNln)
-                t
-                (function
-                 | IdentifierOrDot.Ident identNode -> genSingleTextNode identNode
-                 | IdentifierOrDot.KnownDot dot -> genSingleTextNode dot
-                 | IdentifierOrDot.UnknownDot -> sepDot)
-            +> trailing
-        )
-    | _ -> sepNone
-
 let (|EndsWithDualListApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
     if not (config.ExperimentalElmish || config.IsStroustrupStyle) then
         None
@@ -2605,9 +2708,30 @@ let genAppWithLambda sep (node: ExprAppWithLambdaNode) =
     expressionFitsOnRestOfLine short long |> genNode node
 
 let sepSpaceBeforeParenInFuncInvocation (functionExpr: Expr) (argExpr: Expr) ctx =
+    // A chain that ends in an index access (`a.A.[0]`) invokes the indexed value —
+    // like new-style `xs[0]`, the `(` stays tight regardless of the space-before
+    // settings, since a space would read as applying the index to the parens.
+    let chainEndsInIndex =
+        match functionExpr with
+        | Expr.Chain node ->
+            match node.Terminal, List.tryLast node.Segments with
+            | ChainTerminal.NoTerminal, Some(ChainSegment.DotIndex _) -> true
+            | _ -> false
+        | _ -> false
+
+    // An empty index written tight against its receiver (`x.G[]`) is index syntax, not an
+    // application to an empty list — keep it tight. Adjacency distinguishes it from a real
+    // empty-list argument `f []`, which keeps its space.
+    let isEmptyIndex =
+        match argExpr with
+        | Expr.ArrayOrList arrayNode ->
+            List.isEmpty arrayNode.Elements
+            && RangeHelpers.isAdjacentTo (Expr.Node functionExpr).Range arrayNode.Range
+        | _ -> false
+
     match functionExpr, argExpr with
-    | Expr.DotLambda _, _ -> ctx
     | Expr.IndexWithoutDot _, ParenExpr _ -> ctx
+    | _ when chainEndsInIndex || isEmptyIndex -> ctx
     | Expr.Constant _, _ -> sepSpace ctx
     | ParenExpr _, _ -> sepSpace ctx
     | UppercaseExpr, ParenExpr _ -> onlyIf ctx.Config.SpaceBeforeUppercaseInvocation sepSpace ctx

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -466,10 +466,25 @@ let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : 
     // Move the whole lambda argument onto its own indented line when leaving it where it is
     // would read badly:
     //   * a single parameter that is itself multiline (a record pattern), or
-    //   * the opener does not fit, meaning `(fun` plus the parameters up to the arrow. The F#
-    //     style guide asks for all arguments up to the arrow to sit on one line, and rejects
-    //     parameters aligned under the opening parenthesis, since that column depends on the
-    //     length of the identifier in front of it.
+    //   * the opener does not fit. The opener is the parenthesis, `fun`, the parameters and the
+    //     arrow: everything that has to be written before the body can start.
+    //
+    //         items |> List.tryPick (fun (Interface(ty = t; keyword = k)) ->
+    //                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the opener
+    //
+    //     When that runs past the margin, the whole argument moves down a level:
+    //
+    //         items
+    //         |> List.tryPick
+    //             (fun (Interface(ty = t; keyword = k)) -> body)
+    //
+    //     The alternative is to leave `(fun` where it is and hang the parameters underneath it.
+    //     The F# style guide rejects that, because the column they hang from depends on the
+    //     length of the name in front of them:
+    //
+    //         items
+    //         |> List.tryPick (fun
+    //                              (Interface(ty = t; keyword = k)) -> body)
     fun (ctx: Context) ->
         let singleMultilineParameter: bool =
             match lambdaNode.Parameters with
@@ -2905,10 +2920,33 @@ let genAppWithLambda sep (node: ExprAppWithLambdaNode) =
                              +> genSingleTextNode node.ClosingParen))
                     +> unindent
 
-            (genExpr node.FunctionName
-             +> ifElse (List.isEmpty node.Arguments) sep (indent +> sepNln)
-             +> genArguments)
-                ctx
+            // A lone lambda argument is asked the same question as in the branch below, and the
+            // same one `genLambdaParenArg` asks for a call reached through a dot: does the
+            // opener fit, meaning everything up to the arrow? See the worked example there.
+            // Without this, the setting being on was enough to skip the question entirely.
+            let openerDoesNotFit: bool =
+                match node.Arguments, node.Lambda with
+                | [], Choice1Of2 lambdaNode ->
+                    futureNlnCheck
+                        (genExpr node.FunctionName
+                         +> sep
+                         +> genSingleTextNode node.OpeningParen
+                         +> enterNode lambdaNode
+                         +> genSingleTextNode lambdaNode.Fun
+                         +> sepSpace
+                         +> col sepSpace lambdaNode.Parameters genPat
+                         +> sepSpace
+                         +> genSingleTextNode lambdaNode.Arrow)
+                        ctx
+                | _ -> false
+
+            if openerDoesNotFit then
+                (genExpr node.FunctionName +> indent +> sepNln +> genArguments +> unindent) ctx
+            else
+                (genExpr node.FunctionName
+                 +> ifElse (List.isEmpty node.Arguments) sep (indent +> sepNln)
+                 +> genArguments)
+                    ctx
         else
             match node.Lambda with
             | Choice1Of2 lambdaNode ->

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -407,7 +407,7 @@ let requiresMultilineToPreserveSemantics (exprs: Expr list) =
 ///   * whether the opening `(` is allowed to leave the member name, which is a grammar
 ///     constraint rather than a style choice, and
 ///   * whether a `(function` argument is forced onto its own line, which is a readability call.
-[<RequireQualifiedAccess>]
+[<RequireQualifiedAccess; Struct>]
 type ChainCallPosition =
     /// A call with more chain after it, e.g. `.Foo(x)` in `a.Foo(x).Bar()`.
     | Intermediate

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -516,9 +516,9 @@ let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : 
         else
             genParenLambda ctx
 
-/// Layout for `(function | ... -> ...)`. This is the one argument shape whose layout depends on
-/// where the call sits: mid-chain the clauses would run on underneath a line that still
-/// continues with further steps, so `function` is given its own line.
+/// Layout for `(function | ... -> ...)`. Identical wherever the call sits in its chain:
+/// `MultiLineLambdaClosingNewline`, or a break the user already made after the `(`, decides
+/// whether `function` goes on its own line.
 let genMatchLambdaParenArg (parenNode: ExprParenNode) (matchLambdaNode: ExprMatchLambdaNode) : Context -> Context =
     let keepFunctionWithParen: Context -> Context =
         genSingleTextNode parenNode.OpeningParen
@@ -556,7 +556,7 @@ let genMatchLambdaParenArg (parenNode: ExprParenNode) (matchLambdaNode: ExprMatc
 
 /// Multiline layout of a call's parenthesised argument `( ... )`, shared by intermediate calls
 /// (genSegment) and the terminal call (genTerminal). Everything between `(` and `)` is laid out
-/// by the ordinary argument rules; the chain only gets a say in the two places named on
+/// by the ordinary argument rules; the chain only gets a say in the one place named on
 /// `ChainCallPosition`.
 let genMultilineParenArg (position: ChainCallPosition) (parenNode: ExprParenNode) : Context -> Context =
     // Content attached before the argument is decided ahead of the argument's shape, so this is
@@ -729,8 +729,7 @@ let genChain (node: ExprChain) : Context -> Context =
     // source order with no line breaks between them; only the terminal call's arguments may
     // wrap (`genTerminal` breaks them like an ordinary `f(args)`). This same rendering
     // doubles as the "does the whole chain fit on one line?" candidate — when it fits, it
-    // *is* the one-liner. (The design notes in `chain-formatting-rationale.md` call this
-    // layout "Option A".)
+    // *is* the one-liner. (`Chains.md` calls this layout "keeping the chain together".)
     let genChainKeptTogether: Context -> Context =
         genExpr node.Head +> col sepNone node.Segments genSegment +> genTerminal node
 
@@ -777,19 +776,21 @@ let genChain (node: ExprChain) : Context -> Context =
         | ChainTerminal.NoSpaceAllowed _ -> true
         | ChainTerminal.NoTerminal -> false
 
-    // Is the receiver a plain value — a bare identifier or dotted path (`config`,
-    // `this`, the dot-lambda `_`)? Only then may it share its line with the navigation
-    // and method name of a single trailing call. A compound receiver — a call `Mock()`,
-    // a parenthesised expression `(x :> T)`, a generic `Animal<Id>` — is not eligible to
-    // be kept together and leads a pipeline instead.
+    // Is the receiver a plain value, a bare identifier like `config`, `this` or the
+    // dot-lambda `_`? A dotted path never lands here: every dot became a segment, so the
+    // head of `config.Settings.GetValue(x)` is just `config`. Only a plain value may share
+    // its line with the navigation and method name of a single trailing call. A compound
+    // receiver (a call `Mock()`, a parenthesised expression `(x :> T)`, a generic
+    // `Animal<Id>`) is not eligible to be kept together and leads a pipeline instead.
     let headIsSimple: bool =
         match node.Head with
         | Expr.Ident _
         | Expr.OptVar _ -> true
         | _ -> false
 
-    // Leading-dot pipeline: two or more actions, or a chain that ends in
-    // navigation. Walk the segments and place each one:
+    // Leading-dot pipeline: two or more actions, a chain that ends in navigation, a
+    // compound receiver, or a head plus navigation that does not fit on one line (see
+    // the branch on `headAndSegmentsFit` below). Walk the segments and place each one:
     //   * every ACTION starts its own line, led by its dot;
     //   * light NAVIGATION rides at the front of the line of the action it
     //     introduces — or, directly after the receiver, on the receiver's line;

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -428,11 +428,28 @@ let requiresMultilineToPreserveSemantics (exprs: Expr list) =
 
 // Chain printing helpers
 
-/// Where a call sits in its chain. This governs exactly two things about the layout of the
-/// call's parenthesised argument, and nothing else:
-///   * whether the opening `(` is allowed to leave the member name, which is a grammar
-///     constraint rather than a style choice, and
-///   * whether a `(function` argument is forced onto its own line, which is a readability call.
+/// A column in a chain's rendered output, counting from the left margin: where one of its
+/// lines starts, where a step would land, or the right margin the run has to stay inside.
+type ChainColumn = int
+
+/// How wide a single chain step renders, in characters.
+type ChainStepWidth = int
+
+/// What one chain step does to the line it lands on, as decided by `balanceNavigationRun`.
+[<RequireQualifiedAccess; Struct>]
+type ChainStepPlacement =
+    /// The step continues the line the step before it ended on.
+    | RidesOnCurrentLine
+    /// The step opens a fresh line, indented to the run's own column.
+    | OpensNewLine
+
+/// Where a call sits in its chain. This governs exactly one thing about the layout of the
+/// call's parenthesised argument, and nothing else: whether the opening `(` is allowed to leave
+/// the member name, which is a grammar constraint rather than a style choice.
+///
+/// Nothing about a lambda argument depends on it. `fun` and `function` are laid out the same
+/// way wherever their call sits, as the F# style guide asks ("Treat match lambda's in a similar
+/// fashion").
 [<RequireQualifiedAccess; Struct>]
 type ChainCallPosition =
     /// A call with more chain after it, e.g. `.Foo(x)` in `a.Foo(x).Bar()`.
@@ -443,32 +460,32 @@ type ChainCallPosition =
 /// Layout for an argument carrying a directive or comment before it (e.g. `(` on its own line
 /// above a `#if`): the argument is pushed onto its own indented lines and the closing `)`
 /// returns to the method's column.
-let genParenArgWithContentBefore (position: ChainCallPosition) (p: ExprParenNode) : Context -> Context =
+let genParenArgWithContentBefore (position: ChainCallPosition) (parenNode: ExprParenNode) : Context -> Context =
     // An INTERMEDIATE call may not be separated from its `(` — `a.Foo (x).Bar()` parses as
     // `a.Foo ((x).Bar())` — so there the paren stays welded to the member name and the break
     // happens after it. Only a terminal call may put the `(` on the indented line.
     let genOpeningParen: Context -> Context =
         match position with
-        | ChainCallPosition.Intermediate -> genSingleTextNode p.OpeningParen +> indent +> sepNln
-        | ChainCallPosition.Terminal -> indent +> sepNln +> genSingleTextNode p.OpeningParen +> sepNln
+        | ChainCallPosition.Intermediate -> genSingleTextNode parenNode.OpeningParen +> indent +> sepNln
+        | ChainCallPosition.Terminal -> indent +> sepNln +> genSingleTextNode parenNode.OpeningParen +> sepNln
 
     genOpeningParen
-    +> genExpr p.Expr
+    +> genExpr parenNode.Expr
     +> unindent
     +> sepNlnUnlessLastEventIsNewline
-    +> genSingleTextNode p.ClosingParen
-    |> genNode p
+    +> genSingleTextNode parenNode.ClosingParen
+    |> genNode parenNode
 
 /// Layout for `(fun params -> body)`. Identical wherever the call sits: `MultiLineLambdaClosingNewline`
 /// decides where the closing `)` lands, exactly as it would for a call with no receiver.
-let genLambdaParenArg (p: ExprParenNode) (lambdaNode: ExprLambdaNode) : Context -> Context =
+let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : Context -> Context =
     // `startColumn` is remembered so the closing `)` can be indented back to it — important
     // when the body ends at a shallow column (e.g. a verbatim string in column 0), where a `)`
     // left there breaks the offside rule and produces invalid F#.
     let genParenLambda (ctx: Context) : Context =
         let startColumn: int = ctx.WriterModel.Indent
 
-        (genSingleTextNode p.OpeningParen
+        (genSingleTextNode parenNode.OpeningParen
          +> genLambdaWithParen lambdaNode
          +> ifElseCtx
              (fun ctx ->
@@ -476,7 +493,7 @@ let genLambdaParenArg (p: ExprParenNode) (lambdaNode: ExprLambdaNode) : Context 
                  && not (isStroustrupStyleExpr ctx.Config lambdaNode.Expr))
              sepNln
              (sepNlnWhenWriteBeforeNewlineNotEmpty +> addFixedSpaces startColumn)
-         +> genSingleTextNode p.ClosingParen)
+         +> genSingleTextNode parenNode.ClosingParen)
             ctx
 
     // Move the whole lambda argument onto its own indented line when leaving `(fun` at the
@@ -492,7 +509,7 @@ let genLambdaParenArg (p: ExprParenNode) (lambdaNode: ExprLambdaNode) : Context 
             | _ -> false
 
         let openerDoesNotFit: bool =
-            futureNlnCheck (genSingleTextNode p.OpeningParen +> genSingleTextNode lambdaNode.Fun) ctx
+            futureNlnCheck (genSingleTextNode parenNode.OpeningParen +> genSingleTextNode lambdaNode.Fun) ctx
 
         if singleMultilineParameter || openerDoesNotFit then
             indentSepNlnUnindent genParenLambda ctx
@@ -502,21 +519,17 @@ let genLambdaParenArg (p: ExprParenNode) (lambdaNode: ExprLambdaNode) : Context 
 /// Layout for `(function | ... -> ...)`. This is the one argument shape whose layout depends on
 /// where the call sits: mid-chain the clauses would run on underneath a line that still
 /// continues with further steps, so `function` is given its own line.
-let genMatchLambdaParenArg
-    (position: ChainCallPosition)
-    (p: ExprParenNode)
-    (matchLambdaNode: ExprMatchLambdaNode)
-    : Context -> Context =
+let genMatchLambdaParenArg (parenNode: ExprParenNode) (matchLambdaNode: ExprMatchLambdaNode) : Context -> Context =
     let keepFunctionWithParen: Context -> Context =
-        genSingleTextNode p.OpeningParen
+        genSingleTextNode parenNode.OpeningParen
         +> (genSingleTextNode matchLambdaNode.Function
             +> indentSepNlnUnindent (genClauses matchLambdaNode.Clauses)
             |> genNode matchLambdaNode)
         +> sepNlnWhenWriteBeforeNewlineNotEmpty
-        +> genSingleTextNode p.ClosingParen
+        +> genSingleTextNode parenNode.ClosingParen
 
     let breakAfterParen: Context -> Context =
-        genSingleTextNode p.OpeningParen
+        genSingleTextNode parenNode.OpeningParen
         +> indentSepNlnUnindent (
             genSingleTextNode matchLambdaNode.Function
             +> sepNln
@@ -524,18 +537,17 @@ let genMatchLambdaParenArg
             |> genNode matchLambdaNode
         )
         +> sepNln
-        +> genSingleTextNode p.ClosingParen
+        +> genSingleTextNode parenNode.ClosingParen
 
     // The user already broke after the `(` themselves — `function` starts on a line below it.
     let userBrokeAfterParen: bool =
-        matchLambdaNode.Range.StartLine > p.OpeningParen.Range.EndLine
+        matchLambdaNode.Range.StartLine > parenNode.OpeningParen.Range.EndLine
 
     fun (ctx: Context) ->
+        // Where the call sits in its chain has no say here: a match lambda is laid out the same
+        // way as a `fun` lambda, whether its call is the last step or the first.
         let breakOpener: bool =
-            match position with
-            // Mid-chain the other considerations do not get a say.
-            | ChainCallPosition.Intermediate -> true
-            | ChainCallPosition.Terminal -> ctx.Config.MultiLineLambdaClosingNewline || userBrokeAfterParen
+            ctx.Config.MultiLineLambdaClosingNewline || userBrokeAfterParen
 
         if breakOpener then
             breakAfterParen ctx
@@ -546,16 +558,16 @@ let genMatchLambdaParenArg
 /// (genSegment) and the terminal call (genTerminal). Everything between `(` and `)` is laid out
 /// by the ordinary argument rules; the chain only gets a say in the two places named on
 /// `ChainCallPosition`.
-let genMultilineParenArg (position: ChainCallPosition) (p: ExprParenNode) : Context -> Context =
+let genMultilineParenArg (position: ChainCallPosition) (parenNode: ExprParenNode) : Context -> Context =
     // Content attached before the argument is decided ahead of the argument's shape, so this is
     // an `if` rather than another match arm.
-    if p.HasContentBefore || (Expr.Node p.Expr).HasContentBefore then
-        genParenArgWithContentBefore position p
+    if parenNode.HasContentBefore || (Expr.Node parenNode.Expr).HasContentBefore then
+        genParenArgWithContentBefore position parenNode
     else
-        match p.Expr with
-        | Expr.Lambda lambdaNode -> genLambdaParenArg p lambdaNode
-        | Expr.MatchLambda matchLambdaNode -> genMatchLambdaParenArg position p matchLambdaNode
-        | _ -> genMultilineFunctionApplicationArguments (Expr.Paren p)
+        match parenNode.Expr with
+        | Expr.Lambda lambdaNode -> genLambdaParenArg parenNode lambdaNode
+        | Expr.MatchLambda matchLambdaNode -> genMatchLambdaParenArg parenNode matchLambdaNode
+        | _ -> genMultilineFunctionApplicationArguments (Expr.Paren parenNode)
 
 let genSegment (segment: ChainSegment) : Context -> Context =
     match segment with
@@ -565,42 +577,152 @@ let genSegment (segment: ChainSegment) : Context -> Context =
         +> genExpr expr
         +> match call with
            | ChainCall.Unit u -> genUnit u
-           | ChainCall.Paren p ->
+           | ChainCall.Paren parenNode ->
                // Intermediate paren calls are always tight — space would change the parse tree.
                expressionFitsOnRestOfLine
-                   (genExpr (Expr.Paren p))
-                   (genMultilineParenArg ChainCallPosition.Intermediate p)
-    | ChainSegment.DotIndex(dot, idx) ->
+                   (genExpr (Expr.Paren parenNode))
+                   (genMultilineParenArg ChainCallPosition.Intermediate parenNode)
+    | ChainSegment.DotIndex(dot, index) ->
         // DotIndex (.[i]) is structurally like DotMember with no call: the dot is explicit
         // for trivia, but the [ ] brackets are not part of the index expression and must
         // be added here rather than delegated to genExpr.
-        genSingleTextNode dot +> sepOpenLFixed +> genExpr idx +> sepCloseLFixed
+        genSingleTextNode dot +> sepOpenLFixed +> genExpr index +> sepCloseLFixed
+
+/// The opener of a step: the part that has to fit on the line before the step's arguments get
+/// any say. For navigation that is the whole step (`.Name`); for a call it stops at the `(`,
+/// because what sits between the parentheses is the argument's business, not the chain's.
+let genSegmentOpener (segment: ChainSegment) : Context -> Context =
+    match segment with
+    | ChainSegment.DotApplication(dot, expr, call) ->
+        genSingleTextNode dot
+        +> genExpr expr
+        +> match call with
+           | ChainCall.Unit u -> genUnit u
+           | ChainCall.Paren parenNode -> genSingleTextNode parenNode.OpeningParen
+    | ChainSegment.DotMember _
+    | ChainSegment.DotIndex _ -> genSegment segment
+
+/// The space a setting may ask for between the last member name and the terminal call's `(`.
+/// Only the final call of a chain is eligible; see the note on tightness in `Chains.md`.
+let genTerminalSpace (node: ExprChain) (call: ChainCall) : Context -> Context =
+    match node.Terminal with
+    | ChainTerminal.NoSpaceAllowed _ -> sepNone
+    | ChainTerminal.NoTerminal -> sepNone
+    | ChainTerminal.SpaceAllowed _ ->
+        match List.tryLast node.Segments with
+        | Some(ChainSegment.DotMember(_, funcExpr)) ->
+            match call with
+            | ChainCall.Unit u -> sepSpaceBeforeParenInFuncInvocation funcExpr (Expr.Constant(Constant.Unit u))
+            | ChainCall.Paren parenNode -> sepSpaceBeforeParenInFuncInvocation funcExpr (Expr.Paren parenNode)
+        | _ -> sepNone
+
+/// The opener of the terminal call — the `(` and any space in front of it. This is the least
+/// the navigation before it has to leave room for.
+let genTerminalOpener (node: ExprChain) : Context -> Context =
+    match node.Terminal with
+    | ChainTerminal.NoTerminal -> sepNone
+    | ChainTerminal.SpaceAllowed call
+    | ChainTerminal.NoSpaceAllowed call ->
+        genTerminalSpace node call
+        +> match call with
+           | ChainCall.Unit u -> genUnit u
+           | ChainCall.Paren parenNode -> genSingleTextNode parenNode.OpeningParen
+
+/// A whole step on one line: navigation, or a call with its arguments. Used to ask whether a
+/// wrap exists that would leave the call intact, so its arguments never have to break. This
+/// deliberately renders the one-line form rather than asking whether it fits *here*, because
+/// where "here" is, is exactly what the wrap is about to decide.
+let genSegmentOnOneLine (segment: ChainSegment) : Context -> Context =
+    match segment with
+    | ChainSegment.DotApplication(dot, expr, call) ->
+        genSingleTextNode dot
+        +> genExpr expr
+        +> match call with
+           | ChainCall.Unit u -> genUnit u
+           | ChainCall.Paren parenNode -> genExpr (Expr.Paren parenNode)
+    | ChainSegment.DotMember _
+    | ChainSegment.DotIndex _ -> genSegment segment
+
+/// The terminal call on one line, arguments included. The counterpart of `genTerminalOpener`.
+let genTerminalOnOneLine (node: ExprChain) : Context -> Context =
+    match node.Terminal with
+    | ChainTerminal.NoTerminal -> sepNone
+    | ChainTerminal.SpaceAllowed call
+    | ChainTerminal.NoSpaceAllowed call ->
+        genTerminalSpace node call
+        +> match call with
+           | ChainCall.Unit u -> genUnit u
+           | ChainCall.Paren parenNode -> genExpr (Expr.Paren parenNode)
 
 let genTerminal (node: ExprChain) : Context -> Context =
     match node.Terminal with
     | ChainTerminal.NoTerminal -> sepNone
     | ChainTerminal.SpaceAllowed call
     | ChainTerminal.NoSpaceAllowed call ->
-        let addSpace: Context -> Context =
-            match node.Terminal with
-            | ChainTerminal.NoSpaceAllowed _ -> sepNone
-            | _ ->
-                match List.tryLast node.Segments with
-                | Some(ChainSegment.DotMember(_, funcExpr)) ->
-                    match call with
-                    | ChainCall.Unit u -> sepSpaceBeforeParenInFuncInvocation funcExpr (Expr.Constant(Constant.Unit u))
-                    | ChainCall.Paren p -> sepSpaceBeforeParenInFuncInvocation funcExpr (Expr.Paren p)
-                | _ -> sepNone
+        let addSpace: Context -> Context = genTerminalSpace node call
 
         match call with
         | ChainCall.Unit u -> addSpace +> genUnit u
-        | ChainCall.Paren p ->
-            let short: Context -> Context = addSpace +> genExpr (Expr.Paren p)
+        | ChainCall.Paren parenNode ->
+            let short: Context -> Context = addSpace +> genExpr (Expr.Paren parenNode)
 
             let long: Context -> Context =
-                addSpace +> genMultilineParenArg ChainCallPosition.Terminal p
+                addSpace +> genMultilineParenArg ChainCallPosition.Terminal parenNode
 
             expressionFitsOnRestOfLine short long
+
+/// Decide where a run of navigation steps breaks when it does not fit on one line.
+///
+/// `widths` holds the rendered width of each step, in order. The run starts at column
+/// `startColumn`, every line after the first starts at `indentColumn`, and no line should pass
+/// `maxColumn`. The result says, for each step, whether it opens a fresh line.
+///
+/// Filling greedily — take steps until the margin is reached, then break — leaves one line
+/// packed to the margin with a short remnant behind it. Instead we look for the narrowest
+/// margin that still fits the run in the same number of lines, and fill greedily against
+/// *that*. Squeezing the margin evens the lines out, it can never cost an extra line, and
+/// because the fill underneath is still greedy the earlier lines stay the longer ones.
+let balanceNavigationRun
+    (startColumn: ChainColumn)
+    (indentColumn: ChainColumn)
+    (maxColumn: ChainColumn)
+    (widths: ChainStepWidth list)
+    : ChainStepPlacement list =
+    // One placement per step, threading the column the next step would start at: a step that
+    // still fits rides on the current line, one that does not opens a fresh line at the run's
+    // indent.
+    let fillAt (margin: ChainColumn) : ChainStepPlacement list =
+        let placeNextStep (column: ChainColumn) (width: ChainStepWidth) : ChainStepPlacement * ChainColumn =
+            if column + width <= margin then
+                ChainStepPlacement.RidesOnCurrentLine, column + width
+            else
+                ChainStepPlacement.OpensNewLine, indentColumn + width
+
+        List.mapFold placeNextStep startColumn widths |> fst
+
+    let lineCount (placements: ChainStepPlacement list) : int =
+        let opensLine (placement: ChainStepPlacement) : bool =
+            placement = ChainStepPlacement.OpensNewLine
+
+        1 + List.length (List.filter opensLine placements)
+
+    // The fewest lines this run can take: whatever the real margin already achieves.
+    let fewestLines: int = lineCount (fillAt maxColumn)
+
+    // Narrow the margin as far as it will go without buying an extra line. A run only ever
+    // needs more lines as the margin shrinks, so a binary search finds the narrowest one.
+    let rec narrowest (low: ChainColumn) (high: ChainColumn) : ChainColumn =
+        if low >= high then
+            high
+        else
+            let middle: ChainColumn = (low + high) / 2
+
+            if lineCount (fillAt middle) <= fewestLines then
+                narrowest low middle
+            else
+                narrowest (middle + 1) high
+
+    fillAt (narrowest 0 maxColumn)
 
 let genChain (node: ExprChain) : Context -> Context =
     // The receiver, every navigation step and the method name are rendered together in
@@ -617,28 +739,28 @@ let genChain (node: ExprChain) : Context -> Context =
     // large enough to render on multiple lines (a long `.Cast<..>`, a big `.[expr]`).
     // Everything else is light NAVIGATION (`.Name`, a short `.[0]`) and rides at the
     // front of the next line instead of taking one of its own.
-    let isHeavy (seg: ChainSegment) (ctx: Context) : bool =
+    let isHeavy (segment: ChainSegment) (ctx: Context) : bool =
         // Heavy only when the member's own bracket payload renders on multiple lines.
         // We probe the payload alone (not the whole segment) so a comment attached to a
         // plain `.Name` does not masquerade as a multiline type application, and so mere
         // right-margin overflow does not count either.
         let payloadIsMultiline (payload: Context -> Context) = fst (futureNlnCheckMem (payload, ctx))
 
-        match seg with
+        match segment with
         | ChainSegment.DotApplication _ -> true
         | ChainSegment.DotMember(_, expr) ->
             match expr with
             | Expr.TypeApp _ -> payloadIsMultiline (genExpr expr)
             | _ -> false
-        | ChainSegment.DotIndex(_, idx) -> payloadIsMultiline (genExpr idx)
+        | ChainSegment.DotIndex(_, index) -> payloadIsMultiline (genExpr index)
 
     // A `#if`/`#else` directive before a segment's dot pins that segment to its own line.
     // Directly after the receiver this makes the navigation split from the call it would
     // otherwise lead; deeper in the chain the segment already starts a fresh line, so the
     // directive changes nothing and the following call still rides with it.
-    let segmentBeginsWithDirective (seg: ChainSegment) : bool =
+    let segmentBeginsWithDirective (segment: ChainSegment) : bool =
         let dot =
-            match seg with
+            match segment with
             | ChainSegment.DotMember(dot, _)
             | ChainSegment.DotApplication(dot, _, _)
             | ChainSegment.DotIndex(dot, _) -> dot
@@ -671,36 +793,164 @@ let genChain (node: ExprChain) : Context -> Context =
     //   * every ACTION starts its own line, led by its dot;
     //   * light NAVIGATION rides at the front of the line of the action it
     //     introduces — or, directly after the receiver, on the receiver's line;
-    //   * a run of navigation with no action fills the line greedily, breaking
-    //     before a dot when the current line is full.
+    //   * a run of navigation too long for one line is balanced across several
+    //     (see `balanceNavigationRun`).
     let genLeadingDotPipeline (ctx: Context) : Context =
+        // Width of a fragment as it would render right here. A fragment that takes lines of
+        // its own — a comment on the dot forces that — adds nothing to the line the run is
+        // filling, so it contributes no width rather than a meaningless one.
+        let widthOf (fragment: Context -> Context) (ctx: Context) : ChainStepWidth =
+            if fst (futureNlnCheckMem (fragment, ctx)) then
+                0
+            else
+                ctx.WithDummy(fragment, keepPageWidth = true).Column - ctx.Column
+
+        // Does this segment claim a line of its own? Actions always do, and so does a
+        // segment whose dot carries an `#if` directive while we are still on the
+        // receiver's line: that splits the navigation from the call it would lead.
+        let claimsOwnLine (onHeadLine: bool) (segment: ChainSegment) (ctx: Context) : bool =
+            isHeavy segment ctx || (onHeadLine && segmentBeginsWithDirective segment)
+
+        // A step whose dot carries a comment renders on more than one line all by itself, so
+        // it has no width to balance and cannot share a line with what came before. It opens
+        // one instead, and the steps after it are measured afresh from where it left off.
+        let rendersOnItsOwnLines (segment: ChainSegment) (ctx: Context) : bool =
+            fst (futureNlnCheckMem (genSegment segment, ctx))
+
+        // Emit one navigation step, either on the current line or opening a fresh one.
+        // Leaving the receiver's line is also where the pipeline's indent is established.
+        let placeStep (onHeadLine: bool) (placement: ChainStepPlacement) (segment: ChainSegment) : Context -> Context =
+            match placement with
+            | ChainStepPlacement.OpensNewLine -> onlyIf onHeadLine indent +> sepNln +> genSegment segment
+            | ChainStepPlacement.RidesOnCurrentLine -> genSegment segment
+
+        // Walk a run of navigation whose placements have already been decided, reporting
+        // back whether the receiver's line is still the current one.
+        let rec placeRun
+            (onHeadLine: bool)
+            (steps: (ChainSegment * ChainStepPlacement) list)
+            (ctx: Context)
+            : bool * Context =
+            match steps with
+            | [] -> onHeadLine, ctx
+            | (segment, placement) :: rest ->
+                let stillOnHeadLine: bool =
+                    match placement with
+                    | ChainStepPlacement.OpensNewLine -> false
+                    | ChainStepPlacement.RidesOnCurrentLine -> onHeadLine
+
+                placeRun stillOnHeadLine rest (placeStep onHeadLine placement segment ctx)
+
         // onHeadLine — still on the receiver's line; no break has been emitted
         //              yet, so the first break must also `indent`.
         // mustBreak  — the previous segment was an action, so whatever comes
         //              next has to start on a fresh line.
-        let rec place (onHeadLine: bool) (mustBreak: bool) (segs: ChainSegment list) (ctx: Context) : Context =
-            match segs with
+        let rec place (onHeadLine: bool) (mustBreak: bool) (segments: ChainSegment list) (ctx: Context) : Context =
+            match segments with
             | [] -> (genTerminal node +> onlyIfNot onHeadLine unindent) ctx
-            | seg :: rest ->
-                if isHeavy seg ctx || (onHeadLine && segmentBeginsWithDirective seg) then
-                    // An action starts a new line when it opens the pipeline
-                    // (leaving the receiver's line) or follows another action;
-                    // otherwise it rides after the navigation that introduced it.
-                    let placeAction: Context -> Context =
-                        if onHeadLine then indent +> sepNln +> genSegment seg
-                        elif mustBreak then sepNln +> genSegment seg
-                        else genSegment seg
+            | segment :: rest when claimsOwnLine onHeadLine segment ctx ->
+                // An action starts a new line when it opens the pipeline
+                // (leaving the receiver's line) or follows another action;
+                // otherwise it rides after the navigation that introduced it.
+                let placeAction: Context -> Context =
+                    if onHeadLine then indent +> sepNln +> genSegment segment
+                    elif mustBreak then sepNln +> genSegment segment
+                    else genSegment segment
 
-                    place false true rest (placeAction ctx)
-                elif mustBreak then
-                    // Navigation that introduces the next action: give it a fresh line.
-                    place false false rest ((onlyIf onHeadLine indent +> sepNln +> genSegment seg) ctx)
-                elif not (futureNlnCheck (genSegment seg) ctx) then
-                    // Navigation that still fits: ride on the current line.
-                    place onHeadLine false rest (genSegment seg ctx)
-                else
-                    // Navigation that no longer fits: break before its dot.
-                    place false false rest ((onlyIf onHeadLine indent +> sepNln +> genSegment seg) ctx)
+                place false true rest (placeAction ctx)
+            | segment :: rest when rendersOnItsOwnLines segment ctx ->
+                place false false rest ((onlyIf onHeadLine indent +> sepNln +> genSegment segment) ctx)
+            | _ ->
+                // A run of navigation, taken as a whole so its breaks can be balanced. It stops
+                // at anything that cannot share a line, so every step in it has a real width.
+                let run, afterRun =
+                    segments
+                    |> List.partitionWhile (fun _ segment ->
+                        not (claimsOwnLine onHeadLine segment ctx)
+                        && not (rendersOnItsOwnLines segment ctx))
+
+                // Where a fresh line would start, and where this run starts.
+                let indentColumn: ChainColumn =
+                    ctx.WithDummy(onlyIf onHeadLine indent +> sepNln, keepPageWidth = true).Column
+
+                let startColumn: ChainColumn = if mustBreak then indentColumn else ctx.Column
+
+                let maxColumn: ChainColumn = ctx.Config.MaxLineLength
+
+                let decidePlacements (widths: ChainStepWidth list) : ChainStepPlacement list =
+                    // A run that follows an action always opens a fresh line. The balance below
+                    // already measured from that line's indent, so only the placement of the
+                    // first step needs correcting.
+                    let balanced: ChainStepPlacement list =
+                        match balanceNavigationRun startColumn indentColumn maxColumn widths with
+                        | _ :: rest when mustBreak -> ChainStepPlacement.OpensNewLine :: rest
+                        | placements -> placements
+
+                    // The receiver is not a step, so a line holding nothing but the receiver has
+                    // nothing on it to balance — it is a wasted line, not a short one. Whenever
+                    // the receiver's line can hold the first step, it keeps it, and the rest of
+                    // the run is balanced from there.
+                    match balanced, widths with
+                    | ChainStepPlacement.OpensNewLine :: _, firstWidth :: laterWidths when
+                        not mustBreak && startColumn + firstWidth <= maxColumn
+                        ->
+                        ChainStepPlacement.RidesOnCurrentLine
+                        :: balanceNavigationRun (startColumn + firstWidth) indentColumn maxColumn laterWidths
+                    | _ -> balanced
+
+                // The steps on their own, carrying nothing for what comes after them.
+                let stepWidths: ChainStepWidth list =
+                    run |> List.map (fun segment -> widthOf (genSegment segment) ctx)
+
+                let plainPlacements: ChainStepPlacement list = decidePlacements stepWidths
+
+                // Does the run really share its last line with what follows it? The terminal
+                // call always rides there. An intermediate action does too — unless the run
+                // never left the receiver's line, because an action leaving that line claims
+                // one of its own and the run has nothing to make room for.
+                let sharesItsLastLine: bool =
+                    List.isEmpty afterRun
+                    || not onHeadLine
+                    || List.contains ChainStepPlacement.OpensNewLine plainPlacements
+
+                let placements: ChainStepPlacement list =
+                    if not sharesItsLastLine then
+                        plainPlacements
+                    else
+                        // Nothing after the run means the chain's terminal call rides there.
+                        let opener, whole =
+                            match afterRun with
+                            | [] -> genTerminalOpener node, genTerminalOnOneLine node
+                            | action :: _ -> genSegmentOpener action, genSegmentOnOneLine action
+
+                        // Charge the run's final step for `part` of the call that rides after it.
+                        let charge (part: Context -> Context) : ChainStepWidth list =
+                            let lastStep: int = List.length run - 1
+                            let callWidth: ChainStepWidth = widthOf part ctx
+
+                            stepWidths
+                            |> List.mapi (fun i width -> if i = lastStep then width + callWidth else width)
+
+                        // Wrapping the navigation to make room for the arguments beats breaking
+                        // the arguments, so the call is charged whole whenever a line of the run
+                        // could hold it. When none can — the arguments are too wide however the
+                        // navigation wraps — only the opener has to fit and the arguments break
+                        // as usual.
+                        let chargingWhole: ChainStepWidth list = charge whole
+
+                        let wholeCallFitsOnALine: bool =
+                            not (fst (futureNlnCheckMem (whole, ctx)))
+                            && chargingWhole |> List.forall (fun width -> indentColumn + width <= maxColumn)
+
+                        decidePlacements (
+                            if wholeCallFitsOnALine then
+                                chargingWhole
+                            else
+                                charge opener
+                        )
+
+                let onHeadLine, ctx = placeRun onHeadLine (List.zip run placements) ctx
+                place onHeadLine false afterRun ctx
 
         // Indexing a parenthesised value — `(expr).[0]` — is a plain access, not a
         // pipeline: the index rides tight onto the closing paren instead of breaking.
@@ -728,7 +978,7 @@ let genChain (node: ExprChain) : Context -> Context =
         // Keeping the chain together is only allowed for a single call at the very end:
         // every segment is light navigation and the terminal is the one and only action.
         let everySegmentIsLight: bool =
-            node.Segments |> List.forall (fun seg -> not (isHeavy seg ctx))
+            node.Segments |> List.forall (fun segment -> not (isHeavy segment ctx))
 
         // Keeping the chain together holds the receiver, navigation and method name on one
         // line. It gives way to the leading-dot pipeline when a comment between the steps
@@ -1694,10 +1944,10 @@ let genExpr (e: Expr) =
         // argument, so the arguments can break when the whole statement is too long.
         | Expr.Chain chainNode ->
             match chainNode.Terminal with
-            | ChainTerminal.SpaceAllowed(ChainCall.Paren p)
-            | ChainTerminal.NoSpaceAllowed(ChainCall.Paren p) ->
+            | ChainTerminal.SpaceAllowed(ChainCall.Paren parenNode)
+            | ChainTerminal.NoSpaceAllowed(ChainCall.Paren parenNode) ->
                 let funcExpr = genExpr chainNode.Head +> col sepNone chainNode.Segments genSegment
-                genDotIndexedSetWithApp funcExpr (Expr.Paren p) chainNode
+                genDotIndexedSetWithApp funcExpr (Expr.Paren parenNode) chainNode
             | _ -> genDotIndexedSet
 
         | _ -> genDotIndexedSet

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -855,11 +855,20 @@ let genChain (node: ExprChain) : Context -> Context =
         let rendersOnItsOwnLines (segment: ChainSegment) (ctx: Context) : bool =
             fst (futureNlnCheckMem (genSegment segment, ctx))
 
+        // Open a fresh line for a step. The step that leaves the receiver's line is also the one
+        // that establishes the pipeline's indent, hence the flag. Both forms are trivia aware: a
+        // comment already ended the line it sits on, so a second newline would open a blank one,
+        // and every further pass would open another.
+        let openLine (establishIndent: bool) : Context -> Context =
+            if establishIndent then
+                indentSepNlnWithTriviaAwareness
+            else
+                sepNlnUnlessLastEventIsNewline
+
         // Emit one navigation step, either on the current line or opening a fresh one.
-        // Leaving the receiver's line is also where the pipeline's indent is established.
         let placeStep (onHeadLine: bool) (placement: ChainStepPlacement) (segment: ChainSegment) : Context -> Context =
             match placement with
-            | ChainStepPlacement.OpensNewLine -> onlyIf onHeadLine indent +> sepNln +> genSegment segment
+            | ChainStepPlacement.OpensNewLine -> openLine onHeadLine +> genSegment segment
             | ChainStepPlacement.RidesOnCurrentLine -> genSegment segment
 
         // Walk a run of navigation whose placements have already been decided, reporting
@@ -891,13 +900,13 @@ let genChain (node: ExprChain) : Context -> Context =
                 // (leaving the receiver's line) or follows another action;
                 // otherwise it rides after the navigation that introduced it.
                 let placeAction: Context -> Context =
-                    if onHeadLine then indent +> sepNln +> genSegment segment
-                    elif mustBreak then sepNln +> genSegment segment
+                    if onHeadLine then openLine true +> genSegment segment
+                    elif mustBreak then openLine false +> genSegment segment
                     else genSegment segment
 
                 place false true rest (placeAction ctx)
             | segment :: rest when rendersOnItsOwnLines segment ctx ->
-                place false false rest ((onlyIf onHeadLine indent +> sepNln +> genSegment segment) ctx)
+                place false false rest ((openLine onHeadLine +> genSegment segment) ctx)
             | _ ->
                 // A run of navigation, taken as a whole so its breaks can be balanced. It stops
                 // at anything that cannot share a line, so every step in it has a real width.
@@ -1001,11 +1010,22 @@ let genChain (node: ExprChain) : Context -> Context =
                 | _ -> false)
             && not terminalIsCall
 
+        // A comment after the receiver ends its line whatever the rest of the chain wanted, so
+        // the navigation behind it cannot ride along. Where the comment is attached depends on
+        // how it was written: a trailing `config // note` lands on the receiver's own node,
+        // while one written on the line below lands on the last identifier inside it. Both
+        // print the same way, so both have to be found, or the steps after the comment resume
+        // at the receiver's own indent and the result no longer parses.
+        let rec endsWithComment (n: Node) : bool =
+            n.HasContentAfter
+            || (match Array.tryLast n.Children with
+                | Some last -> endsWithComment last
+                | None -> false)
+
         // Otherwise the first segment starts a fresh line when the receiver is compound
-        // (it leads a pipeline), or when the receiver carries a trailing comment — else
-        // that comment would be stranded in the middle of the first call.
+        // (it leads a pipeline).
         let receiverForcesBreak: bool =
-            (Expr.Node node.Head).HasContentAfter
+            endsWithComment (Expr.Node node.Head)
             || (not headIsSimple && not isParenThenIndex)
 
         place true receiverForcesBreak node.Segments (genExpr node.Head ctx)

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -966,8 +966,6 @@ let futureNlnCheck f (ctx: Context) =
     let isMultiLine, isLong = futureNlnCheckMem (f, ctx)
     isMultiLine || isLong
 
-/// similar to futureNlnCheck but validates whether the expression is going over the max page width
-/// This functions is does not use any caching
 let exceedsWidth maxWidth f (ctx: Context) =
     let dummyResult = ctx.WithDummy(f, keepPageWidth = true)
 

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -108,6 +108,12 @@ val atCurrentColumn: f: (Context -> Context) -> ctx: Context -> Context
 /// }
 /// `atCurrentColumn` was called on `X`, then `indent` was called, "some long string" have indent 6, because it is indented from `atCurrentColumn` pos (2).
 val atCurrentColumnIndent: f: (Context -> Context) -> ctx: Context -> Context
+
+/// Indent and open a new line, taking trailing trivia into account.
+/// When the emitted content ends with a comment, the indent is spliced in ahead of that comment
+/// so it sits at the indented level, and the newline the comment already wrote is reused instead
+/// of a second one being added. Without trailing trivia this is plain `indent +> sepNln`.
+val indentSepNlnWithTriviaAwareness: ctx: Context -> Context
 val indentSepNlnUnindent: f: (Context -> Context) -> (Context -> Context)
 
 // =============================================================================

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -277,8 +277,8 @@ val futureNlnCheck: f: (Context -> Context) -> ctx: Context -> bool
 /// is `isMultiline || isLong`; callers that care only about multiline layout
 /// (not width) use the first component.
 val futureNlnCheckMem: f: (Context -> Context) * ctx: Context -> bool * bool
-/// similar to futureNlnCheck but // validates whether the expression is going over the max page width
-/// This functions is does not use any caching
+/// similar to futureNlnCheck but validates whether the expression is going over the given
+/// max width, measured from the current column
 val exceedsWidth: maxWidth: int -> f: (Context -> Context) -> ctx: Context -> bool
 
 // =============================================================================

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -272,6 +272,11 @@ val sepSpaceOrDoubleIndentAndNlnIfExpressionExceedsPageWidth: expr: (Context -> 
 val autoParenthesisIfExpressionExceedsPageWidth: expr: (Context -> Context) -> ctx: Context -> Context
 
 val futureNlnCheck: f: (Context -> Context) -> ctx: Context -> bool
+/// Probe `f` and report `(isMultiline, isLong)` separately: whether it spans
+/// multiple lines, and whether it overflows the right margin. `futureNlnCheck`
+/// is `isMultiline || isLong`; callers that care only about multiline layout
+/// (not width) use the first component.
+val futureNlnCheckMem: f: (Context -> Context) * ctx: Context -> bool * bool
 /// similar to futureNlnCheck but // validates whether the expression is going over the max page width
 /// This functions is does not use any caching
 val exceedsWidth: maxWidth: int -> f: (Context -> Context) -> ctx: Context -> bool

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -3,6 +3,7 @@ namespace Fantomas.Core
 open System
 open System.ComponentModel
 open Fantomas.FCS.Parse
+open Fantomas.FCS.Text
 
 /// Raised when the F# parser produces errors for source code without conditional directives.
 exception ParseException of diagnostics: FSharpParserDiagnostic list
@@ -10,6 +11,24 @@ exception ParseException of diagnostics: FSharpParserDiagnostic list
 /// Raised when Fantomas encounters a problem during formatting.
 type FormatException(msg: string) =
     inherit Exception(msg)
+
+/// Raised when Fantomas reaches a state that its own model says is impossible, for example a
+/// chain whose parts do not fit the shape the transformer guarantees.
+///
+/// Unlike the other exceptions here, this never indicates a problem with the code being
+/// formatted: it is a bug in Fantomas, or a change in how the F# parser groups expressions.
+/// Failing loudly is deliberate — the alternative is silently dropping parts of the source.
+type InvariantViolationException(msg: string, range: range) =
+    inherit
+        FormatException(
+            $"%s{msg}\nAt line %i{range.StartLine}, column %i{range.StartColumn} in %s{range.FileName}.\nThis is a bug in Fantomas. Please report it via https://fsprojects.github.io/fantomas-tools/"
+        )
+
+    /// The invariant that was violated, without the location or "please report" suffix.
+    member _.Invariant = msg
+
+    /// The source range of the construct that triggered the violation.
+    member _.Range = range
 
 /// Raised when one or more conditional compilation define combinations produce invalid syntax trees.
 type DefineParseException(combinations: string list) =

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -107,7 +107,7 @@ type EndOfLineStyle =
         | "crlf" -> Some EndOfLineStyle.CRLF
         | _ -> None
 
-// NOTE: try to keep this list below in sync with the docs (e.g. Documentation.md)
+// NOTE: try to keep this list below in sync with docs/docs/end-users/Configuration.fsx
 type FormatConfig =
     { [<Category("Indentation")>]
       [<DisplayName("Indent spaces")>]

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -103,7 +103,7 @@ type EndOfLineStyle =
     static member OfConfigString(eolString: string) =
         match eolString with
         | "lf" -> Some EndOfLineStyle.LF
-        | "cr" -> failwith "Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'"
+        | "cr" -> raise (FormatException "Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'")
         | "crlf" -> Some EndOfLineStyle.CRLF
         | _ -> None
 

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -237,17 +237,11 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ExprChain as node ->
         let expr = Expr.Chain node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprAppLongIdentAndSingleParenArgNode as node ->
-        let expr = Expr.AppLongIdentAndSingleParenArg node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprAppSingleParenArgNode as node ->
         let expr = Expr.AppSingleParenArg node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprAppWithLambdaNode as node ->
         let expr = Expr.AppWithLambda node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprNestedIndexWithoutDotNode as node ->
-        let expr = Expr.NestedIndexWithoutDot node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprAppNode as node ->
         let expr = Expr.App node
@@ -278,9 +272,6 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprLongIdentSetNode as node ->
         let expr = Expr.LongIdentSet node
-        mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
-    | :? ExprDotIndexedGetNode as node ->
-        let expr = Expr.DotIndexedGet node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
     | :? ExprDotIndexedSetNode as node ->
         let expr = Expr.DotIndexedSet node

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -128,7 +128,7 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
 
         mkExtractableOakFromModule md (node.GetType())
 
-    // ModuleDecl.Expr
+    // ModuleDecl.DeclExpr
     | :? ExprLazyNode as node ->
         let expr = Expr.Lazy node
         mkOakFromModuleDecl (ModuleDecl.DeclExpr expr)
@@ -337,7 +337,7 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
     | :? ValNode as node -> mkOakFromModuleDecl (ModuleDecl.Val node)
     | _ ->
         // Deliberately not an InvariantViolationException: this is not an impossible state but a
-        // node kind selection does not support yet, and release builds degrade to `Unsupported`
+        // node kind that selection does not support yet, and release builds degrade to `Unsupported`
         // rather than failing. The DEBUG-only throw exists to make the gap loud while developing.
 #if DEBUG
         failwithf $"%s{node.GetType().Name} is currently unsupported"

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -336,6 +336,9 @@ let mkTreeWithSingleNode (node: Node) : TreeForSelection =
         mkOakFromModuleDecl (ModuleDecl.TypeDefn tdn)
     | :? ValNode as node -> mkOakFromModuleDecl (ModuleDecl.Val node)
     | _ ->
+        // Deliberately not an InvariantViolationException: this is not an impossible state but a
+        // node kind selection does not support yet, and release builds degrade to `Unsupported`
+        // rather than failing. The DEBUG-only throw exists to make the gap loud while developing.
 #if DEBUG
         failwithf $"%s{node.GetType().Name} is currently unsupported"
 #endif

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1380,57 +1380,81 @@ type ExprIndexWithoutDotNode(identifierExpr: Expr, indexExpr: Expr, range) =
     member val Identifier = identifierExpr
     member val Index = indexExpr
 
-/// A chain link where a function is applied to a parenthesised argument, e.g. `foo(x)` in `a.foo(x).bar`.
-type LinkSingleAppParen(functionName: Expr, parenExpr: ExprParenNode, range) =
-    inherit NodeBase(range)
-    override val Children: Node array = [| yield Expr.Node functionName; yield parenExpr |]
-    member val FunctionName = functionName
-    member val Paren = parenExpr
-
-/// A chain link where a function is applied to a unit argument, e.g. `Dispose()` in `x.Dispose()`.
-type LinkSingleAppUnit(functionName: Expr, unit: UnitNode, range) =
-    inherit NodeBase(range)
-    override val Children: Node array = [| yield Expr.Node functionName; yield unit |]
-    member val FunctionName = functionName
-    member val Unit = unit
-
-/// A single link in a method-call or property-access chain (e.g. <c>a.b().c[0]</c>).
-/// The chain is represented as an ordered list of <c>ChainLink</c> values so that the
-/// printer can decide whether to keep the chain on one line or break at each dot.
+/// The argument of a call within a chain — either a parenthesised expression or unit.
 [<RequireQualifiedAccess; NoComparison; NoEquality>]
-type ChainLink =
-    | Identifier of Expr
-    | Dot of SingleTextNode
-    | Expr of Expr
-    | AppParen of
-        // There should only be one argument
-        LinkSingleAppParen
-    | AppUnit of LinkSingleAppUnit
-    // [ expr ] from DotIndexedGet
-    | IndexExpr of Expr // e.[f]
+type ChainCall =
+    | Paren of ExprParenNode
+    | Unit of UnitNode
 
-    static member Node(link: ChainLink) : Node =
-        match link with
-        | Identifier e -> Expr.Node e
-        | Dot n -> n
-        | Expr e -> Expr.Node e
-        | AppParen n -> n
-        | AppUnit n -> n
-        | IndexExpr e -> Expr.Node e
+/// A single dot-prefixed step in a member-access or call chain.
+/// Every step is reached through a <c>.</c>; the dot is an explicit <see cref="SingleTextNode"/>
+/// so that trivia (comments, blank lines) attached to it are preserved during formatting.
+///
+/// A segment is always <em>intermediate</em>: the final call of a chain is the
+/// <c>ExprChain.Terminal</c>, never a segment here.  That is why <c>DotApplication</c> (an
+/// intermediate call) is distinct from <c>DotMember</c> (plain access) — the distinction the
+/// layout cares about (navigation vs. action) is then visible in the shape of the data itself.
+[<RequireQualifiedAccess; NoComparison; NoEquality>]
+type ChainSegment =
+    ///   .Foo        — plain property access (navigation)
+    ///   .Items[0]   — expr = IndexWithoutDot(Items, [0]), no dedicated case needed
+    | DotMember of dot: SingleTextNode * expr: Expr
+    ///   .Foo(x)     — intermediate call — always tight, never a space before (
+    ///   .Foo()      — intermediate unit call — always tight
+    /// e.g. the `.Foo(x)` in `a.Foo(x).Bar`.  The terminal call of a chain is not a segment.
+    | DotApplication of dot: SingleTextNode * expr: Expr * call: ChainCall
+    /// Old dot-bracket index syntax: <c>arr.[i]</c>.
+    /// <c>DotIndex</c> is a separate case rather than <c>DotMember</c> because the <c>[</c> and
+    /// <c>]</c> brackets are <em>not</em> part of <c>indexExpr</c> in the AST — <c>genExpr
+    /// indexExpr</c> produces only the content (e.g. <c>0</c>), not <c>[0]</c>.  No existing
+    /// <c>Expr</c> type naturally renders bracketed index content, so the printer must add
+    /// <c>[</c> and <c>]</c> explicitly.  From a layout perspective <c>DotIndex</c> is
+    /// identical to <c>DotMember</c> — both are navigation segments with no call.
+    | DotIndex of dot: SingleTextNode * indexExpr: Expr
 
-/// Example: `person.Address.City.ToUpper()` — a chain of dot-separated member accesses and calls
-type ExprChain(links: ChainLink list, range) =
+/// Controls whether and how a space is emitted before the terminal call's parenthesis.
+/// The terminal call is the only position in a chain where a space is negotiable;
+/// intermediate calls are always tight (adding a space before their parens changes the parse tree).
+[<RequireQualifiedAccess; NoComparison; NoEquality>]
+type ChainTerminal =
+    | SpaceAllowed of ChainCall // regular chain — space governed by SpaceBeforeUppercaseInvocation
+    | NoSpaceAllowed of ChainCall // DotLambda body — space never permitted (compiler constraint)
+    | NoTerminal // chain ends with a property access or index, no invocation
+
+/// Example: `person.Address.City.ToUpper()` — a chain of dot-separated member accesses and calls.
+/// <c>Head</c> is the leading receiver expression (fully decomposed; no dotted content remains in it).
+/// <c>Segments</c> are the dot-paired steps. <c>Terminal</c> is the optional outermost call.
+type ExprChain(head: Expr, segments: ChainSegment list, terminal: ChainTerminal, range) =
     inherit NodeBase(range)
-    override val Children: Node array = List.map ChainLink.Node links |> List.toArray
-    member val Links = links
+    member val Head = head
+    member val Segments = segments
+    member val Terminal = terminal
 
-/// Example: `List.map(f)` — a qualified name (dotted identifier) applied to a single parenthesised argument
-type ExprAppLongIdentAndSingleParenArgNode(functionName: IdentListNode, argExpr: Expr, range) =
-    inherit NodeBase(range)
+    override val Children: Node array =
+        [| yield Expr.Node head
 
-    override val Children: Node array = [| yield functionName; yield Expr.Node argExpr |]
-    member val FunctionName = functionName
-    member val ArgExpr = argExpr
+           for segment in segments do
+               match segment with
+               | ChainSegment.DotMember(dot, expr) ->
+                   yield dot
+                   yield Expr.Node expr
+               | ChainSegment.DotApplication(dot, expr, call) ->
+                   yield dot
+                   yield Expr.Node expr
+
+                   match call with
+                   | ChainCall.Paren p -> yield p
+                   | ChainCall.Unit u -> yield u
+               | ChainSegment.DotIndex(dot, idx) ->
+                   yield dot
+                   yield Expr.Node idx
+
+           match terminal with
+           | ChainTerminal.SpaceAllowed(ChainCall.Paren p)
+           | ChainTerminal.NoSpaceAllowed(ChainCall.Paren p) -> yield p
+           | ChainTerminal.SpaceAllowed(ChainCall.Unit u)
+           | ChainTerminal.NoSpaceAllowed(ChainCall.Unit u) -> yield u
+           | ChainTerminal.NoTerminal -> () |]
 
 /// Example: `f(a)` — a general expression (not a simple dotted name) applied to a single parenthesised argument
 type ExprAppSingleParenArgNode(functionExpr: Expr, argExpr: Expr, range) =
@@ -1469,20 +1493,6 @@ type ExprAppWithLambdaNode
     member val OpeningParen = openingParen
     member val Lambda = lambda
     member val ClosingParen = closingParen
-
-/// Example: `xs[i] arg` — an indexed expression (`xs[i]`) immediately applied to an argument.
-/// Used for cases like `arr[0] + 1` where the index result is itself called or applied.
-type ExprNestedIndexWithoutDotNode(identifierExpr: Expr, indexExpr: Expr, argumentExpr: Expr, range) =
-    inherit NodeBase(range)
-
-    override val Children: Node array =
-        [| yield Expr.Node identifierExpr
-           yield Expr.Node indexExpr
-           yield Expr.Node argumentExpr |]
-
-    member val Identifier = identifierExpr
-    member val Index = indexExpr
-    member val Argument = argumentExpr
 
 /// Example: `List.map f xs` — a function applied to two or more space-separated arguments
 type ExprAppNode(functionExpr: Expr, arguments: Expr list, range) =
@@ -1716,13 +1726,6 @@ type ExprLongIdentSetNode(identifier: IdentListNode, rhs: Expr, range) =
     member val Identifier = identifier
     member val Expr = rhs
 
-/// Example: `arr.[i]` — indexed get using the older dot-bracket syntax (deprecated in F# 6).
-type ExprDotIndexedGetNode(objectExpr: Expr, indexExpr: Expr, range) =
-    inherit NodeBase(range)
-    override val Children: Node array = [| yield Expr.Node objectExpr; yield Expr.Node indexExpr |]
-    member val ObjectExpr = objectExpr
-    member val IndexExpr = indexExpr
-
 /// Example: `arr.[i] <- value` — indexed set using the older dot-bracket syntax (deprecated in F# 6).
 type ExprDotIndexedSetNode(objectExpr: Expr, indexExpr: Expr, valueExpr: Expr, range) =
     inherit NodeBase(range)
@@ -1874,15 +1877,6 @@ type ExprIndexFromEndNode(expr: Expr, range) =
     override val Children: Node array = [| Expr.Node expr |]
     member val Expr = expr
 
-/// Example: `_.ToUpper()` or `_.Length` — a dot-lambda shorthand (F# 8+).
-/// `Underscore` is the `_` placeholder, `Dot` is the `.`, and `Expr` is the member access or call.
-type ExprDotLambda(underscore: SingleTextNode, dot: SingleTextNode, expr: Expr, range: range) =
-    inherit NodeBase(range)
-    override val Children: Node array = [| underscore; dot; Expr.Node expr |]
-    member val Underscore = underscore
-    member val Dot = dot
-    member val Expr = expr
-
 /// Example: `begin expr end` — explicit `begin`/`end` block delimiters (equivalent to parentheses).
 type ExprBeginEndNode(beginNode: SingleTextNode, expr: Expr, endNode: SingleTextNode, range) =
     inherit NodeBase(range)
@@ -1941,10 +1935,8 @@ type Expr =
     | SameInfixApps of ExprSameInfixAppsNode
     | InfixApp of ExprInfixAppNode
     | IndexWithoutDot of ExprIndexWithoutDotNode
-    | AppLongIdentAndSingleParenArg of ExprAppLongIdentAndSingleParenArgNode
     | AppSingleParenArg of ExprAppSingleParenArgNode
     | AppWithLambda of ExprAppWithLambdaNode
-    | NestedIndexWithoutDot of ExprNestedIndexWithoutDotNode
     | App of ExprAppNode
     | TypeApp of ExprTypeAppNode
     | TryWithSingleClause of ExprTryWithSingleClauseNode
@@ -1956,7 +1948,6 @@ type Expr =
     | Ident of SingleTextNode
     | OptVar of ExprOptVarNode
     | LongIdentSet of ExprLongIdentSetNode
-    | DotIndexedGet of ExprDotIndexedGetNode
     | DotIndexedSet of ExprDotIndexedSetNode
     | NamedIndexedPropertySet of ExprNamedIndexedPropertySetNode
     | DotNamedIndexedPropertySet of ExprDotNamedIndexedPropertySetNode
@@ -1969,7 +1960,6 @@ type Expr =
     | IndexFromEnd of ExprIndexFromEndNode
     | Typar of SingleTextNode
     | Chain of ExprChain
-    | DotLambda of ExprDotLambda
     | BeginEnd of ExprBeginEndNode
     | ExplicitConstructorThenExpr of ExprExplicitConstructorThenExpr
 
@@ -2010,10 +2000,8 @@ type Expr =
         | SameInfixApps n -> n
         | InfixApp n -> n
         | IndexWithoutDot n -> n
-        | AppLongIdentAndSingleParenArg n -> n
         | AppSingleParenArg n -> n
         | AppWithLambda n -> n
-        | NestedIndexWithoutDot n -> n
         | App n -> n
         | TypeApp n -> n
         | TryWithSingleClause n -> n
@@ -2025,7 +2013,6 @@ type Expr =
         | Ident n -> n
         | OptVar n -> n
         | LongIdentSet n -> n
-        | DotIndexedGet n -> n
         | DotIndexedSet n -> n
         | NamedIndexedPropertySet n -> n
         | DotNamedIndexedPropertySet n -> n
@@ -2038,7 +2025,6 @@ type Expr =
         | IndexFromEnd n -> n
         | Typar n -> n
         | Chain n -> n
-        | DotLambda n -> n
         | BeginEnd n -> n
         | ExplicitConstructorThenExpr n -> n
 

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1440,7 +1440,7 @@ type ChainSegment =
 [<RequireQualifiedAccess; NoComparison; NoEquality>]
 type ChainTerminal =
     | SpaceAllowed of ChainCall // regular chain — space governed by SpaceBeforeUppercaseInvocation / SpaceBeforeLowercaseInvocation, depending on the casing of the called identifier
-    | NoSpaceAllowed of ChainCall // DotLambda body — space never permitted (compiler constraint)
+    | NoSpaceAllowed of ChainCall // space never permitted: a DotLambda body (compiler constraint), a call used as a chain receiver, or any atomic position (see mkAtomicExpr)
     | NoTerminal // chain ends with a property access or index, no invocation
 
 /// Example: `person.Address.City.ToUpper()` — a chain of dot-separated member accesses and calls.
@@ -1485,7 +1485,7 @@ type ExprAppSingleParenArgNode(functionExpr: Expr, argExpr: Expr, range) =
     member val FunctionExpr = functionExpr
     member val ArgExpr = argExpr
 
-/// Example: `List.map (fun x -> x + 1) xs` — a function applied to zero or more prefix arguments
+/// Example: `f a b (fun y -> y)`, a function applied to zero or more prefix arguments
 /// followed by a parenthesised lambda or `function` expression as the last argument.
 type ExprAppWithLambdaNode
     (

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -1439,7 +1439,7 @@ type ChainSegment =
 /// intermediate calls are always tight (adding a space before their parens changes the parse tree).
 [<RequireQualifiedAccess; NoComparison; NoEquality>]
 type ChainTerminal =
-    | SpaceAllowed of ChainCall // regular chain — space governed by SpaceBeforeUppercaseInvocation
+    | SpaceAllowed of ChainCall // regular chain — space governed by SpaceBeforeUppercaseInvocation / SpaceBeforeLowercaseInvocation, depending on the casing of the called identifier
     | NoSpaceAllowed of ChainCall // DotLambda body — space never permitted (compiler constraint)
     | NoTerminal // chain ends with a property access or index, no invocation
 

--- a/src/Fantomas.Tests/EditorConfigurationTests.fs
+++ b/src/Fantomas.Tests/EditorConfigurationTests.fs
@@ -344,8 +344,10 @@ end_of_line = cr
 
     use fsharpFile = new FSharpFile(rootDir)
 
+    // A FormatException rather than a bare exception, because that is the type the CLI matches
+    // on to decide what to print. Anything else reports an empty message at normal verbosity.
     let ex =
-        Assert.Throws(fun () -> EditorConfig.readConfiguration fsharpFile.FSharpFile |> ignore)
+        Assert.Throws<FormatException>(fun () -> EditorConfig.readConfiguration fsharpFile.FSharpFile |> ignore)
 
     ex.Message
     == "Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'"


### PR DESCRIPTION
Fixes #3364.

The old model held a chain as a flat `ChainLink list` with an `isLastLink` flag deciding whether a space could precede a call's opening paren. Position and permission to add a space are only incidentally the same thing, and they came apart inside a dot-lambda body: with `space_before_uppercase_invocation` enabled, `_.Substring(0, 16).ToLower()` gained a space and stopped compiling, because the printer had no way to know it was inside a `_.` lambda (#3364).

A chain is now a head, a list of `ChainSegment`, and a `ChainTerminal`. Each segment carries its own dot, since a dot always belongs with what follows it, which makes two adjacent dots unrepresentable. Only the terminal negotiates a space. That is a grammar constraint rather than a style choice: a space mid-chain reparses `a.Foo (x).Bar()` as `a.Foo ((x).Bar())`. `ChainTerminal.NoSpaceAllowed` therefore makes 'no space is permitted here' a property of the node, instead of something the printer has to rediscover from context.

Nodes that were chains in all but name are absorbed, leaving `Expr.Chain` as the single representation of a dotted expression:

  - ExprDotLambda
  - ExprAppLongIdentAndSingleParenArg
  - ExprDotIndexedGet
  - AppWithLambda with no prefix arguments

ExprNestedIndexWithoutDot is removed as dead; nothing ever constructed it. This breaks the public Oak API: a dotted long ident such as `a.b.c` now yields `Expr.Chain` rather than `Expr.OptVar` in expression position. `docs/docs/end-users/UpgradeGuide.md` gains a `Fantomas.Core API` section covering this, with a link-by-link mapping from the old `ChainLink` model to the new one. That section also picks up the earlier v8 API changes that were never written down: the `ComputationExpressionStatement` collapse, `NamePatPair` to `NamePatPairNode`, `PatRecordField`, the new `DefineParseException`, and the added `CodeFormatter` overloads.

## Layout

The layout rules follow from the model. A chain whose only call is its last step keeps the receiver, navigation and method name together and breaks the call's arguments, exactly as a call with no receiver would. Two or more calls, or a call followed by further navigation, use the leading-dot pipeline.

`docs/docs/contributors/Chains.md` states the rules in full, including the alternatives that were considered and turned down. They are intended for the F# style guide and live under Contributors until they are adopted there, so they should be read as a proposal being tested rather than settled guidance.

In practice most chains already formatted this way. Four changes are visible to users, each verified against the `7.0.1` tool:

**A long run of property access wraps instead of overflowing.** The breaks are chosen so the longest resulting line is as short as possible. At `max_line_length = 80`:

```fsharp
// before
let navigation =
    builder.Services.Configuration.Providers.Defaults.Primary.Fallback.Value.Inner

// after
let navigation =
    builder.Services.Configuration.Providers
        .Defaults.Primary.Fallback.Value.Inner
```

**A comment no longer fans the chain out one step per line.** A comment between the steps forces the break whatever the margin allows. Every step used to take that break; now only a call claims a line and navigation rides along in front of it:

```fsharp
// before
let a =
    config
        // note
        .Settings
        .GetValue(key)

// after
let a =
    config
        // note
        .Settings.GetValue(key)
```

**A match lambda keeps `function` beside the `(`**, with `multi_line_lambda_closing_newline = false` (the default). A call reached through a dot used to push `function` down, while the same call without a receiver kept it beside the `(`. The dot no longer makes a difference:

```fsharp
// before
let b =
    builder
        .Build()
        .Configure(
            function
            | Some v -> handleSome v
            | None -> handleNone ()
        )

// after, and what `configureTheThing (function ...)` already did
let b =
    builder
        .Build()
        .Configure(function
            | Some v -> handleSome v
            | None -> handleNone ())
```

**A lambda whose opening line does not fit moves to its own line**, with `multi_line_lambda_closing_newline = true`. The parameters are no longer hung under the opening parenthesis. This applies to calls with and without a receiver:

```fsharp
// before
let dotted ifaces =
    ifaces
    |> List.tryPick (fun
                         (SynInterfaceImpl(
                             interfaceTy = ty; withKeyword = withRange)) ->
        Some(ty, withRange)
    )

// after
let dotted ifaces =
    ifaces
    |> List.tryPick
        (fun (SynInterfaceImpl(interfaceTy = ty; withKeyword = withRange)) ->
            Some(ty, withRange)
        )
```


## Trivia and the opening parenthesis

Trivia inside a call's parentheses no longer moves the parenthesis around. Which node carries the trivia is what decides the layout. A comment or a directive in front of the argument is written after the `(`, so the parenthesis stays with the member name wherever the call sits in the chain and only the argument moves down. Only trivia in front of the `(` itself, such as a comment between a member name and its parenthesis, takes a terminal call down to a line of its own.

This is mostly an internal rule keeping the new model honest, and it is what lets an intermediate call stay welded to its `(` while its argument carries a `#if`. One user-visible improvement comes with it: a comment between a member name and its `(` is now idempotent, where `8.0.0-alpha-013` collapses the argument on a second pass.

```fsharp
// input
let x =
    builder.Configure
        // between name and paren
        (theArgument)

// alpha-013, first pass
let x =
    builder.Configure
    // between name and paren
    (
        theArgument
    )

// alpha-013, second pass, different again
let x =
    builder.Configure
    // between name and paren
    (theArgument)

// this branch, stable from the first pass
let x =
    builder.Configure
        // between name and paren
        (theArgument)
```


## Failing loudly

Branches in the chain transformer that are unreachable by construction now raise the new `InvariantViolationException` rather than silently returning an empty list. It derives from `FormatException`, which matters because the CLI selects its message by exception type and a bare `failwith` fell through to an empty message at normal verbosity. Each carries the source range of the construct involved and points at fantomas-tools.

## Coverage

Adds a Coverage pipeline (`dotnet fsi build.fsx -- -p Coverage`) built on AltCover and ReportGenerator. It is how the unreachable branches were identified, and how two branches that looked dead were shown to be reachable but untested, which would have turned valid F# into a crash.

## What this means for existing code

A chain that already fits on one line is untouched, which is most of them. Reformatting the whole of `Fantomas.Core` with this branch is byte-identical to `8.0.0-alpha-013`, and against `7.0.1` it moves a handful of lines, none of them in a chain. The layout changes bite when a chain has to break, and the four cases above are what that looks like.

`docs/docs/end-users/UpgradeGuide.md` carries the same four with before-and-after examples, alongside the Oak API migration. Anyone consuming `Fantomas.Core` as a library needs that section; anyone just running the tool will mostly notice the comment case, since a comment forces a break regardless of line length.

The Oak change is the breaking one. `Expr.Chain` no longer holds a flat `ChainLink list`, and four `Expr` cases are gone, so a library that pattern-matches on dotted expressions has to be updated. The guide has a link-by-link mapping table.

## Testing

Twelve existing tests across nine files change their expected output, all of them chain, indexer or lambda layout. `trivia around paren lambda with conditional compilation, 2844` is the one worth a second look: its opening paren sat on a line of its own only because the input had it there, and it now stays with the member name. The new output parses under both define combinations and is idempotent.

Around 1700 lines of new tests come with this: `ChainFormattingTests` walks the layout rules case by case against `Chains.md`, `ASTTransformerTests` pins the shape of the produced Oak, and `ChainTests`, `DotLambdaTests`, `DynamicOperatorTests` and `ValidationTests` gain cases. Idempotency is asserted inside `formatSourceString`, so every new formatting test covers it.

The `CodePrinter` benchmark was last run on this branch at 42.74 ms and 110.45 MB, against 84.70 ms and 284.85 MB before the recent perf work, so the 2x improvement from #3388 survives the redesign despite the extra speculative rendering the layout rules need. That run predates the last few `CodePrinter` commits and is worth repeating before merge.

`scripts/chain.fsx` is added for inspecting the head, segments and terminal of a chain, and is listed in `AGENTS.md` alongside the other diagnostic scripts.
