### PR TITLE
Fix extern with a nullable type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ pipelines run them alongside the two analyzer packages.
 | `FANTOMAS-PRIVATE-001` | No `let private` beside a signature file | Error |
 | `FANTOMAS-ARMORDER-001` | Shortest match arm first | Warning |
 | `FANTOMAS-ANNOTATE-001` | Annotate every `let` binding | Warning |
-| `FANTOMAS-XMLDOC-001` | No doc comment beside a signature file | Warning |
+| `FANTOMAS-XMLDOC-001` | No doc comment the signature file already carries | Warning |
 
 [analyzers/AGENTS.md](analyzers/AGENTS.md) has what each one asks for and why, how to suppress a
 finding, and what to know before writing another. `dotnet fsi build.fsx -- -p AnalyzeChanged` will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Breaking: `Fantomas.Core.ParseException` now derives from `FormatException`, as the other exceptions the library raises already did, so `:? FormatException` catches every way formatting can fail. It could not before: it was declared with F#'s `exception` keyword, which cannot name a base class. Its `Message` names the first error by position instead of dumping every diagnostic record through `%A`, and the records are reachable as `.Diagnostics` rather than only by matching the exception pattern. Code matching `| ParseException diagnostics ->` becomes `| :? ParseException as e -> e.Diagnostics`; raising and constructing it are unchanged. [#3415](https://github.com/fsprojects/fantomas/pull/3415)
+- A construct Fantomas cannot model is now reported through the same mechanism as a parse failure, instead of as a `%A` dump of a syntax tree node in the middle of the message. The report says in words what could not be modelled, names the union case responsible, positions it in the file being formatted rather than in the `tmp.fsx` the parser was handed, and draws a snippet of the source with a caret under the construct, so the enclosing declaration is visible without having to bisect the file by hand. The syntax tree node is still reported, at `--verbosity d`, where it serves whoever triages the issue rather than whoever files it. This covers every such report, from a type the transformer has no Oak node for to the chain and leading-keyword invariants behind it. `--check` and the daemon position them the same way, so an editor shows its user the snippet rather than a bare line and column. [#3415](https://github.com/fsprojects/fantomas/pull/3415)
+
+### Fixed
+
+- Getting a 'no Oak node is defined for this type' error when formatting a p/invoke signature with nullability annotations. [#3414](https://github.com/fsprojects/fantomas/issues/3414)
+- An `extern` declaration returning an array, such as `extern byte[] f(int options)`, lost the element type of the array and was written as ``extern `[]` f(int options)``. [#3415](https://github.com/fsprojects/fantomas/pull/3415)
+
 ## [8.0.0-alpha-015] - 2026-08-24
 
 ### Added

--- a/analyzers/AGENTS.md
+++ b/analyzers/AGENTS.md
@@ -11,7 +11,7 @@ feedback arrives while you work instead of in review. They are ordinary F# analy
 | [`FANTOMAS-PRIVATE-001`](#fantomas-private-001) | No `let private` beside a signature file | Error | both pipelines |
 | [`FANTOMAS-ARMORDER-001`](#fantomas-armorder-001) | Shortest match arm first | Warning | both pipelines |
 | [`FANTOMAS-ANNOTATE-001`](#fantomas-annotate-001) | Annotate every `let` binding | Warning | `AnalyzeChanged` only |
-| [`FANTOMAS-XMLDOC-001`](#fantomas-xmldoc-001) | No doc comment beside a signature file | Warning | `AnalyzeChanged` only |
+| [`FANTOMAS-XMLDOC-001`](#fantomas-xmldoc-001) | No doc comment the signature file already carries | Warning | `AnalyzeChanged` only |
 
 ## FANTOMAS-PIPEBACK-001
 
@@ -51,9 +51,10 @@ match tool with
 
 The short arm is nearly always the one that gets out of the way, and reading it first says what the
 rest of the expression is not about. It is also the order `fsharp_experimental_keep_indent_in_branch`
-wants: with the long arm last, its body can hold the indentation of the match instead of stepping in
-another level. Nothing here is formatted with that setting on, but writing the arms in the order that
-suits it costs nothing.
+wants, which the repository's `.editorconfig` turns on: with the long arm last, its body can hold the
+indentation of the match instead of stepping in another level. That is what lets a second `match` in
+the final arm sit at the indentation of the first rather than one level in, which is worth reaching
+for when one lookup falls through to another.
 
 The analyzer is deliberately narrower than the rule, because arm order is semantically significant
 and reordering overlapping patterns changes meaning. It speaks only for exactly two arms, with no
@@ -103,11 +104,19 @@ Documentation comments belong in the signature file only, never in both. A `///`
 alongside one in the `.fsi` is a second copy to keep in step, and the one readers and tooling see is
 the signature.
 
-The rule takes the looser of the two readings: it reports any `///` in a file that has a signature
-file, because it cannot tell whether the signature documents the same binding. So a helper that
-appears in neither is reported too, and the answer there is an ordinary `//` comment. That is the
-convention in this folder, and it is worth knowing before writing a rule: `///` here means the
-signature file.
+A declaration the signature file does not carry is left alone, doc comment and all. There is no
+second copy to keep in step, so there is nothing for the rule to be about: write `///` on a private
+helper in a file that has an `.fsi` and nothing complains.
+
+The rule used to report every `///` in a file that had a signature file, because it could not tell
+which of them were duplicated, and the answer there was to write `//` instead. That is no longer
+the convention, and the `//` comments left over from it are not worth converting on sight.
+
+What it asks the compiler is `FSharpSymbol.SignatureLocation`, and that is worth knowing before
+using it elsewhere: it is not the yes or no it reads as. For a symbol the signature does not carry it
+falls back to the declaration itself, so it is `Some` for every symbol and `IsSome` answers nothing.
+What separates the two is which file it points at — into the `.fsi` for a symbol the signature
+declares, back at the `.fs` for one it does not.
 
 ## Severity and scope
 
@@ -182,10 +191,15 @@ rather than that the run succeeded.
 
 Every rule is registered twice, as a `CliAnalyzer` and as an `EditorAnalyzer`, with both attributes
 in the signature file. The pipelines use the first; the second is what makes the rule show up in
-Ionide as you type. Between them the five rules read exactly three things, `ctx.FileName`,
-`ctx.ProjectOptions.SourceFiles` and `ctx.ParseFileResults.ParseTree`, all of which `EditorContext`
-carries as well as `CliContext` does. Reach for the typed tree and that stops being true, and the
-editor registration has to go.
+Ionide as you type. Four of the five rules read only `ctx.FileName`, `ctx.ProjectOptions.SourceFiles`
+and `ctx.ParseFileResults.ParseTree`, all of which `EditorContext` carries as well as `CliContext`
+does.
+
+`FANTOMAS-XMLDOC-001` also reads `ctx.CheckFileResults`, because the untyped tree cannot say whether
+the signature file declares the same binding. That does not cost the editor registration:
+`EditorContext` carries check results too, as an option rather than outright, so the editor analyzer
+matches on it and says nothing when they are absent. A rule that needs the typed tree is fine; one
+that cannot answer without it has to be quiet in the editor rather than wrong there.
 
 Where a rule needs to know whether a file has a signature file, ask `ctx.ProjectOptions.SourceFiles`
 rather than the filesystem. An `.fsi` that is not compiled says nothing about what is visible, and a
@@ -227,8 +241,9 @@ dotnet msbuild src/Fantomas.Core/Fantomas.Core.fsproj -t:CoreCompile \
   -p:BuildProjectReferences=false -p:DesignTimeBuild=true -getItem:FscCommandLineArgs
 ```
 
-None of this is currently load bearing. Parsing every file of `Fantomas.Core` under the default
-options, both define sets, `--strict-indentation+` and `--langversion:preview` produces identical
-findings from all five rules, which is what you would expect of rules that read only the untyped
-tree. The defines are the only option that could change a verdict, since they decide which branch of
+None of this is currently load bearing for the four rules that read only the untyped tree. Parsing
+every file of `Fantomas.Core` under the default options, both define sets, `--strict-indentation+`
+and `--langversion:preview` produces identical findings from them, which is what you would expect.
+`FANTOMAS-XMLDOC-001` reads the typed tree and so does depend on the project options resolving, which
+is another reason the fixture checks they came back non-empty. The defines are the only option that could change a verdict, since they decide which branch of
 an `#if` reaches the tree, and `DEBUG` in `Selection.fs` is the only one in real source anywhere.

--- a/analyzers/Fantomas.Analyzers.Tests/XmlDocAnalyzerTests.fs
+++ b/analyzers/Fantomas.Analyzers.Tests/XmlDocAnalyzerTests.fs
@@ -69,3 +69,76 @@ let y: Holder = Number 1"""
 
     analyzeWithSignature cliAnalyzer signature implementation
     |> assertLines [ 3; 5 ]
+
+[<Test>]
+let ``a doc comment on a helper the signature does not declare is not reported`` () =
+    let signature: string =
+        """module M
+
+val y: int"""
+
+    let implementation: string =
+        """module M
+
+/// Doubles a number.
+let private double (x: int) : int = x * 2
+
+let y: int = double 21"""
+
+    analyzeWithSignature cliAnalyzer signature implementation |> assertLines []
+
+[<Test>]
+let ``a doc comment is reported on the declaration the signature carries and not on the helper beside it`` () =
+    let signature: string =
+        """module M
+
+val y: int"""
+
+    let implementation: string =
+        """module M
+
+/// Doubles a number.
+let private double (x: int) : int = x * 2
+
+/// The answer.
+let y: int = double 21"""
+
+    analyzeWithSignature cliAnalyzer signature implementation |> assertLines [ 6 ]
+
+[<Test>]
+let ``a doc comment on a local binding is not reported`` () =
+    let signature: string =
+        """module M
+
+val y: int"""
+
+    let implementation: string =
+        """module M
+
+let y: int =
+    /// Half of it.
+    let half: int = 21
+    half * 2"""
+
+    analyzeWithSignature cliAnalyzer signature implementation |> assertLines []
+
+[<Test>]
+let ``a doc comment on a type the signature does not declare is not reported`` () =
+    let signature: string =
+        """module M
+
+val y: int"""
+
+    let implementation: string =
+        """module M
+
+/// Holds a number.
+type private Holder =
+    /// The number.
+    | Number of int
+
+let y: int =
+    match Number 1 with
+    | Number n -> n"""
+
+    analyzeWithSignature cliAnalyzer signature implementation |> assertLines []

--- a/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fs
@@ -2,6 +2,8 @@ module Fantomas.Analyzers.XmlDocAnalyzer
 
 open FSharp.Analyzers.SDK
 open FSharp.Analyzers.SDK.ASTCollecting
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open FSharp.Compiler.Xml
@@ -15,69 +17,154 @@ let Name: string = "XmlDocAnalyzer"
 
 [<Literal>]
 let ShortDescription: string =
-    "Detects a documentation comment in an implementation file that has a signature file, where the signature is the copy readers and tooling see."
+    "Detects a documentation comment that is duplicated in an implementation file and its signature file, where the signature is the copy readers and tooling see."
 
 [<Literal>]
 let HelpUri: string =
     "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-xmldoc-001"
 
-// Documentation comments in a file whose signature file is the one readers and tooling see.
+// The name a declaration introduces, and where that name sits.
 //
-// The untyped tree hangs a `PreXmlDoc` off every declaration that can carry one, so this needs no
-// trivia and no second parse. What it cannot tell on its own is whether the signature documents
-// the same binding, so a private helper that appears in neither is reported too. That is the
-// looser of the two readings of the rule, and the one to revisit if it proves noisy.
-let analyze (fileName: string) (sourceFiles: string list) (parsedInput: ParsedInput) : Message list =
+// The doc comment's own range is what gets reported, but the name is what answers whether the
+// signature file declares the same thing, so both travel together.
+[<NoComparison; NoEquality>]
+type DocumentedDeclaration =
+    {
+        DocRange: range
+        Name: string
+        NameRange: range
+    }
+
+// The last identifier of a pattern is the name a `let` introduces. A pattern that introduces
+// several names, or none, is not a documented declaration this rule can speak for.
+let bindingName (pat: SynPat) : Ident option =
+    match pat with
+    | SynPat.Named(ident = SynIdent(ident, _)) -> Some ident
+    | SynPat.LongIdent(longDotId = SynLongIdent(id = ids)) -> List.tryLast ids
+    | _ -> None
+
+/// Whether the signature file declares the same thing the implementation documents.
+///
+/// `SignatureLocation` is not the yes or no it reads as: for a symbol the signature does not carry
+/// it falls back to the declaration itself, so it is `Some` for every symbol and asking `IsSome`
+/// answers nothing. What separates the two is which file it points at. A symbol the signature
+/// declares points into the `.fsi`; one it does not points back at the `.fs` it was declared in.
+///
+/// A symbol that cannot be resolved is treated as not declared in the signature. Reporting it would
+/// put the burden of proof on the wrong side: the rule is about a doc comment that exists twice, and
+/// nothing here says this one does.
+let declaredInSignature
+    (checkResults: FSharpCheckFileResults)
+    (sourceText: ISourceText)
+    (declaration: DocumentedDeclaration)
+    : bool =
+    let line: int = declaration.NameRange.EndLine
+
+    if line < 1 || line > sourceText.GetLineCount() then
+        false
+    else
+        let lineText: string = sourceText.GetLineString(line - 1)
+
+        checkResults.GetSymbolUseAtLocation(line, declaration.NameRange.EndColumn, lineText, [ declaration.Name ])
+        |> Option.map (fun (symbolUse: FSharpSymbolUse) ->
+            match symbolUse.Symbol.SignatureLocation, symbolUse.Symbol.DeclarationLocation with
+            | Some signature, Some declaration -> signature.FileName <> declaration.FileName
+            | _ -> false)
+        |> Option.defaultValue false
+
+// Documentation comments that the signature file already carries.
+//
+// The untyped tree hangs a `PreXmlDoc` off every declaration that can carry one, so finding them
+// needs no trivia and no second parse. Deciding which of them are duplicated does need the symbol,
+// because the name in the implementation is all the tree has to go on.
+let analyze
+    (checkResults: FSharpCheckFileResults)
+    (sourceText: ISourceText)
+    (fileName: string)
+    (sourceFiles: string list)
+    (parsedInput: ParsedInput)
+    : Message list =
     if not (hasSignatureFile fileName sourceFiles) then
         []
     else
 
-        let ranges: ResizeArray<range> = ResizeArray<range>()
+        let documented: ResizeArray<DocumentedDeclaration> =
+            ResizeArray<DocumentedDeclaration>()
 
-        let collect (doc: PreXmlDoc) : unit =
-            if not doc.IsEmpty then
-                ranges.Add doc.Range
+        let collect (doc: PreXmlDoc) (name: Ident option) : unit =
+            match name with
+            | None -> ()
+            | Some ident ->
+                if not doc.IsEmpty then
+                    documented.Add
+                        {
+                            DocRange = doc.Range
+                            Name = ident.idText
+                            NameRange = ident.idRange
+                        }
 
         let walker: SyntaxCollectorBase =
             { new SyntaxCollectorBase() with
                 override _.WalkBinding(_path: SyntaxVisitorPath, binding: SynBinding) : unit =
                     match binding with
-                    | SynBinding(xmlDoc = doc) -> collect doc
+                    | SynBinding(xmlDoc = doc; headPat = pat) -> collect doc (bindingName pat)
 
                 override _.WalkComponentInfo(_path: SyntaxVisitorPath, info: SynComponentInfo) : unit =
                     match info with
-                    | SynComponentInfo(xmlDoc = doc) -> collect doc
+                    | SynComponentInfo(xmlDoc = doc; longId = ids) -> collect doc (List.tryLast ids)
 
                 override _.WalkUnionCase(_path: SyntaxVisitorPath, unionCase: SynUnionCase) : unit =
                     match unionCase with
-                    | SynUnionCase(xmlDoc = doc) -> collect doc
+                    | SynUnionCase(xmlDoc = doc; ident = SynIdent(ident, _)) -> collect doc (Some ident)
 
                 override _.WalkEnumCase(_path: SyntaxVisitorPath, enumCase: SynEnumCase) : unit =
                     match enumCase with
-                    | SynEnumCase(xmlDoc = doc) -> collect doc
+                    | SynEnumCase(xmlDoc = doc; ident = SynIdent(ident, _)) -> collect doc (Some ident)
 
                 override _.WalkField(_path: SyntaxVisitorPath, field: SynField) : unit =
                     match field with
-                    | SynField(xmlDoc = doc) -> collect doc
+                    | SynField(xmlDoc = doc; idOpt = idOpt) -> collect doc idOpt
             }
 
         walkAst walker parsedInput
 
-        ranges
-        |> Seq.map (fun (doc: range) ->
+        documented
+        |> Seq.filter (declaredInSignature checkResults sourceText)
+        |> Seq.map (fun (declaration: DocumentedDeclaration) ->
             {
                 Type = Name
                 Message =
                     "Move this documentation comment to the signature file. Keeping a copy in both is a second one to keep in step, and the signature is the one readers and tooling see."
                 Code = Code
                 Severity = Severity.Warning
-                Range = doc
+                Range = declaration.DocRange
                 Fixes = []
             })
         |> Seq.toList
 
 let cliAnalyzer (ctx: CliContext) : Async<Message list> =
-    async { return analyze ctx.FileName ctx.ProjectOptions.SourceFiles ctx.ParseFileResults.ParseTree }
+    async {
+        return
+            analyze
+                ctx.CheckFileResults
+                ctx.SourceText
+                ctx.FileName
+                ctx.ProjectOptions.SourceFiles
+                ctx.ParseFileResults.ParseTree
+    }
 
+// Without check results there is no symbol to ask, and the rule cannot tell a duplicated doc
+// comment from one that only exists here. It says nothing rather than guessing.
 let editorAnalyzer (ctx: EditorContext) : Async<Message list> =
-    async { return analyze ctx.FileName ctx.ProjectOptions.SourceFiles ctx.ParseFileResults.ParseTree }
+    async {
+        match ctx.CheckFileResults with
+        | None -> return []
+        | Some checkResults ->
+            return
+                analyze
+                    checkResults
+                    ctx.SourceText
+                    ctx.FileName
+                    ctx.ProjectOptions.SourceFiles
+                    ctx.ParseFileResults.ParseTree
+    }

--- a/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fsi
+++ b/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fsi
@@ -10,16 +10,16 @@ val Name: string = "XmlDocAnalyzer"
 
 [<Literal>]
 val ShortDescription: string =
-    "Detects a documentation comment in an implementation file that has a signature file, where the signature is the copy readers and tooling see."
+    "Detects a documentation comment that is duplicated in an implementation file and its signature file, where the signature is the copy readers and tooling see."
 
 [<Literal>]
 val HelpUri: string = "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-xmldoc-001"
 
-/// Reports every documentation comment in a file that has a signature file.
+/// Reports a documentation comment on a declaration that the file's signature file also declares.
 ///
-/// This takes the looser of the two readings of the rule. It cannot tell whether the signature
-/// documents the same binding, so a helper that appears in neither is reported too, and the answer
-/// there is an ordinary `//` comment rather than a `///` one.
+/// A declaration the signature does not carry is left alone, doc comment and all: there is no second
+/// copy to keep in step, so there is nothing for the rule to be about. The signature is asked for
+/// through the symbol's `SignatureLocation` rather than guessed at from the name.
 [<CliAnalyzer(Name, ShortDescription, HelpUri)>]
 val cliAnalyzer: ctx: CliContext -> Async<Message list>
 

--- a/src/Fantomas.Core.Tests/ExternTests.fs
+++ b/src/Fantomas.Core.Tests/ExternTests.fs
@@ -250,3 +250,80 @@ type T() =
     [<DllImport("kernel32.dll")>]
     extern UIntPtr private GetProcessHeap()
 """
+
+[<Test>]
+let ``nullable array parameter in extern declaration, 3414`` () =
+    formatSourceString
+        """
+module private XAttrHandler =
+
+    [<SupportedOSPlatform("macos")>]
+    [<DllImport("/usr/lib/libSystem.dylib", EntryPoint = "getxattr", SetLastError = true)>]
+    extern int64 private getxattrMacOs(string path, string name, byte[] | null value, uint64 size, uint32 position, int options)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module private XAttrHandler =
+
+    [<SupportedOSPlatform("macos")>]
+    [<DllImport("/usr/lib/libSystem.dylib", EntryPoint = "getxattr", SetLastError = true)>]
+    extern int64 private getxattrMacOs(
+        string path,
+        string name,
+        byte[] | null value,
+        uint64 size,
+        uint32 position,
+        int options
+    )
+"""
+
+[<Test>]
+let ``nullable parameter in extern declaration`` () =
+    formatSourceString
+        """
+[<DllImport("x")>]
+extern int64 private f(string | null path, int options)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<DllImport("x")>]
+extern int64 private f(string | null path, int options)
+"""
+
+[<Test>]
+let ``nullable return type in extern declaration`` () =
+    formatSourceString
+        """
+[<DllImport("x")>]
+extern string | null private f(int options)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<DllImport("x")>]
+extern string | null private f(int options)
+"""
+
+[<Test>]
+let ``array return type in extern declaration`` () =
+    formatSourceString
+        """
+[<DllImport("x")>]
+extern byte[] private f(int options)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<DllImport("x")>]
+extern byte[] private f(int options)
+"""

--- a/src/Fantomas.Core.Tests/ValidationTests.fs
+++ b/src/Fantomas.Core.Tests/ValidationTests.fs
@@ -86,3 +86,42 @@ let ``InvariantViolationException reports where in the source the violation happ
     ex.Message |> should haveSubstring "line 7"
     ex.Message |> should haveSubstring "column 4"
     ex.Message |> should haveSubstring "Sample.fs"
+
+// The invariant stays on one line and the source is not quoted into it: positioning the violation
+// against the source is the reporter's job, and the reporter that draws a parse failure does it.
+[<Test>]
+let ``InvariantViolationException keeps the invariant on one line`` () =
+    let ex =
+        Fantomas.Core.InvariantViolationException(
+            "no Oak node is defined for this type: SynType.App",
+            sampleRange,
+            "App (LongIdent ...)"
+        )
+
+    ex.Invariant |> should equal "no Oak node is defined for this type: SynType.App"
+
+[<Test>]
+let ``InvariantViolationException keeps the syntax tree node off the message`` () =
+    let ex =
+        Fantomas.Core.InvariantViolationException("chain head is Foo", sampleRange, "App (LongIdent ...)")
+
+    ex.SyntaxNode |> should equal "App (LongIdent ...)"
+    ex.Message |> should not' (haveSubstring "App (LongIdent ...)")
+
+[<Test>]
+let ``InvariantViolationException carries no syntax tree node when it was not given one`` () =
+    let ex = Fantomas.Core.InvariantViolationException("chain head is Foo", sampleRange)
+
+    ex.SyntaxNode |> should equal ""
+
+// Naming the union case is what replaces the %A dump of a syntax tree node in an error message.
+[<Test>]
+let ``UnionCase.name qualifies the case with the type it belongs to`` () =
+    let t: Fantomas.FCS.Syntax.SynType =
+        Fantomas.FCS.Syntax.SynType.Anon(Fantomas.FCS.Text.Range.range0)
+
+    Fantomas.Core.UnionCase.name t |> should equal "SynType.Anon"
+
+[<Test>]
+let ``UnionCase.name falls back to the type name for something that is not a union`` () =
+    Fantomas.Core.UnionCase.name 42 |> should equal "Int32"

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -17,6 +17,22 @@ open Microsoft.FSharp.Core
 let invariantViolation (range: range) format =
     Printf.kprintf (fun msg -> raise (InvariantViolationException(msg, range))) format
 
+/// Raise an <see cref="T:Fantomas.Core.InvariantViolationException"/> about a particular syntax
+/// tree node, with a printf-style message.
+///
+/// The node is dumped onto the exception rather than into the message. What it holds is for whoever
+/// triages the report, and a `%A` in the middle of a sentence buries the sentence: it is several
+/// lines long, it wraps wherever the terminal decides to, and it says nothing to whoever hit it. Say
+/// the invariant in words, and name the union case with `UnionCase.name` where knowing it helps.
+let invariantViolationAbout (range: range) (node: 'node) (format: Printf.StringFormat<'T, 'Result>) : 'T =
+    Printf.kprintf (fun msg -> raise (InvariantViolationException(msg, range, $"%A{node}"))) format
+
+/// The dotted text of a long identifier, for a message that has to name one.
+let longIdentText (sli: SynLongIdent) : string =
+    sli.LongIdent
+    |> List.map (fun (ident: Ident) -> ident.idText)
+    |> String.concat "."
+
 [<NoComparison>]
 type CreationAide =
     {
@@ -27,6 +43,22 @@ type CreationAide =
         match x.SourceText with
         | None -> fallback ()
         | Some sourceText -> sourceText.GetSubTextFromRange range
+
+/// Raise for a syntax tree node that the Oak model has no case for.
+///
+/// `construct` names what was being built, such as "type", and `node` is the node that had no case.
+/// The message names the union case rather than dumping the node, and says nothing about where the
+/// node sits beyond its range: positioning it against the source is the reporter's job, and the one
+/// that already draws a parse failure does it better than a string here could. The dump travels on
+/// the exception for whoever triages the report.
+let missingOakNode (construct: string) (range: range) (node: 'node) : 'result =
+    raise (
+        InvariantViolationException(
+            $"no Oak node is defined for this %s{construct}: %s{UnionCase.name node}",
+            range,
+            $"%A{node}"
+        )
+    )
 
 let stn text range = SingleTextNode(text, range)
 
@@ -796,7 +828,11 @@ let mkLinksFromFunctionName (mkLinkFromExpr: SynExpr -> LinkExpr) (functionName:
         // A generic function name only reaches here from a dotted chain, so it always has
         // at least two identifiers (`a.Foo<T>`); `Foo<T>` on its own is not a chain.
         | []
-        | [ _ ] -> invariantViolation functionName.Range "generic function name %A has fewer than two identifiers" sli
+        | [ _ ] ->
+            invariantViolationAbout
+                functionName.Range
+                sli
+                $"the generic function name `%s{longIdentText sli}` has fewer than two identifiers"
         | synIdents ->
             let leftLinks = mkLinksFromSynLongIdent sli
             let lastSynIdent = List.last synIdents
@@ -823,7 +859,11 @@ let mkLinksFromFunctionName (mkLinkFromExpr: SynExpr -> LinkExpr) (functionName:
         // Likewise a plain function name: an undotted `f(x)` never becomes a chain, so by the
         // time we are building links there are always at least two identifiers.
         | []
-        | [ _ ] -> invariantViolation functionName.Range "function name %A has fewer than two identifiers" sli
+        | [ _ ] ->
+            invariantViolationAbout
+                functionName.Range
+                sli
+                $"the function name `%s{longIdentText sli}` has fewer than two identifiers"
         | synIdents ->
             let leftLinks = mkLinksFromSynLongIdent sli
             let lastSynIdent = List.last synIdents
@@ -870,16 +910,16 @@ let rec visitChainLinks (e: SynExpr) (continuation: LinkExpr list -> LinkExpr li
                         | ParenExpr(lpr, innerExpr, rpr, pr) -> [ LinkExpr.AppParen(typeApp, lpr, innerExpr, rpr, pr) ]
                         // Unreachable: the outer pattern already constrained argExpr to Paren or Unit.
                         | _ ->
-                            invariantViolation
+                            invariantViolationAbout
                                 e.Range
-                                "generic call argument %A is neither a unit nor a parenthesised expression"
                                 argExpr
+                                $"a generic call argument is a %s{UnionCase.name argExpr}, which is neither a unit nor a parenthesised expression"
                     // Unreachable: visiting a DotGet always ends the link list with an Identifier.
                     | _ ->
-                        invariantViolation
+                        invariantViolationAbout
                             e.Range
-                            "generic call has no identifier to attach its type arguments to (links: %A)"
                             leftLinks
+                            "a generic call has no identifier to attach its type arguments to"
 
                 let leftLinks = List.cutOffLast leftLinks
                 continuation [ yield! leftLinks; yield! lastLink ]
@@ -906,10 +946,7 @@ let rec visitChainLinks (e: SynExpr) (continuation: LinkExpr list -> LinkExpr li
                         ]
                     // Unreachable: visiting a DotGet always ends the link list with an Identifier.
                     | _ ->
-                        invariantViolation
-                            e.Range
-                            "type application has no identifier to attach to (links: %A)"
-                            leftLinks
+                        invariantViolationAbout e.Range leftLinks "a type application has no identifier to attach to"
 
                 let leftLinks = List.cutOffLast leftLinks
                 continuation [ yield! leftLinks; yield! lastLink ]
@@ -924,7 +961,7 @@ let rec visitChainLinks (e: SynExpr) (continuation: LinkExpr list -> LinkExpr li
                     match List.tryLast sli.IdentsWithTrivia with
                     // Unreachable: a DotGet always carries at least one identifier after its dot.
                     | None ->
-                        invariantViolation e.Range "indexed member access has no identifier after the dot (%A)" sli
+                        invariantViolationAbout e.Range sli "an indexed member access has no identifier after the dot"
                     | Some lastMiddleLink ->
                         let middleLinks = mkLinksFromSynLongIdent sli |> List.cutOffLast
 
@@ -985,13 +1022,12 @@ let rec visitChainLinks (e: SynExpr) (continuation: LinkExpr list -> LinkExpr li
                     // Unreachable: `(|ChainExpr|_|)` only routes Unit/Paren arguments here, and a
                     // dot-lambda body cannot be a space-separated application.
                     | _ ->
-                        invariantViolation
+                        invariantViolationAbout
                             e.Range
-                            "call argument %A is neither a unit nor a parenthesised expression"
                             argExpr
+                            $"a call argument is a %s{UnionCase.name argExpr}, which is neither a unit nor a parenthesised expression"
                 // Unreachable: visiting a DotGet always ends the link list with an Identifier.
-                | _ ->
-                    invariantViolation e.Range "call has no identifier to apply its argument to (links: %A)" leftLinks
+                | _ -> invariantViolationAbout e.Range leftLinks "a call has no identifier to apply its argument to"
             )
 
     | SynExpr.DotGet(expr, rangeOfDot, longDotId, _) ->
@@ -1033,10 +1069,7 @@ let rec visitChainLinks (e: SynExpr) (continuation: LinkExpr list -> LinkExpr li
                         ]
                     // Unreachable: visiting a LongIdent always ends the link list with an Identifier.
                     | _ ->
-                        invariantViolation
-                            e.Range
-                            "indexed application has no identifier to index (links: %A)"
-                            leftLinks
+                        invariantViolationAbout e.Range leftLinks "an indexed application has no identifier to index"
 
                 let leftLinks = List.cutOffLast leftLinks
                 continuation [ yield! leftLinks; yield! app ]
@@ -1115,7 +1148,11 @@ let mkChainFromLinks
                 )
 
             Expr.Chain headChain, rest
-        | other -> invariantViolation range "chain head is %A, which is not a receiver the model allows" other
+        | other ->
+            invariantViolationAbout
+                range
+                other
+                $"a chain head is a %s{UnionCase.name other}, which is not a receiver the model allows"
 
     // Expected input: the links *after* the head, which `visitChainLinks` always emits as a
     // repeating `Dot` + one content link (`Identifier` / `AppUnit` / `AppParen` / `IndexExpr` /
@@ -1186,11 +1223,10 @@ let mkChainFromLinks
             seg :: segs, terminal
 
         | other ->
-            invariantViolation
+            invariantViolationAbout
                 range
-                "unexpected link pattern in chain.\nExpected a `Dot` followed by exactly one content link, but got:\n%A\nFull link list for this chain:\n%A"
-                other
-                links
+                {| Pattern = other; FullChain = links |}
+                "a chain has a link pattern that is not a `Dot` followed by exactly one content link"
 
     let segments, terminal = processLinks rest
     ExprChain(head, segments, terminal, range) |> Expr.Chain
@@ -2006,7 +2042,7 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
             [ LinkExpr.Identifier underscore; LinkExpr.Dot mDot; yield! bodyLinks ]
 
         mkChainFromLinks creationAide allLinks ChainTerminal.NoSpaceAllowed exprRange
-    | _ -> invariantViolation exprRange "no Oak node is defined for this expression: %A" e
+    | _ -> missingOakNode "expression" exprRange e
 
 let mkExprQuote creationAide isRaw e range : ExprQuoteNode =
     let startToken, endToken =
@@ -2171,7 +2207,7 @@ let mkPat (creationAide: CreationAide) (p: SynPat) =
         |> Pattern.IsInst
     | SynPat.QuoteExpr(SynExpr.Quote(_, isRaw, e, _, _), _) ->
         mkExprQuote creationAide isRaw e patternRange |> Pattern.QuoteExpr
-    | pat -> invariantViolation pat.Range $"no Oak node is defined for this pattern: %A{pat}"
+    | pat -> missingOakNode "pattern" pat.Range pat
 
 let mkBindingReturnInfo creationAide (returnInfo: SynBindingReturnInfo option) =
     Option.bind
@@ -2361,20 +2397,11 @@ let mkExternBinding
     let externNode =
         match trivia.LeadingKeyword with
         | SynLeadingKeyword.Extern mExtern -> stn "extern" mExtern
-        | _ -> invariantViolation range "an extern binding has a leading keyword other than `extern`"
-
-    let attributesOfReturnType, returnType =
-        match returnInfo with
-        | None -> invariantViolation range "an extern binding has no return type"
-        | Some(SynBindingReturnInfo(typeName = t; attributes = a)) ->
-            let attrs = mkAttributes creationAide a
-
-            let returnType =
-                match t with
-                | SynType.App(typeName = t) -> mkType creationAide t
-                | _ -> mkType creationAide t
-
-            attrs, returnType
+        | _ ->
+            invariantViolationAbout
+                range
+                trivia.LeadingKeyword
+                $"an extern binding has %s{UnionCase.name trivia.LeadingKeyword} as its leading keyword rather than `extern`"
 
     let (|Ampersand|_|) (it: IdentTrivia) =
         match it with
@@ -2419,7 +2446,16 @@ let mkExternBinding
         | SynType.App(typeName = typeName; isPostfix = true; typeArgs = [ argType ]) ->
             TypeAppPostFixNode(mkExternType argType, mkExternType typeName, t.Range)
             |> Type.AppPostfix
+        // `byte[] | null`, the inner type still carries the extern wrapping so `mkType` cannot take it.
+        | SynType.WithNull(innerType, _, EndRange 4 (mNull, m), { BarRange = mBar }) ->
+            TypeOrNode(mkExternType innerType, stn "|" mBar, Type.Var(stn "null" mNull), m)
+            |> Type.Or
         | _ -> mkType creationAide t
+
+    let attributesOfReturnType, returnType =
+        match returnInfo with
+        | None -> invariantViolation range "an extern binding has no return type"
+        | Some(SynBindingReturnInfo(typeName = t; attributes = a)) -> mkAttributes creationAide a, mkExternType t
 
     let mkExternPat pat =
         match pat with
@@ -2516,7 +2552,7 @@ let mkModuleDecl (creationAide: CreationAide) (decl: SynModuleDecl) =
             declRange
         )
         |> ModuleDecl.NestedModule
-    | decl -> invariantViolation decl.Range $"no Oak node is defined for this module declaration: %A{decl}"
+    | decl -> missingOakNode "module declaration" decl.Range decl
 
 let mkSynTyparDecl
     (creationAide: CreationAide)
@@ -2821,7 +2857,7 @@ let mkType (creationAide: CreationAide) (t: SynType) : Type =
         let nullType = stn "null" mNull |> Type.Var
 
         TypeOrNode(mkType creationAide innerType, stn "|" mBar, nullType, m) |> Type.Or
-    | t -> invariantViolation t.Range $"no Oak node is defined for this type: %A{t}"
+    | t -> missingOakNode "type" t.Range t
 
 [<TailCall>]
 let rec visitOpenL acc decls =
@@ -3012,7 +3048,10 @@ let mkTypeDefn
                 | SynTypeDefnLeadingKeyword.And mAnd -> stn "and" mAnd
                 | SynTypeDefnLeadingKeyword.StaticType _
                 | SynTypeDefnLeadingKeyword.Synthetic ->
-                    invariantViolation range "unexpected leading keyword %A" trivia.LeadingKeyword
+                    invariantViolationAbout
+                        range
+                        trivia.LeadingKeyword
+                        $"unexpected leading keyword %s{UnionCase.name trivia.LeadingKeyword}"
 
             let implicitConstructorNode =
                 match implicitConstructor with
@@ -3114,7 +3153,7 @@ let mkTypeDefn
             | SynTypeDefnKind.Class, StartRange 5 (mClass, _) -> stn "class" mClass
             | SynTypeDefnKind.Interface, StartRange 9 (mInterface, _) -> stn "interface" mInterface
             | SynTypeDefnKind.Struct, StartRange 6 (mStruct, _) -> stn "struct" mStruct
-            | _ -> invariantViolation range "unexpected type definition kind"
+            | _ -> invariantViolationAbout range tdk $"unexpected type definition kind: %s{UnionCase.name tdk}"
 
         let objectMembers =
             objectMembers
@@ -3173,7 +3212,7 @@ let mkTypeDefn
             [ yield! objectMembers; yield! members ]
 
         TypeDefnRegularNode(typeNameNode, allMembers, typeDefnRange) |> TypeDefn.Regular
-    | _ -> invariantViolation range $"no Oak node is defined for this type definition: %A{typeRepr}"
+    | _ -> missingOakNode "type definition" range typeRepr
 
 let mkWithGetSet
     (withKeyword: range option)
@@ -3635,7 +3674,7 @@ let mkMemberDefn (creationAide: CreationAide) (md: SynMemberDefn) =
             )
             |> MemberDefn.PropertyGetSet
         | _ -> invariantViolation md.Range "a get/set member has a getter but no setter"
-    | _ -> invariantViolation md.Range "no Oak node is defined for this member definition: %A" md
+    | _ -> missingOakNode "member definition" md.Range md
 
 let mkVal
     (creationAide: CreationAide)
@@ -3684,7 +3723,7 @@ let mkMemberSig (creationAide: CreationAide) (ms: SynMemberSig) =
         MemberDefnInheritNode(stn "inherit" mInherit, mkType creationAide t, memberSigRange)
         |> MemberDefn.Inherit
     | SynMemberSig.ValField(f, _) -> mkSynField creationAide f |> MemberDefn.ValField
-    | _ -> invariantViolation ms.Range "no Oak node is defined for this member signature: %A" ms
+    | _ -> missingOakNode "member signature" ms.Range ms
 
 [<TailCall>]
 let rec mkModuleDecls
@@ -3883,7 +3922,7 @@ let mkModuleSigDecl (creationAide: CreationAide) (decl: SynModuleSigDecl) =
         )
         |> ModuleDecl.NestedModule
     | SynModuleSigDecl.Val(valSig, _) -> mkVal creationAide valSig |> ModuleDecl.Val
-    | decl -> invariantViolation decl.Range $"no Oak node is defined for this signature declaration: %A{decl}"
+    | decl -> missingOakNode "signature declaration" decl.Range decl
 
 let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRepr, members, range, trivia)) : TypeDefn =
     let typeNameNode =
@@ -3898,7 +3937,10 @@ let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRep
                 | SynTypeDefnLeadingKeyword.And mAnd -> stn "and" mAnd
                 | SynTypeDefnLeadingKeyword.StaticType _
                 | SynTypeDefnLeadingKeyword.Synthetic ->
-                    invariantViolation range "unexpected leading keyword %A" trivia.LeadingKeyword
+                    invariantViolationAbout
+                        range
+                        trivia.LeadingKeyword
+                        $"unexpected leading keyword %s{UnionCase.name trivia.LeadingKeyword}"
 
             let m =
                 if not px.IsEmpty then
@@ -3999,7 +4041,7 @@ let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRep
             | SynTypeDefnKind.Class, StartRange 5 (mClass, _) -> stn "class" mClass
             | SynTypeDefnKind.Interface, StartRange 9 (mInterface, _) -> stn "interface" mInterface
             | SynTypeDefnKind.Struct, StartRange 6 (mStruct, _) -> stn "struct" mStruct
-            | _ -> invariantViolation range "unexpected type definition kind"
+            | _ -> invariantViolationAbout range tdk $"unexpected type definition kind: %s{UnionCase.name tdk}"
 
         let objectMembers = objectMembers |> List.map (mkMemberSig creationAide)
 
@@ -4045,7 +4087,7 @@ let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRep
             [ yield! objectMembers; yield! members ]
 
         TypeDefnRegularNode(typeNameNode, allMembers, typeDefnRange) |> TypeDefn.Regular
-    | _ -> invariantViolation range "no Oak node is defined for this type definition: %A" typeRepr
+    | _ -> missingOakNode "type definition" range typeRepr
 
 [<TailCall>]
 let rec mkModuleSigDecls

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -38,8 +38,9 @@ let rec (|UppercaseType|LowercaseType|) (t: Type) : Choice<unit, unit> =
     | _ ->
         raise (
             InvariantViolationException(
-                $"cannot tell whether this type is uppercase or lowercase: %A{t}",
-                (Type.Node t).Range
+                $"cannot tell whether this type is uppercase or lowercase: %s{UnionCase.name t}",
+                (Type.Node t).Range,
+                $"%A{t}"
             )
         )
 
@@ -85,8 +86,9 @@ let rec (|UppercaseExpr|LowercaseExpr|) (expr: Expr) =
     | _ ->
         raise (
             InvariantViolationException(
-                $"cannot tell whether this expression is uppercase or lowercase: %A{expr}",
-                (Expr.Node expr).Range
+                $"cannot tell whether this expression is uppercase or lowercase: %s{UnionCase.name expr}",
+                (Expr.Node expr).Range,
+                $"%A{expr}"
             )
         )
 

--- a/src/Fantomas.Core/Exceptions.fs
+++ b/src/Fantomas.Core/Exceptions.fs
@@ -1,0 +1,95 @@
+namespace Fantomas.Core
+
+open System
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.Parse
+open Fantomas.FCS.Text
+
+// The ways formatting can fail, and nothing else. Every one of them derives from `FormatException`,
+// which the CLI matches on to decide what to print, so a failure that reaches a caller with nothing
+// better to say still has a message rather than an empty string.
+//
+// Each carries what went wrong as data and composes its message in an override of `Message` rather
+// than in the call to the base constructor, which is why each hands the base an empty one. The
+// message is then built only if something asks for it, and on the usual path nothing does: every
+// reporter in Fantomas renders from the data and reaches for the message only as a last resort.
+//
+// They live apart from `FormatConfig` because they share nothing with it: a setting and a failure
+// are not the same subject, and a reader looking for one of these would not think to open a file
+// named for the other. `FormatConfig` does raise `FormatException` for a setting it will not accept,
+// which is why this file compiles first.
+
+/// Raised when Fantomas encounters a problem during formatting.
+type FormatException(msg: string) =
+    inherit Exception(msg)
+
+/// Raised when the F# parser produces errors for source code without conditional directives.
+type ParseException(diagnostics: FSharpParserDiagnostic list) =
+    inherit FormatException(String.Empty)
+
+    /// Every diagnostic the parser produced, warnings included. A warning is often what explains the
+    /// error, and which of them are worth showing is the reporter's decision rather than this type's.
+    member _.Diagnostics = diagnostics
+
+    override _.Message =
+        // One line naming an error, not the `%A` dump of every record that the `exception` keyword
+        // this replaces produced. Earliest by position rather than first the parser gave, so it
+        // names the same error a reporter draws its caret under: in an offside cascade that is the
+        // line that caused it rather than the innocent line the parser gave up on.
+        let position (d: FSharpParserDiagnostic) : int * int =
+            match d.Range with
+            | None -> Int32.MaxValue, 0
+            | Some range -> range.StartLine, range.StartColumn
+
+        let firstError: FSharpParserDiagnostic option =
+            diagnostics
+            |> List.filter (fun (d: FSharpParserDiagnostic) -> d.Severity = FSharpDiagnosticSeverity.Error)
+            |> List.sortBy position
+            |> List.tryHead
+
+        match firstError with
+        | None -> "Fantomas could not parse the source."
+        | Some error ->
+
+        match error.Range with
+        | None -> $"Fantomas could not parse the source: %s{error.Message}"
+        | Some range ->
+            $"Fantomas could not parse the source: %s{error.Message} at line %i{range.StartLine}, column %i{range.StartColumn + 1}."
+
+/// Raised when Fantomas reaches a state that its own model says is impossible, for example a
+/// chain whose parts do not fit the shape the transformer guarantees.
+///
+/// Unlike the other exceptions here, this never indicates a problem with the code being
+/// formatted: it is a bug in Fantomas, or a change in how the F# parser groups expressions.
+/// Failing loudly is deliberate — the alternative is silently dropping parts of the source.
+type InvariantViolationException(msg: string, range: range, syntaxNode: string) =
+    inherit FormatException(String.Empty)
+
+    new(msg: string, range: range) = InvariantViolationException(msg, range, String.Empty)
+
+    /// The invariant that was violated, on one line, without the location or the "please report"
+    /// suffix. A caller that positions the violation against the source itself reports this and
+    /// draws the rest from `Range`.
+    member _.Invariant = msg
+
+    /// The source range of the construct that triggered the violation.
+    member _.Range = range
+
+    /// The syntax tree node that triggered the violation, dumped in full, or an empty string when
+    /// there is none to show. This is what a maintainer triaging the issue needs and what whoever
+    /// filed it does not, so it is kept off the message and reported at detailed verbosity.
+    member _.SyntaxNode = syntaxNode
+
+    override _.Message =
+        $"%s{msg}\nAt line %i{range.StartLine}, column %i{range.StartColumn} in %s{range.FileName}.\nThis is a bug in Fantomas. Please report it via https://fsprojects.github.io/fantomas-tools/"
+
+/// Raised when one or more conditional compilation define combinations produce invalid syntax trees.
+type DefineParseException(combinations: string list) =
+    inherit FormatException(String.Empty)
+
+    /// The define combinations that failed to parse.
+    member _.Combinations = combinations
+
+    override _.Message =
+        let joined: string = combinations |> String.concat ", "
+        $"Parsing failed for define combination(s): %s{joined}."

--- a/src/Fantomas.Core/Fantomas.Core.fsproj
+++ b/src/Fantomas.Core/Fantomas.Core.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="RangeHelpers.fs" />
     <Compile Include="Utils.fsi" />
     <Compile Include="Utils.fs" />
+    <Compile Include="Exceptions.fs" />
     <Compile Include="FormatConfig.fs" />
     <Compile Include="SyntaxOak.fs" />
     <Compile Include="ASTTransformer.fsi" />

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -1,45 +1,11 @@
 namespace Fantomas.Core
 
-open System
 open System.ComponentModel
-open Fantomas.FCS.Parse
-open Fantomas.FCS.Text
 
-/// Raised when the F# parser produces errors for source code without conditional directives.
-exception ParseException of diagnostics: FSharpParserDiagnostic list
-
-/// Raised when Fantomas encounters a problem during formatting.
-type FormatException(msg: string) =
-    inherit Exception(msg)
-
-/// Raised when Fantomas reaches a state that its own model says is impossible, for example a
-/// chain whose parts do not fit the shape the transformer guarantees.
-///
-/// Unlike the other exceptions here, this never indicates a problem with the code being
-/// formatted: it is a bug in Fantomas, or a change in how the F# parser groups expressions.
-/// Failing loudly is deliberate — the alternative is silently dropping parts of the source.
-type InvariantViolationException(msg: string, range: range) =
-    inherit
-        FormatException(
-            $"%s{msg}\nAt line %i{range.StartLine}, column %i{range.StartColumn} in %s{range.FileName}.\nThis is a bug in Fantomas. Please report it via https://fsprojects.github.io/fantomas-tools/"
-        )
-
-    /// The invariant that was violated, without the location or "please report" suffix.
-    member _.Invariant = msg
-
-    /// The source range of the construct that triggered the violation.
-    member _.Range = range
-
-/// Raised when one or more conditional compilation define combinations produce invalid syntax trees.
-type DefineParseException(combinations: string list) =
-    inherit
-        FormatException(
-            let joined = combinations |> String.concat ", "
-            $"Parsing failed for define combination(s): %s{joined}."
-        )
-
-    /// The define combinations that failed to parse.
-    member _.Combinations = combinations
+// `System` is deliberately not opened. It carries a `FormatException` of its own, and an explicit
+// open outranks the enclosing namespace, so `raise (FormatException ...)` below would quietly build
+// a `System.FormatException` instead of the one in `Exceptions.fs`. That used to be safe only
+// because both were declared in this file. The one thing wanted from `System` is spelled out.
 
 type Num = int
 
@@ -91,7 +57,7 @@ type EndOfLineStyle =
         | CRLF -> "\r\n"
 
     static member FromEnvironment =
-        match Environment.NewLine with
+        match System.Environment.NewLine with
         | "\n" -> LF
         | "\r\n" -> CRLF
         | other -> failwithf "Unknown system newline string found: %s" other

--- a/src/Fantomas.Core/Utils.fs
+++ b/src/Fantomas.Core/Utils.fs
@@ -2,6 +2,19 @@ namespace Fantomas.Core
 
 open System
 open Microsoft.FSharp.Core.CompilerServices
+open Microsoft.FSharp.Reflection
+
+[<RequireQualifiedAccess>]
+module UnionCase =
+
+    let name (value: 'T) : string =
+        let unionType: Type = typeof<'T>
+
+        if isNull (box value) || not (FSharpType.IsUnion unionType) then
+            unionType.Name
+        else
+            let case, _ = FSharpValue.GetUnionFields(value, unionType)
+            $"%s{unionType.Name}.%s{case.Name}"
 
 [<RequireQualifiedAccess>]
 module String =

--- a/src/Fantomas.Core/Utils.fsi
+++ b/src/Fantomas.Core/Utils.fsi
@@ -1,6 +1,14 @@
 namespace Fantomas.Core
 
 [<RequireQualifiedAccess>]
+module UnionCase =
+    /// The qualified name of the union case `value` is, such as `SynType.App`. Names a syntax tree
+    /// node in an error message without dumping every field it carries, which is what the reader of
+    /// the message needs and what `%A` buries. Falls back to the type's own name when `value` is not
+    /// a union.
+    val name: value: 'T -> string
+
+[<RequireQualifiedAccess>]
 module String =
     val startsWithOrdinal: prefix: string -> str: string -> bool
     val endsWithOrdinal: postfix: string -> str: string -> bool

--- a/src/Fantomas.Tests/DiagnosticsTests.fs
+++ b/src/Fantomas.Tests/DiagnosticsTests.fs
@@ -243,3 +243,70 @@ let ``without source there is no snippet`` () =
 let ``an exception that is not a parse failure is not this module's to describe`` () =
     Diagnostics.describeParseFailure "bad.fs" (fun () -> source) (exn "boom")
     |> should equal None
+
+// An invariant violation is rendered from a construct Fantomas could not model rather than from a
+// parser diagnostic, so it is built here the same way: what these tests are about is the rendering.
+let private externSource: string =
+    "module A\n\nlet before = 1\n\nextern int64 private f(byte[] | null value)\n\nlet after = 2\n"
+
+let private violation () : Fantomas.Core.InvariantViolationException =
+    Fantomas.Core.InvariantViolationException(
+        "no Oak node is defined for this type: SynType.App",
+        Range.mkRange "tmp.fsx" (Position.mkPos 5 23) (Position.mkPos 5 27),
+        "App\n  (LongIdent (SynLongIdent ([byte], [], [None])), None, [], [], None, false)"
+    )
+
+[<Test>]
+let ``an invariant violation is positioned and shown with a caret under the construct`` () =
+    let rendered =
+        Diagnostics.renderInvariantViolation "bad.fs" externSource false (violation ())
+
+    lines rendered
+    |> should
+        equal
+        [
+            "Fantomas could not format bad.fs:"
+            ""
+            "bad.fs(5,24): error: no Oak node is defined for this type: SynType.App"
+            ""
+            "3 | let before = 1"
+            "4 | "
+            "5 | extern int64 private f(byte[] | null value)"
+            "  |                        ^^^^"
+            "6 | "
+            "7 | let after = 2"
+            ""
+            "This is a bug in Fantomas, not a problem with your code. Please report it with the snippet above via https://fsprojects.github.io/fantomas-tools/, or at https://github.com/fsprojects/fantomas/issues/new if the file is too large for the tool to carry."
+            ""
+        ]
+
+[<Test>]
+let ``the path comes from the caller, not from the name the parser was handed`` () =
+    let rendered =
+        Diagnostics.renderInvariantViolation "src/XAttr.fs" externSource false (violation ())
+
+    rendered |> should haveSubstring "src/XAttr.fs(5,24)"
+    rendered |> should not' (haveSubstring "tmp.fsx")
+
+[<Test>]
+let ``the syntax tree node is left out by default and shown when asked for`` () =
+    Diagnostics.renderInvariantViolation "bad.fs" externSource false (violation ())
+    |> should not' (haveSubstring "SynLongIdent")
+
+    let verbose =
+        Diagnostics.renderInvariantViolation "bad.fs" externSource true (violation ())
+
+    verbose |> should haveSubstring "Syntax tree node:"
+    verbose |> should haveSubstring "SynLongIdent"
+
+[<Test>]
+let ``an invariant violation without source is still positioned`` () =
+    let rendered = Diagnostics.renderInvariantViolation "bad.fs" "" false (violation ())
+
+    rendered |> should haveSubstring "bad.fs(5,24)"
+    rendered |> should not' (haveSubstring "^^^^")
+
+[<Test>]
+let ``an exception that is not an invariant violation is not this module's to describe`` () =
+    Diagnostics.describeInvariantViolation "bad.fs" (fun () -> externSource) false (exn "boom")
+    |> should equal None

--- a/src/Fantomas/Daemon.fs
+++ b/src/Fantomas/Daemon.fs
@@ -144,11 +144,20 @@ type FantomasDaemon(sender: Stream, reader: Stream, environment: DaemonEnvironme
                 else
                     do! notified
 
-                // A ParseException's own Message is an %A dump of the diagnostic records, and it is
-                // the editor's user who would have been shown it.
+                // A ParseException's own Message names only the first error the parser gave, and an
+                // InvariantViolationException says nothing about where in the source it happened
+                // beyond a line and a column. It is the editor's user who would have been shown
+                // either, so both are positioned against the source the request carried.
+                let source () : string = sourceCode
+
                 let message =
-                    Diagnostics.describeParseFailure filePath (fun () -> sourceCode) ex
-                    |> Option.defaultValue ex.Message
+                    match Diagnostics.describeParseFailure filePath source ex with
+                    | Some described -> described
+                    | None ->
+
+                    match Diagnostics.describeInvariantViolation filePath source false ex with
+                    | Some described -> described
+                    | None -> ex.Message
 
                 return onError message
         }

--- a/src/Fantomas/Diagnostics.fs
+++ b/src/Fantomas/Diagnostics.fs
@@ -122,5 +122,55 @@ let renderParseFailure (file: string) (source: string) (diagnostics: FSharpParse
 
 let describeParseFailure (file: string) (source: unit -> string) (error: exn) : string option =
     match error with
-    | ParseException diagnostics -> Some(renderParseFailure file (source ()) diagnostics)
+    | :? ParseException as parseFailure -> Some(renderParseFailure file (source ()) parseFailure.Diagnostics)
+    | _ -> None
+
+let renderInvariantViolation
+    (file: string)
+    (source: string)
+    (verbose: bool)
+    (violation: InvariantViolationException)
+    : string
+    =
+    // The range names the file the parser was handed, `tmp.fsx`, so the path comes from the caller
+    // here as it does for a parse diagnostic. Naming a file that is not the one being formatted is
+    // worse than saying nothing, because it reads as though Fantomas looked somewhere else.
+    let headline: string =
+        $"%s{file}(%i{violation.Range.StartLine},%i{violation.Range.StartColumn + 1}): error: %s{violation.Invariant}"
+
+    let snippetLines: string list =
+        if String.IsNullOrEmpty source then
+            []
+        else
+            let lines: string array = source.Replace("\r\n", "\n").Split('\n')
+
+            match snippet lines violation.Range with
+            | [] -> []
+            | snippetLines -> "" :: snippetLines
+
+    // The dump of the syntax tree node is what tells a maintainer which parser shape went
+    // unhandled, and it is noise to everyone else, so it is shown only when asked for.
+    let syntaxNodeLines: string list =
+        if not verbose || String.IsNullOrWhiteSpace violation.SyntaxNode then
+            []
+        else
+            [ ""; "Syntax tree node:"; "" ]
+            @ List.ofArray (violation.SyntaxNode.Split('\n'))
+
+    [
+        yield $"Fantomas could not format %s{file}:"
+        yield ""
+        yield headline
+        yield! snippetLines
+        yield! syntaxNodeLines
+        yield ""
+        yield
+            "This is a bug in Fantomas, not a problem with your code. Please report it with the snippet above via https://fsprojects.github.io/fantomas-tools/, or at https://github.com/fsprojects/fantomas/issues/new if the file is too large for the tool to carry."
+        yield ""
+    ]
+    |> String.concat "\n"
+
+let describeInvariantViolation (file: string) (source: unit -> string) (verbose: bool) (error: exn) : string option =
+    match error with
+    | :? InvariantViolationException as violation -> Some(renderInvariantViolation file (source ()) verbose violation)
     | _ -> None

--- a/src/Fantomas/Diagnostics.fsi
+++ b/src/Fantomas/Diagnostics.fsi
@@ -35,3 +35,22 @@ val renderParseFailure: file: string -> source: string -> diagnostics: FSharpPar
 /// turns out to be a parse failure. A caller that has to read a file to produce it therefore does
 /// not read one for a failure that has nothing to do with parsing.
 val describeParseFailure: file: string -> source: (unit -> string) -> error: exn -> string option
+
+/// Render an invariant violation the same way a parse failure is rendered: one MSBuild style line
+/// saying what Fantomas could not model and where, then a snippet of `source` with a caret run
+/// under the construct that could not be modelled.
+///
+/// The position comes from the violation's range but the path comes from `file`, because the range
+/// carries the name the parser was handed rather than the file being formatted.
+///
+/// `verbose` adds the syntax tree node the violation carries. It is what a maintainer triaging the
+/// report needs and noise to whoever ran the tool, so it is not shown by default.
+val renderInvariantViolation:
+    file: string -> source: string -> verbose: bool -> violation: Fantomas.Core.InvariantViolationException -> string
+
+/// Render `error` as the text to report for `file`, when it is an invariant violation and therefore
+/// points at a construct Fantomas could not model. Anything else comes back as `None`.
+///
+/// `source` yields the text being formatted, and is called only once `error` turns out to be an
+/// invariant violation.
+val describeInvariantViolation: file: string -> source: (unit -> string) -> verbose: bool -> error: exn -> string option

--- a/src/Fantomas/JsonReport.fs
+++ b/src/Fantomas/JsonReport.fs
@@ -78,8 +78,8 @@ let describeDiagnostic (diagnostic: FSharpParserDiagnostic) : Diagnostic =
 // without opening the file. Everything else has only a message, so it is carried as one.
 let describeFileFailure (file: string) (error: exn) : FileOutcome =
     match error with
-    | ParseException diagnostics ->
-        FileOutcome.Failed($"Fantomas could not parse %s{file}", List.map describeDiagnostic diagnostics)
+    | :? ParseException as parseFailure ->
+        FileOutcome.Failed($"Fantomas could not parse %s{file}", List.map describeDiagnostic parseFailure.Diagnostics)
     | _ ->
         let message: string = describeFailure error |> Option.defaultValue error.Message
 

--- a/src/Fantomas/Report.fs
+++ b/src/Fantomas/Report.fs
@@ -63,10 +63,17 @@ let reportError (env: CliEnvironment) (verbosity: VerbosityLevel) (file: string,
         else
             $"Failed to format file: %s{file} : %s{message}"
 
-    // A parse failure describes itself, positions and all, rather than being reduced to a
-    // single line saying only that it happened.
-    match Diagnostics.describeParseFailure file (fun () -> sourceOf env.FileSystem file) error with
-    | Some parseFailure -> env.Log.Error parseFailure
+    let source () : string = sourceOf env.FileSystem file
+    let verbose: bool = verbosity = VerbosityLevel.Detailed
+
+    // A parse failure and an invariant violation both describe themselves, positions and all,
+    // rather than being reduced to a single line saying only that they happened.
+    match Diagnostics.describeParseFailure file source error with
+    | Some report -> env.Log.Error report
+    | None ->
+
+    match Diagnostics.describeInvariantViolation file source verbose error with
+    | Some report -> env.Log.Error report
     | None -> env.Log.Error(describeOther ())
 
 let reportProfileInfo (log: ILogger) (profile: bool) (file: string, profileInfo: ProfileInfo option) : unit =
@@ -135,8 +142,14 @@ let reportFormatResults (env: CliEnvironment) (settings: CliSettings) (results: 
 
 let reportCheckResults (env: CliEnvironment) (checkResult: CheckResult) : unit =
     for filename, exn in checkResult.Errors do
-        match Diagnostics.describeParseFailure filename (fun () -> sourceOf env.FileSystem filename) exn with
-        | Some parseFailure -> env.Log.Error parseFailure
+        let source () : string = sourceOf env.FileSystem filename
+
+        match Diagnostics.describeParseFailure filename source exn with
+        | Some report -> env.Log.Error report
+        | None ->
+
+        match Diagnostics.describeInvariantViolation filename source false exn with
+        | Some report -> env.Log.Error report
         | None -> env.Log.Error $"error: Failed to format %s{filename}: %s{exn.ToString()}"
 
     for filename in checkResult.Formatted do


### PR DESCRIPTION
An extern parameter or return type written as `byte[] | null` crashed with "no Oak node is defined for this type". The nullable type arrives as a SynType.WithNull whose inner type still carries the wrapping the parser puts around every extern type, and only mkExternType knows how to take that off, so falling through to mkType hit a shape it has no case for. Return types were not going through mkExternType at all, which also meant an extern returning an array lost its element type and was written as ``extern `[]` f(int options)``.

A construct that cannot be modelled was reported as a %A dump of the syntax tree node, several lines long and wrapped wherever the terminal decided, leaving the reporter to guess which declaration was at fault and bisect the file by hand. The message now says in words what could not be modelled and names the union case, and the reporter positions it against the source with a snippet and a caret, as it already did for a parse failure. The node itself moved onto the exception and is shown at --verbosity d, where it serves whoever triages the report rather than whoever files it. The CLI, --check and the daemon all say the same thing, and they name the file being formatted rather than the tmp.fsx the parser was handed.

The exceptions moved out of FormatConfig.fs into their own file, since a setting and a failure are not the same subject. Each now carries what went wrong as data and composes its message only when something asks for it, which on every path in this repository is never. ParseException is declared like the other three instead of with the `exception` keyword, which could not name a base class and generated a message that was itself a %A dump.

Fixes #3414
