### PR TITLE
Stop indenting a list on the right of a no-break infix operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [8.0.0-alpha-020] - 2026-08-27
+
+### Fixed
+
+- A list or an array on the right of `=`, `>`, `<`, `%` or `%%` is indented from the binding again, so `let a = b = [ ... ]` breaks to `b = [` with its items one level in and the `]` back at the column of `b`. Since `8.0.0-alpha-003` both the items and the closing bracket sat a further level to the right. The right-hand side of these operators is indented so that a comment between the operator and that side lands below the operator, which is what [#2944](https://github.com/fsprojects/fantomas/issues/2944) asked for, and so that the lines under a chain or an application are not read as a continuation of the left-hand side. A list or an array needs neither: its bracket says where the right-hand side begins and indents its items from the left-hand side by itself, so indenting it again pushed the items and the closing bracket a level too far. This concerns `aligned`, which is the default, and `stroustrup`. `cramped` lines the items up under the opening bracket, so the indent never reached them and nothing changes there. Right-hand sides that open a bracket in some other way, such as `seq { }`, `<@ @>`, `begin ... end` and `new T(...)`, still carry the extra level; where a no-break operator should put what follows it is a wider question than this fix. [#3428](https://github.com/fsprojects/fantomas/issues/3428)
+
 ## [8.0.0-alpha-019] - 2026-08-26
 
 ### Fixed

--- a/scripts/shared.fsx
+++ b/scripts/shared.fsx
@@ -1,6 +1,6 @@
 #r "../artifacts/bin/Fantomas.FCS/debug/Fantomas.FCS.dll"
 #r "../artifacts/bin/Fantomas.Core/debug/Fantomas.Core.dll"
-#r "nuget: editorconfig"
+#r "nuget: editorconfig, 0.15.0"
 
 #load "../src/Fantomas/Suggestion.fs"
 #load "../src/Fantomas/EditorConfig.fs"

--- a/src/Fantomas.Core.Tests/OperatorTests.fs
+++ b/src/Fantomas.Core.Tests/OperatorTests.fs
@@ -1492,3 +1492,221 @@ let ``comment between lines breaks indentation, 2944`` () =
   // a comment
   5
 """
+
+// A list or an array on the right of a no-break infix operator indents its items from the binding,
+// not from the operator. `Cramped` lines the items up under the opening bracket instead and is
+// unaffected either way. See 3428.
+
+[<Test>]
+let ``list on the right of a no-break infix operator, cramped`` () =
+    formatSourceString
+        """
+let v = xs = [ "aaaaaaaaaa"; "bbbbbbbbbb"; "cccccccccc"; "dddddddddd"; "eeeeeeeeee"; "ffffffffff" ]
+"""
+        { config with
+            MaxLineLength = 80
+            MultilineBracketStyle = Cramped
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    xs = [ "aaaaaaaaaa"
+           "bbbbbbbbbb"
+           "cccccccccc"
+           "dddddddddd"
+           "eeeeeeeeee"
+           "ffffffffff" ]
+"""
+
+[<Test>]
+let ``list on the right of a no-break infix operator, aligned, 3428`` () =
+    formatSourceString
+        """
+let v = xs = [ "aaaaaaaaaa"; "bbbbbbbbbb"; "cccccccccc"; "dddddddddd"; "eeeeeeeeee"; "ffffffffff" ]
+"""
+        { config with
+            MaxLineLength = 80
+            MultilineBracketStyle = Aligned
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    xs = [
+        "aaaaaaaaaa"
+        "bbbbbbbbbb"
+        "cccccccccc"
+        "dddddddddd"
+        "eeeeeeeeee"
+        "ffffffffff"
+    ]
+"""
+
+[<Test>]
+let ``list on the right of a no-break infix operator, stroustrup, 3428`` () =
+    formatSourceString
+        """
+let v = xs = [ "aaaaaaaaaa"; "bbbbbbbbbb"; "cccccccccc"; "dddddddddd"; "eeeeeeeeee"; "ffffffffff" ]
+"""
+        { config with
+            MaxLineLength = 80
+            MultilineBracketStyle = Stroustrup
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    xs = [
+        "aaaaaaaaaa"
+        "bbbbbbbbbb"
+        "cccccccccc"
+        "dddddddddd"
+        "eeeeeeeeee"
+        "ffffffffff"
+    ]
+"""
+
+[<Test>]
+let ``array on the right of a no-break infix operator, cramped`` () =
+    formatSourceString
+        """
+let v = xs = [| "aaaaaaaaaa"; "bbbbbbbbbb"; "cccccccccc"; "dddddddddd"; "eeeeeeeeee"; "ffffff" |]
+"""
+        { config with
+            MaxLineLength = 80
+            MultilineBracketStyle = Cramped
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    xs = [| "aaaaaaaaaa"
+            "bbbbbbbbbb"
+            "cccccccccc"
+            "dddddddddd"
+            "eeeeeeeeee"
+            "ffffff" |]
+"""
+
+[<Test>]
+let ``array on the right of a no-break infix operator, aligned, 3428`` () =
+    formatSourceString
+        """
+let v = xs = [| "aaaaaaaaaa"; "bbbbbbbbbb"; "cccccccccc"; "dddddddddd"; "eeeeeeeeee"; "ffffff" |]
+"""
+        { config with
+            MaxLineLength = 80
+            MultilineBracketStyle = Aligned
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    xs = [|
+        "aaaaaaaaaa"
+        "bbbbbbbbbb"
+        "cccccccccc"
+        "dddddddddd"
+        "eeeeeeeeee"
+        "ffffff"
+    |]
+"""
+
+[<Test>]
+let ``array on the right of a no-break infix operator, stroustrup, 3428`` () =
+    formatSourceString
+        """
+let v = xs = [| "aaaaaaaaaa"; "bbbbbbbbbb"; "cccccccccc"; "dddddddddd"; "eeeeeeeeee"; "ffffff" |]
+"""
+        { config with
+            MaxLineLength = 80
+            MultilineBracketStyle = Stroustrup
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    xs = [|
+        "aaaaaaaaaa"
+        "bbbbbbbbbb"
+        "cccccccccc"
+        "dddddddddd"
+        "eeeeeeeeee"
+        "ffffff"
+    |]
+"""
+
+[<Test>]
+let ``short list forced multiline on the right of a no-break infix operator, 3428`` () =
+    formatSourceString
+        """
+let a = b = [ 1; 2 ]
+"""
+        { config with
+            ArrayOrListMultilineFormatter = NumberOfItems
+            MaxArrayOrListNumberOfItems = 1
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let a =
+    b = [
+        1
+        2
+    ]
+"""
+
+[<Test>]
+let ``chain on the right of a no-break infix operator keeps its indent, 3428`` () =
+    formatSourceString
+        """
+let v = xs = expected.Replace(1, 2).Replace(3, 4).Replace(5, 6).Replace(7, 8).Replace(9, 10)
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    xs = expected
+            .Replace(1, 2)
+            .Replace(3, 4)
+            .Replace(5, 6)
+            .Replace(7, 8)
+            .Replace(9, 10)
+"""
+
+[<Test>]
+let ``comment in front of a list on the right of a no-break infix operator keeps the indent, 3428`` () =
+    formatSourceString
+        """
+let v =
+    xs =
+        // a comment
+        [ "aaaaaaaaaa"; "bbbbbbbbbb"; "cccccccccc"; "dddddddddd"; "eeeeeeeeee"; "ffffffffff" ]
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    xs =
+        // a comment
+        [
+            "aaaaaaaaaa"
+            "bbbbbbbbbb"
+            "cccccccccc"
+            "dddddddddd"
+            "eeeeeeeeee"
+            "ffffffffff"
+        ]
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1647,18 +1647,37 @@ let genExpr (e: Expr) =
         if isOpenEndedExpression node.LeftHandSide then
             genMultilineInfixExpr node |> genNode node
         // No-break operators (=, >, <, %) keep the operator on the same line as the LHS.
-        // When the expression doesn't fit on one line, indent the RHS to preserve
-        // correct indentation when trivia (comments) precedes it. See #2944.
         elif isNoBreakInfixOp then
+            // The right-hand side is indented so that a comment between it and the operator lands
+            // below the operator rather than at the column of the left-hand side, and so that the
+            // lines under an application or a chain are not read as a continuation of the
+            // left-hand side. See #2944.
+            // A list or an array that opens on the line of the operator needs neither: the bracket
+            // says where the right-hand side begins and indents its items from the left-hand side
+            // itself, so indenting it again pushes the items and the closing bracket a level too
+            // far. See #3428. Other bracketed right-hand sides have the same problem and are left
+            // alone here on purpose: where a no-break operator should put what follows it is a
+            // wider question than this fix.
+            let genRightHandSide (ctx: Context) : Context =
+                let opensBracketOnThisLine: bool =
+                    (match node.RightHandSide with
+                     | Expr.ArrayOrList _ -> true
+                     | _ -> false)
+                    && not (hasWriteBeforeNewlineContent ctx)
+                    && not (Expr.Node node.RightHandSide).HasContentBefore
+
+                (onlyIfNot opensBracketOnThisLine indent
+                 +> sepNlnWhenWriteBeforeNewlineNotEmpty
+                 +> sepSpace
+                 +> genRhsExpr node.RightHandSide
+                 +> onlyIfNot opensBracketOnThisLine unindent)
+                    ctx
+
             let genLongNoBreakInfixExpr =
                 genExpr node.LeftHandSide
                 +> sepSpace
                 +> genSingleTextNode node.Operator
-                +> indent
-                +> sepNlnWhenWriteBeforeNewlineNotEmpty
-                +> sepSpace
-                +> genRhsExpr node.RightHandSide
-                +> unindent
+                +> genRightHandSide
 
             fun ctx ->
                 genNode


### PR DESCRIPTION
The right-hand side of =, >, <, % and %% is indented so that a comment between the operator and that side lands below the operator, which is what #2944 asked for, and so that the lines under a chain or an application are not read as a continuation of the left-hand side.

A list or an array needs neither. Its bracket already says where the right-hand side begins and already indents its items from the left-hand side, so indenting it again pushed the items and the closing bracket a level past where they belong. `let a = b = [ ... ]` breaks to `b = [` with its items one level in and the `]` back at the column of `b`, as it did before 8.0.0-alpha-003.

This concerns the aligned and stroustrup bracket styles. Cramped lines the items up under the opening bracket, so the indent never reached them and nothing changes there. There is a list test and an array test for each of the three.

Right-hand sides that open a bracket in some other way, such as seq { }, <@ @> and begin ... end, still carry the extra level. Where a no-break operator should put what follows it is a style question rather than a bug, and belongs at fsharp/fslang-design rather than here.

Fixes #3428
