### PR TITLE
Stop counting a constant as a name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [8.0.0-alpha-019] - 2026-08-26
+
+### Fixed
+
+- A call on a constant receiver keeps its parenthesis tight, so `"yow".Substring (0, 3)` and `3L.ToString ()` come out as `"yow".Substring(0, 3)` and `3L.ToString()`. `8.0.0-alpha-018` gave a constant receiver a space it was never meant to have. The rule there says a call keeps the space only when the whole thing being called is a plain dotted name, and the comment agreed at [fslang-design#648](https://github.com/fsharp/fslang-design/issues/648) lists `"yow".Substring(0, 3)` under "a receiver that is not a name", beside `(f x)` and `[ 1; 2 ]`. The alpha carved constants back out on the reasoning that a constant is atomic rather than bracketed, which went past what was agreed and was not deliberate. A constant is a value, the rule asks for a name, so it goes tight. A type parameter really is a name, so `'T.set_StaticProperty (3)` is unaffected. [#3426](https://github.com/fsprojects/fantomas/pull/3426)
+
 ## [8.0.0-alpha-018] - 2026-08-26
 
 ### Added

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -112,7 +112,7 @@ Neither setting is about chains as such. Both govern a call with no receiver at 
 
 #### Neither setting applies once the chain is more than a name
 
-**Neither setting can put the space back.** Once a call, an index, a bracketed receiver, or a type application appears anywhere in the chain, the parenthesis is tight and no configuration will change it.
+**Neither setting can put the space back.** Once a call, an index, a receiver that is not a name, or a type application appears anywhere in the chain, the parenthesis is tight and no configuration will change it.
 
 The space survives only when **the whole thing being called is a plain dotted name**.
 
@@ -124,20 +124,19 @@ Every line below calls the same `.Bar`, and the only difference is what else the
 // a plain dotted name, so the setting applies and the space is there
 obj.Bar ()
 a.B.C.Bar ()        // however long the name gets
-"yow".Bar ()        // a literal is atomic, so it counts as a name
-3L.Bar ()           // as does any other constant
 
 // something other than a name is in the way, so no space is available to ask for
 a.Foo(x).Bar(y)     // a call, before the final one
 Foo().Bar(y)        // a call, as the receiver
 arr[0].Bar(y)       // an index, before the final call
-(f x).Bar(y)        // a bracketed receiver
-[ 1; 2 ].Bar(y)     // and brackets of any kind count
+(f x).Bar(y)        // a receiver that is not a name
+[ 1; 2 ].Bar(y)     // brackets of any kind count
+"yow".Bar(y)        // and a constant is a value rather than a name
 X<Y>.Bar(y)         // a type application, before the final call
 a.B.Bar<int>(y)     // a type application, on the final call itself
 ```
 
-A type parameter is atomic in the same way, so `'T.set_StaticProperty (3)` keeps its space too.
+A type parameter is a name like any other, so `'T.set_StaticProperty (3)` keeps its space.
 
 This one is a style decision rather than a grammar requirement. Unlike the tightness of an intermediate call above, nothing here would fail to parse with the space in place. It exists so that a chain does not end up with one surviving space that has no visible reason to be there, and it was agreed at [fslang-design#648](https://github.com/fsharp/fslang-design/issues/648).
 

--- a/docs/docs/end-users/Configuration.fsx
+++ b/docs/docs/end-users/Configuration.fsx
@@ -216,7 +216,7 @@ fsharp_space_before_parameter = false
 Add a space after the name of a lowercased function and before the opening parenthesis of the first argument.
 This setting influences function invocation in expressions and patterns.
 Only the name immediately in front of the parenthesis decides whether this setting or `fsharp_space_before_uppercase_invocation` applies, so `a.B.foo (x)` follows this one and `a.b.Foo(x)` follows the other.
-Neither applies unless the whole thing being called is a plain dotted name: a call, an index, a bracketed receiver, or a type application anywhere in it keeps the parenthesis tight, which leaves `xs.map(f).filter(g)` and `unbox<int>(obj)` untouched by either setting.
+Neither applies unless the whole thing being called is a plain dotted name: a call, an index, a receiver that is not a name, or a type application anywhere in it keeps the parenthesis tight, which leaves `xs.map(f).filter(g)` and `unbox<int>(obj)` untouched by either setting.
 See [Formatting chain expressions](../contributors/Chains.html#The-two-space-settings).
 *)
 
@@ -246,7 +246,7 @@ fsharp_space_before_lowercase_invocation = false
 Add a space after the name of a uppercase function and before the opening parenthesis of the first argument.
 This setting influences function invocation in expressions and patterns.
 Only the name immediately in front of the parenthesis decides whether this setting or `fsharp_space_before_lowercase_invocation` applies, so `a.b.Foo (x)` follows this one and `a.B.foo(x)` follows the other.
-Neither applies unless the whole thing being called is a plain dotted name: a call, an index, a bracketed receiver, or a type application anywhere in it keeps the parenthesis tight, which leaves `a.Foo(x).Bar(y)` and `X<Y>.Foo(x)` untouched by either setting.
+Neither applies unless the whole thing being called is a plain dotted name: a call, an index, a receiver that is not a name, or a type application anywhere in it keeps the parenthesis tight, which leaves `a.Foo(x).Bar(y)` and `X<Y>.Foo(x)` untouched by either setting.
 See [Formatting chain expressions](../contributors/Chains.html#The-two-space-settings).
 *)
 

--- a/docs/docs/end-users/UpgradeGuide.md
+++ b/docs/docs/end-users/UpgradeGuide.md
@@ -285,7 +285,7 @@ are most likely to notice.
 
 `fsharp_space_before_uppercase_invocation` and `fsharp_space_before_lowercase_invocation` ask for a
 space before the parenthesis of a call. They now get a say only when the whole thing being called
-is a plain dotted name. A call, an index, a bracketed receiver, or a type application
+is a plain dotted name. A call, an index, a receiver that is not a name, or a type application
 anywhere in it, and the parenthesis stays tight whatever the settings say.
 
 On default settings, where `fsharp_space_before_lowercase_invocation` is `true`:

--- a/src/Fantomas.Core.Tests/SpaceBeforeLowercaseInvocationTests.fs
+++ b/src/Fantomas.Core.Tests/SpaceBeforeLowercaseInvocationTests.fs
@@ -285,7 +285,7 @@ match x with
 """
 
 /// The setting only gets a say when the whole thing being called is a plain dotted name.
-/// A call, an index, a bracketed receiver, or a type application anywhere in it, and the
+/// A call, an index, a receiver that is not a name, or a type application anywhere in it, and the
 /// parenthesis stays tight. Agreed at https://github.com/fsharp/fslang-design/issues/648.
 /// The uppercase half of these live in SpaceBeforeUppercaseInvocationTests.
 

--- a/src/Fantomas.Core.Tests/SpaceBeforeUppercaseInvocationTests.fs
+++ b/src/Fantomas.Core.Tests/SpaceBeforeUppercaseInvocationTests.fs
@@ -406,7 +406,7 @@ Bar(1)[key]
 """
 
 /// The setting only gets a say when the whole thing being called is a plain dotted name.
-/// A call, an index, a bracketed receiver, or a type application anywhere in it, and the
+/// A call, an index, a receiver that is not a name, or a type application anywhere in it, and the
 /// parenthesis stays tight. Agreed at https://github.com/fsharp/fslang-design/issues/648.
 /// The lowercase half of these live in SpaceBeforeLowercaseInvocationTests.
 
@@ -515,7 +515,7 @@ let ``no space when the receiver is a parenthesised expression`` () =
 """
 
 [<Test>]
-let ``space before a call on a literal, which is atomic like a name`` () =
+let ``no space when the receiver is a constant`` () =
     formatSourceString
         """
 "yow".Substring(0, 3)
@@ -526,12 +526,12 @@ let ``space before a call on a literal, which is atomic like a name`` () =
     |> should
         equal
         """
-"yow".Substring (0, 3)
-3L.ToString ()
+"yow".Substring(0, 3)
+3L.ToString()
 """
 
 [<Test>]
-let ``no space when the receiver is bracketed rather than atomic`` () =
+let ``no space when the receiver is a list or an anonymous record`` () =
     formatSourceString
         """
 [ 1; 2 ].Contains(1)
@@ -544,20 +544,6 @@ let ``no space when the receiver is bracketed rather than atomic`` () =
         """
 [ 1; 2 ].Contains(1)
 {| X = 1 |}.ToString()
-"""
-
-[<Test>]
-let ``no space when a literal receiver is followed by a call`` () =
-    formatSourceString
-        """
-"yow".Trim().Substring(0, 3)
-"""
-        spaceBeforeConfig
-    |> prepend newline
-    |> should
-        equal
-        """
-"yow".Trim().Substring(0, 3)
 """
 
 [<Test>]

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -677,15 +677,14 @@ let genSegmentOpener (segment: ChainSegment) : Context -> Context =
 /// A name with no dotted content of its own: the shape the head of a chain and a `DotMember`
 /// step both take when nothing is happening beyond navigation.
 ///
-/// A type parameter and a literal count too. `'T.set_StaticProperty (3)` and
-/// `"yow".Substring (0, 3)` both call through something atomic, which is what the name in the
-/// rule is standing for. A bracketed receiver such as `[ 1; 2 ]` or `{| X = 1 |}` does not: it is
-/// a compound expression like `(f x)`, and is answered by the wildcard below.
+/// A type parameter counts too, since `'T` is a name like any other. A constant does not: `"yow"`
+/// and `3L` are values, and the rule asks for a name. Neither does a receiver that is bracketed
+/// rather than written out, such as `(f x)`, `[ 1; 2 ]` or `{| X = 1 |}`; those are answered by
+/// the wildcard below.
 let isPlainName (expr: Expr) : bool =
     match expr with
     | Expr.Ident _
-    | Expr.Typar _
-    | Expr.Constant _ -> true
+    | Expr.Typar _ -> true
     | Expr.OptVar node ->
         match node.Identifier.Content with
         | [ IdentifierOrDot.Ident _ ] -> true
@@ -693,7 +692,7 @@ let isPlainName (expr: Expr) : bool =
     | _ -> false
 
 /// Whether the whole thing being called is a plain dotted name, which is what the space before
-/// the terminal call's `(` depends on. A call, an index, a bracketed receiver, or a type
+/// the terminal call's `(` depends on. A call, an index, a receiver that is not a name, or a type
 /// application anywhere in it answers no.
 ///
 /// A type application does not have to be excluded here. One on the called member lifts the call

--- a/src/Fantomas.Core/FormatConfig.fs
+++ b/src/Fantomas.Core/FormatConfig.fs
@@ -102,12 +102,12 @@ type FormatConfig =
 
         [<Category("Spacing")>]
         [<DisplayName("Before lowercase invocation")>]
-        [<Description("Add a space between a lower-case function or method name and the opening parenthesis of its argument. Only the name immediately in front of the parenthesis decides which of the two invocation settings applies, and neither applies unless the whole thing being called is a plain dotted name: a call, an index, a bracketed receiver, or a type application anywhere in it keeps the parenthesis tight.")>]
+        [<Description("Add a space between a lower-case function or method name and the opening parenthesis of its argument. Only the name immediately in front of the parenthesis decides which of the two invocation settings applies, and neither applies unless the whole thing being called is a plain dotted name: a call, an index, a receiver that is not a name, or a type application anywhere in it keeps the parenthesis tight.")>]
         SpaceBeforeLowercaseInvocation: bool
 
         [<Category("Spacing")>]
         [<DisplayName("Before uppercase invocation")>]
-        [<Description("Add a space between an upper-case function or method name and the opening parenthesis of its argument. Only the name immediately in front of the parenthesis decides which of the two invocation settings applies, and neither applies unless the whole thing being called is a plain dotted name: a call, an index, a bracketed receiver, or a type application anywhere in it keeps the parenthesis tight.")>]
+        [<Description("Add a space between an upper-case function or method name and the opening parenthesis of its argument. Only the name immediately in front of the parenthesis decides which of the two invocation settings applies, and neither applies unless the whole thing being called is a plain dotted name: a call, an index, a receiver that is not a name, or a type application anywhere in it keeps the parenthesis tight.")>]
         SpaceBeforeUppercaseInvocation: bool
 
         [<Category("Spacing")>]


### PR DESCRIPTION
The rule from fslang-design#648 keeps the space before a call's parenthesis only when the whole thing being called is a plain dotted name. The previous commit read a constant as a name, on the grounds that "yow" and 3L are atomic rather than bracketed, so "yow".Substring (0, 3) and 3L.ToString () kept their space.

The comment actually posted at #648 does not say that. It lists "yow".Substring(0, 3) under "a receiver that is not a name", alongside (f x) and [ 1; 2 ], and that is the rule agreed to. A constant is a value, and the rule asks for a name. Both now go tight.

A type parameter is unaffected, since 'T is a name like any other, so 'T.set_StaticProperty (3) still keeps its space.

The prose everywhere the rule is written up says "a receiver that is not a name" rather than "a bracketed receiver", which is the posted wording and no longer needs a carve-out for what counts as atomic.

The test for a literal receiver followed by a call is dropped: the constant alone decides it now, so it no longer asserts the combination it was written for.
