### PR TITLE
Write warnings and errors to standard error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Breaking: warnings and errors are written to standard error instead of standard out. Informational output stays on standard out, including `--version` and the files `--check` reports as needing formatting, so a caller can tell the tool's output apart from its diagnostics by stream. Scripts that capture standard out to detect failures need to capture standard error as well. [#3399](https://github.com/fsprojects/fantomas/pull/3399)
+
+### Fixed
+
+- `--verbosity` with an unrecognised value exited with code 1 and printed nothing, because the message was logged before the logger was configured. It now reports `Invalid verbosity level` on standard error. [#3399](https://github.com/fsprojects/fantomas/pull/3399)
+
 ## [8.0.0-alpha-014] - 2026-08-20
 
 ### Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,6 @@
         <PackageVersion Include="SemanticVersioning" Version="3.0.0" />
         <PackageVersion Include="Serilog" Version="4.3.1"/>
         <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-        <PackageVersion Include="SerilogTraceListener" Version="3.2.1-dev-00011" />
         <PackageVersion Include="Argu" Version="6.2.5" />
         <PackageVersion Include="Thoth.Json.Net" Version="12.0.0" />
         <PackageVersion Include="editorconfig" Version="0.15.0" />

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="Integration\ConfigTests.fs" />
     <Compile Include="Integration\IgnoreFilesTests.fs" />
     <Compile Include="Integration\ExitCodeTests.fs" />
+    <Compile Include="Integration\StandardStreamTests.fs" />
     <Compile Include="Integration\MultiplePathsTests.fs" />
     <Compile Include="Integration\WriteTests.fs" />
     <Compile Include="Integration\DaemonTests.fs" />

--- a/src/Fantomas.Tests/Integration/ConfigTests.fs
+++ b/src/Fantomas.Tests/Integration/ConfigTests.fs
@@ -48,9 +48,9 @@ end_of_line=cr
         )
 
     let args = DetailedVerbosity @ [ fileFixture.Filename ]
-    let { ExitCode = exitCode; Output = output } = runFantomasTool args
+    let { ExitCode = exitCode; Error = error } = runFantomasTool args
     exitCode |> should equal 1
-    Assert.That(output, Does.Contain "Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'")
+    Assert.That(error, Does.Contain "Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'")
 
 let valid_eol_settings = [ "lf"; "crlf" ]
 

--- a/src/Fantomas.Tests/Integration/StandardStreamTests.fs
+++ b/src/Fantomas.Tests/Integration/StandardStreamTests.fs
@@ -1,0 +1,53 @@
+module Fantomas.Tests.Integration.StandardStreamTests
+
+open NUnit.Framework
+open FsUnit
+open Fantomas.Tests.TestHelpers
+
+[<Literal>]
+let WithErrors = """let a ="""
+
+[<Test>]
+let ``errors are written to standard error and not to standard out`` () =
+    use fileFixture = new TemporaryFileCodeSample(WithErrors)
+
+    let {
+            ExitCode = exitCode
+            Output = output
+            Error = error
+        } =
+        formatCode [ fileFixture.Filename ]
+
+    exitCode |> should equal 1
+    output |> should equal ""
+    Assert.That(error, Does.Contain "Could not parse the file.")
+
+[<Test>]
+let ``progress messages are written to standard out and not to standard error`` () =
+    use fileFixture = new TemporaryFileCodeSample("let a =   0")
+
+    let {
+            ExitCode = exitCode
+            Output = output
+            Error = error
+        } =
+        formatCode [ fileFixture.Filename ]
+
+    exitCode |> should equal 0
+    Assert.That(output, Does.Contain "was formatted")
+    error |> should equal ""
+
+// Fantomas.Client discovers the tool by running `--version` and reading standard out.
+// Moving this to standard error would break every editor integration.
+[<Test>]
+let ``version is written to standard out`` () =
+    let {
+            ExitCode = exitCode
+            Output = output
+            Error = error
+        } =
+        runFantomasTool [ "--version" ]
+
+    exitCode |> should equal 0
+    Assert.That(output, Does.Contain "Fantomas v")
+    error |> should equal ""

--- a/src/Fantomas.Tests/Integration/StandardStreamTests.fs
+++ b/src/Fantomas.Tests/Integration/StandardStreamTests.fs
@@ -11,11 +11,9 @@ let WithErrors = """let a ="""
 let ``errors are written to standard error and not to standard out`` () =
     use fileFixture = new TemporaryFileCodeSample(WithErrors)
 
-    let {
-            ExitCode = exitCode
-            Output = output
-            Error = error
-        } =
+    let { ExitCode = exitCode
+          Output = output
+          Error = error } =
         formatCode [ fileFixture.Filename ]
 
     exitCode |> should equal 1
@@ -26,11 +24,9 @@ let ``errors are written to standard error and not to standard out`` () =
 let ``progress messages are written to standard out and not to standard error`` () =
     use fileFixture = new TemporaryFileCodeSample("let a =   0")
 
-    let {
-            ExitCode = exitCode
-            Output = output
-            Error = error
-        } =
+    let { ExitCode = exitCode
+          Output = output
+          Error = error } =
         formatCode [ fileFixture.Filename ]
 
     exitCode |> should equal 0
@@ -41,11 +37,9 @@ let ``progress messages are written to standard out and not to standard error`` 
 // Moving this to standard error would break every editor integration.
 [<Test>]
 let ``version is written to standard out`` () =
-    let {
-            ExitCode = exitCode
-            Output = output
-            Error = error
-        } =
+    let { ExitCode = exitCode
+          Output = output
+          Error = error } =
         runFantomasTool [ "--version" ]
 
     exitCode |> should equal 0

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -267,7 +267,6 @@
           "Ignore": "[0.2.1, )",
           "Serilog": "[4.3.1, )",
           "Serilog.Sinks.Console": "[6.1.1, )",
-          "SerilogTraceListener": "[3.2.1-dev-00011, )",
           "Spectre.Console": "[0.55.0, )",
           "StreamJsonRpc": "[2.25.29, )",
           "System.IO.Abstractions": "[22.1.0, )",
@@ -343,15 +342,6 @@
         "contentHash": "8jbqgjUyZlfCuSTaJk6lOca465OndqOz3KZP6Cryt/IqZYybyBu7GP0fE/AXBzrrQB3EBmQntBFAvMVz1COvAA==",
         "dependencies": {
           "Serilog": "4.0.0"
-        }
-      },
-      "SerilogTraceListener": {
-        "type": "CentralTransitive",
-        "requested": "[3.2.1-dev-00011, )",
-        "resolved": "3.2.1-dev-00011",
-        "contentHash": "Lcd96moPFhTzFOJR+EIxu0PSzZPPoX1BGNfpm7ArJ4/3MnMw3iTblEJBn8EpcSzS66DJyiy+WaXVkE7fuHhU3A==",
-        "dependencies": {
-          "Serilog": "2.8.0"
         }
       },
       "Spectre.Console": {

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -41,7 +41,6 @@
     <PackageReference Include="StreamJsonRpc" />
     <PackageReference Include="Argu" />
     <PackageReference Include="Thoth.Json.Net" />
-    <PackageReference Include="SerilogTraceListener" />
     <PackageReference Include="editorconfig" />
     <PackageReference Include="Ignore" />
     <PackageReference Include="System.IO.Abstractions" />

--- a/src/Fantomas/Logging.fs
+++ b/src/Fantomas/Logging.fs
@@ -1,32 +1,42 @@
 module Fantomas.Logging
 
+open System
 open Serilog
+open Serilog.Events
 
 [<RequireQualifiedAccess>]
 type VerbosityLevel =
     | Normal
     | Detailed
 
-let initLogger (level: VerbosityLevel) : VerbosityLevel =
-    let logger =
+let createLogger (level: VerbosityLevel) (standardErrorFromLevel: LogEventLevel) : VerbosityLevel =
+    let configuration =
         match level with
         | VerbosityLevel.Normal ->
             LoggerConfiguration()
                 .MinimumLevel.Information()
-                .WriteTo.Console(outputTemplate = "{Message:lj}{NewLine}{Exception}")
-                .CreateLogger()
-        | VerbosityLevel.Detailed -> LoggerConfiguration().MinimumLevel.Debug().WriteTo.Console().CreateLogger()
+                .WriteTo.Console(
+                    outputTemplate = "{Message:lj}{NewLine}{Exception}",
+                    standardErrorFromLevel = Nullable standardErrorFromLevel
+                )
+        | VerbosityLevel.Detailed ->
+            LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.Console(standardErrorFromLevel = Nullable standardErrorFromLevel)
 
-    Log.Logger <- logger
+    Log.Logger <- configuration.CreateLogger()
     level
 
-/// log a message
+let initLogger (level: VerbosityLevel) : VerbosityLevel =
+    createLogger level LogEventLevel.Warning
+
+let initDaemonLogger (level: VerbosityLevel) : VerbosityLevel =
+    createLogger level LogEventLevel.Verbose
+
 let stdlog (s: string) = Log.Logger.Information(s)
 
-/// log an error
 let elog (s: string) = Log.Logger.Error(s)
 
-/// log a message if the verbosity level is >= Detailed
 let logGrEqDetailed s = Log.Logger.Debug(s)
 
 let closeAndFlushLog () = Log.CloseAndFlush()

--- a/src/Fantomas/Logging.fsi
+++ b/src/Fantomas/Logging.fsi
@@ -5,7 +5,15 @@ type VerbosityLevel =
     | Normal
     | Detailed
 
+/// Initialise the logger for command line use.
+/// Informational messages are written to standard out, warnings and errors to standard error,
+/// so a caller can tell the tool's output apart from its diagnostics by stream.
 val initLogger: level: VerbosityLevel -> VerbosityLevel
+
+/// Initialise the logger for daemon mode, where standard out carries the JSON-RPC protocol.
+/// Everything is written to standard error, because a single log line on standard out would
+/// corrupt the protocol stream and fault the client connection.
+val initDaemonLogger: level: VerbosityLevel -> VerbosityLevel
 
 /// log a message
 val stdlog: s: string -> unit

--- a/src/Fantomas/Program.fs
+++ b/src/Fantomas/Program.fs
@@ -278,16 +278,26 @@ Join us on the F# Discord:       https://discord.com/channels/196693847965696000
         results.TryGetResult <@ Arguments.Verbosity @>
         |> Option.map (fun v -> v.ToLowerInvariant())
 
-    let verbosity =
+    let verbosityLevel =
         match maybeVerbosity with
         | None
         | Some "n"
-        | Some "normal" -> initLogger VerbosityLevel.Normal
+        | Some "normal" -> VerbosityLevel.Normal
         | Some "d"
-        | Some "detailed" -> initLogger VerbosityLevel.Detailed
+        | Some "detailed" -> VerbosityLevel.Detailed
         | Some _ ->
-            elog "Invalid verbosity level"
+            // The logger is not up yet, so this cannot go through elog.
+            eprintfn "Invalid verbosity level"
             exit 1
+
+    let isDaemon = results.Contains <@ Arguments.Daemon @>
+
+    // In daemon mode standard out carries the JSON-RPC protocol, so the logger must stay off it.
+    let verbosity =
+        if isDaemon then
+            initDaemonLogger verbosityLevel
+        else
+            initLogger verbosityLevel
 
     AppDomain.CurrentDomain.ProcessExit.Add(fun _ -> closeAndFlushLog ())
 
@@ -362,7 +372,6 @@ Join us on the F# Discord:       https://discord.com/channels/196693847965696000
         (fileTasks @ folderTasks)
 
     let check = results.Contains <@ Arguments.Check @>
-    let isDaemon = results.Contains <@ Arguments.Daemon @>
 
     let partitionResults (results: #(FormatResult seq)) =
         (([], [], [], []), results)

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -69,15 +69,6 @@
           "Serilog": "4.0.0"
         }
       },
-      "SerilogTraceListener": {
-        "type": "Direct",
-        "requested": "[3.2.1-dev-00011, )",
-        "resolved": "3.2.1-dev-00011",
-        "contentHash": "Lcd96moPFhTzFOJR+EIxu0PSzZPPoX1BGNfpm7ArJ4/3MnMw3iTblEJBn8EpcSzS66DJyiy+WaXVkE7fuHhU3A==",
-        "dependencies": {
-          "Serilog": "2.8.0"
-        }
-      },
       "Spectre.Console": {
         "type": "Direct",
         "requested": "[0.55.0, )",


### PR DESCRIPTION
All output went to standard out, so a caller could not tell formatted content and progress messages apart from diagnostics by stream. The Serilog console sink now splits at Warning. Informational output stays where it was, which keeps `--version` on standard out where Fantomas.Client reads it to discover the tool.

Daemon mode gets its own logger that writes everything to standard error. Standard out carries the JSON-RPC protocol there, and until now the logger was installed on that same stream, so any message logged from a daemon request would have corrupted the protocol and faulted the client connection. Deciding the mode before initialising the logger is what makes that possible.

That reordering also fixes an unrecognised `--verbosity` value exiting silently. The message was logged before any logger existed, so Serilog dropped it.

Drops the SerilogTraceListener package reference, which was never used in code. It bridges System.Diagnostics.Trace to Serilog, and the daemon sets its JSON-RPC TraceSource to Verbose, so wiring it up would have written every request and response into the protocol stream.
