### PR TITLE
Drop Thoth.Json.Net

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,6 @@
         <PackageVersion Include="Serilog" Version="4.3.1"/>
         <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageVersion Include="Argu" Version="6.2.5" />
-        <PackageVersion Include="Thoth.Json.Net" Version="12.0.0" />
         <PackageVersion Include="editorconfig" Version="0.15.0" />
         <PackageVersion Include="Ignore" Version="0.2.1" />
         <PackageVersion Include="System.IO.Abstractions" Version="22.1.0" />

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -81,14 +81,6 @@
           "TestableIO.System.IO.Abstractions.TestingHelpers": "22.1.1"
         }
       },
-      "Fable.Core": {
-        "type": "Transitive",
-        "resolved": "3.1.6",
-        "contentHash": "w6M1F0zoLk4kTFc1Lx6x1Ft6BD3QwRe0eaLiinAqbjVkcF+iK+NiXGJO+a6q9RAF9NCg0vI48Xku7aNeqG4JVw==",
-        "dependencies": {
-          "FSharp.Core": "4.7.1"
-        }
-      },
       "MessagePack": {
         "type": "Transitive",
         "resolved": "2.5.302",
@@ -276,7 +268,6 @@
           "Spectre.Console": "[0.55.0, )",
           "StreamJsonRpc": "[2.25.29, )",
           "System.IO.Abstractions": "[22.1.0, )",
-          "Thoth.Json.Net": "[12.0.0, )",
           "editorconfig": "[0.15.0, )"
         }
       },
@@ -381,17 +372,6 @@
         "dependencies": {
           "TestableIO.System.IO.Abstractions": "22.1.0",
           "TestableIO.System.IO.Abstractions.Wrappers": "22.1.0"
-        }
-      },
-      "Thoth.Json.Net": {
-        "type": "CentralTransitive",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "n2YyONYdWCFS4Pu7wrqgV/l5tPuN+t3gxEfs/2RwqCiQkRnbgKs9dK61zHeZS5YganAoFbxLSwbaNL7SvSrS9g==",
-        "dependencies": {
-          "FSharp.Core": "4.7.2",
-          "Fable.Core": "3.1.6",
-          "Newtonsoft.Json": "13.0.1"
         }
       }
     }

--- a/src/Fantomas/Daemon.fs
+++ b/src/Fantomas/Daemon.fs
@@ -4,10 +4,11 @@ open System
 open System.Diagnostics
 open System.IO
 open System.IO.Abstractions
+open System.Text.Json
+open System.Text.Json.Nodes
 open System.Threading
 open System.Threading.Tasks
 open StreamJsonRpc
-open Thoth.Json.Net
 open Fantomas.FCS.Text
 open Fantomas.Client.Contracts
 open Fantomas.Client.LSPFantomasServiceTypes
@@ -141,12 +142,25 @@ type FantomasDaemon(sender: Stream, reader: Stream, environment: DaemonEnvironme
 
     [<JsonRpcMethod(Methods.Configuration)>]
     member _.Configuration() : string =
+        let jsonString (value: string) : JsonNode = JsonValue.Create value :> JsonNode
+
+        let jsonObject (properties: (string * JsonNode) list) : JsonNode =
+            let node = JsonObject()
+
+            for key, value in properties do
+                node.Add(key, value)
+
+            node :> JsonNode
+
+        let jsonStringArray (values: string list) : JsonNode =
+            JsonArray(values |> List.map jsonString |> List.toArray) :> JsonNode
+
         let settings =
             Reflection.getRecordFields FormatConfig.Default
             |> Array.toList
             |> List.choose (fun (recordField, defaultValue) ->
                 let optionalField key value =
-                    value |> Option.toList |> List.map (fun v -> key, Encode.string v)
+                    value |> Option.toList |> List.map (fun v -> key, v)
 
                 let meta =
                     List.concat
@@ -156,63 +170,41 @@ type FantomasDaemon(sender: Stream, reader: Stream, environment: DaemonEnvironme
 
                 let type' =
                     match defaultValue with
-                    | :? bool as b ->
-                        Some(
-                            Encode.object
-                                [ yield "type", Encode.string "boolean"
-                                  yield "defaultValue", Encode.string (if b then "true" else "false")
-                                  yield! meta ]
-                        )
-                    | :? int as i ->
-                        Some(
-                            Encode.object
-                                [ yield "type", Encode.string "number"
-                                  yield "defaultValue", Encode.string (string<int> i)
-                                  yield! meta ]
-                        )
+                    | :? bool as b -> Some("boolean", (if b then "true" else "false"))
+                    | :? int as i -> Some("number", string<int> i)
                     | :? MultilineFormatterType as m ->
-                        Some(
-                            Encode.object
-                                [ yield "type", Encode.string "multilineFormatterType"
-                                  yield "defaultValue", Encode.string (MultilineFormatterType.ToConfigString m)
-                                  yield! meta ]
-                        )
-                    | :? EndOfLineStyle as e ->
-                        Some(
-                            Encode.object
-                                [ yield "type", Encode.string "endOfLineStyle"
-                                  yield "defaultValue", Encode.string (EndOfLineStyle.ToConfigString e)
-                                  yield! meta ]
-                        )
+                        Some("multilineFormatterType", MultilineFormatterType.ToConfigString m)
+                    | :? EndOfLineStyle as e -> Some("endOfLineStyle", EndOfLineStyle.ToConfigString e)
                     | :? MultilineBracketStyle as m ->
-                        Some(
-                            Encode.object
-                                [ yield "type", Encode.string "multilineBracketStyle"
-                                  yield "defaultValue", Encode.string (MultilineBracketStyle.ToConfigString m)
-                                  yield! meta ]
-                        )
+                        Some("multilineBracketStyle", MultilineBracketStyle.ToConfigString m)
                     | _ -> None
 
-                type' |> Option.map (fun t -> toEditorConfigName recordField.PropertyName, t))
-            |> Encode.object
+                type'
+                |> Option.map (fun (typeName, defaultString) ->
+                    let value =
+                        ("type", typeName) :: ("defaultValue", defaultString) :: meta
+                        |> List.map (fun (key, value) -> key, jsonString value)
+                        |> jsonObject
+
+                    toEditorConfigName recordField.PropertyName, value))
+            |> jsonObject
 
         let enumOptions =
-            Encode.object
+            jsonObject
                 [ "multilineFormatterType",
-                  Encode.list
-                      [ (MultilineFormatterType.ToConfigString MultilineFormatterType.CharacterWidth
-                         |> Encode.string)
-                        (MultilineFormatterType.ToConfigString MultilineFormatterType.NumberOfItems
-                         |> Encode.string) ]
+                  jsonStringArray
+                      [ MultilineFormatterType.ToConfigString MultilineFormatterType.CharacterWidth
+                        MultilineFormatterType.ToConfigString MultilineFormatterType.NumberOfItems ]
                   "endOfLineStyle",
-                  Encode.list
-                      [ (EndOfLineStyle.ToConfigString EndOfLineStyle.LF |> Encode.string)
-                        (EndOfLineStyle.ToConfigString EndOfLineStyle.CRLF |> Encode.string) ]
+                  jsonStringArray
+                      [ EndOfLineStyle.ToConfigString EndOfLineStyle.LF
+                        EndOfLineStyle.ToConfigString EndOfLineStyle.CRLF ]
                   "multilineBracketStyle",
-                  Encode.list
-                      [ (MultilineBracketStyle.ToConfigString Aligned |> Encode.string)
-                        (MultilineBracketStyle.ToConfigString Cramped |> Encode.string)
-                        (MultilineBracketStyle.ToConfigString Stroustrup |> Encode.string) ] ]
+                  jsonStringArray
+                      [ MultilineBracketStyle.ToConfigString Aligned
+                        MultilineBracketStyle.ToConfigString Cramped
+                        MultilineBracketStyle.ToConfigString Stroustrup ] ]
 
-        Encode.object [ "settings", settings; "enumOptions", enumOptions ]
-        |> Encode.toString 4
+        let json = jsonObject [ "settings", settings; "enumOptions", enumOptions ]
+
+        json.ToJsonString(JsonSerializerOptions(WriteIndented = true, IndentSize = 4))

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -57,7 +57,6 @@
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="StreamJsonRpc" />
     <PackageReference Include="Argu" />
-    <PackageReference Include="Thoth.Json.Net" />
     <PackageReference Include="editorconfig" />
     <PackageReference Include="Ignore" />
     <PackageReference Include="System.IO.Abstractions" />

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -102,25 +102,6 @@
           "TestableIO.System.IO.Abstractions.Wrappers": "22.1.0"
         }
       },
-      "Thoth.Json.Net": {
-        "type": "Direct",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "n2YyONYdWCFS4Pu7wrqgV/l5tPuN+t3gxEfs/2RwqCiQkRnbgKs9dK61zHeZS5YganAoFbxLSwbaNL7SvSrS9g==",
-        "dependencies": {
-          "FSharp.Core": "4.7.2",
-          "Fable.Core": "3.1.6",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Fable.Core": {
-        "type": "Transitive",
-        "resolved": "3.1.6",
-        "contentHash": "w6M1F0zoLk4kTFc1Lx6x1Ft6BD3QwRe0eaLiinAqbjVkcF+iK+NiXGJO+a6q9RAF9NCg0vI48Xku7aNeqG4JVw==",
-        "dependencies": {
-          "FSharp.Core": "4.7.1"
-        }
-      },
       "MessagePack": {
         "type": "Transitive",
         "resolved": "2.5.302",


### PR DESCRIPTION
The daemon only used it to encode the configuration response, which the framework can do on its own. That JSON is now built with System.Text.Json, so the tool no longer carries Thoth.Json.Net or Fable.Core.

The response is byte for byte what it was before, indentation included.
