### PR TITLE
Keep a return attribute written in front of an extern binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [8.0.0-alpha-017] - 2026-08-25
 
 ### Added
 
@@ -15,6 +15,10 @@
 - Breaking: that report carries what the parser said about the rejected output, and the lines of the output around it with a caret under the failure, so there is a small reproduction to cut from it. Up to now the run said only that something was invalid, and finding out what meant running again with `--force` and reading the result. The diagnostics carry no line and column of their own: the output they would count into is written nowhere, so a position in it is a coordinate you cannot follow, and a path an editor could open would take you to the wrong line of the right file. The carets say where, and the report says out loud that the lines below it are the output rather than your file. `--json` carries the same diagnostics in the `diagnostics` array a parse failure already uses. `fantomas check` reports all of it the same way, where it used to run the whole explanation on after `could not be checked:`. [#3419](https://github.com/fsprojects/fantomas/pull/3419)
 - The two reports that ask you to file a bug, for output Fantomas would not accept and for a construct it cannot model, name one place to send it rather than two. They used to add the issue tracker as an alternative for a file too large for the online tool to carry, which offered a choice at the point somebody least wants one. [#3419](https://github.com/fsprojects/fantomas/pull/3419)
 - Breaking: `Fantomas.Core.CodeFormatter.IsValidFSharpCodeAsync` became `ValidateFSharpCodeAsync` and answers with a `ValidationResult` rather than a `bool`. Read `.IsValid` off it where the verdict was all you wanted; `.Diagnostics` is what Fantomas refused, positioned, and is empty exactly when the source is valid. The boolean discarded it, so anything that had to say why had to parse the source a second time to find out, which is why the tool could not show you its own bad output. A warning Fantomas tolerates, such as [#3396](https://github.com/fsprojects/fantomas/issues/3396) on IWSAM types, is not among them. [#3419](https://github.com/fsprojects/fantomas/pull/3419)
+
+### Fixed
+
+- A `[<return: ...>]` attribute written in front of an `extern` declaration was dropped from the output. The parser moves such an attribute out of the binding's attribute list and into its arity information, and the `extern` path never looked there, so the line was silently deleted. Bindings already put those attributes back; `extern` now does the same. An attribute written on the return type itself, `extern [<MarshalAs(UnmanagedType.I1)>] bool f(int options)`, is reported in both places and stays where it was written. [#3420](https://github.com/fsprojects/fantomas/issues/3420)
 
 ## [8.0.0-alpha-016] - 2026-08-25
 

--- a/build.fsx
+++ b/build.fsx
@@ -55,14 +55,26 @@ let isDryRun =
     let args = fsi.CommandLineArgs
     Array.exists (fun arg -> arg = "--dry-run") args
 
+/// `--json` when a hosted runner is what is reading the output, and nothing when a person is.
+///
+/// GitHub Actions sets `CI` to `true`, and so does nearly every other hosted runner; nothing sets
+/// it on a development machine. The value itself is not worth matching on, only whether it is
+/// there, because no two runners agree on what to put in it.
+let jsonFlagDuringCI: string =
+    if String.IsNullOrEmpty(Environment.GetEnvironmentVariable "CI") then
+        String.Empty
+    else
+        "--json"
+
 pipeline "Build" {
     workingDir __SOURCE_DIRECTORY__
     stage "RestoreTools" { run "dotnet tool restore" }
     stage "Clean" { run (cleanFolders [| analysisReportsDir; artifactsDir |]) }
-    stage "CheckFormat" { run "dotnet fantomas src analyzers docs scripts build.fsx --check --json" }
+    stage "CheckFormat" { run $"dotnet fantomas check src analyzers docs scripts build.fsx {jsonFlagDuringCI}" }
     stage "BuildDebug" { run $"dotnet build \"{scriptProject}\" --tl" }
     stage "CheckScripts" { run checkScripts }
     stage "Build" { run "dotnet build -c Release --tl" }
+    stage "CheckDocScripts" { run checkDocScripts }
     stage "UnitTests" { run "dotnet test -c Release --tl" }
     stage "Pack" { run "dotnet pack --no-restore -c Release --tl" }
     stage "Docs" {

--- a/build.fsx
+++ b/build.fsx
@@ -10,6 +10,7 @@
 // above it to be in scope and does not load them itself. Loading a file twice would compile it
 // twice, and two copies of a type are two different types, so the order lives here and nowhere else.
 #load "scripts/BuildCommon.fsx"
+#load "scripts/BuildScripts.fsx"
 #load "scripts/BuildAnalyzers.fsx"
 #load "scripts/BuildRelease.fsx"
 #load "scripts/BuildCompiler.fsx"
@@ -19,6 +20,7 @@ open System.IO
 open Fun.Build
 open CliWrap
 open BuildCommon
+open BuildScripts
 open BuildAnalyzers
 open BuildRelease
 open BuildCompiler
@@ -58,6 +60,8 @@ pipeline "Build" {
     stage "RestoreTools" { run "dotnet tool restore" }
     stage "Clean" { run (cleanFolders [| analysisReportsDir; artifactsDir |]) }
     stage "CheckFormat" { run "dotnet fantomas src analyzers docs scripts build.fsx --check --json" }
+    stage "BuildDebug" { run $"dotnet build \"{scriptProject}\" --tl" }
+    stage "CheckScripts" { run checkScripts }
     stage "Build" { run "dotnet build -c Release --tl" }
     stage "UnitTests" { run "dotnet test -c Release --tl" }
     stage "Pack" { run "dotnet pack --no-restore -c Release --tl" }

--- a/docs/docs/end-users/Configuration.fsx
+++ b/docs/docs/end-users/Configuration.fsx
@@ -23,6 +23,7 @@ UI might be available depending on the IDE.
 #r "../../../artifacts/bin/Fantomas.FCS/release/Fantomas.FCS.dll"
 #r "../../../artifacts/bin/Fantomas.Core/release/Fantomas.Core.dll"
 #r "../../../artifacts/bin/Fantomas/release/EditorConfig.Core.dll"
+#load "../../../src/Fantomas/Suggestion.fs"
 #load "../../../src/Fantomas/EditorConfig.fs"
 
 open System

--- a/docs/docs/end-users/Recipes.fsx
+++ b/docs/docs/end-users/Recipes.fsx
@@ -22,6 +22,7 @@ Sometimes, it makes sense to tweak a few setting for a subset of your codebase.
 #r "../../../artifacts/bin/Fantomas.FCS/release/Fantomas.FCS.dll"
 #r "../../../artifacts/bin/Fantomas.Core/release/Fantomas.Core.dll"
 #r "../../../artifacts/bin/Fantomas/release/EditorConfig.Core.dll"
+#load "../../../src/Fantomas/Suggestion.fs"
 #load "../../../src/Fantomas/EditorConfig.fs"
 
 open System

--- a/scripts/BuildScripts.fsx
+++ b/scripts/BuildScripts.fsx
@@ -1,0 +1,105 @@
+#r "nuget: CliWrap, 3.6.4"
+
+open System.IO
+open System.Text.RegularExpressions
+open CliWrap
+open CliWrap.Buffered
+// Loaded by `build.fsx`, after `BuildCommon.fsx`. An error here saying BuildCommon is not defined
+// means this file was run on its own; it is a library, so run a pipeline from build.fsx instead.
+open BuildCommon
+
+// Compiling this repository's own scripts without running them.
+//
+// Nothing else in the build looks at them, so a rename in `src/` that one of them refers to breaks
+// it silently: the script keeps sitting there and fails the next time somebody reaches for it,
+// which is usually in the middle of something else.
+
+/// The project the diagnostic scripts are compiled against.
+///
+/// Anchored at `repositoryRoot` rather than written relative, so it names the same project whatever
+/// the working directory of the run is.
+///
+/// `shared.fsx` references the debug build of Fantomas.Core, and Fantomas.Core references
+/// Fantomas.FCS, so building this one project puts both assemblies where the scripts look for them.
+/// The CLI and the test projects are no part of what a script loads and are not built for this.
+///
+/// It is the debug build they reference, and that is not a detail to tidy away into the release
+/// build the rest of the pipeline makes: these scripts are for prototyping against a local
+/// Fantomas, which is something you want to be able to step through.
+let scriptProject: string =
+    repositoryRoot </> "src" </> "Fantomas.Core" </> "Fantomas.Core.fsproj"
+
+/// Every `.fsx` in the repository that is meant to be run directly: `build.fsx` and the diagnostic
+/// scripts beside this file.
+///
+/// A script that another script `#load`s is left out, because it is already compiled as part of
+/// whatever loads it. Several of them cannot be compiled alone at all, by design: this file and its
+/// neighbours expect `BuildCommon.fsx` to be in scope, which is only true when `build.fsx` did the
+/// loading. Reading the `#load` lines rather than listing those exceptions means a script added
+/// later is checked without anything here having to be edited.
+let runnableScripts () : string list =
+    let scripts: string list =
+        [
+            repositoryRoot </> "build.fsx"
+            yield! Directory.EnumerateFiles(repositoryRoot </> "scripts", "*.fsx")
+        ]
+
+    let loadDirective: Regex = Regex("^\\s*#load\\s+\"([^\"]+)\"")
+
+    let loaded: Set<string> =
+        scripts
+        |> Seq.collect (fun (script: string) ->
+            let folder: string = Path.GetDirectoryName script
+
+            File.ReadLines script
+            |> Seq.choose (fun (line: string) ->
+                let matched: Match = loadDirective.Match line
+
+                if matched.Success then
+                    Some(Path.GetFullPath(folder </> matched.Groups[1].Value))
+                else
+                    None))
+        |> Set.ofSeq
+
+    scripts
+    |> List.filter (fun (script: string) -> not (loaded.Contains(Path.GetFullPath script)))
+
+/// Compile one script and stop short of running it, reporting whatever the compiler said.
+let private typecheckScript (script: string) : Async<string * int * string> =
+    async {
+        let! result =
+            Cli
+                .Wrap("dotnet")
+                .WithArguments($"fsi --typecheck-only --nologo \"{script}\"")
+                .WithWorkingDirectory(repositoryRoot)
+                .WithValidation(CommandResultValidation.None)
+                .ExecuteBufferedAsync()
+                .Task
+            |> Async.AwaitTask
+
+        return script, result.ExitCode, (result.StandardOutput + result.StandardError).Trim()
+    }
+
+/// Compile every script that is meant to be run directly, and report what the compiler said about
+/// any that would not compile. Writes nothing: no script is run, and the assemblies they reference
+/// are built by the stage before this one.
+let checkScripts _ : Async<int> =
+    async {
+        // One at a time: the compiler output of a script that fails is the point of this, and
+        // running them together interleaves it beyond reading.
+        let! results = runnableScripts () |> List.map typecheckScript |> Async.Sequential
+
+        for (script: string), (exitCode: int), (output: string) in results do
+            let name: string = Path.GetRelativePath(repositoryRoot, script)
+
+            if exitCode = 0 then
+                printfn "%s compiles." name
+            else
+                printfn "%s does not compile:" name
+                printfn "%s" output
+
+        let failed: int =
+            results |> Array.filter (fun (_, exitCode, _) -> exitCode <> 0) |> Array.length
+
+        return (if failed = 0 then 0 else 1)
+    }

--- a/scripts/BuildScripts.fsx
+++ b/scripts/BuildScripts.fsx
@@ -12,7 +12,12 @@ open BuildCommon
 //
 // Nothing else in the build looks at them, so a rename in `src/` that one of them refers to breaks
 // it silently: the script keeps sitting there and fails the next time somebody reaches for it,
-// which is usually in the middle of something else.
+// which is usually in the middle of something else. The documentation scripts have exactly that
+// problem too, and both of the ones that `#load` a file out of `src/` were broken this way.
+//
+// They fall into two groups, and the difference is which build they reference: the scripts beside
+// this file take the debug build, the documentation takes the release one. That is why there are
+// two entry points here rather than one, run from two different points of the pipeline.
 
 /// The project the diagnostic scripts are compiled against.
 ///
@@ -29,21 +34,14 @@ open BuildCommon
 let scriptProject: string =
     repositoryRoot </> "src" </> "Fantomas.Core" </> "Fantomas.Core.fsproj"
 
-/// Every `.fsx` in the repository that is meant to be run directly: `build.fsx` and the diagnostic
-/// scripts beside this file.
+/// Of the given scripts, the ones that are meant to be run directly.
 ///
-/// A script that another script `#load`s is left out, because it is already compiled as part of
-/// whatever loads it. Several of them cannot be compiled alone at all, by design: this file and its
+/// A script that another of them `#load`s is left out, because it is already compiled as part of
+/// whatever loads it. Several cannot be compiled alone at all, by design: this file and its
 /// neighbours expect `BuildCommon.fsx` to be in scope, which is only true when `build.fsx` did the
 /// loading. Reading the `#load` lines rather than listing those exceptions means a script added
 /// later is checked without anything here having to be edited.
-let runnableScripts () : string list =
-    let scripts: string list =
-        [
-            repositoryRoot </> "build.fsx"
-            yield! Directory.EnumerateFiles(repositoryRoot </> "scripts", "*.fsx")
-        ]
-
+let private runnableIn (scripts: string list) : string list =
     let loadDirective: Regex = Regex("^\\s*#load\\s+\"([^\"]+)\"")
 
     let loaded: Set<string> =
@@ -64,6 +62,21 @@ let runnableScripts () : string list =
     scripts
     |> List.filter (fun (script: string) -> not (loaded.Contains(Path.GetFullPath script)))
 
+/// `build.fsx` and the diagnostic scripts beside this file, which reference the debug build.
+let runnableScripts () : string list =
+    [
+        repositoryRoot </> "build.fsx"
+        yield! Directory.EnumerateFiles(repositoryRoot </> "scripts", "*.fsx")
+    ]
+    |> runnableIn
+
+/// The documentation scripts, which fsdocs turns into the pages of the site. They reference the
+/// release build, so they can only be compiled once the pipeline has made one.
+let runnableDocScripts () : string list =
+    Directory.EnumerateFiles(repositoryRoot </> "docs", "*.fsx", SearchOption.AllDirectories)
+    |> List.ofSeq
+    |> runnableIn
+
 /// Compile one script and stop short of running it, reporting whatever the compiler said.
 let private typecheckScript (script: string) : Async<string * int * string> =
     async {
@@ -80,14 +93,14 @@ let private typecheckScript (script: string) : Async<string * int * string> =
         return script, result.ExitCode, (result.StandardOutput + result.StandardError).Trim()
     }
 
-/// Compile every script that is meant to be run directly, and report what the compiler said about
-/// any that would not compile. Writes nothing: no script is run, and the assemblies they reference
-/// are built by the stage before this one.
-let checkScripts _ : Async<int> =
+/// Compile each of the given scripts, and report what the compiler said about any that would not
+/// compile. Writes nothing: no script is run, and the assemblies they reference are built by the
+/// stage before whichever one calls this.
+let private check (scripts: string list) : Async<int> =
     async {
         // One at a time: the compiler output of a script that fails is the point of this, and
         // running them together interleaves it beyond reading.
-        let! results = runnableScripts () |> List.map typecheckScript |> Async.Sequential
+        let! results = scripts |> List.map typecheckScript |> Async.Sequential
 
         for (script: string), (exitCode: int), (output: string) in results do
             let name: string = Path.GetRelativePath(repositoryRoot, script)
@@ -103,3 +116,9 @@ let checkScripts _ : Async<int> =
 
         return (if failed = 0 then 0 else 1)
     }
+
+/// Compile `build.fsx` and the diagnostic scripts. Needs the debug build.
+let checkScripts _ : Async<int> = check (runnableScripts ())
+
+/// Compile the documentation scripts. Needs the release build.
+let checkDocScripts _ : Async<int> = check (runnableDocScripts ())

--- a/scripts/shared.fsx
+++ b/scripts/shared.fsx
@@ -2,6 +2,7 @@
 #r "../artifacts/bin/Fantomas.Core/debug/Fantomas.Core.dll"
 #r "nuget: editorconfig"
 
+#load "../src/Fantomas/Suggestion.fs"
 #load "../src/Fantomas/EditorConfig.fs"
 
 open System.IO
@@ -17,7 +18,9 @@ let parseEditorConfigContent (content: string) : FormatConfig =
     File.WriteAllText(fsharpFile, "")
 
     try
-        readConfiguration fsharpFile
+        match tryReadConfiguration fsharpFile with
+        | Some result -> result.Config
+        | None -> FormatConfig.Default
     finally
         Directory.Delete(tempDir, true)
 

--- a/src/Fantomas.Core.Tests/ExternTests.fs
+++ b/src/Fantomas.Core.Tests/ExternTests.fs
@@ -327,3 +327,113 @@ extern byte[] private f(int options)
 [<DllImport("x")>]
 extern byte[] private f(int options)
 """
+
+[<Test>]
+let ``return attribute in front of an extern binding, 3420`` () =
+    formatSourceString
+        """
+module Native =
+
+    /// <summary>Whether the parser had to guess anywhere inside this node.</summary>
+    [<DllImport(core)>]
+    [<return: MarshalAs(UnmanagedType.I1)>]
+    extern bool ts_node_has_error(TSNode node)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module Native =
+
+    /// <summary>Whether the parser had to guess anywhere inside this node.</summary>
+    [<DllImport(core)>]
+    [<return: MarshalAs(UnmanagedType.I1)>]
+    extern bool ts_node_has_error(TSNode node)
+"""
+
+[<Test>]
+let ``return attribute written in the same list as another attribute`` () =
+    formatSourceString
+        """
+[<DllImport(core); return: MarshalAs(UnmanagedType.I1)>]
+extern bool ts_node_has_error(TSNode node)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<DllImport(core); return: MarshalAs(UnmanagedType.I1)>]
+extern bool ts_node_has_error(TSNode node)
+"""
+
+[<Test>]
+let ``return attribute is the only attribute of an extern binding`` () =
+    formatSourceString
+        """
+[<return: MarshalAs(UnmanagedType.I1)>]
+extern bool ts_node_has_error(TSNode node)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<return: MarshalAs(UnmanagedType.I1)>]
+extern bool ts_node_has_error(TSNode node)
+"""
+
+[<Test>]
+let ``return attribute written before the other attributes of an extern binding`` () =
+    formatSourceString
+        """
+[<return: MarshalAs(UnmanagedType.I1)>]
+[<DllImport(core)>]
+extern bool ts_node_has_error(TSNode node)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<return: MarshalAs(UnmanagedType.I1)>]
+[<DllImport(core)>]
+extern bool ts_node_has_error(TSNode node)
+"""
+
+[<Test>]
+let ``return attribute in front of an extern member`` () =
+    formatSourceString
+        """
+type Native =
+    [<DllImport(core)>]
+    [<return: MarshalAs(UnmanagedType.I1)>]
+    extern bool ts_node_has_error(TSNode node)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Native =
+    [<DllImport(core)>]
+    [<return: MarshalAs(UnmanagedType.I1)>]
+    extern bool ts_node_has_error(TSNode node)
+"""
+
+[<Test>]
+let ``attribute on the return type of an extern binding stays on the type`` () =
+    formatSourceString
+        """
+[<DllImport(core)>]
+extern [<MarshalAs(UnmanagedType.I1)>] bool ts_node_has_error(TSNode node)
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[<DllImport(core)>]
+extern [<MarshalAs(UnmanagedType.I1)>] bool ts_node_has_error(TSNode node)
+"""

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -2380,12 +2380,16 @@ let mkExternBinding
         accessibility = accessibility
         attributes = attributes
         xmlDoc = xmlDoc
+        valData = valData
         headPat = pat
         returnInfo = returnInfo
         range = range
         trivia = trivia))
     : ExternBindingNode
     =
+    let attributes: SynAttributes =
+        restoreRotatedReturnAttributes attributes valData returnInfo
+
     let m =
         if not xmlDoc.IsEmpty then
             unionRanges xmlDoc.Range pat.Range


### PR DESCRIPTION
The parser moves a `[<return: ...>]` attribute out of the binding's attribute list and into its arity information, where nothing prints it. `mkExternBinding` never looked there, so such an attribute was parsed and then written nowhere: formatting silently deleted the line.

`mkBinding` has restored those attributes since the parser started rotating them; `mkExternBinding` now calls the same function, before it works out its own range, so a return attribute written above the other attributes of the declaration is covered by that range.

An attribute written on the return type itself, `extern [<MarshalAs(UnmanagedType.I1)>] bool f(int options)`, is reported both in the arity information and in the return info, and the extern printer already emits the latter. The range filter in the restore keeps that one where it was written instead of printing it a second time.

Fixes #3420
