### PR TITLE
Sync implementation doc comments with signature files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,12 +78,11 @@ changed. A finding in a file you did not touch is dropped, whatever its rule: wi
 changed `.fsproj` pulling in the whole project buries the two files you added under the project's
 existing debt.
 
-Within a file that did change, the two rules that report on pre-existing debt,
-`FANTOMAS-ANNOTATE-001` and `FANTOMAS-XMLDOC-001`, are narrowed further to the lines `git diff`
-says you touched. A file is a much coarser scope than those two rules ask for: one line changed in
-`ASTTransformer.fs` otherwise surfaces every unannotated binding in it. Every other rule reports
-wherever it fires in a file you edited. A file git has never seen is new in its entirety, so
-everything in it is reported.
+Within a file that did change, the one rule that reports on pre-existing debt,
+`FANTOMAS-ANNOTATE-001`, is narrowed further to the lines `git diff` says you touched. A file is a
+much coarser scope than that rule asks for: one line changed in `ASTTransformer.fs` otherwise
+surfaces every unannotated binding in it. Every other rule reports wherever it fires in a file you
+edited. A file git has never seen is new in its entirety, so everything in it is reported.
 
 ```bash
 dotnet fsi build.fsx -- -p Analyze

--- a/analyzers/AGENTS.md
+++ b/analyzers/AGENTS.md
@@ -11,7 +11,7 @@ feedback arrives while you work instead of in review. They are ordinary F# analy
 | [`FANTOMAS-PRIVATE-001`](#fantomas-private-001) | No `let private` beside a signature file | Error | both pipelines |
 | [`FANTOMAS-ARMORDER-001`](#fantomas-armorder-001) | Shortest match arm first | Warning | both pipelines |
 | [`FANTOMAS-ANNOTATE-001`](#fantomas-annotate-001) | Annotate every `let` binding | Warning | `AnalyzeChanged` only |
-| [`FANTOMAS-XMLDOC-001`](#fantomas-xmldoc-001) | No doc comment the signature file already carries | Warning | `AnalyzeChanged` only |
+| [`FANTOMAS-XMLDOC-001`](#fantomas-xmldoc-001) | No doc comment the signature file already carries | Warning | both pipelines |
 
 ## FANTOMAS-PIPEBACK-001
 
@@ -129,11 +129,11 @@ non-zero on any finding at error severity, so the two error rules fail `Analyze`
 decides who has to look: a rule excluded from `Analyze` is absent from CI and from GitHub code
 scanning whatever its severity, and still reports locally.
 
-The two advisory rules are excluded from `Analyze` because both report on debt that predates them.
-`AnalyzeChanged` runs them, and narrows them further to the lines `git diff` says you touched: a
-file is a much coarser scope than those two rules ask for, and one line changed in a file of several
-thousand otherwise surfaces every unannotated binding in it. Every other rule reports wherever it
-fires in a file you edited, because a finding from one of those is worth seeing.
+`FANTOMAS-ANNOTATE-001` is excluded from `Analyze` because it reports on debt that predates it.
+`AnalyzeChanged` runs it, and narrows it further to the lines `git diff` says you touched: a file is
+a much coarser scope than that rule asks for, and one line changed in a file of several thousand
+otherwise surfaces every unannotated binding in it. Every other rule reports wherever it fires in a
+file you edited, because a finding from one of those is worth seeing.
 
 The narrowing reads the tool's own output format and fails open, so anything it cannot parse is
 kept. A change upstream makes it stop narrowing rather than start hiding.

--- a/scripts/BuildAnalyzers.fsx
+++ b/scripts/BuildAnalyzers.fsx
@@ -309,16 +309,15 @@ let mergeSarifReports (reports: string list) (target: string) : unit =
 let localErrorRules: string list =
     [ "FANTOMAS-PIPEBACK-001"; "FANTOMAS-PRIVATE-001" ]
 
-/// The local analyzers that are kept out of the full run.
+/// The local analyzer that is kept out of the full run.
 ///
-/// Both report on debt that predates them, and a finding in `Analyze` becomes a code scanning alert
-/// on the pull request whatever its severity. `AnalyzeChanged` still runs them, over the files you
-/// touched, which is the scope the rules ask for. Drop this once the debt is gone.
-let localAdvisoryAnalyzers: string list = [ "AnnotationAnalyzer"; "XmlDocAnalyzer" ]
+/// It reports on debt that predates it, and a finding in `Analyze` becomes a code scanning alert on
+/// the pull request whatever its severity. `AnalyzeChanged` still runs it, over the files you
+/// touched, which is the scope the rule asks for. Drop this once the debt is gone.
+let localAdvisoryAnalyzers: string list = [ "AnnotationAnalyzer" ]
 
-/// The codes of those same rules, which is what a finding carries.
-let localAdvisoryCodes: Set<string> =
-    set [ "FANTOMAS-ANNOTATE-001"; "FANTOMAS-XMLDOC-001" ]
+/// The code of that same rule, which is what a finding carries.
+let localAdvisoryCodes: Set<string> = set [ "FANTOMAS-ANNOTATE-001" ]
 
 /// Decides whether a finding is worth showing, from its rule, its file and its line. `Analyze`
 /// shows all of them; only `AnalyzeChanged` narrows.
@@ -335,11 +334,11 @@ let everyFinding: FindingFilter = fun _ _ _ -> true
 /// under the project's existing debt, and a run whose findings you have to hand-filter is a run that
 /// tells you nothing.
 ///
-/// **And, for the two advisory rules, is it on a line that changed?** A file is a much coarser scope
-/// than those two ask for: one line changed in a file of several thousand otherwise surfaces every
-/// unannotated binding in it, and the annotation rule explicitly says to leave alone the bindings you
-/// had no reason to open. Every other rule reports anywhere in a file you edited, which is the scope
-/// those rules do ask for.
+/// **And, for the advisory rule, is it on a line that changed?** A file is a much coarser scope than
+/// it asks for: one line changed in a file of several thousand otherwise surfaces every unannotated
+/// binding in it, and the annotation rule explicitly says to leave alone the bindings you had no
+/// reason to open. Every other rule reports anywhere in a file you edited, which is the scope those
+/// rules do ask for.
 ///
 /// A file git has never seen is new in its entirety, so everything in it is worth reporting.
 let keepFinding (scopes: Map<string, ChangedLines>) : FindingFilter =
@@ -351,11 +350,11 @@ let keepFinding (scopes: Map<string, ChangedLines>) : FindingFilter =
 
 /// Drops the advisory findings that sit on lines the working tree did not touch.
 ///
-/// `AnalyzeChanged` scopes itself to the files you edited, which for these two rules is much
-/// coarser than the rules ask for: one line changed in a file of several thousand surfaces every
-/// unannotated binding in it, and the annotation rule explicitly says to leave the bindings you had
-/// no reason to open alone. The other rules are left alone, because a finding from one of those is
-/// worth seeing wherever it is.
+/// `AnalyzeChanged` scopes itself to the files you edited, which for the annotation rule is much
+/// coarser than the rule asks for: one line changed in a file of several thousand surfaces every
+/// unannotated binding in it, and the rule explicitly says to leave the bindings you had no reason
+/// to open alone. The other rules are left alone, because a finding from one of those is worth
+/// seeing wherever it is.
 ///
 /// Reads the tool's own output format. Anything it cannot parse is kept, so a change upstream makes
 /// this stop narrowing rather than start hiding.

--- a/src/Fantomas.Client/Contracts.fs
+++ b/src/Fantomas.Client/Contracts.fs
@@ -45,12 +45,8 @@ and FormatCursorPosition =
 type FormatSelectionRequest =
     {
         SourceCode: string
-        /// File path will be used to identify the .editorconfig options
-        /// Unless the configuration is passed
         FilePath: string
-        /// Overrides the found .editorconfig.
         Config: IReadOnlyDictionary<string, string> option
-        /// Range follows the same semantics of the FSharp Compiler Range type.
         Range: FormatSelectionRange
     }
 

--- a/src/Fantomas.Client/FantomasToolLocator.fs
+++ b/src/Fantomas.Client/FantomasToolLocator.fs
@@ -134,12 +134,6 @@ let (|CompatibleTool|_|) (lines: string list) : FantomasVersion voption =
 
 let isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
 
-/// The version `fantomas --version` printed, as `dotnet tool list` would have written it.
-///
-/// `--version` answers `Fantomas v8.0.0-alpha-014+e4a1c9d...`, `dotnet tool list` answers
-/// `8.0.0-alpha-014`. Daemons are cached by this string, so both the leading `v` and the commit
-/// hash have to go: with either of them left on, the same Fantomas resolved once from the manifest
-/// and once from the PATH counts as two versions and gets two processes.
 let normalizeVersion (printed: string) : string =
     let dropPrefix (prefix: string) (text: string) : string =
         if text.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) then

--- a/src/Fantomas.Client/FantomasToolLocator.fsi
+++ b/src/Fantomas.Client/FantomasToolLocator.fsi
@@ -7,6 +7,9 @@ open Fantomas.Client.LSPFantomasServiceTypes
 /// manifest side is. Daemons are cached by this string, so the same Fantomas resolved once from a
 /// tool manifest and once from the PATH has to come out of both as the same text, or it gets two
 /// processes.
+///
+/// `--version` answers `Fantomas v8.0.0-alpha-014+e4a1c9d...`, `dotnet tool list` answers
+/// `8.0.0-alpha-014`, and both have to arrive here as the latter.
 val internal normalizeVersion: printed: string -> string
 
 val findFantomasTool: workingDir: Folder -> Result<FantomasToolFound, FantomasToolError>

--- a/src/Fantomas.Core.Tests/TestHelpers.fs
+++ b/src/Fantomas.Core.Tests/TestHelpers.fs
@@ -62,7 +62,6 @@ let formatFSharpString isFsiFile (s: string) config =
 let formatSignatureString = formatFSharpString true
 let formatSourceString = formatFSharpString false
 
-/// The `source` will first be parsed to AST.
 let formatAST isFsiFile (source: string) config =
     async {
         let ast, _ =

--- a/src/Fantomas.Core/CodeFormatterImpl.fs
+++ b/src/Fantomas.Core/CodeFormatterImpl.fs
@@ -80,7 +80,6 @@ let parse (isSignature: bool) (source: ISourceText) : Async<(ParsedInput * Defin
                 )
         }
 
-/// Format an abstract syntax tree using given config
 let formatAST
     (ast: ParsedInput)
     (sourceText: ISourceText option)

--- a/src/Fantomas.Core/CodeFormatterImpl.fsi
+++ b/src/Fantomas.Core/CodeFormatterImpl.fsi
@@ -6,6 +6,7 @@ open Fantomas.FCS.Text
 
 val getSourceText: source: string -> ISourceText
 
+/// Format an abstract syntax tree using given config
 val formatAST:
     ast: ParsedInput -> sourceText: ISourceText option -> config: FormatConfig -> cursor: pos option -> FormatResult
 

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -44,17 +44,11 @@ type WriteModelMode =
 
 type WriterModel =
     {
-        /// number of lines produced so far
         LineCount: int
-        /// current indentation
         Indent: int
-        /// helper indentation information, if AtColumn > Indent after NewLine, Indent will be set to AtColumn
         AtColumn: int
-        /// text to be written before next newline
         WriteBeforeNewline: string
-        /// dummy = "fake" writer used in `autoNln`, `autoNlnByFuture`
         Mode: WriteModelMode
-        /// current length of last line of output
         Column: int
     }
 
@@ -202,12 +196,9 @@ type Context =
         WriterModel: WriterModel
         WriterEvents: EventList
         FormattedCursor: pos option
-        /// When enabled, genNode emits NodeStart/NodeEnd WriterEvents around each Oak node.
-        /// Only used by CodeFormatter.GetWriterEventsAsync for diagnostic output.
         DebugMode: bool
     }
 
-    /// Initialize with a string writer and use space as delimiter
     static member Default =
         {
             Config = FormatConfig.Default
@@ -220,9 +211,6 @@ type Context =
     static member Create config : Context =
         { Context.Default with Config = config }
 
-    /// Run a probe function in dummy mode for speculative formatting.
-    /// Creates a backup point, runs `f` with Mode=Dummy, rolls back the event list,
-    /// and returns the resulting context so the caller can inspect WriterModel metadata.
     member x.WithDummy(f: Context -> Context, ?keepPageWidth) =
         let keepPageWidth = keepPageWidth |> Option.defaultValue false
 
@@ -280,9 +268,6 @@ type Context =
 
     member x.Column = x.WriterModel.Column
 
-/// This adds a WriterEvent to the Context.
-/// One event could potentially be split up into multiple events.
-/// The event is also being processed in the WriterModel of the Context.
 let writerEvent (e: WriterEvent) (ctx: Context) : Context =
     // One event could contain a multiline string or code comments.
     // These need to be split up in multiple events.
@@ -445,16 +430,13 @@ let hasBlankLineBeforeLastWrite ctx =
 
 // A few utility functions from https://github.com/fsharp/powerpack/blob/master/src/FSharp.Compiler.CodeDom/generator.fs
 
-/// Indent one more level based on configuration
 let indent (ctx: Context) =
     // if atColumn is bigger then after indent, then we use atColumn as base for indent
     writerEvent (IndentBy ctx.Config.IndentSize) ctx
 
-/// Unindent one more level based on configuration
 let unindent (ctx: Context) =
     writerEvent (UnIndentBy ctx.Config.IndentSize) ctx
 
-/// Apply function f at an absolute indent level (use with care)
 let atIndentLevel alsoSetIndent level (f: Context -> Context) (ctx: Context) =
     if level < 0 then
         invalidArg "level" "The indent level cannot be negative."
@@ -470,25 +452,10 @@ let atIndentLevel alsoSetIndent level (f: Context -> Context) (ctx: Context) =
      >> writerEvent (RestoreIndent oldIndent))
         ctx
 
-/// Set minimal indentation (`atColumn`) at current column position - next newline will be indented on `max indent atColumn`
-/// Example:
-/// { X = // indent=0, atColumn=2
-///     "some long string" // indent=4, atColumn=2
-///   Y = 1 // indent=0, atColumn=2
-/// }
-/// `atCurrentColumn` was called on `X`, then `indent` was called, but "some long string" have indent only 4, because it is bigger than `atColumn` (2).
 let atCurrentColumn (f: _ -> Context) (ctx: Context) = atIndentLevel false ctx.Column f ctx
 
-/// Write everything at current column indentation, set `indent` and `atColumn` on current column position
-/// /// Example (same as above):
-/// { X = // indent=2, atColumn=2
-///       "some long string" // indent=6, atColumn=2
-///   Y = 1 // indent=2, atColumn=2
-/// }
-/// `atCurrentColumn` was called on `X`, then `indent` was called, "some long string" have indent 6, because it is indented from `atCurrentColumn` pos (2).
 let atCurrentColumnIndent (f: _ -> Context) (ctx: Context) = atIndentLevel true ctx.Column f ctx
 
-/// Function composition operator
 let (+>) (ctx: Context -> Context) (f: _ -> Context) x =
     let y = ctx x
 
@@ -499,7 +466,6 @@ let (+>) (ctx: Context -> Context) (f: _ -> Context) x =
 let (!-) (str: string) = writerEvent (Write str)
 let writeTrivia (s: string) = writerEvent (WriteTrivia s)
 
-/// Similar to col, and supply index as well
 let coli f' (c: 'T seq) f (ctx: Context) =
     let mutable tryPick = true
     let mutable st = ctx
@@ -514,9 +480,6 @@ let coli f' (c: 'T seq) f (ctx: Context) =
 
     st
 
-/// Process collection - keeps context through the whole processing
-/// calls f for every element in sequence and f' between every two elements
-/// as a separator. This is a variant that works on typed collections.
 let col f' (c: 'T seq) f (ctx: Context) =
     let mutable tryPick = true
     let mutable st = ctx
@@ -540,27 +503,22 @@ let colEx f' (c: 'T seq) f (ctx: Context) =
 
     st
 
-/// Similar to col, apply one more function f2 at the end if the input sequence is not empty
 let colPost f2 f1 (c: 'T seq) f (ctx: Context) =
     if Seq.isEmpty c then ctx else f2 (col f1 c f ctx)
 
-/// Similar to col, apply one more function f2 at the beginning if the input sequence is not empty
 let colPre f2 f1 (c: 'T seq) f (ctx: Context) =
     if Seq.isEmpty c then ctx else col f1 c f (f2 ctx)
 
-/// If there is a value, apply f and f' accordingly, otherwise do nothing
 let opt (f': Context -> _) o f (ctx: Context) =
     match o with
     | Some x -> f' (f x ctx)
     | None -> ctx
 
-/// similar to opt, only takes a single function f to apply when there is a value
 let optSingle f o ctx =
     match o with
     | Some x -> f x ctx
     | None -> ctx
 
-/// Similar to opt, but apply f2 at the beginning if there is a value
 let optPre (f2: _ -> Context) (f1: Context -> _) o f (ctx: Context) =
     match o with
     | Some x -> f1 (f x (f2 ctx))
@@ -576,19 +534,16 @@ let getRecordSize ctx fields =
     | MultilineFormatterType.CharacterWidth -> Size.CharacterWidth ctx.Config.MaxRecordWidth
     | MultilineFormatterType.NumberOfItems -> Size.NumberOfItems(List.length fields, ctx.Config.MaxRecordNumberOfItems)
 
-/// b is true, apply f1 otherwise apply f2
 let ifElse b (f1: Context -> Context) f2 (ctx: Context) = if b then f1 ctx else f2 ctx
 
 let ifElseCtx cond (f1: Context -> Context) f2 (ctx: Context) = if cond ctx then f1 ctx else f2 ctx
 
-/// apply f only when cond is true
 let onlyIf cond f ctx = if cond then f ctx else ctx
 
 let onlyIfCtx cond f ctx = if cond ctx then f ctx else ctx
 
 let onlyIfNot cond f ctx = if cond then ctx else f ctx
 
-/// Repeat application of a function n times
 let rep n (f: Context -> Context) (ctx: Context) =
     [ 1..n ] |> List.fold (fun c _ -> f c) ctx
 
@@ -633,18 +588,13 @@ let addSpaceIfSpaceAroundDelimiter (ctx: Context) =
 let addSpaceIfSpaceAfterComma (ctx: Context) =
     onlyIf ctx.Config.SpaceAfterComma sepSpace ctx
 
-/// opening token of list
 let sepOpenLFixed = !-"["
 
-/// closing token of list
 let sepCloseLFixed = !-"]"
 
-/// opening token of anon record
 let sepOpenAnonRecdFixed = !-"{|"
-/// opening token of tuple
 let sepOpenT = !-"("
 
-/// closing token of tuple
 let sepCloseT = !-")"
 
 let wordAnd = sepSpace +> !-"and "
@@ -718,7 +668,6 @@ let isSmallExpression size (smallExpression: Context -> Context) fallbackExpress
         else
             expressionFitsOnRestOfLine smallExpression fallbackExpression ctx
 
-/// provide the line and column before and after the leadingExpression to to the continuation expression
 let leadingExpressionResult leadingExpression continuationExpression (ctx: Context) =
     let lineCountBefore, columnBefore =
         ctx.WriterModel.LineCount, ctx.WriterModel.Column
@@ -730,13 +679,6 @@ let leadingExpressionResult leadingExpression continuationExpression (ctx: Conte
 
     continuationExpression ((lineCountBefore, columnBefore), (lineCountAfter, columnAfter)) contextAfterLeading
 
-/// A leading expression is not considered multiline if it has a comment before it.
-/// For example
-/// let a = 7
-/// // foo
-/// let b = 8
-/// let c = 9
-/// The second binding b is not consider multiline.
 let leadingExpressionIsMultiline (leadingExpression: Context -> Context) continuationExpression (ctx: Context) =
     let snapshotNode = ctx.WriterEvents.CreateBackupPoint()
 
@@ -824,7 +766,6 @@ let expressionExceedsPageWidth beforeShort afterShort beforeLong afterLong expr 
             ctx.WriterEvents.RollbackTo(snapshot)
             fallbackExpression ctx
 
-/// Describes how an expression should be laid out when it doesn't fit on a single line.
 [<Struct>]
 type LongExpressionLayout =
     | IndentAndUnindent
@@ -870,11 +811,6 @@ let findTrailingTriviaNewline (events: EventList) : EventNode =
             if foundTrivia then current else null
         | _ -> null
 
-/// Indent + newline that is aware of trailing trivia.
-/// If the DLL tail has trailing trivia (comment + WriteLineBecauseOfTrivia),
-/// splice IndentBy before the trivia block so the comment is already at the indented level.
-/// The trivia's own newline serves as the sepNln — no extra newline is added.
-/// Otherwise, fall back to normal indent + sepNln.
 let indentSepNlnWithTriviaAwareness (ctx: Context) =
     let indentAmount = ctx.Config.IndentSize
     let triviaNewline = findTrailingTriviaNewline ctx.WriterEvents
@@ -903,8 +839,6 @@ let indentSepNlnWithTriviaAwareness (ctx: Context) =
     else
         (indent +> sepNln) ctx
 
-/// This replaces the pattern of `+> unindent` after expressions that may have trailing trivia,
-/// centralizing the splice + WriterModel update in one place.
 let unindentWithTriviaAwareness (ctx: Context) =
     let unindentAmount = ctx.Config.IndentSize
     let triviaNewline = findTrailingTriviaNewline ctx.WriterEvents
@@ -945,8 +879,6 @@ let expressionExceedsPageWidthWithLayout (layout: LongExpressionLayout) (addSpac
 
         expressionExceedsPageWidth beforeShort sepNone beforeLong afterLong expr ctx
 
-/// try and write the expression on the remainder of the current line
-/// add an indent and newline if the expression is longer
 let autoIndentAndNlnIfExpressionExceedsPageWidth expr (ctx: Context) =
     expressionExceedsPageWidthWithLayout IndentAndUnindent false expr ctx
 
@@ -1035,7 +967,6 @@ let colAutoNlnSkip0i f' (c: 'T seq) f (ctx: Context) =
         )
         ctx
 
-/// Similar to col, skip auto newline for index 0
 let colAutoNlnSkip0 f' c f = colAutoNlnSkip0i f' c (fun _ -> f)
 
 let sepSpaceBeforeClassConstructor ctx =
@@ -1231,25 +1162,6 @@ let isMultilineItem (expr: Context -> Context) (ctx: Context) : bool * Context =
         found
 
     isExpressionMultiline, nextCtx
-
-/// This helper function takes a list of expressions and ranges.
-/// If the expression is multiline it will add a newline before and after the expression.
-/// Unless it is the first expression in the list, that will never have a leading new line.
-/// F.ex.
-/// let a = AAAA
-/// let b =
-///     BBBB
-///     BBBB
-/// let c = CCCC
-///
-/// will be formatted as:
-/// let a = AAAA
-///
-/// let b =
-///     BBBB
-///     BBBBB
-///
-/// let c = CCCC
 
 let colWithNlnWhenItemIsMultiline (items: ColMultilineItem list) (ctx: Context) : Context =
     match items with

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -212,12 +212,12 @@ val colAutoNlnSkip0: f': (Context -> Context) -> c: 'a seq -> f: ('a -> Context 
 // Option handling
 // =============================================================================
 
-/// If there is a // value, apply f and f' accordingly, otherwise do nothing
+/// If there is a value, apply f and f' accordingly, otherwise do nothing
 val opt: f': (Context -> Context) -> o: 'a option -> f: ('a -> Context -> Context) -> ctx: Context -> Context
-/// similar to opt, only takes a single function f to apply when there is a // value
+/// similar to opt, only takes a single function f to apply when there is a value
 val optSingle: f: ('a -> 'b -> 'b) -> o: 'a option -> ctx: 'b -> 'b
 
-/// Similar to opt, but apply f2 at the beginning if there is a // value
+/// Similar to opt, but apply f2 at the beginning if there is a value
 val optPre:
     f2: (Context -> Context) ->
     f1: (Context -> Context) ->
@@ -253,6 +253,7 @@ val getRecordSize: ctx: Context -> fields: 'a list -> Size
 /// Unindent that is aware of trailing trivia (comments before closing brackets).
 /// If the DLL tail ends with a comment followed by WriteLineBecauseOfTrivia,
 /// splice the UnIndentBy before that trailing newline. Otherwise, fall back to normal unindent.
+/// Use this rather than `unindent` after an expression that may carry trailing trivia.
 val unindentWithTriviaAwareness: ctx: Context -> Context
 
 /// Describes how an expression should be laid out when it doesn't fit on a single line.

--- a/src/Fantomas.Core/RangeHelpers.fs
+++ b/src/Fantomas.Core/RangeHelpers.fs
@@ -5,7 +5,6 @@ open Fantomas.FCS.Text
 [<RequireQualifiedAccess>]
 module RangeHelpers =
 
-    /// Checks if Range B is fully contained by Range A
     let rangeContainsRange (a: Range) (b: Range) =
         Position.posGeq b.Start a.Start && Position.posGeq a.End b.End
 

--- a/src/Fantomas.Core/Validation.fs
+++ b/src/Fantomas.Core/Validation.fs
@@ -32,7 +32,6 @@ let noWarningOrErrorDiagnostics diagnostics =
     )
     |> List.isEmpty
 
-/// Check whether an input string is invalid in F# by looking for errors and warnings in the diagnostics.
 let isValidFSharpCode (isSignature: bool) (source: string) : Async<bool> =
     async {
         // First get the syntax tree without any defines

--- a/src/Fantomas/EditorConfigReport.fs
+++ b/src/Fantomas/EditorConfigReport.fs
@@ -18,12 +18,6 @@ let fantomasVersion: string =
     else
         version.Substring(0, buildMetadata)
 
-/// Close enough that naming the other one is help rather than noise. Three edits is roughly a
-/// doubled letter, a dropped one and a swapped pair; beyond that the guess is worse than silence.
-///
-/// Deliberately looser than `MaximumUnprefixedTypoDistance`, which decides whether to say anything
-/// at all. By the time a suggestion is offered we have already decided the setting is a mistake,
-/// so a slightly wilder guess costs nothing.
 [<Literal>]
 let MaximumSuggestionDistance = 3
 

--- a/src/Fantomas/EditorConfigReport.fsi
+++ b/src/Fantomas/EditorConfigReport.fsi
@@ -12,7 +12,13 @@ type EditorConfigReporter = string -> EditorConfigProblem list -> unit
 /// settings a user is pointed at are tied to a version they can act on.
 val fantomasVersion: string
 
-/// How far a setting may be from a supported one before the guess is worse than silence.
+/// How far a setting may be from a supported one before the guess is worse than silence. Three
+/// edits is roughly a doubled letter, a dropped one and a swapped pair; beyond that naming the
+/// other setting is noise rather than help.
+///
+/// Deliberately looser than the distance at which an unprefixed key is read as a misspelling at
+/// all. By the time a suggestion is offered the setting is already known to be a mistake, so a
+/// slightly wilder guess costs nothing.
 [<Literal>]
 val MaximumSuggestionDistance: int = 3
 


### PR DESCRIPTION
In short: When a source file has a signature file, we want the doc comments to live in the signature file and not repeat it in the implementation because these can easily drift.