### PR TITLE
Recognise more expression forms as open-ended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `doctor` names the `.fantomasignore` above the one that governs a file, when a pattern in it would have skipped that file. Fantomas reads the nearest ignore file at or above a file and no other, so a pattern written at the root of a repository has no effect on a folder that has an ignore file of its own beside it. Up to now the report named the ignore file that did decide and said nothing about the one that did not, which answers "which file" and leaves "then why did mine not" for the reader to work out. It quotes the pattern that would have matched, with its line number, the way it already quotes the line that decided. `--json` carries every ignore file above the governing one under `shadowed`, each with `wouldIgnore` and the lines of it that match, whether or not it would have decided anything. [#3423](https://github.com/fsprojects/fantomas/pull/3423)
 
+### Fixed
+
+- More expression forms count as open-ended, so a record, list, array or tuple that holds one of them in a non-last position stays multiline instead of collapsing onto a line that means something else. [#3279](https://github.com/fsprojects/fantomas/issues/3279) settled `fun`, `if`, `match` and `try`, and left the forms that wrap one of those or end in one: `lazy`, `yield`, `return`, `do`, `assert` and `fixed`, an assignment such as `x.P <- fun y -> y`, and `let x = 1 in body`. `{ A = 1; B = lazy fun x -> x; C = 3 }` reads back as a lambda that swallowed `C = 3`. A wrapper around something that closes on its own, `lazy a` or `x.P <- 1`, collapses as it always did. When this happens, why, and how to get the single line back is written up under [Open-ended expressions](https://fsprojects.github.io/fantomas/docs/end-users/OpenEndedExpressions.html). [#3424](https://github.com/fsprojects/fantomas/pull/3424)
+
 ## [8.0.0-alpha-017] - 2026-08-25
 
 ### Added

--- a/docs/docs/end-users/ConditionalCompilationDirectives.md
+++ b/docs/docs/end-users/ConditionalCompilationDirectives.md
@@ -1,7 +1,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 13
+index: 14
 ---
 # Conditional Compilation Directives
 

--- a/docs/docs/end-users/Configuration.fsx
+++ b/docs/docs/end-users/Configuration.fsx
@@ -2,7 +2,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 3
+index: 4
 ---
 *)
 

--- a/docs/docs/end-users/FantomasClient.md
+++ b/docs/docs/end-users/FantomasClient.md
@@ -1,7 +1,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 14
+index: 15
 ---
 # Formatting from an editor with Fantomas.Client
 

--- a/docs/docs/end-users/FormattingCheck.md
+++ b/docs/docs/end-users/FormattingCheck.md
@@ -1,7 +1,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 5
+index: 6
 ---
 
 # Formatting Check

--- a/docs/docs/end-users/GeneratingCode.fsx
+++ b/docs/docs/end-users/GeneratingCode.fsx
@@ -2,7 +2,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 10
+index: 11
 ---
 *)
 (**

--- a/docs/docs/end-users/GitHooks.md
+++ b/docs/docs/end-users/GitHooks.md
@@ -1,7 +1,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 6
+index: 7
 ---
 # Git hooks
 ## A git pre-commit hook sample

--- a/docs/docs/end-users/IgnoreFiles.md
+++ b/docs/docs/end-users/IgnoreFiles.md
@@ -1,7 +1,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 4
+index: 5
 ---
 # Ignore Files 
 

--- a/docs/docs/end-users/OpenEndedExpressions.md
+++ b/docs/docs/end-users/OpenEndedExpressions.md
@@ -1,0 +1,122 @@
+---
+category: End-users
+categoryindex: 1
+index: 3
+---
+# Open-ended expressions
+
+Sometimes Fantomas leaves a short record, list or tuple spread over several lines when it would
+comfortably fit on one. This page explains when that happens and why, because it is deliberate
+rather than a missed opportunity.
+
+## The symptom
+
+This record is well under the width Fantomas would collapse at, and it stays as it is:
+
+```fsharp
+let r =
+    {
+        A = 1
+        B = fun x -> x + 1
+        C = 3
+    }
+```
+
+Take the lambda out and the same record goes to one line:
+
+```fsharp
+let r = { A = 1; B = 2; C = 3 }
+```
+
+## Why
+
+In F#, `fun` extends as far to the right as it can. That is a rule of the language, not a
+formatting preference. Written on one line, the record above says something else entirely:
+
+```fsharp
+let r = { A = 1; B = fun x -> x + 1; C = 3 }
+```
+
+The compiler reads that as a record with **two** fields, not three, because everything after
+the arrow belongs to the lambda:
+
+```fsharp
+let r = { A = 1; B = fun x -> (x + 1; C = 3) }
+```
+
+The `;` that Fantomas would write to separate the fields becomes a sequential expression inside
+the lambda body instead.
+
+[Fantomas re-types your entire source](https://fsprojects.github.io/fantomas/docs/end-users/StyleGuide.html#How-Fantomas-formats-code) rather than
+adjusting whitespace in place, so it carries the responsibility that what it prints means what
+you wrote. Collapsing here would break that, so it does not collapse.
+
+## Where it applies
+
+An expression is *open-ended* when it has no closing token and so runs on to the right. The
+common ones are `fun`, `if ... then ... else`, `match`, `function` and `try`, along with
+anything that wraps one of them, such as `lazy`, `yield` or an assignment.
+
+Fantomas keeps the layout multiline when an open-ended expression sits anywhere but **last** in
+a record, an anonymous record, a list, an array or a tuple, or on the **left** of an infix
+operator:
+
+```fsharp
+let xs =
+    [
+        1, fun () -> 1
+        2, fun () -> 2
+    ]
+
+let a =
+    fun x -> x + 1
+    |> g
+```
+
+The last position is fine as it is, because the closing bracket ends the expression and there is
+nothing left for it to swallow:
+
+```fsharp
+let r = { A = 1; C = 3; B = fun x -> x + 1 }
+```
+
+What counts is whether the expression really does run on. `lazy` around a lambda does, `lazy`
+around a plain value does not, so only the first of these stays multiline:
+
+```fsharp
+let xs =
+    [
+        lazy fun x -> x
+        2
+    ]
+
+let ys = [ lazy a; 2 ]
+```
+
+## Getting the single line back
+
+Put the parentheses in yourself. They close the expression, so nothing can run past them and
+Fantomas is free to collapse:
+
+```fsharp
+let r = { A = 1; B = (fun x -> x + 1); C = 3 }
+
+let xs = [ 1, (fun () -> 1); 2, (fun () -> 2) ]
+```
+
+This is a change to your code rather than to your formatting, which is exactly why Fantomas
+leaves it to you.
+
+## Why not add the parentheses for you
+
+That was the other option, and it was put to the community as
+[RFC #3279](https://github.com/fsprojects/fantomas/issues/3279). Both options produce
+deterministic output; the question was only which one. The vote went 23 to 3 in favour of
+staying multiline, on the grounds that a formatter should not introduce syntax that was not in
+the source, and Fantomas has behaved this way since `v8.0.0-alpha-008`.
+
+Note that neither option is about preserving what you wrote. Written on one line to begin with,
+the parenthesised record above stays on one line; written across several, it is collapsed onto
+one. What decides the layout is the expression, never the way you happened to type it.
+
+<fantomas-nav previous="{{fsdocs-previous-page-link}}" next="{{fsdocs-next-page-link}}"></fantomas-nav>

--- a/docs/docs/end-users/Recipes.fsx
+++ b/docs/docs/end-users/Recipes.fsx
@@ -2,7 +2,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 12
+index: 13
 ---
 # Recipes
 

--- a/docs/docs/end-users/Rider.md
+++ b/docs/docs/end-users/Rider.md
@@ -1,7 +1,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 7
+index: 8
 ---
 # JetBrains Rider
 The resharper-fsharp uses Fantomas under the hood to format the source code. No need for any additional plugins.  

--- a/docs/docs/end-users/StyleGuide.md
+++ b/docs/docs/end-users/StyleGuide.md
@@ -17,6 +17,8 @@ The benefit of these guides is that this allows us, as the F# community, to writ
 Fantomas rewrites the entire source text after formatting. Think of it like a word document: Fantomas will re-type your entire text according to its rules in a new file.  
 It does not modify the original text. This approach ensures complete consistency and adherence to the formatting rules, but it means that all formatting decisions are made by Fantomas according to its opinionated style guide.
 
+Because the output has to mean what the input meant, Fantomas will sometimes keep code multiline that would otherwise fit on a single line. See [open-ended expressions](https://fsprojects.github.io/fantomas/docs/end-users/OpenEndedExpressions.html).
+
 ## Let it go
 
 If you are not used to having a code formatter, you might struggle a bit at first. A part of using a code formatter is about letting go how you wrote things and accept a common consistent style instead.  

--- a/docs/docs/end-users/UpgradeGuide.md
+++ b/docs/docs/end-users/UpgradeGuide.md
@@ -1,7 +1,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 11
+index: 12
 ---
 # Upgrade guide
 

--- a/docs/docs/end-users/VSCode.md
+++ b/docs/docs/end-users/VSCode.md
@@ -1,7 +1,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 9
+index: 10
 ---
 # Visual Studio Code
 The recommended way to use Fantomas in Visual Studio Code is by using the [Ionide plugin](http://ionide.io/). Fantomas is integrated in [FSAutoComplete](https://github.com/fsharp/FsAutoComplete/) which is the language server used by Ionide.  

--- a/docs/docs/end-users/VisualStudio.md
+++ b/docs/docs/end-users/VisualStudio.md
@@ -1,7 +1,7 @@
 ---
 category: End-users
 categoryindex: 1
-index: 8
+index: 9
 ---
 # Visual Studio
 The F# Formatting extension sets up Fantomas as the default formatter for F# files, configurable from Visual Studio's options.  

--- a/src/Fantomas.Core.Tests/RequiresMultilineToPreserveSemanticsTests.fs
+++ b/src/Fantomas.Core.Tests/RequiresMultilineToPreserveSemanticsTests.fs
@@ -368,6 +368,259 @@ let ``nested open-ended in non-last record field stays multiline`` () =
 }
 """
 
+// Open-ended expression forms
+
+[<Test>]
+let ``let-in in non-last record field stays multiline`` () =
+    formatSourceString
+        """
+{ A = 1
+  B = let y = 1 in y
+  C = 3 }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+{
+    A = 1
+    B = let y = 1 in y
+    C = 3
+}
+"""
+
+[<Test>]
+let ``let-in in non-last anonymous record field stays multiline`` () =
+    formatSourceString
+        """
+{| A = 1
+   B = let y = 1 in y
+   C = 3 |}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+{|
+    A = 1
+    B = let y = 1 in y
+    C = 3
+|}
+"""
+
+[<Test>]
+let ``lazy wrapping a lambda as non-last list element stays multiline`` () =
+    formatSourceString
+        """
+[
+    lazy fun x -> x
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[
+    lazy fun x -> x
+    2
+]
+"""
+
+[<Test>]
+let ``lazy wrapping a plain expression as non-last list element stays on one line`` () =
+    formatSourceString
+        """
+[
+    lazy a
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[ lazy a; 2 ]
+"""
+
+[<Test>]
+let ``yield wrapping a lambda as non-last list element stays multiline`` () =
+    formatSourceString
+        """
+[
+    yield fun x -> x
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[
+    yield fun x -> x
+    2
+]
+"""
+
+[<Test>]
+let ``assert wrapping a lambda as non-last list element stays multiline`` () =
+    formatSourceString
+        """
+[
+    assert fun x -> x
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[
+    assert fun x -> x
+    2
+]
+"""
+
+[<Test>]
+let ``property assignment of a lambda as non-last list element stays multiline`` () =
+    formatSourceString
+        """
+[
+    x.P <- fun y -> y
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[
+    x.P <- fun y -> y
+    2
+]
+"""
+
+[<Test>]
+let ``property assignment of a plain expression as non-last list element stays on one line`` () =
+    formatSourceString
+        """
+[
+    x.P <- 1
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[ x.P <- 1; 2 ]
+"""
+
+[<Test>]
+let ``indexed assignment of a lambda as non-last list element stays multiline`` () =
+    formatSourceString
+        """
+[
+    a.[0] <- fun y -> y
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[
+    a.[0] <- fun y -> y
+    2
+]
+"""
+
+[<Test>]
+let ``indexed assignment of a plain expression as non-last list element stays on one line`` () =
+    formatSourceString
+        """
+[
+    a.[0] <- 1
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[ a.[0] <- 1; 2 ]
+"""
+
+[<Test>]
+let ``dynamic assignment of a lambda as non-last list element stays multiline`` () =
+    formatSourceString
+        """
+[
+    x?y <- fun z -> z
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[
+    x?y <- fun z -> z
+    2
+]
+"""
+
+[<Test>]
+let ``named indexed property assignment of a lambda as non-last list element stays multiline`` () =
+    formatSourceString
+        """
+[
+    a.Item(0) <- fun y -> y
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[
+    a.Item(0) <- fun y -> y
+    2
+]
+"""
+
+[<Test>]
+let ``dot named indexed property assignment of a lambda as non-last list element stays multiline`` () =
+    formatSourceString
+        """
+[
+    (f x).Item(0) <- fun y -> y
+    2
+]
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+[
+    (f x).Item(0) <- fun y -> y
+    2
+]
+"""
+
 // Regression tests
 
 [<Test>]

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -408,7 +408,7 @@ let (|IsIfThenElse|_|) (e: Expr) =
 
 /// Does this expression end with a construct whose body extends
 /// unboundedly to the right (lambda, if-then-else, tuple, ...)?
-let rec isOpenEndedExpression (e: Expr) =
+let rec isOpenEndedExpression (e: Expr) : bool =
     match e with
     | Expr.Lambda _
     | Expr.IfThen _
@@ -418,7 +418,23 @@ let rec isOpenEndedExpression (e: Expr) =
     | Expr.MatchLambda _
     | Expr.TryWith _
     | Expr.TryWithSingleClause _
-    | Expr.TryFinally _ -> true
+    | Expr.TryFinally _
+    // The body of `let x = 1 in body` is a sequential expression, so anything written
+    // after it joins that body instead of ending it. The same holds for a loop body.
+    | Expr.CompExprBody _
+    | Expr.While _
+    | Expr.For _
+    | Expr.ForEach _ -> true
+    // `lazy`, `yield`, `return`, `assert`, `fixed`, ... only wrap what follows them,
+    // so they end wherever the expression they wrap ends.
+    | Expr.Lazy node -> isOpenEndedExpression node.Expr
+    | Expr.Single node -> isOpenEndedExpression node.Expr
+    // An assignment ends where the value it assigns ends.
+    | Expr.Set node -> isOpenEndedExpression node.Set
+    | Expr.LongIdentSet node -> isOpenEndedExpression node.Expr
+    | Expr.DotIndexedSet node -> isOpenEndedExpression node.Value
+    | Expr.NamedIndexedPropertySet node -> isOpenEndedExpression node.Value
+    | Expr.DotNamedIndexedPropertySet node -> isOpenEndedExpression node.Set
     | Expr.InfixApp node -> isOpenEndedExpression node.RightHandSide
     | Expr.SameInfixApps node ->
         match List.tryLast node.SubsequentExpressions with


### PR DESCRIPTION
`isOpenEndedExpression` decides whether collapsing a record, list, array or
tuple onto a single line would let a non-last item swallow what comes after
it. It knew `fun`, `if`, `match` and `try`, and nothing that wraps one of
those or ends in one, so `{ A = 1; B = lazy fun x -> x; C = 3 }` reads back
as a lambda that took `C = 3` for its body.

`lazy` and the single keyword forms (`yield`, `return`, `do`, `assert`,
`fixed`) now answer for the expression they wrap, and the five assignment
forms answer for the value they assign. Recursing rather than answering yes
outright is what keeps `lazy a` and `x.P <- 1` collapsing as before: it is
the thing being wrapped or assigned that runs on, not the wrapper. The body
of `let x = 1 in body` and the body of a loop are sequential expressions, so
those are open-ended whatever they contain.

Fixes #3279
