### PR TITLE
Show the output Fantomas would not accept from itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Breaking: output that Fantomas will not accept from itself is reported as what it is, and shows you the part of that output it would not accept. `Fantomas produced code that is not valid F#.` read as though the file were at fault, and reaching it always means the opposite: the input parsed, or a parse failure would have been reported instead. The report now says that nothing was written and the file is untouched, that this is a bug in Fantomas rather than a problem with the code, and where to report it, in the shape a parse failure and an unmodellable construct already print. [#3419](https://github.com/fsprojects/fantomas/pull/3419)
+- Breaking: that report carries what the parser said about the rejected output, and the lines of the output around it with a caret under the failure, so there is a small reproduction to cut from it. Up to now the run said only that something was invalid, and finding out what meant running again with `--force` and reading the result. The diagnostics carry no line and column of their own: the output they would count into is written nowhere, so a position in it is a coordinate you cannot follow, and a path an editor could open would take you to the wrong line of the right file. The carets say where, and the report says out loud that the lines below it are the output rather than your file. `--json` carries the same diagnostics in the `diagnostics` array a parse failure already uses. `fantomas check` reports all of it the same way, where it used to run the whole explanation on after `could not be checked:`. [#3419](https://github.com/fsprojects/fantomas/pull/3419)
+- The two reports that ask you to file a bug, for output Fantomas would not accept and for a construct it cannot model, name one place to send it rather than two. They used to add the issue tracker as an alternative for a file too large for the online tool to carry, which offered a choice at the point somebody least wants one. [#3419](https://github.com/fsprojects/fantomas/pull/3419)
+- Breaking: `Fantomas.Core.CodeFormatter.IsValidFSharpCodeAsync` became `ValidateFSharpCodeAsync` and answers with a `ValidationResult` rather than a `bool`. Read `.IsValid` off it where the verdict was all you wanted; `.Diagnostics` is what Fantomas refused, positioned, and is empty exactly when the source is valid. The boolean discarded it, so anything that had to say why had to parse the source a second time to find out, which is why the tool could not show you its own bad output. A warning Fantomas tolerates, such as [#3396](https://github.com/fsprojects/fantomas/issues/3396) on IWSAM types, is not among them. [#3419](https://github.com/fsprojects/fantomas/pull/3419)
+
 ## [8.0.0-alpha-016] - 2026-08-25
 
 ### Added

--- a/docs/docs/end-users/UpgradeGuide.md
+++ b/docs/docs/end-users/UpgradeGuide.md
@@ -117,6 +117,7 @@ fsharp_experimental_stroustrup_style = true
 - A file that cannot be parsed is reported as `src/A.fs could not be parsed by Fantomas:` rather than `Fantomas could not parse src/A.fs:`, and a construct that could not be modelled as `src/A.fs could not be formatted by Fantomas:`. A script matching on the old text needs updating.
 - `--check` no longer reports a file that will not parse twice, once as an error and once as needing formatting.
 - `--force` announces invalid output as a warning on standard error rather than on standard out, and says what happened rather than only that it happened.
+- Output that Fantomas will not accept from itself is reported as a bug in Fantomas rather than as a problem with your file, and says that nothing was written and where to report it. `Formatting A.fs leads to invalid F# code` became `src/A.fs could not be formatted by Fantomas:` followed by that explanation, what the parser said about the output, and the lines of the output around it with a caret under the failure. Those are lines of the output, which is written nowhere and is not your file, and the report says so; the diagnostics carry no line and column of their own for the same reason. Up to `v7` you were told only that something was invalid and left to run again with `--force` and find it yourself. `--check` reports it the same way. A script matching on the old text needs updating.
 - `--version` prints the commit hash trimmed to the short form the `--help` page has always shown, and the whole of it at `--verbosity d`. `Fantomas.Client` is unaffected: it cuts the version at `+`.
 - A `.fantomasignore` in a subfolder is now honoured by the command line. See "`.fantomasignore` in a subfolder" below.
 - `--json` no longer names a file that `.fantomasignore` matched, and `ignored` is no longer a status a file can carry. See "What a run says about skipped files" below.
@@ -387,8 +388,18 @@ has to be rebuilt against `v8`.
 
 #### CodeFormatter
 
-All additions, nothing was removed:
+- `CodeFormatter.IsValidFSharpCodeAsync` was replaced by `CodeFormatter.ValidateFSharpCodeAsync`, which answers with a `ValidationResult` instead of a `bool`:
 
+  ```fsharp
+  // v7
+  let! isValid = CodeFormatter.IsValidFSharpCodeAsync(isSignature, source)
+
+  // v8
+  let! validation = CodeFormatter.ValidateFSharpCodeAsync(isSignature, source)
+  let isValid = validation.IsValid
+  ```
+
+  `ValidationResult.Diagnostics` carries what Fantomas refused: every error, and every warning it does not tolerate, positioned in the source it was given. It is empty exactly when `IsValid` is true. The boolean threw that away, so a caller that had to tell somebody why the source was refused had to parse it a second time to find out. This is what lets the command line show you the line of its own output that failed.
 - `CodeFormatter.FormatASTAsync(ast, config, source)` was added, next to the existing `FormatASTAsync(ast, source)`.
 - `CodeFormatter.GetWriterEventsAsync` was added for debugging. It returns the writer events produced while formatting.
 

--- a/src/Fantomas.Core.Tests/TestHelpers.fs
+++ b/src/Fantomas.Core.Tests/TestHelpers.fs
@@ -69,9 +69,9 @@ let formatAST isFsiFile (source: string) config =
             Fantomas.FCS.Parse.parseFile isFsiFile (Fantomas.FCS.Text.SourceText.ofString source) []
 
         let! formattedCode = CodeFormatter.FormatASTAsync(ast, config = config)
-        let! isValid = CodeFormatter.IsValidFSharpCodeAsync(isFsiFile, formattedCode)
+        let! validation = CodeFormatter.ValidateFSharpCodeAsync(isFsiFile, formattedCode)
 
-        if not isValid then
+        if not validation.IsValid then
             failwithf $"The formatted result is not valid F# code or contains warnings\n%s{formattedCode}"
 
         return formattedCode.Replace("\r\n", "\n")
@@ -105,7 +105,10 @@ let formatSourceStringWithDefines defines (s: string) config =
     String.normalizeNewLine mergedFormatResult.Code
 
 let isValidFSharpCode isFsiFile s =
-    CodeFormatter.IsValidFSharpCodeAsync(isFsiFile, s) |> Async.RunSynchronously
+    let validation: ValidationResult =
+        CodeFormatter.ValidateFSharpCodeAsync(isFsiFile, s) |> Async.RunSynchronously
+
+    validation.IsValid
 
 let equal x =
     let x =

--- a/src/Fantomas.Core.Tests/ValidationTests.fs
+++ b/src/Fantomas.Core.Tests/ValidationTests.fs
@@ -56,6 +56,47 @@ type IWSAMTest<'e> =
 """
     |> should equal true
 
+// What the verdict is built from. `isValidFSharpCode` above reads `IsValid` off the same result, so
+// these are about the half of it a caller could not see before.
+
+let private validate (isSignature: bool) (source: string) : Fantomas.Core.ValidationResult =
+    Fantomas.Core.CodeFormatter.ValidateFSharpCodeAsync(isSignature, source)
+    |> Async.RunSynchronously
+
+[<Test>]
+let ``source Fantomas accepts has nothing to report about it`` () =
+    let result = validate false "let a = 1\n"
+
+    result.IsValid |> should equal true
+    result.Diagnostics |> should be Empty
+
+[<Test>]
+let ``source Fantomas refuses says what it refused`` () =
+    let result = validate false "let a = (1\n"
+
+    result.IsValid |> should equal false
+    result.Diagnostics |> should not' (be Empty)
+
+    // Positioned, because positioning it against the source is the whole reason a caller asks.
+    let diagnostic = List.head result.Diagnostics
+    diagnostic.Range |> should not' (equal None)
+
+[<Test>]
+let ``a warning Fantomas tolerates is not a reason to refuse, 3396`` () =
+    // The set of tolerated warnings is what makes `IsValid` more than "the parser had nothing to
+    // say", and the diagnostics have to be filtered by it too, or a report points at a warning that
+    // was never the reason.
+    let result =
+        validate
+            false
+            """
+type IWSAMTest<'e> =
+    static abstract member Test: int -> 'e
+"""
+
+    result.IsValid |> should equal true
+    result.Diagnostics |> should be Empty
+
 // InvariantViolationException marks a state the transformer's own model says is impossible.
 // It must derive from FormatException: the CLI matches on that type to decide what to print,
 // and anything else falls through to an empty message at normal verbosity.

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -57,8 +57,8 @@ type CodeFormatter =
         CodeFormatterImpl.getSourceText source
         |> Selection.formatSelection config isSignature selection
 
-    static member IsValidFSharpCodeAsync(isSignature: bool, source: string) =
-        Validation.isValidFSharpCode isSignature source
+    static member ValidateFSharpCodeAsync(isSignature: bool, source: string) =
+        Validation.validateFSharpCode isSignature source
 
     static member GetVersion() = Version.fantomasVersion.Value
 

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -55,8 +55,19 @@ type CodeFormatter =
     static member FormatSelectionAsync:
         isSignature: bool * source: string * selection: range * config: FormatConfig -> Async<string * range>
 
-    /// Check whether an input string is invalid in F# by attempting to parse the code.
-    static member IsValidFSharpCodeAsync: isSignature: bool * source: string -> Async<bool>
+    /// <summary>
+    /// Check whether an input string is valid F# by attempting to parse the code, and report what
+    /// about it is not when it is not.
+    /// </summary>
+    /// <remarks>
+    /// This replaces <c>IsValidFSharpCodeAsync</c>, which answered with a bare boolean. A caller
+    /// that has to tell somebody why the source was refused could not reconstruct the reason from
+    /// that answer, and asking a second time would parse the source a second time. Read
+    /// <c>IsValid</c> off the result where the verdict alone is what was wanted.
+    /// </remarks>
+    /// <param name="isSignature">Determines whether the F# parser will process the source as signature file.</param>
+    /// <param name="source">F# source code</param>
+    static member ValidateFSharpCodeAsync: isSignature: bool * source: string -> Async<ValidationResult>
 
     /// Returns the version of Fantomas found in the AssemblyInfo
     static member GetVersion: unit -> string

--- a/src/Fantomas.Core/CodeFormatterTypes.fs
+++ b/src/Fantomas.Core/CodeFormatterTypes.fs
@@ -1,5 +1,6 @@
 ﻿namespace Fantomas.Core
 
+open Fantomas.FCS.Parse
 open Fantomas.FCS.Text
 
 [<NoComparison>]
@@ -11,3 +12,23 @@ type FormatResult =
         /// This can be None when no cursor was passed as input or no position was resolved.
         Cursor: pos option
     }
+
+/// What Fantomas made of a piece of F# source when it was asked whether that source is valid.
+///
+/// The verdict and the reason for it together, because a caller that has to tell somebody why
+/// cannot reconstruct it from a boolean, and asking twice would parse the source twice.
+[<NoComparison>]
+type ValidationResult =
+    {
+        /// The diagnostics that make the source invalid: every error, and every warning Fantomas
+        /// does not tolerate. Everything the parser was willing to overlook is left out, so this is
+        /// empty exactly when the source is valid rather than being all the parser had to say.
+        ///
+        /// When the source carries conditional directives, these come from the first define
+        /// combination that failed. Every combination is parsed from the same text, so the
+        /// positions are positions in that text whichever combination produced them.
+        Diagnostics: FSharpParserDiagnostic list
+    }
+
+    /// Whether the source is valid F# as far as Fantomas is concerned.
+    member this.IsValid: bool = List.isEmpty this.Diagnostics

--- a/src/Fantomas.Core/Validation.fs
+++ b/src/Fantomas.Core/Validation.fs
@@ -18,7 +18,7 @@ let safeToIgnoreWarnings =
             3535 // tcUsingInterfacesWithAbstractStaticMembers
         ]
 
-let noWarningOrErrorDiagnostics diagnostics =
+let invalidatingDiagnostics (diagnostics: FSharpParserDiagnostic list) : FSharpParserDiagnostic list =
     diagnostics
     |> List.filter (fun e ->
         match e.Severity with
@@ -30,10 +30,11 @@ let noWarningOrErrorDiagnostics diagnostics =
             | None -> true
             | Some errorNumber -> not (safeToIgnoreWarnings.Contains(errorNumber))
     )
-    |> List.isEmpty
 
-/// Check whether an input string is invalid in F# by looking for errors and warnings in the diagnostics.
-let isValidFSharpCode (isSignature: bool) (source: string) : Async<bool> =
+let noWarningOrErrorDiagnostics (diagnostics: FSharpParserDiagnostic list) : bool =
+    List.isEmpty (invalidatingDiagnostics diagnostics)
+
+let validateFSharpCode (isSignature: bool) (source: string) : Async<ValidationResult> =
     async {
         // First get the syntax tree without any defines
         let sourceText = SourceText.ofString source
@@ -45,18 +46,32 @@ let isValidFSharpCode (isSignature: bool) (source: string) : Async<bool> =
             | ParsedInput.SigFile(ParsedSigFileInput(trivia = { ConditionalDirectives = directives })) -> directives
 
         match hashDirectives with
-        | [] -> return noWarningOrErrorDiagnostics baseDiagnostics
+        | [] ->
+            return
+                {
+                    Diagnostics = invalidatingDiagnostics baseDiagnostics
+                }
 
         | hashDirectives ->
 
             let defineCombinations = Defines.getDefineCombination hashDirectives
 
-            let isValidForCombinations =
+            // The first combination that fails is the one reported, and the ones after it are not
+            // parsed at all. Every combination is parsed from the same text, so whichever failed
+            // positions a reader in the same source; and the answer to whether the whole is valid
+            // was settled the moment one of them was not.
+            let offending: FSharpParserDiagnostic list option =
                 defineCombinations
-                |> List.map (fun defineCombination ->
+                |> List.tryPick (fun defineCombination ->
                     let _, diagnostics = parseFile isSignature sourceText defineCombination.Value
-                    noWarningOrErrorDiagnostics diagnostics
+
+                    match invalidatingDiagnostics diagnostics with
+                    | [] -> None
+                    | offending -> Some offending
                 )
 
-            return Seq.forall id isValidForCombinations
+            return
+                {
+                    Diagnostics = Option.defaultValue [] offending
+                }
     }

--- a/src/Fantomas.Core/Validation.fsi
+++ b/src/Fantomas.Core/Validation.fsi
@@ -2,6 +2,12 @@ module internal Fantomas.Core.Validation
 
 open Fantomas.FCS.Parse
 
+/// The diagnostics that make source invalid, rather than only whether any of them do: every error,
+/// and every warning that is not one of the few `safeToIgnoreWarnings` names. Empty when there is
+/// nothing among them Fantomas would refuse.
+val invalidatingDiagnostics: diagnostics: FSharpParserDiagnostic list -> FSharpParserDiagnostic list
+
 val noWarningOrErrorDiagnostics: diagnostics: FSharpParserDiagnostic list -> bool
-/// Check whether an input string is invalid in F# by looking for errors and warnings in the diagnostics.
-val isValidFSharpCode: isSignature: bool -> source: string -> Async<bool>
+
+/// Parse an input string and report what about it, if anything, Fantomas will not accept.
+val validateFSharpCode: isSignature: bool -> source: string -> Async<ValidationResult>

--- a/src/Fantomas.Tests/DiagnosticsTests.fs
+++ b/src/Fantomas.Tests/DiagnosticsTests.fs
@@ -286,7 +286,7 @@ let ``an invariant violation is positioned and shown with a caret under the cons
             "6 | "
             "7 | let after = 2"
             ""
-            "This is a bug in Fantomas, not a problem with your code. Please report it with the snippet above via https://fsprojects.github.io/fantomas-tools/, or at https://github.com/fsprojects/fantomas/issues/new if the file is too large for the tool to carry."
+            "This is a bug in Fantomas, not a problem with your code. Please report it with the snippet above via https://fsprojects.github.io/fantomas-tools/."
             ""
         ]
 
@@ -321,6 +321,106 @@ let ``an invariant violation without source is still positioned`` () =
 let ``an exception that is not an invariant violation is not this module's to describe`` () =
     Diagnostics.describeInvariantViolation plain "bad.fs" (fun () -> externSource) false (exn "boom")
     |> should equal None
+
+// Output Fantomas would not accept is the one failure here whose positions are not positions in the
+// file, so what these pin is that the report says so and draws the right lines.
+let private rejectedOutput: string =
+    "module A\n\nlet a = 1\n\nlet b = (2\n\nlet c = 3\n"
+
+[<Test>]
+let ``invalid output shows what the parser said and the lines it said it about`` () =
+    let rendered: string =
+        Diagnostics.renderInvalidOutput plain "src/A.fs" rejectedOutput [ error 583 "Unmatched '('" (5, 8) (5, 9) ]
+
+    lines rendered
+    |> should
+        equal
+        [
+            "src/A.fs could not be formatted by Fantomas:"
+            ""
+            "Fantomas formatted this file and then found that its own output did not pass validation, so the output was thrown away and your file is unchanged."
+            ""
+            "This is what the parser made of that output. The lines below are the output, not your file."
+            ""
+            "error FS0583: Unmatched '('"
+            ""
+            "3 | let a = 1"
+            "4 | "
+            "5 | let b = (2"
+            "  |         ^"
+            "6 | "
+            "7 | let c = 3"
+            ""
+            "This is a bug in Fantomas, not a problem with your code. Please report it with the file via https://fsprojects.github.io/fantomas-tools/."
+            ""
+        ]
+
+[<Test>]
+let ``a position in the output is not given, since there is nowhere to go`` () =
+    // Line 5 of the output is not line 5 of the file, and the output is written nowhere, so a
+    // coordinate into it is one the reader cannot follow. `src/A.fs(5,9)` would be worse: a link an
+    // editor follows to the wrong line of the right file. The caret is what says where.
+    let rendered: string =
+        Diagnostics.renderInvalidOutput plain "src/A.fs" rejectedOutput [ error 583 "Unmatched '('" (5, 8) (5, 9) ]
+
+    rendered |> should not' (haveSubstring "src/A.fs(5,9)")
+    rendered |> should not' (haveSubstring "(5,9)")
+    rendered |> should haveSubstring "error FS0583: Unmatched '('"
+    rendered |> should haveSubstring "  |         ^"
+
+    // Named once, in the header, where it is the file it really is about.
+    rendered.Split("src/A.fs").Length - 1 |> should equal 1
+
+[<Test>]
+let ``invalid output with nothing to say leaves the section out`` () =
+    // Nothing produces this today: the validation hands back what it refused, and it refused
+    // something. It is the shape of the data rather than a state to reach, and a report with an
+    // empty heading over no diagnostics would be worse than one without the heading.
+    let rendered: string =
+        Diagnostics.renderInvalidOutput plain "src/A.fs" rejectedOutput []
+
+    rendered |> should not' (haveSubstring "the lines below")
+    rendered |> should haveSubstring "your file is unchanged"
+    rendered |> should haveSubstring "a bug in Fantomas"
+
+[<Test>]
+let ``a warning Fantomas will not tolerate is pointed at like an error`` () =
+    // The validation refuses some warnings outright, so a report can arrive with no error in it at
+    // all. It still has somewhere to draw the caret.
+    let rendered: string =
+        Diagnostics.renderInvalidOutput
+            plain
+            "src/A.fs"
+            rejectedOutput
+            [ warning 25 "Incomplete pattern match" (5, 8) (5, 9) ]
+
+    rendered |> should haveSubstring "warning FS0025"
+    rendered |> should haveSubstring "  |         ^"
+
+[<Test>]
+let ``the message the failure carries is the report without the parser's words`` () =
+    // Which is what lets it stand alone where there is no console to draw a report on: it says what
+    // happened and where to take it, and leaves the positions to whoever can show the lines too.
+    let explanation: string = Diagnostics.invalidOutputExplanation plain
+
+    explanation |> should not' (haveSubstring "src/A.fs")
+    explanation |> should not' (haveSubstring "the lines below")
+    explanation |> should haveSubstring "your file is unchanged"
+
+    explanation
+    |> should haveSubstring "a bug in Fantomas, not a problem with your code"
+
+[<Test>]
+let ``invalid output does not blame the file it was given`` () =
+    // The input parsed, or a parse failure would have been reported instead, so the one thing this
+    // report may not do is read as though the file were at fault.
+    let rendered: string =
+        Diagnostics.renderInvalidOutput plain "src/A.fs" rejectedOutput [ error 583 "Unmatched '('" (5, 8) (5, 9) ]
+
+    rendered
+    |> should haveSubstring "a bug in Fantomas, not a problem with your code"
+
+    rendered |> should haveSubstring "your file is unchanged"
 
 // What colour lands where. The report is one block of text rather than a row of fields, so what is
 // pinned is that each part carries its own colour and that removing the colour leaves the plain
@@ -361,7 +461,7 @@ let ``a parse failure colours the place, the severity, the number, the gutter an
     rendered |> should haveSubstring "\u001b[31m^\u001b[0m"
 
 [<Test>]
-let ``an invariant violation colours the place, the severity and the two links`` () =
+let ``an invariant violation colours the place, the severity and the link`` () =
     let rendered: string =
         Diagnostics.renderInvariantViolation coloured "bad.fs" externSource false (violation ())
 
@@ -369,6 +469,22 @@ let ``an invariant violation colours the place, the severity and the two links``
     |> should haveSubstring "\u001b[38;5;38mbad.fs\u001b[0m could not be formatted"
 
     rendered |> should haveSubstring "\u001b[31merror\u001b[0m:"
+
+    rendered
+    |> should haveSubstring "\u001b[38;5;38mhttps://fsprojects.github.io/fantomas-tools/\u001b[0m"
+
+[<Test>]
+let ``invalid output colours the file, the severity and the link`` () =
+    let rendered: string =
+        Diagnostics.renderInvalidOutput coloured "src/A.fs" rejectedOutput [ error 583 "Unmatched '('" (5, 8) (5, 9) ]
+
+    rendered
+    |> should haveSubstring "\u001b[38;5;38msrc/A.fs\u001b[0m could not be formatted"
+
+    rendered |> should haveSubstring "\u001b[31merror\u001b[0m"
+
+    // Grey for the error number, which is scaffolding a reader looks up rather than reads.
+    rendered |> should haveSubstring "\u001b[38;5;245mFS0583\u001b[0m"
 
     rendered
     |> should haveSubstring "\u001b[38;5;38mhttps://fsprojects.github.io/fantomas-tools/\u001b[0m"

--- a/src/Fantomas.Tests/FormatCommandTests.fs
+++ b/src/Fantomas.Tests/FormatCommandTests.fs
@@ -297,8 +297,15 @@ let ``without force, output that is not valid F# is not written`` () =
     match format fs (InputPath.File input) (OutputPath.IO output) |> results with
     | [| FormatResult.Error(f, error) |] ->
         f |> shouldEqual input
-        error.Message |> shouldContainText "not valid F#"
         fs.File.Exists output |> shouldEqual false
+
+        // The failure carries what was refused and why, which is the whole of what a report can
+        // show: the output is written nowhere, so there is no second place to read it from.
+        match error with
+        | :? InvalidCodeException as invalid ->
+            invalid.FormattedContent |> shouldNotEqual ""
+            invalid.Diagnostics |> List.isEmpty |> shouldEqual false
+        | other -> failwith $"Expected an InvalidCodeException, got %A{other}"
     | other -> failwith $"Expected the invalid output to be withheld, got %A{other}"
 
 [<Test>]

--- a/src/Fantomas.Tests/JsonReportTests.fs
+++ b/src/Fantomas.Tests/JsonReportTests.fs
@@ -193,14 +193,50 @@ let ``a failure that is not a parse failure is carried as its message alone`` ()
 
 [<Test>]
 let ``output Fantomas invalidated is reported as a failure of that file`` () =
-    let document: JsonElement = completed [ FormatResult.InvalidCode("a.fs", "") ]
+    let rejection: Fantomas.FCS.Parse.FSharpParserDiagnostic list =
+        [
+            {
+                Severity = Fantomas.FCS.Diagnostics.FSharpDiagnosticSeverity.Error
+                SubCategory = "parse"
+                Range =
+                    Some(
+                        Fantomas.FCS.Text.Range.mkRange
+                            "tmp.fsx"
+                            (Fantomas.FCS.Text.Position.mkPos 3 9)
+                            (Fantomas.FCS.Text.Position.mkPos 3 10)
+                    )
+                ErrorNumber = Some 583
+                Message = "Unmatched '('"
+            }
+        ]
+
+    let document: JsonElement =
+        completed [ FormatResult.InvalidCode("a.fs", "module A\n\nlet a = (1\n", rejection) ]
+
     let file: JsonElement = files document |> List.exactlyOne
     snd (statusOf file) |> shouldEqual "error"
 
     // The path is a key of its own beside the message, so the message does not repeat it.
     file.GetProperty("path").GetString() |> shouldEqual "a.fs"
 
-    file.GetProperty("message").GetString() |> shouldContainText "not valid F#"
+    // The same wording the console prints, minus the colour and the file in front of it, rather
+    // than a shorter sentence written for this document alone.
+    let message: string = file.GetProperty("message").GetString()
+    message |> shouldContainText "your file is unchanged"
+    message |> shouldContainText "a bug in Fantomas"
+
+    // What was wrong with the output, carried the way a parse failure's diagnostics are, so a
+    // caller has the position without having to read it back out of the prose.
+    let diagnostic: JsonElement =
+        file.GetProperty("diagnostics").EnumerateArray()
+        |> List.ofSeq
+        |> List.exactlyOne
+
+    diagnostic.GetProperty("severity").GetString() |> shouldEqual "error"
+    diagnostic.GetProperty("code").GetString() |> shouldEqual "FS0583"
+
+    diagnostic.GetProperty("range").GetProperty("startLine").GetInt32()
+    |> shouldEqual 3
 
 // Only a file that failed carries them, so a folder of files that were fine does not repeat a null
 // message and an empty list for every one of them.

--- a/src/Fantomas.Tests/ReportTests.fs
+++ b/src/Fantomas.Tests/ReportTests.fs
@@ -5,6 +5,7 @@ open System.IO.Abstractions.TestingHelpers
 open NUnit.Framework
 open FsUnitTyped
 open Fantomas.Core
+open Fantomas.FCS.Text
 open Fantomas.Arguments
 open Fantomas.CommandResult
 open Fantomas.Logging
@@ -17,6 +18,21 @@ let private run () : RecordedRun =
 /// The folder a test's results are pretended to have come from, named back in the messages that
 /// have to name it. Which path it is does not matter to any assertion here.
 let private inputFolder: InputPath = InputPath.Folder "src"
+
+/// Output Fantomas would not accept, and what it would not accept about it. Built here rather than
+/// produced by formatting something, since what these tests are about is the reporting.
+let private rejectedOutput: string = "module A\n\nlet a = (1\n"
+
+let private rejection: Fantomas.FCS.Parse.FSharpParserDiagnostic list =
+    [
+        {
+            Severity = Fantomas.FCS.Diagnostics.FSharpDiagnosticSeverity.Error
+            SubCategory = "parse"
+            Range = Some(Range.mkRange "tmp.fsx" (Position.mkPos 3 9) (Position.mkPos 3 10))
+            ErrorNumber = Some 583
+            Message = "Unmatched '('"
+        }
+    ]
 
 let private reportFormatTo
     (outputPath: OutputPath)
@@ -203,17 +219,30 @@ let ``a single file that failed is reported on error and exits 1`` () =
 [<Test>]
 let ``code that came out invalid is reported as a failure and exits 1`` () =
     let code, log =
-        reportFormat defaultSettings (FormatCommandResult.Completed [| FormatResult.InvalidCode("A.fs", "let a =") |])
+        reportFormat
+            defaultSettings
+            (FormatCommandResult.Completed [| FormatResult.InvalidCode("A.fs", rejectedOutput, rejection) |])
 
     code |> shouldEqual 1
 
-    // The file is named once. It used to be named twice, once by the reporter and again inside the
-    // message the exception carried.
-    log.Error
-    |> shouldEqual
-        [
-            "x A.fs could not be formatted: Fantomas produced code that is not valid F#."
-        ]
+    // One report, and the file named once inside it. It used to be named twice, once by the
+    // reporter and again inside the message the exception carried.
+    let report: string = log.Error |> List.exactlyOne
+    report.Split("A.fs").Length - 1 |> shouldEqual 1
+
+    report.Split('\n')
+    |> Array.head
+    |> shouldEqual "x A.fs could not be formatted by Fantomas:"
+
+    // The four things the report exists to say: whose fault this is, that nothing was lost, where
+    // to take it, and what was wrong with the output. It used to say only that the code was not
+    // valid, which reads as though the file were at fault and leaves the reader with nothing to do
+    // but run again with `--force` and find it themselves.
+    report |> shouldContainText "a bug in Fantomas"
+    report |> shouldContainText "your file is unchanged"
+    report |> shouldContainText "https://fsprojects.github.io/fantomas-tools/"
+    report |> shouldContainText "error FS0583: Unmatched '('"
+    report |> shouldContainText "3 | let a = (1"
 
 [<Test>]
 let ``a failure says what went wrong at any verbosity`` () =
@@ -370,6 +399,34 @@ let ``a single file that was skipped or failed names no destination`` () =
             (FormatCommandResult.Completed [| FormatResult.IgnoredFile "A.fs" |])
 
     log.Information |> shouldEqual [ "- A.fs was ignored by .fantomasignore." ]
+
+[<Test>]
+let ``a check reports invalid output the same way a format run does`` () =
+    // The two commands had a copy each of the match that asks a failure to describe itself, and the
+    // check copy knew about two of the three: it printed the whole explanation after `could not be
+    // checked:` where a format run printed the block.
+    let code, log =
+        reportCheck (
+            CheckCommandResult.Completed(
+                [],
+                {
+                    Errors = [ "A.fs", InvalidCodeException(rejectedOutput, rejection) ]
+                    Formatted = []
+                    Unchanged = []
+                }
+            )
+        )
+
+    code |> shouldEqual 1
+
+    let report: string = log.Error |> List.exactlyOne
+
+    report.Split('\n')
+    |> Array.head
+    |> shouldEqual "x A.fs could not be formatted by Fantomas:"
+
+    report |> shouldContainText "your file is unchanged"
+    report |> shouldContainText "error FS0583: Unmatched '('"
 
 [<Test>]
 let ``a check that looked at no file says so rather than passing in silence`` () =

--- a/src/Fantomas/CheckCommand.fs
+++ b/src/Fantomas/CheckCommand.fs
@@ -41,7 +41,8 @@ let checkCode (env: CliEnvironment) (filenames: string seq) : Async<CheckResult>
         let getErrors: FormatResult -> (string * exn) option =
             function
             | FormatResult.Error(f, e) -> Some(f, e)
-            | FormatResult.InvalidCode(f, _) -> Some(f, invalidResultException () :> exn)
+            | FormatResult.InvalidCode(f, formattedContent, diagnostics) ->
+                Some(f, InvalidCodeException(formattedContent, diagnostics) :> exn)
             | _ -> None
 
         let errors: (string * exn) list = formatted |> Seq.choose getErrors |> Seq.toList

--- a/src/Fantomas/CommandResult.fs
+++ b/src/Fantomas/CommandResult.fs
@@ -2,12 +2,14 @@ module Fantomas.CommandResult
 
 open System
 open Fantomas.Core
+open Fantomas.FCS.Parse
+open Fantomas.Theme
 
 [<RequireQualifiedAccess; NoComparison>]
 type FormatResult =
     | Formatted of filename: string * formattedContent: string
     | Unchanged of filename: string
-    | InvalidCode of filename: string * formattedContent: string
+    | InvalidCode of filename: string * formattedContent: string * diagnostics: FSharpParserDiagnostic list
     | Error of filename: string * formattingError: exn
     | IgnoredFile of filename: string
 
@@ -23,11 +25,14 @@ type CheckResult =
     member this.NeedsFormatting = List.isNotEmpty this.Formatted
     member this.IsValid = List.isEmpty this.Errors && List.isEmpty this.Formatted
 
-// Not naming the file. Every reporter that shows this already has the file in hand and puts it in
-// front: the line came out as `A.fs could not be formatted: Formatting A.fs leads to invalid F#
-// code`, and the JSON document carries the message next to a `path` key saying the same thing.
-let invalidResultException () : FormatException =
-    FormatException("Fantomas produced code that is not valid F#.")
+type InvalidCodeException(formattedContent: string, diagnostics: FSharpParserDiagnostic list) =
+    inherit FormatException(String.Empty)
+
+    member _.FormattedContent = formattedContent
+
+    member _.Diagnostics = diagnostics
+
+    override _.Message = Diagnostics.invalidOutputExplanation Theme.plain
 
 [<RequireQualifiedAccess; Struct>]
 type InputProblem =

--- a/src/Fantomas/CommandResult.fsi
+++ b/src/Fantomas/CommandResult.fsi
@@ -1,11 +1,13 @@
 module Fantomas.CommandResult
 
+open Fantomas.FCS.Parse
+
 /// What formatting one file came to.
 [<RequireQualifiedAccess; NoComparison>]
 type FormatResult =
     | Formatted of filename: string * formattedContent: string
     | Unchanged of filename: string
-    | InvalidCode of filename: string * formattedContent: string
+    | InvalidCode of filename: string * formattedContent: string * diagnostics: FSharpParserDiagnostic list
     | Error of filename: string * formattingError: exn
     | IgnoredFile of filename: string
 
@@ -27,14 +29,25 @@ type CheckResult =
 
     member NeedsFormatting: bool
 
-/// The failure that a `FormatResult.InvalidCode` stands for. Formatting produced something that is
-/// not F#, which is a bug in Fantomas rather than in the file it was given.
+/// The failure that a `FormatResult.InvalidCode` stands for. Formatting produced output that
+/// Fantomas itself would not accept, which is a bug in Fantomas rather than in the file it was
+/// given, and nothing was written.
 ///
-/// The message does not name the file, because nothing that shows it is short of one: every
-/// reporter puts the path in front of the message, and the JSON document carries it as a key beside
-/// it. Naming it here made the line read `A.fs could not be formatted: Formatting A.fs leads to
-/// invalid F# code`.
-val invalidResultException: unit -> Fantomas.Core.FormatException
+/// It is a type of its own so that a reporter can recognise it, since what it has to say does not
+/// fit the one line that every other failure is reduced to. `Diagnostics.invalidOutputExplanation`
+/// is the wording, and is what this carries as its message.
+type InvalidCodeException =
+    inherit Fantomas.Core.FormatException
+
+    new: formattedContent: string * diagnostics: FSharpParserDiagnostic list -> InvalidCodeException
+
+    /// The diagnostics that made that output unacceptable: every error, and every warning Fantomas
+    /// does not tolerate. A diagnostic it was willing to overlook is not among them.
+    member Diagnostics: FSharpParserDiagnostic list
+
+    /// What Fantomas produced and then would not accept. It is written nowhere, so a report that
+    /// wants to show a line of it has nowhere else to read it from.
+    member FormattedContent: string
 
 /// A reason the input paths cannot be worked with. Both commands can end this way and both are
 /// described from here, which is what keeps their wording from drifting apart.

--- a/src/Fantomas/Diagnostics.fs
+++ b/src/Fantomas/Diagnostics.fs
@@ -113,6 +113,40 @@ let snippet (theme: Theme) (lines: string array) (range: range) : string list =
                     yield String.Concat(blankGutter, " ", indent, negative theme carets)
         ]
 
+// Where to draw the caret. The first error by position, since in an offside cascade that is the
+// line that caused it rather than the innocent line the parser gave up on. Falling back to the
+// first diagnostic that has a range at all, for a report whose diagnostics are warnings that
+// Fantomas will not tolerate and which therefore has no error to point at.
+let caretTarget (ordered: FSharpParserDiagnostic list) : range option =
+    let firstError: range option =
+        ordered
+        |> List.tryPick (fun diagnostic ->
+            match diagnostic.Severity, diagnostic.Range with
+            | FSharpDiagnosticSeverity.Error, Some range -> Some range
+            | _ -> None
+        )
+
+    match firstError with
+    | Some range -> Some range
+    | None -> List.tryPick (fun (diagnostic: FSharpParserDiagnostic) -> diagnostic.Range) ordered
+
+// The snippet as a section of a report: a blank line and then the lines, or nothing at all when
+// there is no source to draw from and no range to draw at. Every report here places it the same
+// way, so where the blank line goes is decided once.
+let snippetFor (theme: Theme) (source: string) (target: range option) : string list =
+    match target with
+    | None -> []
+    | Some range ->
+        if String.IsNullOrEmpty source then
+            []
+        else
+
+        let lines: string array = source.Replace("\r\n", "\n").Split('\n')
+
+        match snippet theme lines range with
+        | [] -> []
+        | snippetLines -> "" :: snippetLines
+
 let renderParseFailure
     (theme: Theme)
     (file: string)
@@ -122,28 +156,9 @@ let renderParseFailure
     =
     let ordered = List.sortBy position diagnostics
 
-    let snippetLines =
-        if String.IsNullOrEmpty source then
-            []
-        else
-            // The caret goes on the first error rather than the first diagnostic. A warning can
-            // sort ahead of the error that stopped the parse, and it is not why the file failed.
-            let firstError =
-                ordered
-                |> List.tryPick (fun diagnostic ->
-                    match diagnostic.Severity, diagnostic.Range with
-                    | FSharpDiagnosticSeverity.Error, Some range -> Some range
-                    | _ -> None
-                )
-
-            match firstError with
-            | None -> []
-            | Some range ->
-                let lines = source.Replace("\r\n", "\n").Split('\n')
-
-                match snippet theme lines range with
-                | [] -> []
-                | snippetLines -> "" :: snippetLines
+    // The caret goes on the first error rather than the first diagnostic. A warning can sort ahead
+    // of the error that stopped the parse, and it is not why the file failed.
+    let snippetLines: string list = snippetFor theme source (caretTarget ordered)
 
     // The report ends with a blank line as well as starting with one, so that a run over several
     // files does not have one file's snippet running into the next file's header.
@@ -160,6 +175,26 @@ let describeParseFailure (theme: Theme) (file: string) (source: unit -> string) 
     match error with
     | :? ParseException as parseFailure -> Some(renderParseFailure theme file (source ()) parseFailure.Diagnostics)
     | _ -> None
+
+// The same request, worded once, so that the two failures Fantomas has to own up to cannot come to
+// ask for a report in two different ways. What differs is the evidence worth sending: one of these
+// points at a construct in the file and the other at what the whole file was turned into.
+//
+// One place to send it. It used to name the issue tracker as well, for a file too large for the
+// tool to carry, which offered a reader a choice at the moment they have least appetite for one and
+// pointed half of them at the slower path. If the tool cannot take a file that size, that is the
+// tool's problem to fix rather than a fork to put in front of somebody reporting a bug.
+//
+// The place to report it is somewhere the reader can go, which is the one thing colour marks in
+// prose, so it is coloured as the link it is and the sentence around it is left alone.
+let reportAsBug (theme: Theme) (evidence: string) : string =
+    String.Concat(
+        "This is a bug in Fantomas, not a problem with your code. Please report it with ",
+        evidence,
+        " via ",
+        link theme "https://fsprojects.github.io/fantomas-tools/",
+        "."
+    )
 
 let renderInvariantViolation
     (theme: Theme)
@@ -180,15 +215,7 @@ let renderInvariantViolation
 
         $"%s{link theme location}: %s{severity}: %s{violation.Invariant}"
 
-    let snippetLines: string list =
-        if String.IsNullOrEmpty source then
-            []
-        else
-            let lines: string array = source.Replace("\r\n", "\n").Split('\n')
-
-            match snippet theme lines violation.Range with
-            | [] -> []
-            | snippetLines -> "" :: snippetLines
+    let snippetLines: string list = snippetFor theme source (Some violation.Range)
 
     // The dump of the syntax tree node is what tells a maintainer which parser shape went
     // unhandled, and it is noise to everyone else, so it is shown only when asked for.
@@ -199,17 +226,7 @@ let renderInvariantViolation
             [ ""; "Syntax tree node:"; "" ]
             @ List.ofArray (violation.SyntaxNode.Split('\n'))
 
-    // The two places to report it are somewhere the reader can go, which is the one thing colour
-    // marks in prose, so they are coloured as the links they are and the sentence around them is
-    // left alone.
-    let reportIt: string =
-        String.Concat(
-            "This is a bug in Fantomas, not a problem with your code. Please report it with the snippet above via ",
-            link theme "https://fsprojects.github.io/fantomas-tools/",
-            ", or at ",
-            link theme "https://github.com/fsprojects/fantomas/issues/new",
-            " if the file is too large for the tool to carry."
-        )
+    let reportIt: string = reportAsBug theme "the snippet above"
 
     [
         yield $"%s{link theme file} could not be formatted by Fantomas:"
@@ -235,3 +252,68 @@ let describeInvariantViolation
     | :? InvariantViolationException as violation ->
         Some(renderInvariantViolation theme file (source ()) verbose violation)
     | _ -> None
+
+// Paragraph one of the report, and the opening of the message the failure carries. Split out
+// because the report puts the parser's own words between it and the request for a report, and the
+// message does not. Nothing in it is coloured, so it needs no theme.
+let invalidOutputSummary: string =
+    "Fantomas formatted this file and then found that its own output did not pass validation, so the output was thrown away and your file is unchanged."
+
+// Asked in one place so that the report and the message cannot come to send a reader after
+// different things. The file, because it is the input that reproduces this and the only part of it
+// the reader still has: the output that failed is thrown away.
+let invalidOutputReportRequest (theme: Theme) : string = reportAsBug theme "the file"
+
+let invalidOutputExplanation (theme: Theme) : string =
+    String.Concat(invalidOutputSummary, "\n\n", invalidOutputReportRequest theme)
+
+// No position, which is the one thing this drops from the shape every other diagnostic here is
+// printed in. A position is somewhere to go, and there is nowhere to go: the output it counts lines
+// into is thrown away and was never written. `src/A.fs(4708,25)` would be worse than useless, since
+// an editor turns it into a link to line 4708 of the input, which is not the line it means. The
+// carets below are what says where, and they say it by pointing at the line itself.
+let outputHeadline (theme: Theme) (diagnostic: FSharpParserDiagnostic) : string =
+    let message: string = diagnostic.Message.Replace("\r\n", " ").Replace("\n", " ")
+    let severity: string = severityColour theme diagnostic
+    let number: string = placeholder theme (errorNumber diagnostic)
+
+    $"%s{severity} %s{number}: %s{message}"
+
+let renderInvalidOutput
+    (theme: Theme)
+    (file: string)
+    (output: string)
+    (diagnostics: FSharpParserDiagnostic list)
+    : string
+    =
+    let ordered: FSharpParserDiagnostic list = List.sortBy position diagnostics
+
+    // What the parser said, and the output around it. Without this the reader is told that
+    // something was wrong with a file they cannot see and left to find it by running again with
+    // `--force` and reading the result. With it they have the line to cut a small reproduction
+    // from, which is what a report needs and what nobody can produce from prose.
+    //
+    // Said out loud that these lines are the output. They look exactly like the lines of the file
+    // and they are not: nothing else Fantomas prints a snippet of is anything but the source.
+    let diagnosticLines: string list =
+        if List.isEmpty ordered then
+            []
+        else
+            [
+                yield ""
+                yield "This is what the parser made of that output. The lines below are the output, not your file."
+                yield ""
+                yield! List.map (outputHeadline theme) ordered
+                yield! snippetFor theme output (caretTarget ordered)
+            ]
+
+    [
+        yield $"%s{link theme file} could not be formatted by Fantomas:"
+        yield ""
+        yield invalidOutputSummary
+        yield! diagnosticLines
+        yield ""
+        yield invalidOutputReportRequest theme
+        yield ""
+    ]
+    |> String.concat "\n"

--- a/src/Fantomas/Diagnostics.fsi
+++ b/src/Fantomas/Diagnostics.fsi
@@ -68,3 +68,34 @@ val renderInvariantViolation:
 /// invariant violation.
 val describeInvariantViolation:
     theme: Theme -> file: string -> source: (unit -> string) -> verbose: bool -> error: exn -> string option
+
+/// What to say when formatting produced output that Fantomas itself would not accept. This is the
+/// message the failure carries, so that a caller with no console to draw a report on still has the
+/// whole of it in words.
+///
+/// It does not name the file, because nothing that shows it is short of one: a reporter puts the
+/// path in front of it and the JSON document carries it as a key beside it. Naming it here is what
+/// made the line read `A.fs could not be formatted: Formatting A.fs leads to invalid F# code`.
+///
+/// What it says is that the file was not touched, which is the first thing somebody wants to know
+/// after reading that formatting produced something invalid, and that this is a bug in Fantomas and
+/// where to take it, since reaching this state is never the file's fault.
+val invalidOutputExplanation: theme: Theme -> string
+
+/// Render an invalid output failure for `file`: the same header the other two reports open with,
+/// what happened, what the parser said about `output`, and the request for a bug report.
+///
+/// `output` is what Fantomas produced and would not accept, and `diagnostics` are what it would not
+/// accept about it. Without them the reader is told that something was wrong with a file they cannot
+/// see, and is left to run again with `--force` and find it themselves. With them they have the line
+/// to cut a small reproduction from, which is what a bug report needs and what no amount of prose
+/// supplies. Pass an empty list to leave the whole section out.
+///
+/// Each is rendered without its position, which is where this departs from every other report here.
+/// A position is somewhere to go and there is nowhere to go: `output` is thrown away and written
+/// nowhere, so a line number into it is a coordinate in a buffer the reader cannot open, and
+/// `path(line,column)` would be a link an editor follows to the wrong line of the right file. The
+/// snippet is what says where, by pointing at the line. It is drawn for the first of them, which is
+/// also the first listed, since they are ordered by position.
+val renderInvalidOutput:
+    theme: Theme -> file: string -> output: string -> diagnostics: FSharpParserDiagnostic list -> string

--- a/src/Fantomas/FormatCommand.fs
+++ b/src/Fantomas/FormatCommand.fs
@@ -49,11 +49,16 @@ let formatContentAsync (formatParams: FormatParams) (originalContent: string) : 
                     originalContent <> formattedContent
 
             if contentChanged then
-                let! (isValid: bool) =
-                    CodeFormatter.IsValidFSharpCodeAsync(isSignatureFile, formattedContent)
+                let! (validation: ValidationResult) =
+                    CodeFormatter.ValidateFSharpCodeAsync(isSignatureFile, formattedContent)
 
-                if not isValid then
-                    return FormatResult.InvalidCode(filename = formatParams.File, formattedContent = formattedContent)
+                if not validation.IsValid then
+                    return
+                        FormatResult.InvalidCode(
+                            filename = formatParams.File,
+                            formattedContent = formattedContent,
+                            diagnostics = validation.Diagnostics
+                        )
                 else
                     return FormatResult.Formatted(filename = formatParams.File, formattedContent = formattedContent)
             else
@@ -96,7 +101,7 @@ let readSourceFile (fs: IFileSystem) (file: string) : Async<SourceFile> =
     }
 
 /// Format content that is already in hand, settling there what `--force` means and what output
-/// that is not valid F# comes to, so that a caller is left with one kind of failure to report.
+/// Fantomas would not accept comes to, so that a caller is left with one kind of failure to report.
 let formatSource
     (env: CliEnvironment)
     (settings: CliSettings)
@@ -111,7 +116,7 @@ let formatSource
         let! (formatted: FormatResult) = formatContentAsync formatParams source.Content
 
         match formatted with
-        | FormatResult.InvalidCode(f, formattedContent) when settings.Force ->
+        | FormatResult.InvalidCode(f, formattedContent, _) when settings.Force ->
             // A warning, and on standard error, because it says Fantomas wrote F# it believes is not
             // valid. It used to go to standard out at Information, alongside the ordinary run of
             // things it is the opposite of.
@@ -132,7 +137,8 @@ let formatSource
             )
 
             return FormatResult.Formatted(file, formattedContent)
-        | FormatResult.InvalidCode(f, _) -> return FormatResult.Error(f, invalidResultException ())
+        | FormatResult.InvalidCode(f, formattedContent, diagnostics) ->
+            return FormatResult.Error(f, InvalidCodeException(formattedContent, diagnostics))
         | r -> return r
     }
 

--- a/src/Fantomas/JsonReport.fs
+++ b/src/Fantomas/JsonReport.fs
@@ -73,8 +73,14 @@ let describeDiagnostic (diagnostic: FSharpParserDiagnostic) : Diagnostic =
         Range = Option.map describeRange diagnostic.Range
     }
 
-// A parse failure is the one error worth taking apart: its positions are what a caller can act on
+// The two failures with positions worth taking apart, since those are what a caller can act on
 // without opening the file. Everything else has only a message, so it is carried as one.
+//
+// The positions of an invalid output are positions in output that was thrown away rather than in
+// the file at `path`, which the text report says out loud and this document has nowhere to. A
+// caller reading these as offsets into the file on disk will be reading the wrong lines. What the
+// document is for is knowing that it happened and where to look; the text report is what says what
+// the lines are.
 let describeFileFailure (file: string) (error: exn) : FileOutcome =
     match error with
     | :? ParseException as parseFailure ->
@@ -82,6 +88,8 @@ let describeFileFailure (file: string) (error: exn) : FileOutcome =
             $"%s{file} could not be parsed by Fantomas",
             List.map describeDiagnostic parseFailure.Diagnostics
         )
+    | :? InvalidCodeException as invalid ->
+        FileOutcome.Failed(invalid.Message, List.map describeDiagnostic invalid.Diagnostics)
     | _ ->
         let message: string = describeFailure error |> Option.defaultValue error.Message
 
@@ -115,11 +123,11 @@ let describeResult (result: FormatResult) : FileReport option =
                 Path = file
                 Outcome = describeFileFailure file error
             }
-    | FormatResult.InvalidCode(file, _) ->
+    | FormatResult.InvalidCode(file, formattedContent, diagnostics) ->
         Some
             {
                 Path = file
-                Outcome = describeFileFailure file (invalidResultException ())
+                Outcome = describeFileFailure file (InvalidCodeException(formattedContent, diagnostics))
             }
 
 let formatReport (workingDirectory: string) (result: FormatCommandResult) : RunReport =

--- a/src/Fantomas/Report.fs
+++ b/src/Fantomas/Report.fs
@@ -64,9 +64,10 @@ let outcomes (results: FormatResult array) : Outcomes =
         | FormatResult.Unchanged file -> unchanged.Add file
         | FormatResult.IgnoredFile file -> ignored.Add file
         | FormatResult.Error(file, error) -> errored.Add(file, error)
-        // Formatting produced something that is not F#, which is a failure of Fantomas rather than
-        // of the file it was given, and it is reported as one.
-        | FormatResult.InvalidCode(file, _) -> errored.Add(file, invalidResultException () :> exn)
+        // Formatting produced output Fantomas would not accept, which is a failure of Fantomas
+        // rather than of the file it was given, and it is reported as one.
+        | FormatResult.InvalidCode(file, formattedContent, diagnostics) ->
+            errored.Add(file, InvalidCodeException(formattedContent, diagnostics) :> exn)
 
     {
         Formatted = List.ofSeq formatted |> List.sort
@@ -163,6 +164,33 @@ let summaryLine (theme: Theme) (counts: (int * string) list) : string =
 
     line.Append('.').ToString()
 
+/// Render `error` as the report it writes for itself, when it is one of the failures that has more
+/// to say than a single line stating that it happened. A parse failure and an invariant violation
+/// both draw a caret under the thing they are about; output Fantomas would not accept has no
+/// position to give but still has more to say than one line holds. Anything else comes back as
+/// `None`, for the caller to reduce to a line of its own wording.
+///
+/// Asked in one place because both commands ask it. They had a copy of this each, and the copies
+/// drifted the moment a third failure was given a report of its own: a check run printed the whole
+/// explanation after `could not be checked:` while a format run printed the block.
+///
+/// `source` yields the text the failure came from and is called only by the two that draw a caret,
+/// so a caller that has to read a file to produce it does not read one for a failure with nothing
+/// to point at.
+let describeItself (theme: Theme) (file: string) (source: unit -> string) (verbose: bool) (error: exn) : string option =
+    match Diagnostics.describeParseFailure theme file source error with
+    | Some report -> Some report
+    | None ->
+
+    match Diagnostics.describeInvariantViolation theme file source verbose error with
+    | Some report -> Some report
+    | None ->
+
+    match error with
+    | :? InvalidCodeException as invalid ->
+        Some(Diagnostics.renderInvalidOutput theme file invalid.FormattedContent invalid.Diagnostics)
+    | _ -> None
+
 let reportError (env: CliEnvironment) (verbosity: VerbosityLevel) (file: string, error: exn) : unit =
     let glyphs: StatusGlyphs = statusGlyphs env.ErrorTheme
 
@@ -182,15 +210,9 @@ let reportError (env: CliEnvironment) (verbosity: VerbosityLevel) (file: string,
     let source () : string = sourceOf env.FileSystem file
     let verbose: bool = verbosity = VerbosityLevel.Detailed
 
-    // A parse failure and an invariant violation both describe themselves, positions and all,
-    // rather than being reduced to a single line saying only that they happened. The first line of
-    // each is its header, so the glyph goes in front of the whole block and lands in the column
-    // every other state puts it in.
-    match Diagnostics.describeParseFailure env.ErrorTheme file source error with
-    | Some report -> env.Log.Error(String.Concat(glyphs.Errored, " ", report))
-    | None ->
-
-    match Diagnostics.describeInvariantViolation env.ErrorTheme file source verbose error with
+    // The first line of a report that describes itself is its header, so the glyph goes in front of
+    // the whole block and lands in the column every other state puts it in.
+    match describeItself env.ErrorTheme file source verbose error with
     | Some report -> env.Log.Error(String.Concat(glyphs.Errored, " ", report))
     | None ->
         env.Log.Error(describeOther ())
@@ -232,8 +254,8 @@ let reportSingleResult
     | FormatResult.Error(f, e) -> reportError env settings.Verbosity (f, e)
     | FormatResult.Formatted(f, _) -> env.Log.Information(fileLine theme glyphs.Formatted f formatted)
     | FormatResult.Unchanged f -> env.Log.Information(fileLine theme glyphs.Unchanged f unchanged)
-    | FormatResult.InvalidCode(f, _) ->
-        let ex: FormatException = invalidResultException ()
+    | FormatResult.InvalidCode(f, formattedContent, diagnostics) ->
+        let ex: InvalidCodeException = InvalidCodeException(formattedContent, diagnostics)
         reportError env settings.Verbosity (f, ex)
 
 let reportFormatResults
@@ -441,11 +463,7 @@ let reportCheckResults
     for filename, exn in List.sortBy fst checkResult.Errors do
         let source () : string = sourceOf env.FileSystem filename
 
-        match Diagnostics.describeParseFailure env.ErrorTheme filename source exn with
-        | Some report -> env.Log.Error(String.Concat(errorGlyphs.Errored, " ", report))
-        | None ->
-
-        match Diagnostics.describeInvariantViolation env.ErrorTheme filename source false exn with
+        match describeItself env.ErrorTheme filename source false exn with
         | Some report -> env.Log.Error(String.Concat(errorGlyphs.Errored, " ", report))
         | None ->
             // The message rather than `exn.ToString()`, which carried a stack trace through


### PR DESCRIPTION
`Fantomas produced code that is not valid F#.` left a reader with nothing to act on. It read as though their file were at fault, where reaching that branch always means the opposite: the input parsed, or a parse failure would have been reported instead. It did not say the file had been left untouched, which is the first thing somebody wants to know after reading that formatting produced something invalid. And finding out what was actually wrong meant running again with --force, overwriting the file with code Fantomas believes is broken, and reading output nobody has seen.

The report now says whose fault it is and that nothing was written, then carries what the parser said about the rejected output and the lines around it with a caret under the failure. That is the reproduction the old wording asked the reader to go and make for themselves.

Showing it needs the diagnostics the validation threw away, so CodeFormatter.IsValidFSharpCodeAsync becomes ValidateFSharpCodeAsync and answers with a ValidationResult carrying IsValid and Diagnostics. The boolean already froze which warnings count as invalidating, so handing back the ones that produced the same answer commits to nothing that answer did not. Replacing it rather than adding a sibling leaves one member answering the question, which is how two of them would have drifted.

<img width="1425" height="391" alt="image" src="https://github.com/user-attachments/assets/fbb6590f-acc0-4c66-9dd3-679b07b3e1fc" />
