### PR TITLE
Stop moving an intermediate call's parenthesis with its lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- A call in the middle of a chain keeps its parenthesis against the member name when its lambda argument no longer fits, and breaks behind it instead. Up to now the whole argument moved down a line, `(` and all, which is what the last call of a chain does, but for an earlier one it changes what the code means: `a.Foo (x).Bar()` passes `(x).Bar()` to `Foo` rather than calling `Bar` on the result. With a call behind it the compiler rejected the result with "This argument expression needs parentheses"; with a plain member behind it, such as `.Value`, nothing warned at all and the member quietly became part of the argument. Hanging the parameters under `(fun` would keep the parenthesis in place too, and the F# style guide rules that out, because the column they hang from is the length of the member name. The closing `)` answers to `fsharp_multi_line_lambda_closing_newline` as it did before, and the last call of a chain is untouched, since nothing follows it to be swallowed. [#3432](https://github.com/fsprojects/fantomas/issues/3432)
+
 ## [8.0.0-alpha-020] - 2026-08-27
 
 ### Fixed

--- a/docs/docs/contributors/Chains.md
+++ b/docs/docs/contributors/Chains.md
@@ -759,6 +759,39 @@ let connectionString () =
 
 The difference is not the chain choosing between them. It is the same deference twice: a lambda opener wants to sit on one line with its arrow, and a tuple does not care, so the ordinary argument rules answer differently.
 
+#### Only the last call may move its parenthesis
+
+Moving the argument down is the one answer the ordinary rules can give that the chain does get a say over, and the answer is that only the last call may take it, for the reason set out under [An intermediate call is welded to its parenthesis](#An-intermediate-call-is-welded-to-its-parenthesis). A line break is the same gap there as a space.
+
+Worth knowing what the two mistakes look like, because only one of them is loud. With a call behind it, `.Create()`, the compiler rejects the result with "This argument expression needs parentheses". With a plain member behind it, `.Value`, nothing warns at all: the code reparses quietly and the member becomes part of the argument.
+
+So an intermediate call keeps its `(` welded to the member name and breaks behind it instead. The closing `)` still answers to `fsharp_multi_line_lambda_closing_newline`, exactly as it does when the argument moves:
+
+```fsharp
+// ✅ a step follows, so the parenthesis cannot move
+let register () =
+    Mock<IInstanceApi>()
+        .Calls(
+            fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) ->
+                metadata.Add(key, value))
+        .Create()
+```
+
+Hanging the parameters under `(fun` would keep the `(` in place too, and the F# style guide rules that out, because the column they hang from is the length of the member name. The shape the guide asks for when a lambda's parameters do not fit, one indent below `fun`, is not available here: below a `(` that sits mid-line it breaks the offside rule.
+
+The two shapes read as an inconsistency, and it is worth being clear about what divides them. It is not fluent code against ordinary code. A last call is reached the same way whether the chain is `Mock<IInstanceApi>().Create().Calls` or plain `List.tryPick`, and the style guide asks for the moved parenthesis there:
+
+```fsharp
+// ✔️ the F# style guide, under Formatting lambda expressions
+let printListWithOffset a list1 =
+    List.iter
+        (fun elem ->
+             printfn $"A very long line to format the value: %d{a + elem}")
+        list1
+```
+
+What divides them is whether anything to the right consumes the call's result. Where nothing does, the call is an ordinary application and is laid out like one. Where something does, it is not an ordinary application, and the parser reads the gap as handing that step to the argument. So the same call really is laid out two ways, and adding a step behind it reshapes it, but the difference is one the compiler enforces rather than one chosen here.
+
 #### Match lambdas are no exception
 
 Match lambdas, written `(function`, are the argument shape most likely to look like an exception, so it is worth showing in full that they are not one.
@@ -843,6 +876,8 @@ The one difference left between the two forms is that `function` also moves down
 The setting is the only thing that moves it. Writing `function` on the line below the `(` yourself makes no difference: the same call written across more lines is still the same call, and Fantomas has to land on one answer for both.
 
 In none of these does the chain have a say. `.Configure` is an intermediate call in half of them, so its `(` is welded to it either way; where the lambda goes is the argument's business, and it answers the same way in both positions.
+
+That holds because every opener above fits beside its method name. Once one does not, position is the one thing that does decide, since moving the argument down is an answer only the last call can take; see [Only the last call may move its parenthesis](#Only-the-last-call-may-move-its-parenthesis).
 
 #### A comment beside the parentheses
 

--- a/src/Fantomas.Core.Tests/ChainFormattingTests.fs
+++ b/src/Fantomas.Core.Tests/ChainFormattingTests.fs
@@ -1027,3 +1027,329 @@ let undotted () =
     storageSetConfigurationSettingPublisher
         (fun configName publisher -> publish configName publisher)
 """
+
+// ── A lambda argument to a call that is not the last step ───────────────────
+//
+// The call above is the last step of its chain, which is what lets the `(` move down with the
+// lambda. A call with a step behind it cannot do that: the gap makes `a.Foo (x).Bar()`, which
+// passes `(x).Bar()` to `Foo` instead of calling `Bar` on the result. So the `(` stays against
+// the member name and the break happens behind it.
+//
+// Hanging the parameters under `(fun` is the other way to keep the `(` where it is, and the
+// style guide rules it out: the column would be the length of the member name. The shape the
+// guide asks for instead, parameters indented one level, is not valid F# below a `(` that sits
+// mid-line.
+
+[<Test>]
+let ``lambda argument to an intermediate call keeps its opening parenthesis, 3432`` () =
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls(fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) -> metadata.Add(key, value))
+        .Create()
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls(
+            fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) ->
+                metadata.Add(key, value))
+        .Create()
+"""
+
+[<Test>]
+let ``lambda argument to an intermediate call, member behind it`` () =
+    // A member rather than a call behind the lambda reparses without a diagnostic: the
+    // `.Value` would silently become part of the argument.
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls(fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) -> metadata.Add(key, value))
+        .Value
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls(
+            fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) ->
+                metadata.Add(key, value))
+        .Value
+"""
+
+[<Test>]
+let ``lambda argument to an intermediate call, closing newline true`` () =
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls(fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) -> metadata.Add(key, value))
+        .Create()
+"""
+        { config with
+            MaxLineLength = 80
+            MultiLineLambdaClosingNewline = true
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls(
+            fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) ->
+                metadata.Add(key, value)
+        )
+        .Create()
+"""
+
+[<Test>]
+let ``multiline parameter of a lambda argument to an intermediate call`` () =
+    // A single parameter that is multiline by itself moves the lambda down for the same reason
+    // an opener that does not fit does, so it arrives at the same rule.
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls(fun { Path = path; Key = key; Value = value; Attempt = attempt } -> metadata.Add(key, value))
+        .Create()
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls(
+            fun
+                {
+                    Path = path
+                    Key = key
+                    Value = value
+                    Attempt = attempt
+                } -> metadata.Add(key, value))
+        .Create()
+"""
+
+[<Test>]
+let ``multiline parameter of a lambda argument to an intermediate call, closing newline true`` () =
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls(fun { Path = path; Key = key; Value = value; Attempt = attempt } -> metadata.Add(key, value))
+        .Create()
+"""
+        { config with
+            MaxLineLength = 80
+            MultiLineLambdaClosingNewline = true
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls(
+            fun
+                {
+                    Path = path
+                    Key = key
+                    Value = value
+                    Attempt = attempt
+                } -> metadata.Add(key, value)
+        )
+        .Create()
+"""
+
+[<Test>]
+let ``type arguments on an intermediate call taking a lambda`` () =
+    // Type arguments lift the call out of the chain and lengthen the opener, but neither is what
+    // decides this: the rule is the same one the plain member above answers to.
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls<StepPath * WellKnownStepMetadata>(fun (path: StepPath) (key: WellKnownStepMetadata) -> metadata.Add key)
+        .Create()
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls<StepPath * WellKnownStepMetadata>(
+            fun (path: StepPath) (key: WellKnownStepMetadata) ->
+                metadata.Add key)
+        .Create()
+"""
+
+[<Test>]
+let ``type arguments on an intermediate call taking a lambda, closing newline true`` () =
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls<StepPath * WellKnownStepMetadata>(fun (path: StepPath) (key: WellKnownStepMetadata) -> metadata.Add key)
+        .Create()
+"""
+        { config with
+            MaxLineLength = 80
+            MultiLineLambdaClosingNewline = true
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Calls<StepPath * WellKnownStepMetadata>(
+            fun (path: StepPath) (key: WellKnownStepMetadata) ->
+                metadata.Add key
+        )
+        .Create()
+"""
+
+[<Test>]
+let ``generic intermediate call taking a lambda, 3432`` () =
+    formatSourceString
+        """
+let instanceMetadata =
+            Mock<IInstanceApi>()
+                .Calls<StepPath * AttemptNumber * JobNumber * DateTime option * WellKnownStepMetadata * string>(fun
+                                                                                                                    (path,
+                                                                                                                     _,
+                                                                                                                     _,
+                                                                                                                     _,
+                                                                                                                     key,
+                                                                                                                     value) ->
+                    path |> shouldEqual (StepPath.Parse "/Foo")
+                    metadata.Add (key, value)
+                )
+                .Create ()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let instanceMetadata =
+    Mock<IInstanceApi>()
+        .Calls<StepPath * AttemptNumber * JobNumber * DateTime option * WellKnownStepMetadata * string>(
+            fun (path, _, _, _, key, value) ->
+                path |> shouldEqual (StepPath.Parse "/Foo")
+                metadata.Add(key, value))
+        .Create()
+"""
+
+// The counterparts of the four above, with the lambda call as the last step of the chain. There
+// the `(` is free to move down with the argument, because nothing follows it to be swallowed, so
+// these keep the layout they always had. They are here to mark where the rule above stops.
+
+[<Test>]
+let ``lambda argument to the last call keeps moving down`` () =
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Create()
+        .Calls(fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) -> metadata.Add(key, value))
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Create()
+        .Calls
+            (fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) ->
+                metadata.Add(key, value))
+"""
+
+[<Test>]
+let ``type arguments on the last call taking a lambda`` () =
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Create()
+        .Calls<StepPath * WellKnownStepMetadata>(fun (path: StepPath) (key: WellKnownStepMetadata) -> metadata.Add key)
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Create()
+        .Calls<StepPath * WellKnownStepMetadata>
+            (fun (path: StepPath) (key: WellKnownStepMetadata) ->
+                metadata.Add key)
+"""
+
+[<Test>]
+let ``lambda argument to the last call, closing newline true`` () =
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Create()
+        .Calls(fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) -> metadata.Add(key, value))
+"""
+        { config with
+            MaxLineLength = 80
+            MultiLineLambdaClosingNewline = true
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Create()
+        .Calls
+            (fun (path: StepPath) (key: WellKnownStepMetadata) (value: string) ->
+                metadata.Add(key, value)
+            )
+"""
+
+[<Test>]
+let ``type arguments on the last call taking a lambda, closing newline true`` () =
+    formatSourceString
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Create()
+        .Calls<StepPath * WellKnownStepMetadata>(fun (path: StepPath) (key: WellKnownStepMetadata) -> metadata.Add key)
+"""
+        { config with
+            MaxLineLength = 80
+            MultiLineLambdaClosingNewline = true
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let mock () =
+    Mock<IInstanceApi>()
+        .Create()
+        .Calls<StepPath * WellKnownStepMetadata>
+            (fun (path: StepPath) (key: WellKnownStepMetadata) ->
+                metadata.Add key
+            )
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -475,23 +475,46 @@ type ChainStepPlacement =
     /// The step opens a fresh line, indented to the run's own column.
     | OpensNewLine
 
-/// Layout for `(fun params -> body)`. Identical wherever the call sits: `MultiLineLambdaClosingNewline`
-/// decides where the closing `)` lands, exactly as it would for a call with no receiver.
-let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : Context -> Context =
-    // `startColumn` is remembered so the closing `)` can be indented back to it — important
-    // when the body ends at a shallow column (e.g. a verbatim string in column 0), where a `)`
-    // left there breaks the offside rule and produces invalid F#.
-    let genParenLambda (ctx: Context) : Context =
-        let startColumn: int = ctx.WriterModel.Indent
+/// Where a call sits in its chain, as far as its parenthesis is concerned.
+[<RequireQualifiedAccess; Struct>]
+type ChainCallPosition =
+    /// The last call of the chain. Nothing follows it, so an argument that no longer fits beside
+    /// the member name may take the line below and bring the `(` with it.
+    | Last
+    /// A call with a step behind it. Its `(` may not leave the member name, because the gap would
+    /// change the parse: `a.Foo (x).Bar()` passes `(x).Bar()` to `Foo` rather than calling `Bar`
+    /// on the result.
+    | BeforeAnotherStep
 
-        // The closing parenthesis takes a line of its own when the setting asks for it and the
-        // lambda spans several lines, which is the case the setting is about. Asking whether it
-        // did, rather than assuming it will, matters once the argument can move down: from its own
-        // line the lambda may well fit, and a `)` below a single line would be left dangling.
-        (leadingExpressionIsMultiline
-            (genSingleTextNode parenNode.OpeningParen +> genLambdaWithParen lambdaNode)
+/// Layout for `(fun params -> body)`. `MultiLineLambdaClosingNewline` decides where the closing
+/// `)` lands, exactly as it would for a call with no receiver.
+///
+/// `position` decides whether the `(` is free to move down with the lambda. The note above the
+/// decision below says what it costs when it is not.
+let genLambdaParenArg
+    (position: ChainCallPosition)
+    (parenNode: ExprParenNode)
+    (lambdaNode: ExprLambdaNode)
+    : Context -> Context
+    =
+    // The lambda and the `)` behind it. Both layouts below write the `(` themselves and then hand
+    // over to this, so where the `)` lands is answered once.
+    //
+    // The closing parenthesis takes a line of its own when the setting asks for it and the lambda
+    // spans several lines, which is the case the setting is about. Asking whether it did, rather
+    // than assuming it will, matters once the argument can move down: from its own line the lambda
+    // may well fit, and a `)` below a single line would be left dangling.
+    //
+    // `startColumn` is the column the `(` was written at, so the `)` can be brought back to it,
+    // which matters when the body ends at a shallow column (e.g. a verbatim string in column 0),
+    // where a `)` left there breaks the offside rule and produces invalid F#. `beforeClosing` runs
+    // between the lambda and the `)`, which is where a layout that indented the lambda unindents.
+    let genLambdaAndClosingParen (startColumn: int) (beforeClosing: Context -> Context) : Context -> Context =
+        leadingExpressionIsMultiline
+            (genLambdaWithParen lambdaNode)
             (fun isMultiline ->
-                ifElseCtx
+                beforeClosing
+                +> ifElseCtx
                     (fun ctx ->
                         isMultiline
                         && ctx.Config.MultiLineLambdaClosingNewline
@@ -500,7 +523,12 @@ let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : 
                     sepNln
                     (sepNlnWhenWriteBeforeNewlineNotEmpty +> addFixedSpaces startColumn)
                 +> genSingleTextNode parenNode.ClosingParen
-            ))
+            )
+
+    // The lambda beside its `(`, wherever that parenthesis has ended up.
+    let genParenLambda (ctx: Context) : Context =
+        (genSingleTextNode parenNode.OpeningParen
+         +> genLambdaAndClosingParen ctx.WriterModel.Indent sepNone)
             ctx
 
     // Move the whole lambda argument onto its own indented line when leaving it where it is
@@ -525,6 +553,22 @@ let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : 
     //         items
     //         |> List.tryPick (fun
     //                              (Interface(ty = t; keyword = k)) -> body)
+    //
+    // The same argument for a call that may not let its `(` go: an intermediate call in a chain.
+    // Moving the parenthesis down there changes what the code means, since `a.Foo (x).Bar()`
+    // passes `(x).Bar()` to `Foo` rather than calling `Bar` on the result. So the `(` stays put
+    // and the break happens behind it instead.
+    //
+    //     .CallsSomething(
+    //         fun
+    //             (path, key, value) ->
+    //             body)
+    //
+    // The alternative is to leave `(fun` on the line and hang the parameters underneath it, but
+    // the column they would hang from is the length of the member name, which is what
+    // "Avoid formatting that is sensitive to name length" asks us not to do. Indenting them one
+    // level instead, the shape the guide shows for a lambda whose parameters do not fit, is not
+    // available here: below a `(` that sits mid-line it breaks the offside rule.
     fun (ctx: Context) ->
         let singleMultilineParameter: bool =
             match lambdaNode.Parameters with
@@ -541,10 +585,17 @@ let genLambdaParenArg (parenNode: ExprParenNode) (lambdaNode: ExprLambdaNode) : 
                  +> genSingleTextNode lambdaNode.Arrow)
                 ctx
 
-        if singleMultilineParameter || openerDoesNotFit then
+        if not (singleMultilineParameter || openerDoesNotFit) then
+            genParenLambda ctx
+        elif position = ChainCallPosition.Last then
             indentSepNlnUnindent genParenLambda ctx
         else
-            genParenLambda ctx
+
+        (genSingleTextNode parenNode.OpeningParen
+         +> indent
+         +> sepNln
+         +> genLambdaAndClosingParen ctx.WriterModel.Indent unindent)
+            ctx
 
 /// Layout for `(function | ... -> ...)`. Identical wherever the call sits in its chain:
 /// `MultiLineLambdaClosingNewline` decides whether `function` goes on its own line.
@@ -575,15 +626,17 @@ let genMatchLambdaParenArg (parenNode: ExprParenNode) (matchLambdaNode: ExprMatc
     ifElseCtx (fun ctx -> ctx.Config.MultiLineLambdaClosingNewline) breakAfterParen keepFunctionWithParen
 
 /// Multiline layout of a call's parenthesised argument `( ... )`, shared by intermediate calls
-/// (genSegment) and the terminal call (genTerminal). Where the call sits in its chain makes no
-/// difference: everything between `(` and `)` is laid out by the ordinary argument rules, and the
-/// chain only decides whether the call itself has to move down.
-let genMultilineParenArg (parenNode: ExprParenNode) : Context -> Context =
+/// (genSegment) and the terminal call (genTerminal). Everything between `(` and `)` is laid out by
+/// the ordinary argument rules; the chain only decides whether the call itself has to move down.
+///
+/// `position` is the one thing it does decide. An intermediate call may not let go of its `(`,
+/// because the gap would change the parse; the terminal call is free to.
+let genMultilineParenArg (position: ChainCallPosition) (parenNode: ExprParenNode) : Context -> Context =
     // How the argument breaks, once it is settled where the call starts. Whatever sits between
     // the parentheses is the argument's business, so this is the ordinary layout for one.
     let genByArgumentShape: Context -> Context =
         match parenNode.Expr with
-        | Expr.Lambda lambdaNode -> genLambdaParenArg parenNode lambdaNode
+        | Expr.Lambda lambdaNode -> genLambdaParenArg position parenNode lambdaNode
         | Expr.MatchLambda matchLambdaNode -> genMatchLambdaParenArg parenNode matchLambdaNode
         | _ -> genMultilineFunctionApplicationArguments (Expr.Paren parenNode)
 
@@ -652,8 +705,11 @@ let genSegment (segment: ChainSegment) : Context -> Context =
         +> match call with
            | ChainCall.Unit u -> genUnit u
            | ChainCall.Paren parenNode ->
-               // Intermediate paren calls are always tight — space would change the parse tree.
-               expressionFitsOnRestOfLine (genExpr (Expr.Paren parenNode)) (genMultilineParenArg parenNode)
+               // Intermediate paren calls are always tight: any gap would change the parse tree,
+               // whether it is a space or a line break.
+               expressionFitsOnRestOfLine
+                   (genExpr (Expr.Paren parenNode))
+                   (genMultilineParenArg ChainCallPosition.BeforeAnotherStep parenNode)
     | ChainSegment.DotIndex(dot, index) ->
         // DotIndex (.[i]) is structurally like DotMember with no call: the dot is explicit
         // for trivia, but the [ ] brackets are not part of the index expression and must
@@ -775,7 +831,8 @@ let genTerminal (node: ExprChain) : Context -> Context =
         | ChainCall.Paren parenNode ->
             let short: Context -> Context = addSpace +> genExpr (Expr.Paren parenNode)
 
-            let long: Context -> Context = addSpace +> genMultilineParenArg parenNode
+            let long: Context -> Context =
+                addSpace +> genMultilineParenArg ChainCallPosition.Last parenNode
 
             expressionFitsOnRestOfLine short long
 


### PR DESCRIPTION
A lambda argument whose opener no longer fits beside the member name takes the line below, and the opening parenthesis went with it. That is right for the last call of a chain, but an earlier call may not be separated from its parenthesis at all: `a.Foo (x).Bar()` hands `(x).Bar()` to `Foo` rather than calling `Bar` on the result. A line break is the same gap there as a space.

Only one of the two ways this went wrong was loud. With a call behind it the compiler rejected the result with "This argument expression needs parentheses". With a plain member behind it, such as `.Value`, nothing warned and the member quietly became part of the argument.

An intermediate call now keeps its parenthesis against the member name and breaks behind it instead, with the closing parenthesis answering to fsharp_multi_line_lambda_closing_newline as it did before. Hanging the parameters under `(fun` would keep it in place too, and the F# style guide rules that out, because the column they hang from is the length of the member name. The shape the guide asks for instead, parameters one indent below `fun`, is not valid F# under a parenthesis that sits mid-line.

The last call of a chain is unchanged. It is reached the same way whether the chain is fluent or a plain `List.tryPick`, and the style guide asks for the moved parenthesis there.

Fixes #3432