### PR TITLE
De-indent code for ExperimentalKeepIndentInBranch setting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-[src/**/*.{fs,fsi}]
+[{src,analyzers}/**/*.{fs,fsi}]
 fsharp_keep_max_number_of_blank_lines=1
 fsharp_align_function_signature_to_indentation=true
 fsharp_alternative_long_member_definitions=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ pipelines run them alongside the two analyzer packages.
 | `FANTOMAS-PIPEBACK-001` | No backward pipe | Error |
 | `FANTOMAS-PRIVATE-001` | No `let private` beside a signature file | Error |
 | `FANTOMAS-ARMORDER-001` | Shortest match arm first | Warning |
-| `FANTOMAS-KEEPINDENT-001` | Last match arm keeps the indentation | Warning |
+| `FANTOMAS-BRANCHORDER-001` | Shortest `if` branch first | Warning |
+| `FANTOMAS-KEEPINDENT-001` | Last branch keeps the indentation | Warning |
 | `FANTOMAS-ANNOTATE-001` | Annotate every `let` binding | Warning |
 | `FANTOMAS-XMLDOC-001` | No doc comment the signature file already carries | Warning |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ pipelines run them alongside the two analyzer packages.
 | `FANTOMAS-PIPEBACK-001` | No backward pipe | Error |
 | `FANTOMAS-PRIVATE-001` | No `let private` beside a signature file | Error |
 | `FANTOMAS-ARMORDER-001` | Shortest match arm first | Warning |
+| `FANTOMAS-KEEPINDENT-001` | Last match arm keeps the indentation | Warning |
 | `FANTOMAS-ANNOTATE-001` | Annotate every `let` binding | Warning |
 | `FANTOMAS-XMLDOC-001` | No doc comment the signature file already carries | Warning |
 
@@ -78,11 +79,12 @@ changed. A finding in a file you did not touch is dropped, whatever its rule: wi
 changed `.fsproj` pulling in the whole project buries the two files you added under the project's
 existing debt.
 
-Within a file that did change, the one rule that reports on pre-existing debt,
-`FANTOMAS-ANNOTATE-001`, is narrowed further to the lines `git diff` says you touched. A file is a
-much coarser scope than that rule asks for: one line changed in `ASTTransformer.fs` otherwise
-surfaces every unannotated binding in it. Every other rule reports wherever it fires in a file you
-edited. A file git has never seen is new in its entirety, so everything in it is reported.
+Within a file that did change, `FANTOMAS-ANNOTATE-001` is narrowed further to the lines `git diff`
+says you touched. A file is a much coarser scope than that rule asks for: one line changed in
+`ASTTransformer.fs` otherwise surfaces every unannotated binding in it. Every other rule reports
+wherever it fires in a file you edited, including `FANTOMAS-KEEPINDENT-001`, which also reports on
+pre-existing debt but means an arm's body rather than the `|` lines a swap touches. A file git has
+never seen is new in its entirety, so everything in it is reported.
 
 ```bash
 dotnet fsi build.fsx -- -p Analyze

--- a/analyzers/AGENTS.md
+++ b/analyzers/AGENTS.md
@@ -10,6 +10,7 @@ feedback arrives while you work instead of in review. They are ordinary F# analy
 | [`FANTOMAS-PIPEBACK-001`](#fantomas-pipeback-001) | No backward pipe | Error | both pipelines |
 | [`FANTOMAS-PRIVATE-001`](#fantomas-private-001) | No `let private` beside a signature file | Error | both pipelines |
 | [`FANTOMAS-ARMORDER-001`](#fantomas-armorder-001) | Shortest match arm first | Warning | both pipelines |
+| [`FANTOMAS-KEEPINDENT-001`](#fantomas-keepindent-001) | Last match arm keeps the indentation | Warning | `AnalyzeChanged` only |
 | [`FANTOMAS-ANNOTATE-001`](#fantomas-annotate-001) | Annotate every `let` binding | Warning | `AnalyzeChanged` only |
 | [`FANTOMAS-XMLDOC-001`](#fantomas-xmldoc-001) | No doc comment the signature file already carries | Warning | both pipelines |
 
@@ -67,6 +68,66 @@ something other than a swap, and it offers no fix, because swapping two clauses 
 and indentation is the kind of edit that goes wrong quietly.
 
 So a match it says nothing about is not necessarily in the right order. The rule is still the rule.
+
+## FANTOMAS-KEEPINDENT-001
+
+Once the short arm is first, let the last arm keep the indentation of the match:
+
+```fsharp
+match localToolsListResult with
+| Ok(CompatibleTool version) -> Ok(FantomasToolFound(version, FantomasToolStartInfo.LocalTool workingDir))
+| Error err -> Error(FantomasToolError.DotNetListError err)
+| Ok _localToolListResult ->
+
+let globalToolsListResult = runToolListCmd workingDir true
+
+match globalToolsListResult with
+| Ok(CompatibleTool version) -> Ok(FantomasToolFound(version, FantomasToolStartInfo.GlobalTool))
+| Error err -> Error(FantomasToolError.DotNetListError err)
+| Ok _nonCompatibleGlobalVersion ->
+
+let fantomasOnPathVersion = fantomasVersionOnPath ()
+```
+
+This is the other half of what `FANTOMAS-ARMORDER-001` starts, and the reason that rule cares about
+order in the first place. The short arms say what the rest of the expression is not about and then
+get out of the way, and what is left is the one path that continues, written at the indentation it
+started at. Three lookups falling through to each other cost no indentation at all, where nesting
+them would have cost twelve columns by the third.
+
+`fsharp_experimental_keep_indent_in_branch`, which the repository's `.editorconfig` turns on, is what
+holds the body there, and it only holds a body that was already written that way: it will not
+de-indent for you, and it will re-indent one written that way where the setting is off. So the whole
+style depends on somebody writing it, which is what this rule is for. The `.editorconfig` covers
+`src` and `analyzers`, which together are everything the pipelines analyze, so a finding is never one
+the formatter will undo.
+
+The analyzer is narrower than the rule, because moving a body left can change what runs:
+
+- Only the **last** arm, since that is the only one `CodePrinter` offers the choice to, and since a
+  following arm of the same match would be the first thing a de-indented body swallowed.
+- Only a body that is a **block**: another `match`, an `if`, or a sequence of bindings and
+  statements. That is where the columns are saved again by everything inside. A single application
+  or pipeline has nothing under it to save them for and reads oddly under the blank line the setting
+  writes.
+- Only a body **already on a line of its own** and spanning more than one line. A body that fits
+  beside its arrow gets pulled up next to it and never reaches the branch that would keep it.
+- Only where **nothing follows the match in the same block**. This is the one way the reshape
+  changes meaning. De-indenting moves the offside line of the body out to the bar, and code that
+  follows the match in that block sits in exactly that column, so what was the first thing past the
+  match becomes the last thing inside the arm: it stops running whatever matched and starts running
+  only for that one arm. The rule collects every place one expression is followed by another and
+  stays quiet inside the first of such a pair, unless the follower starts further left than the bar,
+  where an enclosing block is what continues and the arm still ends.
+
+It stays quiet on a `when` guard, because a multiline guard takes a path in `CodePrinter` that
+indents the body whatever column it is in, and whether a guard prints multiline is a page width
+question rather than a tree one. It stays quiet on a conditional directive inside the match. And it
+offers no fix, because re-indenting a block means leaving the multiline strings inside it exactly
+where they are, which is not a thing to do blind, least of all in `Fantomas.Core.Tests`.
+
+`match`, `match!` and `function` all reach the same clause printer, so all three are covered.
+`if`/`then`/`else` has the same setting behind it and is deliberately left out for now.
 
 ## FANTOMAS-ANNOTATE-001
 
@@ -129,11 +190,17 @@ non-zero on any finding at error severity, so the two error rules fail `Analyze`
 decides who has to look: a rule excluded from `Analyze` is absent from CI and from GitHub code
 scanning whatever its severity, and still reports locally.
 
-`FANTOMAS-ANNOTATE-001` is excluded from `Analyze` because it reports on debt that predates it.
-`AnalyzeChanged` runs it, and narrows it further to the lines `git diff` says you touched: a file is
-a much coarser scope than that rule asks for, and one line changed in a file of several thousand
-otherwise surfaces every unannotated binding in it. Every other rule reports wherever it fires in a
-file you edited, because a finding from one of those is worth seeing.
+`FANTOMAS-ANNOTATE-001` and `FANTOMAS-KEEPINDENT-001` are excluded from `Analyze` because both report
+on debt that predates them. `AnalyzeChanged` runs both.
+
+It narrows `FANTOMAS-ANNOTATE-001` further, to the lines `git diff` says you touched: a file is a
+much coarser scope than that rule asks for, and one line changed in a file of several thousand
+otherwise surfaces every unannotated binding in it. `FANTOMAS-KEEPINDENT-001` is deliberately not
+narrowed that way, and the difference is worth knowing before adding a third. It fires on an arm's
+body, which is rarely a line you touched: swapping two arms for `FANTOMAS-ARMORDER-001` changes the
+two lines carrying the `|` and none of the body it then asks you to de-indent, so narrowing to
+changed lines would hide the finding the swap exists to reach. Every other rule reports wherever it
+fires in a file you edited, because a finding from one of those is worth seeing.
 
 The narrowing reads the tool's own output format and fails open, so anything it cannot parse is
 kept. A change upstream makes it stop narrowing rather than start hiding.

--- a/analyzers/AGENTS.md
+++ b/analyzers/AGENTS.md
@@ -10,7 +10,7 @@ feedback arrives while you work instead of in review. They are ordinary F# analy
 | [`FANTOMAS-PIPEBACK-001`](#fantomas-pipeback-001) | No backward pipe | Error | both pipelines |
 | [`FANTOMAS-PRIVATE-001`](#fantomas-private-001) | No `let private` beside a signature file | Error | both pipelines |
 | [`FANTOMAS-ARMORDER-001`](#fantomas-armorder-001) | Shortest match arm first | Warning | both pipelines |
-| [`FANTOMAS-KEEPINDENT-001`](#fantomas-keepindent-001) | Last match arm keeps the indentation | Warning | `AnalyzeChanged` only |
+| [`FANTOMAS-KEEPINDENT-001`](#fantomas-keepindent-001) | Last match arm keeps the indentation | Warning | both pipelines |
 | [`FANTOMAS-ANNOTATE-001`](#fantomas-annotate-001) | Annotate every `let` binding | Warning | `AnalyzeChanged` only |
 | [`FANTOMAS-XMLDOC-001`](#fantomas-xmldoc-001) | No doc comment the signature file already carries | Warning | both pipelines |
 
@@ -112,13 +112,29 @@ The analyzer is narrower than the rule, because moving a body left can change wh
   writes.
 - Only a body **already on a line of its own** and spanning more than one line. A body that fits
   beside its arrow gets pulled up next to it and never reaches the branch that would keep it.
-- Only where **nothing follows the match in the same block**. This is the one way the reshape
-  changes meaning. De-indenting moves the offside line of the body out to the bar, and code that
-  follows the match in that block sits in exactly that column, so what was the first thing past the
-  match becomes the last thing inside the arm: it stops running whatever matched and starts running
-  only for that one arm. The rule collects every place one expression is followed by another and
-  stays quiet inside the first of such a pair, unless the follower starts further left than the bar,
-  where an enclosing block is what continues and the arm still ends.
+- Only where **every other arm is a one liner**. That is the early return shape, and it is what
+  makes the de-indent mean anything: the arms that decline say so and get out of the way, and what
+  is left is the one path that carries on. A match whose other arms are blocks too is not that
+  shape, and de-indenting the last of them alone puts arms of the same kind at two different
+  indentations and says the last is special when it is not.
+- Only where **nothing follows the match in that column**. This is the one way the reshape changes
+  meaning. De-indenting moves the offside line of the body out to the bar, so the first thing after
+  the match that starts in that column or further right stops following the match and starts
+  belonging to its last arm. Anything further left ends the arm exactly as it ended the match.
+
+  The rule answers this by reading the source: it takes the first line after the one the match ends
+  on that has any content, and compares its indentation. Whatever shares the match's last line moves
+  with the body and keeps its place, which is how a closing bracket stays out of it.
+
+  That is deliberately a question about text rather than about the tree, and it is the third
+  attempt. Collecting `SynExpr.Sequential` pairs missed the `json.WriteEndObject()` after the match
+  in `writeDoctorFile`, so it ran for one case out of three and every doctor report came out as
+  truncated JSON. Flattening those sequences properly then missed the `|> genNode attr` under the
+  match in `genAttributesCore`, which applied to the whole match and would have applied to one arm,
+  so everything reached through the other arm lost its trivia and the compiler-define tests failed.
+  Both were shapes to enumerate and there was always going to be another one. The text has none, and
+  it costs a comment its place at worst: a comment under the match counts as content, so the rule
+  stays quiet rather than move it into the arm.
 
 It stays quiet on a `when` guard, because a multiline guard takes a path in `CodePrinter` that
 indents the body whatever column it is in, and whether a guard prints multiline is a page width
@@ -190,17 +206,17 @@ non-zero on any finding at error severity, so the two error rules fail `Analyze`
 decides who has to look: a rule excluded from `Analyze` is absent from CI and from GitHub code
 scanning whatever its severity, and still reports locally.
 
-`FANTOMAS-ANNOTATE-001` and `FANTOMAS-KEEPINDENT-001` are excluded from `Analyze` because both report
-on debt that predates them. `AnalyzeChanged` runs both.
+`FANTOMAS-ANNOTATE-001` is excluded from `Analyze` because it reports on debt that predates it.
+`AnalyzeChanged` runs it, and narrows it further to the lines `git diff` says you touched: a file is
+a much coarser scope than that rule asks for, and one line changed in a file of several thousand
+otherwise surfaces every unannotated binding in it. Every other rule reports wherever it fires in a
+file you edited, because a finding from one of those is worth seeing.
 
-It narrows `FANTOMAS-ANNOTATE-001` further, to the lines `git diff` says you touched: a file is a
-much coarser scope than that rule asks for, and one line changed in a file of several thousand
-otherwise surfaces every unannotated binding in it. `FANTOMAS-KEEPINDENT-001` is deliberately not
-narrowed that way, and the difference is worth knowing before adding a third. It fires on an arm's
-body, which is rarely a line you touched: swapping two arms for `FANTOMAS-ARMORDER-001` changes the
-two lines carrying the `|` and none of the body it then asks you to de-indent, so narrowing to
-changed lines would hide the finding the swap exists to reach. Every other rule reports wherever it
-fires in a file you edited, because a finding from one of those is worth seeing.
+`FANTOMAS-KEEPINDENT-001` arrived with debt of its own and is still in both pipelines, because that
+debt was cleared in the change that added it. The full run therefore has nothing old to report, and
+anything it does report is something the change in front of you introduced, which is the state to
+keep it in: a new case is cheap to fix while you are writing it and becomes a code scanning alert if
+you do not.
 
 The narrowing reads the tool's own output format and fails open, so anything it cannot parse is
 kept. A change upstream makes it stop narrowing rather than start hiding.

--- a/analyzers/AGENTS.md
+++ b/analyzers/AGENTS.md
@@ -10,7 +10,8 @@ feedback arrives while you work instead of in review. They are ordinary F# analy
 | [`FANTOMAS-PIPEBACK-001`](#fantomas-pipeback-001) | No backward pipe | Error | both pipelines |
 | [`FANTOMAS-PRIVATE-001`](#fantomas-private-001) | No `let private` beside a signature file | Error | both pipelines |
 | [`FANTOMAS-ARMORDER-001`](#fantomas-armorder-001) | Shortest match arm first | Warning | both pipelines |
-| [`FANTOMAS-KEEPINDENT-001`](#fantomas-keepindent-001) | Last match arm keeps the indentation | Warning | both pipelines |
+| [`FANTOMAS-BRANCHORDER-001`](#fantomas-branchorder-001) | Shortest `if` branch first | Warning | both pipelines |
+| [`FANTOMAS-KEEPINDENT-001`](#fantomas-keepindent-001) | Last branch keeps the indentation | Warning | both pipelines |
 | [`FANTOMAS-ANNOTATE-001`](#fantomas-annotate-001) | Annotate every `let` binding | Warning | `AnalyzeChanged` only |
 | [`FANTOMAS-XMLDOC-001`](#fantomas-xmldoc-001) | No doc comment the signature file already carries | Warning | both pipelines |
 
@@ -69,9 +70,36 @@ and indentation is the kind of edit that goes wrong quietly.
 
 So a match it says nothing about is not necessarily in the right order. The rule is still the rule.
 
+## FANTOMAS-BRANCHORDER-001
+
+The same for an `if`. Put the shorter branch first, negating the condition to get there:
+
+```fsharp
+if not contentChanged then
+    return FormatResult.Unchanged(filename = formatParams.File)
+else
+    let! validation = CodeFormatter.ValidateFSharpCodeAsync(isSignatureFile, formattedContent)
+    ...
+```
+
+This asks for more than `FANTOMAS-ARMORDER-001` does. A match arm can only be moved, where a branch
+has to be negated as well, so the rule is doing something to the condition and not only to the
+layout. What it does not have to worry about is overlap: the two branches of an `if` are exclusive by
+construction, so the swap is always sound, where reordering two match arms need not be.
+
+What is not always an improvement is the condition it leaves behind. A comparison flips into its
+opposite and an existing `not` falls away, and both of those are still one thing to read. A condition
+joined by `&&` or `||` would have to grow a `not` and a pair of parentheses around the whole of it,
+which is a worse sentence than the branches were worth, so those are left alone. Everything else can
+only gain a `not`, which is fine, and is the common case.
+
+It speaks only for a plain `if`/`then`/`else`. A chain with an `elif` has more than two ways through
+it and no single swap that puts the short one first. It stays quiet on a conditional directive inside
+the expression, and offers no fix, because rewriting a condition is a thing to read before doing.
+
 ## FANTOMAS-KEEPINDENT-001
 
-Once the short arm is first, let the last arm keep the indentation of the match:
+Once the short branch is first, let the last branch keep the indentation of the expression:
 
 ```fsharp
 match localToolsListResult with
@@ -142,8 +170,18 @@ question rather than a tree one. It stays quiet on a conditional directive insid
 offers no fix, because re-indenting a block means leaving the multiline strings inside it exactly
 where they are, which is not a thing to do blind, least of all in `Fantomas.Core.Tests`.
 
-`match`, `match!` and `function` all reach the same clause printer, so all three are covered.
-`if`/`then`/`else` has the same setting behind it and is deliberately left out for now.
+`match`, `match!` and `function` all reach the same clause printer, so all three are covered. So is
+the final `else` of an `if`, which reaches `genKeepIdentIfThenElse` rather than
+`genKeepIdentMatchClause` and is a shade more permissive: it accepts the body in the column of the
+`else` or of the `if`, where a match arm has only the `|` to match. Fantomas prints both in the same
+column, so the rule aims at the `else` and one target is enough. An `elif` chain is printed flat and
+offers the choice to its last `else` alone, so the chain is walked to reach it and every `then` above
+has to be a one liner like any other branch.
+
+The two halves compose, and the composition is the point. `FANTOMAS-BRANCHORDER-001` and
+`FANTOMAS-ARMORDER-001` put the short branches first, which leaves the one that carries on last,
+which is where this rule can reach it. Fixing them in that order is worth doing, because a swap
+creates candidates here that were not there before.
 
 ## FANTOMAS-ANNOTATE-001
 

--- a/analyzers/Fantomas.Analyzers.Tests/ArmOrderAnalyzerTests.fs
+++ b/analyzers/Fantomas.Analyzers.Tests/ArmOrderAnalyzerTests.fs
@@ -44,6 +44,53 @@ let f (x: int option) : int =
 
     analyzeSource cliAnalyzer source |> assertLines []
 
+// A list is matched by `::` and `[]` rather than by union cases, and those two are as disjoint as
+// any pair. `dataToEnd` in Queue.fs is the shape this came from, which is also a `function` rather
+// than a `match`.
+[<Test>]
+let ``a cons arm before an empty list arm is reported`` () =
+    let source: string =
+        """module M
+
+let rec f (acc: int list) : int list -> int list =
+    function
+    | hd :: tl ->
+        let a: int = hd
+        f (a :: acc) tl
+    | [] -> acc"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 8 ]
+
+[<Test>]
+let ``an empty list arm coming first is not reported`` () =
+    let source: string =
+        """module M
+
+let rec f (acc: int list) : int list -> int list =
+    function
+    | [] -> acc
+    | hd :: tl ->
+        let a: int = hd
+        f (a :: acc) tl"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+// `[ x ]` and `x :: rest` both match a one element list, so those two cannot be swapped and the
+// rule has to stay quiet.
+[<Test>]
+let ``a cons arm before a single element list arm is not reported`` () =
+    let source: string =
+        """module M
+
+let f (xs: int list) : int =
+    match xs with
+    | hd :: _ ->
+        let a: int = hd
+        a + 1
+    | [ x ] -> x"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
 [<Test>]
 let ``a wildcard arm is not reported`` () =
     let source: string =
@@ -197,7 +244,7 @@ let f (x: int option) : int =
     analyzeSource cliAnalyzer source |> assertLines [ 8 ]
 
 [<Test>]
-let ``a function keyword is not reported`` () =
+let ``a function keyword is reported`` () =
     let source: string =
         """module M
 
@@ -208,7 +255,7 @@ let f: int option -> int =
         a + 1
     | None -> 0"""
 
-    analyzeSource cliAnalyzer source |> assertLines []
+    analyzeSource cliAnalyzer source |> assertLines [ 8 ]
 
 [<Test>]
 let ``a try with is not reported`` () =

--- a/analyzers/Fantomas.Analyzers.Tests/BranchOrderAnalyzerTests.fs
+++ b/analyzers/Fantomas.Analyzers.Tests/BranchOrderAnalyzerTests.fs
@@ -1,0 +1,161 @@
+module Fantomas.Analyzers.Tests.BranchOrderAnalyzerTests
+
+open NUnit.Framework
+open Fantomas.Analyzers.Tests.TestHelpers
+open Fantomas.Analyzers.BranchOrderAnalyzer
+
+[<Test>]
+let ``a long then before a one line else is reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : int =
+    if x then
+        let a: int = 1
+        a + 1
+    else
+        0"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 8 ]
+
+[<Test>]
+let ``the shorter branch coming first is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : int =
+    if x then
+        0
+    else
+        let a: int = 1
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``two one line branches are not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : int = if x then 1 else 0"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``two long branches are not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : int =
+    if x then
+        let a: int = 1
+        a + 1
+    else
+        let b: int = 2
+        b + 2"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``an if without an else is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : unit =
+    if x then
+        let a: int = 1
+        printfn "%i" a"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``an elif chain is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int) : int =
+    if x = 1 then
+        let a: int = 1
+        a + 1
+    elif x = 2 then
+        2
+    else
+        3"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+// Negating a condition joined by `&&` or `||` means wrapping the whole of it in `not`, which reads
+// worse than the branches were worth.
+[<Test>]
+let ``a condition joined by and is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) (y: bool) : int =
+    if x && y then
+        let a: int = 1
+        a + 1
+    else
+        0"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``a condition joined by or is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) (y: bool) : int =
+    if x || y then
+        let a: int = 1
+        a + 1
+    else
+        0"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``a comparison is reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int) : int =
+    if x > 0 then
+        let a: int = x
+        a + 1
+    else
+        0"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 8 ]
+
+[<Test>]
+let ``an already negated condition is reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : int =
+    if not x then
+        let a: int = 1
+        a + 1
+    else
+        0"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 8 ]
+
+[<Test>]
+let ``a conditional directive inside the if is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : int =
+    if x then
+#if DEBUG
+        let a: int = 1
+#else
+        let a: int = 2
+#endif
+        a + 1
+    else
+        0"""
+
+    analyzeSource cliAnalyzer source |> assertLines []

--- a/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
+++ b/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="PipeBackAnalyzerTests.fs" />
     <Compile Include="PrivateAccessAnalyzerTests.fs" />
     <Compile Include="ArmOrderAnalyzerTests.fs" />
+    <Compile Include="KeepIndentAnalyzerTests.fs" />
     <Compile Include="AnnotationAnalyzerTests.fs" />
     <Compile Include="XmlDocAnalyzerTests.fs" />
   </ItemGroup>

--- a/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
+++ b/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="PrivateAccessAnalyzerTests.fs" />
     <Compile Include="ArmOrderAnalyzerTests.fs" />
     <Compile Include="KeepIndentAnalyzerTests.fs" />
+    <Compile Include="BranchOrderAnalyzerTests.fs" />
     <Compile Include="AnnotationAnalyzerTests.fs" />
     <Compile Include="XmlDocAnalyzerTests.fs" />
   </ItemGroup>

--- a/analyzers/Fantomas.Analyzers.Tests/KeepIndentAnalyzerTests.fs
+++ b/analyzers/Fantomas.Analyzers.Tests/KeepIndentAnalyzerTests.fs
@@ -103,6 +103,43 @@ let f (xs: string list) : string list =
 
     analyzeSource cliAnalyzer source |> assertLines [ 7 ]
 
+// `{ ... } |> Some` is an application at the top and a record underneath, and the record is what
+// indents things. `walkUp` in IgnoreFile.fs is the case this came from.
+[<Test>]
+let ``a body piping a record into a name is reported`` () =
+    let source: string =
+        """module M
+
+type T = { A: int; B: int }
+
+let f (x: bool) : T option =
+    if x then
+        None
+    else
+        {
+            A = 1
+            B = 2
+        }
+        |> Some"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 9 ]
+
+[<Test>]
+let ``a body piping an application into a name is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) (g: int -> int -> int) : int option =
+    if x then
+        None
+    else
+        g
+            1
+            2
+        |> Some"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
 [<Test>]
 let ``a last arm holding a single expression is not reported`` () =
     let source: string =
@@ -282,6 +319,162 @@ let f (x: int option) : int =
         a + 1"""
 
     analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``an else branch holding a block is reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : int =
+    if x then
+        0
+    else
+        let a: int = 1
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 7 ]
+
+[<Test>]
+let ``an else branch already keeping the indentation is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : int =
+    if x then
+        0
+    else
+
+    let a: int = 1
+    a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``the final else of an elif chain is reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int) : string =
+    if x = 1 then
+        "one"
+    elif x = 2 then
+        "two"
+    else
+        let label: string = string x
+        label + "!" """
+
+    analyzeSource cliAnalyzer source |> assertLines [ 9 ]
+
+[<Test>]
+let ``an else branch beside a multiline then branch is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : int =
+    if x then
+        let b: int = 1
+        b + 1
+    else
+        let a: int = 2
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``an elif chain with a multiline branch is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int) : int =
+    if x = 1 then
+        1
+    elif x = 2 then
+        let b: int = 2
+        b
+    else
+        let a: int = 3
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``an if without an else is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : unit =
+    if x then
+        let a: int = 1
+        printfn "%i" a"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``an else branch holding a single expression is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : string =
+    if x then
+        ""
+    else
+        "a"
+        |> string
+        |> String.replicate 2"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``code following the if in the same block is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : unit =
+    if x then
+        ()
+    else
+        let a: int = 1
+        printfn "%i" a
+
+    printfn "done" """
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``a conditional directive inside the if is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: bool) : int =
+    if x then
+        0
+    else
+#if DEBUG
+        let a: int = 1
+#else
+        let a: int = 2
+#endif
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``an else branch reported once, not once per elif`` () =
+    let source: string =
+        """module M
+
+let f (x: int) : int =
+    if x = 1 then
+        1
+    elif x = 2 then
+        2
+    elif x = 3 then
+        3
+    else
+        let a: int = 4
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 11 ]
 
 [<Test>]
 let ``the last arm of a function keyword is reported`` () =

--- a/analyzers/Fantomas.Analyzers.Tests/KeepIndentAnalyzerTests.fs
+++ b/analyzers/Fantomas.Analyzers.Tests/KeepIndentAnalyzerTests.fs
@@ -1,0 +1,185 @@
+module Fantomas.Analyzers.Tests.KeepIndentAnalyzerTests
+
+open NUnit.Framework
+open Fantomas.Analyzers.Tests.TestHelpers
+open Fantomas.Analyzers.KeepIndentAnalyzer
+
+[<Test>]
+let ``a last arm holding a block is reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : int =
+    match x with
+    | None -> 0
+    | Some y ->
+        let a: int = y
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 7 ]
+
+[<Test>]
+let ``a last arm already keeping the indentation is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : int =
+    match x with
+    | None -> 0
+    | Some y ->
+
+    let a: int = y
+    a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``a last arm holding a nested match is reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) (y: int option) : int =
+    match x with
+    | Some a -> a
+    | None ->
+        match y with
+        | None -> 0
+        | Some b -> b"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 7 ]
+
+[<Test>]
+let ``a last arm holding a single expression is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : string =
+    match x with
+    | None -> ""
+    | Some y ->
+        y
+        |> string
+        |> String.replicate 2"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``a one line last arm is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : int =
+    match x with
+    | None -> 0
+    | Some y -> y + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``a block in an arm that is not the last one is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : int =
+    match x with
+    | Some y ->
+        let a: int = y
+        a + 1
+    | None -> 0"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``code following the match in the same block is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : unit =
+    match x with
+    | None -> ()
+    | Some y ->
+        let a: int = y
+        printfn "%i" a
+
+    printfn "done" """
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``code following the match further left is still reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : int =
+    let r: int =
+        match x with
+        | None -> 0
+        | Some y ->
+            let a: int = y
+            a + 1
+
+    r + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 8 ]
+
+[<Test>]
+let ``a guarded last arm is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : int =
+    match x with
+    | None -> 0
+    | Some y when y > 0 ->
+        let a: int = y
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``a conditional directive inside the match is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : int =
+    match x with
+    | None -> 0
+    | Some y ->
+#if DEBUG
+        let a: int = y
+#else
+        let a: int = 0
+#endif
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``the last arm of a function keyword is reported`` () =
+    let source: string =
+        """module M
+
+let f: int option -> int =
+    function
+    | None -> 0
+    | Some y ->
+        let a: int = y
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 7 ]
+
+[<Test>]
+let ``the last arm of a match bang is reported`` () =
+    let source: string =
+        """module M
+
+let f (x: Async<int option>) : Async<int> =
+    async {
+        match! x with
+        | None -> return 0
+        | Some y ->
+            let a: int = y
+            return a + 1
+    }"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 8 ]

--- a/analyzers/Fantomas.Analyzers.Tests/KeepIndentAnalyzerTests.fs
+++ b/analyzers/Fantomas.Analyzers.Tests/KeepIndentAnalyzerTests.fs
@@ -81,6 +81,28 @@ let f (x: Wrapper) : int =
 
     analyzeSource cliAnalyzer source |> assertLines [ 8 ]
 
+// A bracketed body indents its items, and the items of a `for` inside it again. Fantomas holds it
+// in the column of the bar like any other block. `overruledLines` in Report.fs is the case this
+// came from.
+[<Test>]
+let ``a last arm holding a list is reported`` () =
+    let source: string =
+        """module M
+
+let f (xs: string list) : string list =
+    match xs with
+    | [] -> []
+    | files ->
+        [
+            for file in files do
+                let path: string = file
+                path
+
+            "trailing line"
+        ]"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 7 ]
+
 [<Test>]
 let ``a last arm holding a single expression is not reported`` () =
     let source: string =

--- a/analyzers/Fantomas.Analyzers.Tests/KeepIndentAnalyzerTests.fs
+++ b/analyzers/Fantomas.Analyzers.Tests/KeepIndentAnalyzerTests.fs
@@ -48,6 +48,39 @@ let f (x: int option) (y: int option) : int =
 
     analyzeSource cliAnalyzer source |> assertLines [ 7 ]
 
+// De-indenting one of two blocks says the last is a happy path and the other is not, when they are
+// the same kind of thing. `collectTriviaFromCodeComments` in Trivia.fs is the case this came from.
+[<Test>]
+let ``a match with a second block arm is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : int =
+    match x with
+    | None ->
+        let b: int = 1
+        b + 1
+    | Some y ->
+        let a: int = y
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``a single arm destructuring is reported`` () =
+    let source: string =
+        """module M
+
+type Wrapper = Wrapper of int
+
+let f (x: Wrapper) : int =
+    match x with
+    | Wrapper y ->
+        let a: int = y
+        a + 1"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 8 ]
+
 [<Test>]
 let ``a last arm holding a single expression is not reported`` () =
     let source: string =
@@ -104,6 +137,80 @@ let f (x: int option) : unit =
     printfn "done" """
 
     analyzeSource cliAnalyzer source |> assertLines []
+
+// The same swallow, but with a statement ahead of the match, which nests the sequence holding the
+// two rather than leaving the match at the top of it. This is the shape `writeDoctorFile` in
+// JsonReport.fs had, and the first sweep de-indented it and moved `json.WriteEndObject()` into the
+// last arm, so every doctor report came out as truncated JSON.
+[<Test>]
+let ``code following the match is not reported when a statement comes first`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : unit =
+    printfn "start"
+
+    match x with
+    | None -> ()
+    | Some y ->
+        let a: int = y
+        printfn "%i" a
+
+    printfn "done" """
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+// Not a statement after the match but an operator under it, carrying the whole match into a
+// pipeline. This is the shape `genAttributesCore` in CodePrinter.fs had: `|> genNode attr` applied
+// to the match, and de-indenting would have made it apply to the last arm alone, so everything
+// reached through the other arm lost its trivia.
+[<Test>]
+let ``an operator under the match is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : string =
+    match x with
+    | None -> "none"
+    | Some y ->
+        let a: int = y
+        string a
+    |> sprintf "%s!" """
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``a comment under the match is not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : int =
+    match x with
+    | None -> 0
+    | Some y ->
+        let a: int = y
+        a + 1
+
+    // this would end up inside the arm
+    """
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``a closing bracket on the last line of the match is still reported`` () =
+    let source: string =
+        """module M
+
+let f (xs: int option list) : int list =
+    xs
+    |> List.map (fun x ->
+        match x with
+        | None -> 0
+        | Some y ->
+            let a: int = y
+            a + 1)"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 9 ]
 
 [<Test>]
 let ``code following the match further left is still reported`` () =

--- a/analyzers/Fantomas.Analyzers/AnnotationAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/AnnotationAnalyzer.fs
@@ -95,17 +95,18 @@ let missingAnnotations (binding: SynBinding) : (range * string) list =
             if hasReturnType then
                 []
             else
-                // An uppercase name parses as a `LongIdent` rather than a `Named`, because it
-                // could be a union case, so a value can arrive here with no parameters at all.
-                // It is still a value, and asking it for a return type would read oddly.
-                let what: string =
-                    match parameters with
-                    | [] -> "type"
-                    | _ -> "return type"
 
-                match List.tryLast identifiers with
-                | None -> []
-                | Some last -> [ last.idRange, $"`%s{name}` has no %s{what} annotation." ]
+            // An uppercase name parses as a `LongIdent` rather than a `Named`, because it
+            // could be a union case, so a value can arrive here with no parameters at all.
+            // It is still a value, and asking it for a return type would read oddly.
+            let what: string =
+                match parameters with
+                | [] -> "type"
+                | _ -> "return type"
+
+            match List.tryLast identifiers with
+            | None -> []
+            | Some last -> [ last.idRange, $"`%s{name}` has no %s{what} annotation." ]
 
         untypedParameters @ missingReturn
     | _ -> []

--- a/analyzers/Fantomas.Analyzers/AnnotationAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/AnnotationAnalyzer.fs
@@ -87,7 +87,8 @@ let missingAnnotations (binding: SynBinding) : (range * string) list =
                     if isTyped parameter || isUnit parameter then
                         None
                     else
-                        Some(parameter.Range, $"A parameter of `%s{name}` has no type annotation."))
+                        Some(parameter.Range, $"A parameter of `%s{name}` has no type annotation.")
+                )
 
             let missingReturn: (range * string) list =
                 if hasReturnType then
@@ -150,7 +151,8 @@ let analyze (parsedInput: ParsedInput) : Message list =
                         Severity = Severity.Warning
                         Range = name
                         Fixes = []
-                    })
+                    }
+        )
         |> Seq.toList
 
 let cliAnalyzer (ctx: CliContext) : Async<Message list> =

--- a/analyzers/Fantomas.Analyzers/AnnotationAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/AnnotationAnalyzer.fs
@@ -65,49 +65,50 @@ let isLetBinding (keyword: SynLeadingKeyword) : bool =
 let missingAnnotations (binding: SynBinding) : (range * string) list =
     match binding with
     | SynBinding(headPat = headPattern; returnInfo = returnInfo) ->
-        let hasReturnType: bool = Option.isSome returnInfo
 
-        match headPattern with
-        | SynPat.Typed _ -> []
-        | SynPat.Named(ident = SynIdent(ident = name)) ->
+    let hasReturnType: bool = Option.isSome returnInfo
+
+    match headPattern with
+    | SynPat.Typed _ -> []
+    | SynPat.Named(ident = SynIdent(ident = name)) ->
+        if hasReturnType then
+            []
+        else
+            [ name.idRange, $"`%s{name.idText}` has no type annotation." ]
+    | SynPat.LongIdent(longDotId = SynLongIdent(id = identifiers); argPats = SynArgPats.Pats parameters) ->
+        let name: string =
+            identifiers
+            |> List.tryLast
+            |> Option.map (fun (i: Ident) -> i.idText)
+            |> Option.defaultValue "this binding"
+
+        let untypedParameters: (range * string) list =
+            parameters
+            |> List.choose (fun (parameter: SynPat) ->
+                if isTyped parameter || isUnit parameter then
+                    None
+                else
+                    Some(parameter.Range, $"A parameter of `%s{name}` has no type annotation.")
+            )
+
+        let missingReturn: (range * string) list =
             if hasReturnType then
                 []
             else
-                [ name.idRange, $"`%s{name.idText}` has no type annotation." ]
-        | SynPat.LongIdent(longDotId = SynLongIdent(id = identifiers); argPats = SynArgPats.Pats parameters) ->
-            let name: string =
-                identifiers
-                |> List.tryLast
-                |> Option.map (fun (i: Ident) -> i.idText)
-                |> Option.defaultValue "this binding"
+                // An uppercase name parses as a `LongIdent` rather than a `Named`, because it
+                // could be a union case, so a value can arrive here with no parameters at all.
+                // It is still a value, and asking it for a return type would read oddly.
+                let what: string =
+                    match parameters with
+                    | [] -> "type"
+                    | _ -> "return type"
 
-            let untypedParameters: (range * string) list =
-                parameters
-                |> List.choose (fun (parameter: SynPat) ->
-                    if isTyped parameter || isUnit parameter then
-                        None
-                    else
-                        Some(parameter.Range, $"A parameter of `%s{name}` has no type annotation.")
-                )
+                match List.tryLast identifiers with
+                | None -> []
+                | Some last -> [ last.idRange, $"`%s{name}` has no %s{what} annotation." ]
 
-            let missingReturn: (range * string) list =
-                if hasReturnType then
-                    []
-                else
-                    // An uppercase name parses as a `LongIdent` rather than a `Named`, because it
-                    // could be a union case, so a value can arrive here with no parameters at all.
-                    // It is still a value, and asking it for a return type would read oddly.
-                    let what: string =
-                        match parameters with
-                        | [] -> "type"
-                        | _ -> "return type"
-
-                    match List.tryLast identifiers with
-                    | None -> []
-                    | Some last -> [ last.idRange, $"`%s{name}` has no %s{what} annotation." ]
-
-            untypedParameters @ missingReturn
-        | _ -> []
+        untypedParameters @ missingReturn
+    | _ -> []
 
 // Every let binding that is missing a type, with the test bindings passed over.
 //
@@ -117,43 +118,43 @@ let analyze (parsedInput: ParsedInput) : Message list =
     | ParsedInput.SigFile _ -> []
     | ParsedInput.ImplFile _ ->
 
-        let findings: ResizeArray<range * string> = ResizeArray<range * string>()
-        let exempt: ResizeArray<range> = ResizeArray<range>()
+    let findings: ResizeArray<range * string> = ResizeArray<range * string>()
+    let exempt: ResizeArray<range> = ResizeArray<range>()
 
-        let walker: SyntaxCollectorBase =
-            { new SyntaxCollectorBase() with
-                override _.WalkBinding(_path: SyntaxVisitorPath, binding: SynBinding) : unit =
-                    match binding with
-                    | SynBinding(attributes = attributes; trivia = { LeadingKeyword = keyword }) ->
-                        if isTest attributes then
-                            // The body has to be part of this, so that the locals inside a test are
-                            // exempt too. `SynBinding.range` stops before the right hand side.
-                            exempt.Add binding.RangeOfBindingWithRhs
-                        elif isLetBinding keyword then
-                            findings.AddRange(missingAnnotations binding)
-            }
+    let walker: SyntaxCollectorBase =
+        { new SyntaxCollectorBase() with
+            override _.WalkBinding(_path: SyntaxVisitorPath, binding: SynBinding) : unit =
+                match binding with
+                | SynBinding(attributes = attributes; trivia = { LeadingKeyword = keyword }) ->
+                    if isTest attributes then
+                        // The body has to be part of this, so that the locals inside a test are
+                        // exempt too. `SynBinding.range` stops before the right hand side.
+                        exempt.Add binding.RangeOfBindingWithRhs
+                    elif isLetBinding keyword then
+                        findings.AddRange(missingAnnotations binding)
+        }
 
-        walkAst walker parsedInput
+    walkAst walker parsedInput
 
-        // A test body is scaffolding, so the locals inside one are passed over along with the test
-        // itself. The exempt ranges are only known once the whole file has been walked, which is why
-        // this filters at the end rather than while collecting.
-        findings
-        |> Seq.choose (fun (name: range, text: string) ->
-            if Seq.exists (fun (test: range) -> Range.rangeContainsRange test name) exempt then
-                None
-            else
-                Some
-                    {
-                        Type = Name
-                        Message = text
-                        Code = Code
-                        Severity = Severity.Warning
-                        Range = name
-                        Fixes = []
-                    }
-        )
-        |> Seq.toList
+    // A test body is scaffolding, so the locals inside one are passed over along with the test
+    // itself. The exempt ranges are only known once the whole file has been walked, which is why
+    // this filters at the end rather than while collecting.
+    findings
+    |> Seq.choose (fun (name: range, text: string) ->
+        if Seq.exists (fun (test: range) -> Range.rangeContainsRange test name) exempt then
+            None
+        else
+            Some
+                {
+                    Type = Name
+                    Message = text
+                    Code = Code
+                    Severity = Severity.Warning
+                    Range = name
+                    Fixes = []
+                }
+    )
+    |> Seq.toList
 
 let cliAnalyzer (ctx: CliContext) : Async<Message list> =
     async { return analyze ctx.ParseFileResults.ParseTree }

--- a/analyzers/Fantomas.Analyzers/ArmOrderAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/ArmOrderAnalyzer.fs
@@ -3,8 +3,8 @@ module Fantomas.Analyzers.ArmOrderAnalyzer
 open FSharp.Analyzers.SDK
 open FSharp.Analyzers.SDK.ASTCollecting
 open FSharp.Compiler.Syntax
-open FSharp.Compiler.SyntaxTrivia
 open FSharp.Compiler.Text
+open Fantomas.Analyzers.Common
 
 [<Literal>]
 let Code: string = "FANTOMAS-ARMORDER-001"
@@ -19,32 +19,6 @@ let ShortDescription: string =
 [<Literal>]
 let HelpUri: string =
     "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-armorder-001"
-
-// The comments and the conditional directives of a file, which are the two things that make a
-// textual swap of two arms something other than a swap.
-let triviaOf (parsedInput: ParsedInput) : range list * range list =
-    let comments, directives =
-        match parsedInput with
-        | ParsedInput.SigFile(ParsedSigFileInput(trivia = trivia)) -> trivia.CodeComments, trivia.ConditionalDirectives
-        | ParsedInput.ImplFile(ParsedImplFileInput(trivia = trivia)) ->
-            trivia.CodeComments, trivia.ConditionalDirectives
-
-    let commentRanges: range list =
-        comments
-        |> List.map (fun (comment: CommentTrivia) ->
-            match comment with
-            | CommentTrivia.LineComment range -> range
-            | CommentTrivia.BlockComment range -> range)
-
-    let directiveRanges: range list =
-        directives
-        |> List.map (fun (directive: ConditionalDirectiveTrivia) ->
-            match directive with
-            | ConditionalDirectiveTrivia.Else range -> range
-            | ConditionalDirectiveTrivia.EndIf range -> range
-            | ConditionalDirectiveTrivia.If(range = range) -> range)
-
-    commentRanges, directiveRanges
 
 // The final identifier of a pattern that heads an arm, when that pattern is one this rule is
 // willing to reason about.
@@ -88,7 +62,8 @@ let shouldSwap
     (matchRange: range)
     (first: SynMatchClause)
     (second: SynMatchClause)
-    : bool =
+    : bool
+    =
     match first, second with
     | SynMatchClause(pat = firstPattern; whenExpr = None; range = firstRange),
       SynMatchClause(pat = secondPattern; whenExpr = None; range = secondRange) ->
@@ -130,7 +105,8 @@ let analyze (parsedInput: ParsedInput) : Message list =
             Severity = Severity.Warning
             Range = clause
             Fixes = []
-        })
+        }
+    )
     |> Seq.toList
 
 let cliAnalyzer (ctx: CliContext) : Async<Message list> =

--- a/analyzers/Fantomas.Analyzers/ArmOrderAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/ArmOrderAnalyzer.fs
@@ -31,6 +31,14 @@ let caseNameOf (pattern: SynPat) : string option =
     match pattern with
     | SynPat.LongIdent(longDotId = SynLongIdent(id = identifiers)) ->
         identifiers |> List.tryLast |> Option.map (fun (ident: Ident) -> ident.idText)
+    // A list is matched by its own two shapes rather than by union cases, and those two are as
+    // disjoint as any pair of cases: an empty list never has a head. Naming them is what lets the
+    // rule speak about the recursive function that walks a list, which is where the shape lives.
+    //
+    // A non-empty literal such as `[ x ]` is deliberately left unnamed. It overlaps `x :: rest`, so
+    // those two cannot be swapped, and the rule has to stay quiet rather than guess.
+    | SynPat.ListCons _ -> Some "::"
+    | SynPat.ArrayOrList(isArray = isArray; elementPats = []) -> Some(if isArray then "[||]" else "[]")
     | _ -> None
 
 // Whether two arms can never match the same value, which is what makes reordering them sound.
@@ -82,10 +90,8 @@ let analyze (parsedInput: ParsedInput) : Message list =
     let walker: SyntaxCollectorBase =
         { new SyntaxCollectorBase() with
             override _.WalkExpr(_path: SyntaxVisitorPath, expr: SynExpr) : unit =
-                match expr with
-                | SynExpr.Match(clauses = [ first; second ]; range = matchRange) when
-                    shouldSwap comments directives matchRange first second
-                    ->
+                match matchClausesOf expr with
+                | Some(matchRange, [ first; second ]) when shouldSwap comments directives matchRange first second ->
                     match second with
                     | SynMatchClause(pat = pattern; range = clauseRange) ->
                         let name: string = defaultArg (caseNameOf pattern) "this"

--- a/analyzers/Fantomas.Analyzers/ArmOrderAnalyzer.fsi
+++ b/analyzers/Fantomas.Analyzers/ArmOrderAnalyzer.fsi
@@ -23,6 +23,9 @@ val HelpUri: string = "https://github.com/fsprojects/fantomas/blob/main/analyzer
 /// a guard, on a wildcard or a bare binder, on anything other than two arms, and where a comment
 /// between the arms or a conditional directive inside the match would make a swap something other
 /// than a swap. No fix is offered: the point is to make a person look.
+///
+/// Once the arms are the right way around, `FANTOMAS-KEEPINDENT-001` is what asks for the other
+/// half of the reshape.
 [<CliAnalyzer(Name, ShortDescription, HelpUri)>]
 val cliAnalyzer: ctx: CliContext -> Async<Message list>
 

--- a/analyzers/Fantomas.Analyzers/BranchOrderAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/BranchOrderAnalyzer.fs
@@ -1,0 +1,123 @@
+module Fantomas.Analyzers.BranchOrderAnalyzer
+
+open FSharp.Analyzers.SDK
+open FSharp.Analyzers.SDK.ASTCollecting
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.SyntaxTrivia
+open FSharp.Compiler.Text
+open Fantomas.Analyzers.Common
+
+[<Literal>]
+let Code: string = "FANTOMAS-BRANCHORDER-001"
+
+[<Literal>]
+let Name: string = "BranchOrderAnalyzer"
+
+[<Literal>]
+let ShortDescription: string =
+    "Detects an if expression whose long branch comes first, where negating the condition would put the one line branch first instead."
+
+[<Literal>]
+let HelpUri: string =
+    "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-branchorder-001"
+
+// Whether a condition is one this rule is willing to ask somebody to turn around.
+//
+// An `if` can always be reversed on paper, but not every reversal reads as well as the original.
+// A comparison flips into its opposite and a `not` falls away, and both of those are still one
+// thing to read. A condition joined by `&&` or `||` has to grow a `not` and a pair of parentheses
+// around the whole of it, which is a worse sentence than the branches were worth, so those are left
+// alone. So is anything else: a bare call, a property, a pattern test. Those can only gain a `not`,
+// which is fine, and they are the common case.
+//
+// The operator arrives as a `SynExpr.App` of a `SynExpr.LongIdent` holding the compiled name, which
+// is how `op_BooleanAnd` and a spelled out `(&&)` both land here.
+let isReversibleCondition (condition: SynExpr) : bool =
+    let rec joinsWithBooleanOperator (expr: SynExpr) : bool =
+        match expr with
+        | SynExpr.App(funcExpr = funcExpr; argExpr = argExpr) ->
+            joinsWithBooleanOperator funcExpr || joinsWithBooleanOperator argExpr
+        | SynExpr.LongIdent(longDotId = SynLongIdent(id = identifiers)) ->
+            match List.tryLast identifiers with
+            | None -> false
+            | Some name -> name.idText = "op_BooleanAnd" || name.idText = "op_BooleanOr"
+        | SynExpr.Paren _ -> false
+        | _ -> false
+
+    not (joinsWithBooleanOperator condition)
+
+// Whether an if expression has its branches the wrong way around.
+//
+// Everything here is a reason to stay quiet, and the rule only speaks when none of them applies.
+// There has to be an `else`, and no `elif`: a chain has more than two ways through it and no single
+// swap that puts the short one first. The `then` branch has to run to more than one line while the
+// `else` branch fits on one, which is the same measure `FANTOMAS-ARMORDER-001` uses. And a
+// conditional directive inside means the branches this reads are not the branches every build sees.
+//
+// Unlike a match arm there is nothing to prove about overlap. The two branches of an `if` are
+// exclusive by construction, so reversing the condition cannot change which one runs. What it can
+// change is how the condition reads, which is what `isReversibleCondition` is about.
+let shouldReverse (directives: range list) (expr: SynExpr) : (range * range) option =
+    match expr with
+    | SynExpr.IfThenElse(
+        ifExpr = condition; thenExpr = thenExpr; elseExpr = Some elseExpr; range = ifRange; trivia = { IsElif = false }) ->
+
+        let isChain: bool =
+            match elseExpr with
+            | SynExpr.IfThenElse _ -> true
+            | _ -> false
+
+        let longBranchComesFirst: bool =
+            thenExpr.Range.EndLine > thenExpr.Range.StartLine
+            && elseExpr.Range.EndLine = elseExpr.Range.StartLine
+
+        let holdsADirective: bool =
+            directives
+            |> List.exists (fun (directive: range) -> Range.rangeContainsRange ifRange directive)
+
+        if
+            isChain
+            || holdsADirective
+            || not longBranchComesFirst
+            || not (isReversibleCondition condition)
+        then
+            None
+        else
+
+        Some(elseExpr.Range, condition.Range)
+    | _ -> None
+
+// Reported on the one line branch, which is the one that moves.
+let analyze (parsedInput: ParsedInput) : Message list =
+    let _, directives = triviaOf parsedInput
+    let findings: ResizeArray<range> = ResizeArray<range>()
+
+    let walker: SyntaxCollectorBase =
+        { new SyntaxCollectorBase() with
+            override _.WalkExpr(_path: SyntaxVisitorPath, expr: SynExpr) : unit =
+                match shouldReverse directives expr with
+                | None -> ()
+                | Some(elseRange, _) -> findings.Add elseRange
+        }
+
+    walkAst walker parsedInput
+
+    findings
+    |> Seq.map (fun (elseRange: range) ->
+        {
+            Type = Name
+            Message =
+                "Put the shorter branch first. This `else` is a one liner and the `then` above it is not, so negating the condition and swapping the two changes nothing but the reading, and leaves the branch that carries on last where `FANTOMAS-KEEPINDENT-001` can reach it."
+            Code = Code
+            Severity = Severity.Warning
+            Range = elseRange
+            Fixes = []
+        }
+    )
+    |> Seq.toList
+
+let cliAnalyzer (ctx: CliContext) : Async<Message list> =
+    async { return analyze ctx.ParseFileResults.ParseTree }
+
+let editorAnalyzer (ctx: EditorContext) : Async<Message list> =
+    async { return analyze ctx.ParseFileResults.ParseTree }

--- a/analyzers/Fantomas.Analyzers/BranchOrderAnalyzer.fsi
+++ b/analyzers/Fantomas.Analyzers/BranchOrderAnalyzer.fsi
@@ -1,0 +1,36 @@
+module Fantomas.Analyzers.BranchOrderAnalyzer
+
+open FSharp.Analyzers.SDK
+
+[<Literal>]
+val Code: string = "FANTOMAS-BRANCHORDER-001"
+
+[<Literal>]
+val Name: string = "BranchOrderAnalyzer"
+
+[<Literal>]
+val ShortDescription: string =
+    "Detects an if expression whose long branch comes first, where negating the condition would put the one line branch first instead."
+
+[<Literal>]
+val HelpUri: string = "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-branchorder-001"
+
+/// Reports an if expression whose branches should be the other way around, on the one line branch,
+/// which is the one that moves.
+///
+/// This is `FANTOMAS-ARMORDER-001` for an `if`, and it asks for more than that rule does: a match
+/// arm can only be moved, where a condition has to be negated as well. The two branches of an `if`
+/// are exclusive by construction, so there is nothing to prove about overlap and the swap is always
+/// sound. What is not always an improvement is the condition it leaves behind, so the rule stays
+/// quiet where the condition is joined by `&&` or `||` and negating it would mean wrapping the whole
+/// of it in `not`.
+///
+/// It speaks only for a plain `if`/`then`/`else` with no `elif`, since a chain has no single swap
+/// that puts the short branch first, and only where the `then` runs to more than one line while the
+/// `else` fits on one. It stays quiet on a conditional directive inside the expression. No fix is
+/// offered: rewriting a condition is a thing to read before doing.
+[<CliAnalyzer(Name, ShortDescription, HelpUri)>]
+val cliAnalyzer: ctx: CliContext -> Async<Message list>
+
+[<EditorAnalyzer(Name, ShortDescription, HelpUri)>]
+val editorAnalyzer: ctx: EditorContext -> Async<Message list>

--- a/analyzers/Fantomas.Analyzers/Common.fs
+++ b/analyzers/Fantomas.Analyzers/Common.fs
@@ -70,12 +70,13 @@ let isTest (attributes: SynAttributes) : bool =
             match List.tryLast attribute.TypeName.LongIdent with
             | None -> false
             | Some name ->
-                let bare: string =
-                    if name.idText.EndsWith("Attribute", StringComparison.Ordinal) then
-                        name.idText.Substring(0, name.idText.Length - "Attribute".Length)
-                    else
-                        name.idText
 
-                testAttributes.Contains bare
+            let bare: string =
+                if name.idText.EndsWith("Attribute", StringComparison.Ordinal) then
+                    name.idText.Substring(0, name.idText.Length - "Attribute".Length)
+                else
+                    name.idText
+
+            testAttributes.Contains bare
         )
     )

--- a/analyzers/Fantomas.Analyzers/Common.fs
+++ b/analyzers/Fantomas.Analyzers/Common.fs
@@ -3,6 +3,34 @@ module Fantomas.Analyzers.Common
 open System
 open System.IO
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.SyntaxTrivia
+open FSharp.Compiler.Text
+
+let triviaOf (parsedInput: ParsedInput) : range list * range list =
+    let comments, directives =
+        match parsedInput with
+        | ParsedInput.SigFile(ParsedSigFileInput(trivia = trivia)) -> trivia.CodeComments, trivia.ConditionalDirectives
+        | ParsedInput.ImplFile(ParsedImplFileInput(trivia = trivia)) ->
+            trivia.CodeComments, trivia.ConditionalDirectives
+
+    let commentRanges: range list =
+        comments
+        |> List.map (fun (comment: CommentTrivia) ->
+            match comment with
+            | CommentTrivia.LineComment range -> range
+            | CommentTrivia.BlockComment range -> range
+        )
+
+    let directiveRanges: range list =
+        directives
+        |> List.map (fun (directive: ConditionalDirectiveTrivia) ->
+            match directive with
+            | ConditionalDirectiveTrivia.Else range -> range
+            | ConditionalDirectiveTrivia.EndIf range -> range
+            | ConditionalDirectiveTrivia.If(range = range) -> range
+        )
+
+    commentRanges, directiveRanges
 
 let hasSignatureFile (fileName: string) (sourceFiles: string list) : bool =
     let normalize (path: string) : string =
@@ -15,7 +43,8 @@ let hasSignatureFile (fileName: string) (sourceFiles: string list) : bool =
 
         sourceFiles
         |> List.exists (fun (source: string) ->
-            String.Equals(normalize source, signatureFile, StringComparison.OrdinalIgnoreCase))
+            String.Equals(normalize source, signatureFile, StringComparison.OrdinalIgnoreCase)
+        )
 
 let testAttributes: Set<string> =
     set
@@ -47,4 +76,6 @@ let isTest (attributes: SynAttributes) : bool =
                     else
                         name.idText
 
-                testAttributes.Contains bare))
+                testAttributes.Contains bare
+        )
+    )

--- a/analyzers/Fantomas.Analyzers/Common.fs
+++ b/analyzers/Fantomas.Analyzers/Common.fs
@@ -32,6 +32,13 @@ let triviaOf (parsedInput: ParsedInput) : range list * range list =
 
     commentRanges, directiveRanges
 
+let matchClausesOf (expr: SynExpr) : (range * SynMatchClause list) option =
+    match expr with
+    | SynExpr.Match(clauses = clauses; range = range)
+    | SynExpr.MatchBang(clauses = clauses; range = range)
+    | SynExpr.MatchLambda(matchClauses = clauses; range = range) -> Some(range, clauses)
+    | _ -> None
+
 let hasSignatureFile (fileName: string) (sourceFiles: string list) : bool =
     let normalize (path: string) : string =
         Path.GetFullPath(path).Replace('\\', '/')
@@ -39,12 +46,13 @@ let hasSignatureFile (fileName: string) (sourceFiles: string list) : bool =
     if not (fileName.EndsWith(".fs", StringComparison.OrdinalIgnoreCase)) then
         false
     else
-        let signatureFile: string = normalize (fileName + "i")
 
-        sourceFiles
-        |> List.exists (fun (source: string) ->
-            String.Equals(normalize source, signatureFile, StringComparison.OrdinalIgnoreCase)
-        )
+    let signatureFile: string = normalize (fileName + "i")
+
+    sourceFiles
+    |> List.exists (fun (source: string) ->
+        String.Equals(normalize source, signatureFile, StringComparison.OrdinalIgnoreCase)
+    )
 
 let testAttributes: Set<string> =
     set

--- a/analyzers/Fantomas.Analyzers/Common.fsi
+++ b/analyzers/Fantomas.Analyzers/Common.fsi
@@ -11,6 +11,14 @@ open FSharp.Compiler.Text
 /// speak about match arms have to ask, so both ask here.
 val triviaOf: parsedInput: ParsedInput -> range list * range list
 
+/// The arms of everything that prints as a list of match arms, with the range of the expression they
+/// belong to.
+///
+/// `match`, `match!` and `function` all reach the same clause printer in `CodePrinter`, so a rule
+/// about arms means all three of them. Both rules that speak about arms ask here, so neither can
+/// quietly cover fewer shapes than the other.
+val matchClausesOf: expr: SynExpr -> (range * SynMatchClause list) option
+
 /// Whether the file being analyzed has a signature file in the same project.
 ///
 /// The project's own source list answers this rather than a look at the filesystem. An `.fsi` that

--- a/analyzers/Fantomas.Analyzers/Common.fsi
+++ b/analyzers/Fantomas.Analyzers/Common.fsi
@@ -1,6 +1,15 @@
 module Fantomas.Analyzers.Common
 
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
+
+/// The comments of a file and its conditional directives, in that order.
+///
+/// These are the two things that make a reshape of a match something other than a reshape. A
+/// comment between two arms belongs to neither once they have moved, and a conditional directive
+/// inside a match means the arms one rule reads are not the arms every build sees. Both rules that
+/// speak about match arms have to ask, so both ask here.
+val triviaOf: parsedInput: ParsedInput -> range list * range list
 
 /// Whether the file being analyzed has a signature file in the same project.
 ///

--- a/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
+++ b/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
@@ -35,6 +35,8 @@
     <Compile Include="ArmOrderAnalyzer.fs" />
     <Compile Include="KeepIndentAnalyzer.fsi" />
     <Compile Include="KeepIndentAnalyzer.fs" />
+    <Compile Include="BranchOrderAnalyzer.fsi" />
+    <Compile Include="BranchOrderAnalyzer.fs" />
     <Compile Include="AnnotationAnalyzer.fsi" />
     <Compile Include="AnnotationAnalyzer.fs" />
     <Compile Include="XmlDocAnalyzer.fsi" />

--- a/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
+++ b/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
@@ -33,6 +33,8 @@
     <Compile Include="PrivateAccessAnalyzer.fs" />
     <Compile Include="ArmOrderAnalyzer.fsi" />
     <Compile Include="ArmOrderAnalyzer.fs" />
+    <Compile Include="KeepIndentAnalyzer.fsi" />
+    <Compile Include="KeepIndentAnalyzer.fs" />
     <Compile Include="AnnotationAnalyzer.fsi" />
     <Compile Include="AnnotationAnalyzer.fs" />
     <Compile Include="XmlDocAnalyzer.fsi" />

--- a/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fs
@@ -1,0 +1,176 @@
+module Fantomas.Analyzers.KeepIndentAnalyzer
+
+open FSharp.Analyzers.SDK
+open FSharp.Analyzers.SDK.ASTCollecting
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
+open Fantomas.Analyzers.Common
+
+[<Literal>]
+let Code: string = "FANTOMAS-KEEPINDENT-001"
+
+[<Literal>]
+let Name: string = "KeepIndentAnalyzer"
+
+[<Literal>]
+let ShortDescription: string =
+    "Detects a last match arm whose body is a block indented a level past the match, where the indentation of the match could be kept instead."
+
+[<Literal>]
+let HelpUri: string =
+    "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-keepindent-001"
+
+// The arms of everything that prints as a list of match arms, with the range of the expression they
+// belong to. `match`, `match!` and `function` all reach the same clause printer in `CodePrinter`, so
+// the last arm of each is one `fsharp_experimental_keep_indent_in_branch` can speak about.
+let matchClausesOf (expr: SynExpr) : (range * SynMatchClause list) option =
+    match expr with
+    | SynExpr.Match(clauses = clauses; range = range)
+    | SynExpr.MatchBang(clauses = clauses; range = range)
+    | SynExpr.MatchLambda(matchClauses = clauses; range = range) -> Some(range, clauses)
+    | _ -> None
+
+// The column a body has to start in for Fantomas to leave it there.
+//
+// `genKeepIdentMatchClause` compares the body against the bar, falling back to the pattern where
+// there is none, so this is that same column and not a column of this rule's choosing. Only the
+// last arm is ever asked, and the arm without a bar is the first one, but the fallback keeps the
+// two definitions in step.
+let keepIndentColumnOf (clause: SynMatchClause) : int =
+    match clause with
+    | SynMatchClause(pat = pattern; trivia = trivia) ->
+        match trivia.BarRange with
+        | Some bar -> bar.StartColumn
+        | None -> pattern.Range.StartColumn
+
+// Whether a body is the kind of expression that goes on to indent things of its own.
+//
+// This is what the de-indent is for. A block holds bindings, statements or arms that each sit a
+// level in again, so the four columns it saves are saved for everything inside it, and saved again
+// by the next block in. A single application or pipeline has nothing under it to save them for, and
+// reads oddly under the blank line the setting writes.
+let isBlockBody (expr: SynExpr) : bool =
+    match expr with
+    | SynExpr.Sequential _
+    | SynExpr.LetOrUse _
+    | SynExpr.Match _
+    | SynExpr.MatchBang _
+    | SynExpr.MatchLambda _
+    | SynExpr.IfThenElse _ -> true
+    | _ -> false
+
+// Where one expression is followed by another in the same block: the range of the first, and the
+// column the second starts in.
+let followerOf (expr: SynExpr) : (range * int) option =
+    match expr with
+    | SynExpr.Sequential(expr1 = before; expr2 = after)
+    | SynExpr.SequentialOrImplicitYield(expr1 = before; expr2 = after) -> Some(before.Range, after.Range.StartColumn)
+    | _ -> None
+
+// Whether keeping the indentation would pull in code that follows the match.
+//
+// This is the one way the reshape changes meaning, and the only reason the rule needs to look
+// further than the arm. De-indenting moves the offside line of the body out to the bar, and code
+// that follows the match in the same block starts in that same column. What was the first thing
+// past the match becomes the last thing inside the arm: it stops running whatever matched and
+// starts running only for that one arm.
+//
+// So every place one expression is followed by another is collected, and a match sitting inside the
+// first of such a pair is left alone. Unless the second starts further left than the bar, which is
+// an enclosing block continuing rather than this one, and still ends the arm afterwards.
+//
+// A following arm of the same match needs no such care. Only the last arm is ever a candidate, so
+// there is never one of those left to swallow.
+let wouldSwallowFollowingCode (followers: (range * int) list) (matchRange: range) (column: int) : bool =
+    followers
+    |> List.exists (fun (before: range, followerColumn: int) ->
+        followerColumn >= column && Range.rangeContainsRange before matchRange
+    )
+
+// Whether the last arm of a match should keep the indentation of the match.
+//
+// A `when` guard is passed over: a multiline guard takes a different path in `CodePrinter` that
+// indents the body whatever its column, so the rule would be asking for something the formatter
+// then undoes. Which guards print multiline is a page width question rather than a tree one, so all
+// of them are left alone.
+//
+// The body has to be on a line of its own already, because an arm whose body shares the line of its
+// arrow has no indentation to keep, and it has to span more than that one line, because a body that
+// fits beside the arrow is pulled up next to it and never reaches the branch that would keep it.
+let shouldKeepIndent
+    (directives: range list)
+    (followers: (range * int) list)
+    (matchRange: range)
+    (clause: SynMatchClause)
+    : bool
+    =
+    match clause with
+    | SynMatchClause(whenExpr = Some _) -> false
+    | SynMatchClause(resultExpr = body; trivia = { ArrowRange = Some arrow }) ->
+        let column: int = keepIndentColumnOf clause
+        let bodyRange: range = body.Range
+
+        bodyRange.StartLine > arrow.EndLine
+        && bodyRange.EndLine > bodyRange.StartLine
+        && bodyRange.StartColumn > column
+        && isBlockBody body
+        && not (List.exists (fun (directive: range) -> Range.rangeContainsRange matchRange directive) directives)
+        && not (wouldSwallowFollowingCode followers matchRange column)
+    | _ -> false
+
+// Reported on the body, which is the part that moves.
+let analyze (parsedInput: ParsedInput) : Message list =
+    let _, directives = triviaOf parsedInput
+    let followers: ResizeArray<range * int> = ResizeArray<range * int>()
+
+    let candidates: ResizeArray<range * SynMatchClause> =
+        ResizeArray<range * SynMatchClause>()
+
+    let walker: SyntaxCollectorBase =
+        { new SyntaxCollectorBase() with
+            override _.WalkExpr(_path: SyntaxVisitorPath, expr: SynExpr) : unit =
+                match followerOf expr with
+                | None -> ()
+                | Some follower -> followers.Add follower
+
+                match matchClausesOf expr with
+                | None -> ()
+                | Some(matchRange, clauses) ->
+                    match List.tryLast clauses with
+                    | None -> ()
+                    | Some clause -> candidates.Add(matchRange, clause)
+        }
+
+    walkAst walker parsedInput
+
+    // Judged after the walk rather than during it. A match is reached before the sequence that holds
+    // it in some shapes and after it in others, so anything deciding on the followers has to wait
+    // until all of them are in.
+    let followers: (range * int) list = List.ofSeq followers
+
+    candidates
+    |> Seq.choose (fun (matchRange: range, clause: SynMatchClause) ->
+        if not (shouldKeepIndent directives followers matchRange clause) then
+            None
+        else
+
+        match clause with
+        | SynMatchClause(resultExpr = body) ->
+            Some
+                {
+                    Type = Name
+                    Message =
+                        "Keep the indentation of the match in this arm. It is the last one, its body is a block, and nothing follows the match in this block, so the body can start in the column of the `|` rather than a level in. `fsharp_experimental_keep_indent_in_branch` keeps it there, but only once it is written that way."
+                    Code = Code
+                    Severity = Severity.Warning
+                    Range = body.Range
+                    Fixes = []
+                }
+    )
+    |> Seq.toList
+
+let cliAnalyzer (ctx: CliContext) : Async<Message list> =
+    async { return analyze ctx.ParseFileResults.ParseTree }
+
+let editorAnalyzer (ctx: EditorContext) : Async<Message list> =
+    async { return analyze ctx.ParseFileResults.ParseTree }

--- a/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fs
@@ -3,6 +3,7 @@ module Fantomas.Analyzers.KeepIndentAnalyzer
 open FSharp.Analyzers.SDK
 open FSharp.Analyzers.SDK.ASTCollecting
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.SyntaxTrivia
 open FSharp.Compiler.Text
 open Fantomas.Analyzers.Common
 
@@ -14,35 +15,26 @@ let Name: string = "KeepIndentAnalyzer"
 
 [<Literal>]
 let ShortDescription: string =
-    "Detects a last match arm whose body is a block indented a level past the match, where the indentation of the match could be kept instead."
+    "Detects a last branch whose body is a block indented a level past the expression it belongs to, where that indentation could be kept instead."
 
 [<Literal>]
 let HelpUri: string =
     "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-keepindent-001"
 
-// The arms of everything that prints as a list of match arms, with the range of the expression they
-// belong to. `match`, `match!` and `function` all reach the same clause printer in `CodePrinter`, so
-// the last arm of each is one `fsharp_experimental_keep_indent_in_branch` can speak about.
-let matchClausesOf (expr: SynExpr) : (range * SynMatchClause list) option =
-    match expr with
-    | SynExpr.Match(clauses = clauses; range = range)
-    | SynExpr.MatchBang(clauses = clauses; range = range)
-    | SynExpr.MatchLambda(matchClauses = clauses; range = range) -> Some(range, clauses)
-    | _ -> None
-
-// The column a body has to start in for Fantomas to leave it there.
+// The expression a body really starts with, looking through the operators it is piped into.
 //
-// `genKeepIdentMatchClause` compares the body against the bar, falling back to the pattern where
-// there is none, so this is that same column and not a column of this rule's choosing. Only the
-// last arm is ever asked, and the arm without a bar is the first one, but the fallback keeps the
-// two definitions in step.
-let keepIndentColumnOf (clause: SynMatchClause) : int =
-    match clause with
-    | SynMatchClause(pat = pattern; trivia = trivia) ->
-
-    match trivia.BarRange with
-    | Some bar -> bar.StartColumn
-    | None -> pattern.Range.StartColumn
+// `{ ... } |> Some` is an application at the top and a record underneath, and the record is what
+// indents things. What is to the right of the operator is a name, so what decides whether the body
+// is a block is what stands on the left of the first one. `walkUp` in IgnoreFile.fs is the case that
+// showed it, and the same reading covers `{ ... } :: rest`.
+//
+// A pipeline whose left hand side is itself an application is left where it was: `someCall a b |>
+// Some` has nothing under it that a de-indent would save columns for, which is the whole reason a
+// plain application is passed over.
+let rec bodyHead (expr: SynExpr) : SynExpr =
+    match expr with
+    | SynExpr.App(funcExpr = SynExpr.App(isInfix = true; argExpr = leftHandSide)) -> bodyHead leftHandSide
+    | _ -> expr
 
 // Whether a body is the kind of expression that goes on to indent things of its own.
 //
@@ -55,7 +47,7 @@ let keepIndentColumnOf (clause: SynMatchClause) : int =
 // the loop twice over, and Fantomas holds it in the column of the bar like anything else. The
 // `overruledLines` list in Report.fs is the case that showed it.
 let isBlockBody (expr: SynExpr) : bool =
-    match expr with
+    match bodyHead expr with
     | SynExpr.Sequential _
     | SynExpr.LetOrUse _
     | SynExpr.Match _
@@ -70,49 +62,33 @@ let isBlockBody (expr: SynExpr) : bool =
     | SynExpr.ObjExpr _ -> true
     | _ -> false
 
-// Whether the last arm is the only one that is not a one liner.
-//
-// The setting is for the early return shape, which is what makes the de-indent read as anything at
-// all: the arms that decline say so on one line and get out of the way, and what is left is the one
-// path that carries on, written at the indentation it started at. A match whose other arms are
-// blocks too is not that shape, and de-indenting the last of them alone puts arms of the same kind
-// at two different indentations, saying the last one is special when it is not.
-//
-// `collectTriviaFromCodeComments` in Trivia.fs is the case that showed it: both of its arms are a
-// dozen lines, and de-indenting the second read as a mistake rather than as a happy path.
-//
-// One liner is measured on the whole clause, which is how `FANTOMAS-ARMORDER-001` measures it, and
-// that rule is what puts those arms first to begin with. A match with a single arm, destructuring a
-// single case union, qualifies: there is no other arm for it to be out of step with.
-let onlyLastArmIsBlock (clauses: SynMatchClause list) : bool =
-    match List.rev clauses with
-    | [] -> false
-    | _ :: earlier ->
-        earlier
-        |> List.forall (fun (SynMatchClause(range = range)) -> range.EndLine = range.StartLine)
+// Whether a range is a single line, which is how both halves of this rule measure a branch that
+// gets out of the way. `FANTOMAS-ARMORDER-001` measures a short arm the same way.
+let isOneLiner (range: range) : bool = range.EndLine = range.StartLine
 
-// Whether anything follows the match that keeping the indentation would take into the last arm.
+// Whether anything follows the expression that keeping the indentation would take into its last
+// branch.
 //
 // This is the one way the reshape changes meaning, and it is a question about the text rather than
-// the tree. De-indenting moves the offside line of the body out to the bar, so the first thing
-// after the match that starts in that column, or further right, stops following the match and
-// starts belonging to its last arm. What that thing is does not matter: a statement of the
-// enclosing block, an operator carrying the match into a pipeline, a comment. Anything further left
-// ends the arm exactly as it ended the match before.
+// the tree. De-indenting moves the offside line of the body out to the column of the `|` or the
+// `else`, so the first thing after the expression that starts in that column, or further right,
+// stops following the expression and starts belonging to that branch. What that thing is does not
+// matter: a statement of the enclosing block, an operator carrying the expression into a pipeline,
+// a comment. Anything further left ends the branch exactly as it ended the expression before.
 //
-// Only lines after the one the match ends on are asked about. Whatever shares that last line moves
-// with the body and keeps its place, which is how a closing bracket on the same line stays out of
-// this.
+// Only lines after the one the expression ends on are asked about. Whatever shares that last line
+// moves with the body and keeps its place, which is how a closing bracket on the same line stays
+// out of this.
 //
 // Reading the source rather than the tree is deliberate, and is the third attempt. Collecting
 // `SynExpr.Sequential` pairs missed the `json.WriteEndObject()` after the match in
 // `writeDoctorFile`, which then ran for one case out of three. Flattening those sequences properly
 // missed the `|> genNode attr` under the match in `genAttributesCore`, which applied to the whole
-// match and would have applied to one arm, so every attribute reached through the other arm lost
-// its trivia. Both were shapes to enumerate, and there was always going to be another. The text has
+// match and would have applied to one arm, so everything reached through the other arm lost its
+// trivia. Both were shapes to enumerate, and there was always going to be another. The text has
 // none.
-let followedByContentInColumn (source: ISourceText) (matchRange: range) (column: int) : bool =
-    let mutable line: int = matchRange.EndLine
+let followedByContentInColumn (source: ISourceText) (expressionRange: range) (column: int) : bool =
+    let mutable line: int = expressionRange.EndLine
     let mutable answer: bool option = None
 
     while answer.IsNone && line < source.GetLineCount() do
@@ -126,78 +102,143 @@ let followedByContentInColumn (source: ISourceText) (matchRange: range) (column:
 
     defaultArg answer false
 
-// Whether the last arm of a match should keep the indentation of the match.
+// The column a match body has to start in for Fantomas to leave it there.
 //
-// A `when` guard is passed over: a multiline guard takes a different path in `CodePrinter` that
-// indents the body whatever its column, so the rule would be asking for something the formatter
-// then undoes. Which guards print multiline is a page width question rather than a tree one, so all
-// of them are left alone.
+// `genKeepIdentMatchClause` compares the body against the bar, falling back to the pattern where
+// there is none, so this is that same column and not a column of this rule's choosing. Only the
+// last arm is ever asked, and the arm without a bar is the first one, but the fallback keeps the
+// two definitions in step.
+let keepIndentColumnOf (clause: SynMatchClause) : int =
+    match clause with
+    | SynMatchClause(pat = pattern; trivia = trivia) ->
+
+    match trivia.BarRange with
+    | Some bar -> bar.StartColumn
+    | None -> pattern.Range.StartColumn
+
+// The `then` bodies of an if chain, and its final `else` along with the trivia of the branch that
+// owns it.
 //
-// The body has to be on a line of its own already, because an arm whose body shares the line of its
-// arrow has no indentation to keep, and it has to span more than that one line, because a body that
-// fits beside the arrow is pulled up next to it and never reaches the branch that would keep it.
+// `elif` nests in the tree: an `if` whose else is another `if` marked `IsElif`. Fantomas prints the
+// chain flat and offers the choice to the last `else` alone, so the chain has to be walked to reach
+// it, and the branches above are what decides whether the choice is worth taking.
+let rec ifChain (expr: SynExpr) : SynExpr list * (SynExpr * SynExprIfThenElseTrivia) option =
+    match expr with
+    | SynExpr.IfThenElse(thenExpr = thenExpr; elseExpr = elseExpr; trivia = trivia) ->
+        match elseExpr with
+        | None -> [ thenExpr ], None
+        | Some(SynExpr.IfThenElse(trivia = { IsElif = true }) as nested) ->
+            let branches, final = ifChain nested
+            thenExpr :: branches, final
+        | Some elseBody -> [ thenExpr ], Some(elseBody, trivia)
+    | _ -> [], None
+
+// A branch this rule could speak about: the range of the whole expression it belongs to, the column
+// its body would have to start in, and the body itself.
+//
+// A match and an if reach different printers and answer the column differently, one from the `|` and
+// one from the `else`, but everything after that is the same question of the same shape, so both are
+// reduced to this before it gets asked.
+//
+// The two conditions that belong here rather than there are the ones about the other branches. Every
+// branch above the last has to be a one liner, which is the early return shape the setting exists
+// for: the branches that decline say so and get out of the way, and what is left is the one path
+// that carries on. An expression whose other branches are blocks too is not that shape, and
+// de-indenting the last of them alone puts branches of the same kind at two different indentations
+// and says the last is special when it is not. And the body has to be on a line of its own already,
+// because a branch whose body shares the line of its `->` or its `else` has no indentation to keep.
+let keepIndentCandidateOf (expr: SynExpr) : (range * int * SynExpr) option =
+    match matchClausesOf expr with
+    | Some(matchRange, clauses) ->
+        match List.tryLast clauses with
+        | Some(SynMatchClause(whenExpr = None; resultExpr = body; trivia = { ArrowRange = Some arrow }) as clause) ->
+            let earlier: SynMatchClause list = List.truncate (clauses.Length - 1) clauses
+
+            let othersAreOneLiners: bool =
+                earlier |> List.forall (fun (SynMatchClause(range = range)) -> isOneLiner range)
+
+            if othersAreOneLiners && body.Range.StartLine > arrow.EndLine then
+                Some(matchRange, keepIndentColumnOf clause, body)
+            else
+                None
+        | _ -> None
+    | None ->
+
+    // Only the outermost `if` of a chain is asked. An `elif` is reached again as a node of its own,
+    // and answering there as well would report the same `else` twice.
+    match expr with
+    | SynExpr.IfThenElse(range = ifRange; trivia = { IsElif = false }) ->
+        match ifChain expr with
+        | branches, Some(elseBody, { ElseKeyword = Some elseKeyword }) ->
+            let othersAreOneLiners: bool =
+                branches |> List.forall (fun (branch: SynExpr) -> isOneLiner branch.Range)
+
+            if othersAreOneLiners && elseBody.Range.StartLine > elseKeyword.EndLine then
+                Some(ifRange, elseKeyword.StartColumn, elseBody)
+            else
+                None
+        | _ -> None
+    | _ -> None
+
+// Whether a candidate should keep the indentation of the expression it belongs to.
+//
+// The body has to span more than the one line it starts on, because a body that fits beside its
+// `->` or its `else` is pulled up next to it and never reaches the branch that would keep it. A
+// conditional directive inside the expression means the branches this reads are not the branches
+// every build sees, so those are left alone.
+//
+// A `when` guard is already gone by here, filtered out with the rest of the match shape: a multiline
+// guard takes a path in `CodePrinter` that indents the body whatever its column, and whether a guard
+// prints multiline is a page width question rather than a tree one, so all of them are passed over.
 let shouldKeepIndent
     (source: ISourceText)
     (directives: range list)
-    (matchRange: range)
-    (clauses: SynMatchClause list)
-    (clause: SynMatchClause)
+    (expressionRange: range)
+    (column: int)
+    (body: SynExpr)
     : bool
     =
-    match clause with
-    | SynMatchClause(whenExpr = Some _) -> false
-    | SynMatchClause(resultExpr = body; trivia = { ArrowRange = Some arrow }) ->
-        let column: int = keepIndentColumnOf clause
-        let bodyRange: range = body.Range
+    let bodyRange: range = body.Range
 
-        onlyLastArmIsBlock clauses
-        && bodyRange.StartLine > arrow.EndLine
-        && bodyRange.EndLine > bodyRange.StartLine
-        && bodyRange.StartColumn > column
-        && isBlockBody body
-        && not (List.exists (fun (directive: range) -> Range.rangeContainsRange matchRange directive) directives)
-        && not (followedByContentInColumn source matchRange column)
-    | _ -> false
+    not (isOneLiner bodyRange)
+    && bodyRange.StartColumn > column
+    && isBlockBody body
+    && not (List.exists (fun (directive: range) -> Range.rangeContainsRange expressionRange directive) directives)
+    && not (followedByContentInColumn source expressionRange column)
 
 // Reported on the body, which is the part that moves.
 let analyze (source: ISourceText) (parsedInput: ParsedInput) : Message list =
     let _, directives = triviaOf parsedInput
 
-    let candidates: ResizeArray<range * SynMatchClause list> =
-        ResizeArray<range * SynMatchClause list>()
+    let candidates: ResizeArray<range * int * SynExpr> =
+        ResizeArray<range * int * SynExpr>()
 
     let walker: SyntaxCollectorBase =
         { new SyntaxCollectorBase() with
             override _.WalkExpr(_path: SyntaxVisitorPath, expr: SynExpr) : unit =
-                match matchClausesOf expr with
+                match keepIndentCandidateOf expr with
                 | None -> ()
-                | Some(matchRange, clauses) -> candidates.Add(matchRange, clauses)
+                | Some candidate -> candidates.Add candidate
         }
 
     walkAst walker parsedInput
 
     candidates
-    |> Seq.choose (fun (matchRange: range, clauses: SynMatchClause list) ->
-        match List.tryLast clauses with
-        | None -> None
-        | Some clause ->
-
-        if not (shouldKeepIndent source directives matchRange clauses clause) then
+    |> Seq.choose (fun (expressionRange: range, column: int, body: SynExpr) ->
+        if not (shouldKeepIndent source directives expressionRange column body) then
             None
         else
 
-        match clause with
-        | SynMatchClause(resultExpr = body) ->
-            Some
-                {
-                    Type = Name
-                    Message =
-                        "Keep the indentation of the match in this arm. It is the last one, its body is a block, the arms above it are one liners, and nothing follows the match in this block, so the body can start in the column of the `|` rather than a level in. `fsharp_experimental_keep_indent_in_branch` keeps it there, but only once it is written that way."
-                    Code = Code
-                    Severity = Severity.Warning
-                    Range = body.Range
-                    Fixes = []
-                }
+        Some
+            {
+                Type = Name
+                Message =
+                    "Keep the indentation of this expression in its last branch. Every branch above it is a one liner, its own body is a block, and nothing follows the expression in this block, so the body can start in the column of the `|` or the `else` rather than a level in. `fsharp_experimental_keep_indent_in_branch` keeps it there, but only once it is written that way."
+                Code = Code
+                Severity = Severity.Warning
+                Range = body.Range
+                Fixes = []
+            }
     )
     |> Seq.toList
 

--- a/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fs
@@ -46,10 +46,14 @@ let keepIndentColumnOf (clause: SynMatchClause) : int =
 
 // Whether a body is the kind of expression that goes on to indent things of its own.
 //
-// This is what the de-indent is for. A block holds bindings, statements or arms that each sit a
-// level in again, so the four columns it saves are saved for everything inside it, and saved again
+// This is what the de-indent is for. A block holds bindings, statements, arms or items that each sit
+// a level in again, so the four columns it saves are saved for everything inside it, and saved again
 // by the next block in. A single application or pipeline has nothing under it to save them for, and
 // reads oddly under the blank line the setting writes.
+//
+// A bracketed body counts as much as a `match` does. `[` holding a `for` loop indents everything in
+// the loop twice over, and Fantomas holds it in the column of the bar like anything else. The
+// `overruledLines` list in Report.fs is the case that showed it.
 let isBlockBody (expr: SynExpr) : bool =
     match expr with
     | SynExpr.Sequential _
@@ -57,7 +61,13 @@ let isBlockBody (expr: SynExpr) : bool =
     | SynExpr.Match _
     | SynExpr.MatchBang _
     | SynExpr.MatchLambda _
-    | SynExpr.IfThenElse _ -> true
+    | SynExpr.IfThenElse _
+    | SynExpr.ArrayOrList _
+    | SynExpr.ArrayOrListComputed _
+    | SynExpr.Record _
+    | SynExpr.AnonRecd _
+    | SynExpr.ComputationExpr _
+    | SynExpr.ObjExpr _ -> true
     | _ -> false
 
 // Whether the last arm is the only one that is not a one liner.

--- a/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fs
@@ -39,9 +39,10 @@ let matchClausesOf (expr: SynExpr) : (range * SynMatchClause list) option =
 let keepIndentColumnOf (clause: SynMatchClause) : int =
     match clause with
     | SynMatchClause(pat = pattern; trivia = trivia) ->
-        match trivia.BarRange with
-        | Some bar -> bar.StartColumn
-        | None -> pattern.Range.StartColumn
+
+    match trivia.BarRange with
+    | Some bar -> bar.StartColumn
+    | None -> pattern.Range.StartColumn
 
 // Whether a body is the kind of expression that goes on to indent things of its own.
 //
@@ -59,33 +60,61 @@ let isBlockBody (expr: SynExpr) : bool =
     | SynExpr.IfThenElse _ -> true
     | _ -> false
 
-// Where one expression is followed by another in the same block: the range of the first, and the
-// column the second starts in.
-let followerOf (expr: SynExpr) : (range * int) option =
-    match expr with
-    | SynExpr.Sequential(expr1 = before; expr2 = after)
-    | SynExpr.SequentialOrImplicitYield(expr1 = before; expr2 = after) -> Some(before.Range, after.Range.StartColumn)
-    | _ -> None
+// Whether the last arm is the only one that is not a one liner.
+//
+// The setting is for the early return shape, which is what makes the de-indent read as anything at
+// all: the arms that decline say so on one line and get out of the way, and what is left is the one
+// path that carries on, written at the indentation it started at. A match whose other arms are
+// blocks too is not that shape, and de-indenting the last of them alone puts arms of the same kind
+// at two different indentations, saying the last one is special when it is not.
+//
+// `collectTriviaFromCodeComments` in Trivia.fs is the case that showed it: both of its arms are a
+// dozen lines, and de-indenting the second read as a mistake rather than as a happy path.
+//
+// One liner is measured on the whole clause, which is how `FANTOMAS-ARMORDER-001` measures it, and
+// that rule is what puts those arms first to begin with. A match with a single arm, destructuring a
+// single case union, qualifies: there is no other arm for it to be out of step with.
+let onlyLastArmIsBlock (clauses: SynMatchClause list) : bool =
+    match List.rev clauses with
+    | [] -> false
+    | _ :: earlier ->
+        earlier
+        |> List.forall (fun (SynMatchClause(range = range)) -> range.EndLine = range.StartLine)
 
-// Whether keeping the indentation would pull in code that follows the match.
+// Whether anything follows the match that keeping the indentation would take into the last arm.
 //
-// This is the one way the reshape changes meaning, and the only reason the rule needs to look
-// further than the arm. De-indenting moves the offside line of the body out to the bar, and code
-// that follows the match in the same block starts in that same column. What was the first thing
-// past the match becomes the last thing inside the arm: it stops running whatever matched and
-// starts running only for that one arm.
+// This is the one way the reshape changes meaning, and it is a question about the text rather than
+// the tree. De-indenting moves the offside line of the body out to the bar, so the first thing
+// after the match that starts in that column, or further right, stops following the match and
+// starts belonging to its last arm. What that thing is does not matter: a statement of the
+// enclosing block, an operator carrying the match into a pipeline, a comment. Anything further left
+// ends the arm exactly as it ended the match before.
 //
-// So every place one expression is followed by another is collected, and a match sitting inside the
-// first of such a pair is left alone. Unless the second starts further left than the bar, which is
-// an enclosing block continuing rather than this one, and still ends the arm afterwards.
+// Only lines after the one the match ends on are asked about. Whatever shares that last line moves
+// with the body and keeps its place, which is how a closing bracket on the same line stays out of
+// this.
 //
-// A following arm of the same match needs no such care. Only the last arm is ever a candidate, so
-// there is never one of those left to swallow.
-let wouldSwallowFollowingCode (followers: (range * int) list) (matchRange: range) (column: int) : bool =
-    followers
-    |> List.exists (fun (before: range, followerColumn: int) ->
-        followerColumn >= column && Range.rangeContainsRange before matchRange
-    )
+// Reading the source rather than the tree is deliberate, and is the third attempt. Collecting
+// `SynExpr.Sequential` pairs missed the `json.WriteEndObject()` after the match in
+// `writeDoctorFile`, which then ran for one case out of three. Flattening those sequences properly
+// missed the `|> genNode attr` under the match in `genAttributesCore`, which applied to the whole
+// match and would have applied to one arm, so every attribute reached through the other arm lost
+// its trivia. Both were shapes to enumerate, and there was always going to be another. The text has
+// none.
+let followedByContentInColumn (source: ISourceText) (matchRange: range) (column: int) : bool =
+    let mutable line: int = matchRange.EndLine
+    let mutable answer: bool option = None
+
+    while answer.IsNone && line < source.GetLineCount() do
+        let text: string = source.GetLineString line
+        let content: string = text.TrimStart()
+
+        if content <> "" then
+            answer <- Some(text.Length - content.Length >= column)
+
+        line <- line + 1
+
+    defaultArg answer false
 
 // Whether the last arm of a match should keep the indentation of the match.
 //
@@ -98,9 +127,10 @@ let wouldSwallowFollowingCode (followers: (range * int) list) (matchRange: range
 // arrow has no indentation to keep, and it has to span more than that one line, because a body that
 // fits beside the arrow is pulled up next to it and never reaches the branch that would keep it.
 let shouldKeepIndent
+    (source: ISourceText)
     (directives: range list)
-    (followers: (range * int) list)
     (matchRange: range)
+    (clauses: SynMatchClause list)
     (clause: SynMatchClause)
     : bool
     =
@@ -110,47 +140,39 @@ let shouldKeepIndent
         let column: int = keepIndentColumnOf clause
         let bodyRange: range = body.Range
 
-        bodyRange.StartLine > arrow.EndLine
+        onlyLastArmIsBlock clauses
+        && bodyRange.StartLine > arrow.EndLine
         && bodyRange.EndLine > bodyRange.StartLine
         && bodyRange.StartColumn > column
         && isBlockBody body
         && not (List.exists (fun (directive: range) -> Range.rangeContainsRange matchRange directive) directives)
-        && not (wouldSwallowFollowingCode followers matchRange column)
+        && not (followedByContentInColumn source matchRange column)
     | _ -> false
 
 // Reported on the body, which is the part that moves.
-let analyze (parsedInput: ParsedInput) : Message list =
+let analyze (source: ISourceText) (parsedInput: ParsedInput) : Message list =
     let _, directives = triviaOf parsedInput
-    let followers: ResizeArray<range * int> = ResizeArray<range * int>()
 
-    let candidates: ResizeArray<range * SynMatchClause> =
-        ResizeArray<range * SynMatchClause>()
+    let candidates: ResizeArray<range * SynMatchClause list> =
+        ResizeArray<range * SynMatchClause list>()
 
     let walker: SyntaxCollectorBase =
         { new SyntaxCollectorBase() with
             override _.WalkExpr(_path: SyntaxVisitorPath, expr: SynExpr) : unit =
-                match followerOf expr with
-                | None -> ()
-                | Some follower -> followers.Add follower
-
                 match matchClausesOf expr with
                 | None -> ()
-                | Some(matchRange, clauses) ->
-                    match List.tryLast clauses with
-                    | None -> ()
-                    | Some clause -> candidates.Add(matchRange, clause)
+                | Some(matchRange, clauses) -> candidates.Add(matchRange, clauses)
         }
 
     walkAst walker parsedInput
 
-    // Judged after the walk rather than during it. A match is reached before the sequence that holds
-    // it in some shapes and after it in others, so anything deciding on the followers has to wait
-    // until all of them are in.
-    let followers: (range * int) list = List.ofSeq followers
-
     candidates
-    |> Seq.choose (fun (matchRange: range, clause: SynMatchClause) ->
-        if not (shouldKeepIndent directives followers matchRange clause) then
+    |> Seq.choose (fun (matchRange: range, clauses: SynMatchClause list) ->
+        match List.tryLast clauses with
+        | None -> None
+        | Some clause ->
+
+        if not (shouldKeepIndent source directives matchRange clauses clause) then
             None
         else
 
@@ -160,7 +182,7 @@ let analyze (parsedInput: ParsedInput) : Message list =
                 {
                     Type = Name
                     Message =
-                        "Keep the indentation of the match in this arm. It is the last one, its body is a block, and nothing follows the match in this block, so the body can start in the column of the `|` rather than a level in. `fsharp_experimental_keep_indent_in_branch` keeps it there, but only once it is written that way."
+                        "Keep the indentation of the match in this arm. It is the last one, its body is a block, the arms above it are one liners, and nothing follows the match in this block, so the body can start in the column of the `|` rather than a level in. `fsharp_experimental_keep_indent_in_branch` keeps it there, but only once it is written that way."
                     Code = Code
                     Severity = Severity.Warning
                     Range = body.Range
@@ -170,7 +192,7 @@ let analyze (parsedInput: ParsedInput) : Message list =
     |> Seq.toList
 
 let cliAnalyzer (ctx: CliContext) : Async<Message list> =
-    async { return analyze ctx.ParseFileResults.ParseTree }
+    async { return analyze ctx.SourceText ctx.ParseFileResults.ParseTree }
 
 let editorAnalyzer (ctx: EditorContext) : Async<Message list> =
-    async { return analyze ctx.ParseFileResults.ParseTree }
+    async { return analyze ctx.SourceText ctx.ParseFileResults.ParseTree }

--- a/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fsi
+++ b/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fsi
@@ -1,0 +1,35 @@
+module Fantomas.Analyzers.KeepIndentAnalyzer
+
+open FSharp.Analyzers.SDK
+
+[<Literal>]
+val Code: string = "FANTOMAS-KEEPINDENT-001"
+
+[<Literal>]
+val Name: string = "KeepIndentAnalyzer"
+
+[<Literal>]
+val ShortDescription: string =
+    "Detects a last match arm whose body is a block indented a level past the match, where the indentation of the match could be kept instead."
+
+[<Literal>]
+val HelpUri: string = "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-keepindent-001"
+
+/// Reports the last arm of a match whose body could keep the indentation of the match, on the body,
+/// which is the part that moves.
+///
+/// `fsharp_experimental_keep_indent_in_branch` only holds a body in the column of the `|` when the
+/// source already put it there, so a de-indent that would read better is one nothing asks for until
+/// somebody writes it. This is the rule that asks, and the other half of what
+/// `FANTOMAS-ARMORDER-001` starts.
+///
+/// It speaks only for the last arm, whose body is a block already on a line of its own, and only
+/// where nothing follows the match in the same block, since keeping the indentation past that would
+/// take the following code into the arm. It stays quiet on a `when` guard and on a conditional
+/// directive inside the match. No fix is offered: re-indenting a block means leaving the multiline
+/// strings inside it exactly where they are, which is not a thing to do blind.
+[<CliAnalyzer(Name, ShortDescription, HelpUri)>]
+val cliAnalyzer: ctx: CliContext -> Async<Message list>
+
+[<EditorAnalyzer(Name, ShortDescription, HelpUri)>]
+val editorAnalyzer: ctx: EditorContext -> Async<Message list>

--- a/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fsi
+++ b/analyzers/Fantomas.Analyzers/KeepIndentAnalyzer.fsi
@@ -10,7 +10,7 @@ val Name: string = "KeepIndentAnalyzer"
 
 [<Literal>]
 val ShortDescription: string =
-    "Detects a last match arm whose body is a block indented a level past the match, where the indentation of the match could be kept instead."
+    "Detects a last branch whose body is a block indented a level past the expression it belongs to, where that indentation could be kept instead."
 
 [<Literal>]
 val HelpUri: string = "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-keepindent-001"

--- a/analyzers/Fantomas.Analyzers/PipeBackAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/PipeBackAnalyzer.fs
@@ -52,7 +52,8 @@ let analyze (parsedInput: ParsedInput) : Message list =
             Severity = Severity.Error
             Range = operator
             Fixes = []
-        })
+        }
+    )
     |> Seq.toList
 
 let cliAnalyzer (ctx: CliContext) : Async<Message list> =

--- a/analyzers/Fantomas.Analyzers/PrivateAccessAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/PrivateAccessAnalyzer.fs
@@ -47,34 +47,34 @@ let analyze (fileName: string) (sourceFiles: string list) (parsedInput: ParsedIn
         []
     else
 
-        let ranges: ResizeArray<range> = ResizeArray<range>()
+    let ranges: ResizeArray<range> = ResizeArray<range>()
 
-        let walker: SyntaxCollectorBase =
-            { new SyntaxCollectorBase() with
-                override _.WalkBinding(_path: SyntaxVisitorPath, binding: SynBinding) : unit =
-                    match binding with
-                    | SynBinding(headPat = headPattern; trivia = { LeadingKeyword = keyword }) when isLetBinding keyword ->
-                        match accessibilityOf headPattern with
-                        | Some(SynAccess.Private range) -> ranges.Add range
-                        | _ -> ()
+    let walker: SyntaxCollectorBase =
+        { new SyntaxCollectorBase() with
+            override _.WalkBinding(_path: SyntaxVisitorPath, binding: SynBinding) : unit =
+                match binding with
+                | SynBinding(headPat = headPattern; trivia = { LeadingKeyword = keyword }) when isLetBinding keyword ->
+                    match accessibilityOf headPattern with
+                    | Some(SynAccess.Private range) -> ranges.Add range
                     | _ -> ()
-            }
+                | _ -> ()
+        }
 
-        walkAst walker parsedInput
+    walkAst walker parsedInput
 
-        ranges
-        |> Seq.map (fun (keyword: range) ->
-            {
-                Type = Name
-                Message =
-                    "Remove `private`. The signature file is the visibility boundary, so anything it does not list is already hidden."
-                Code = Code
-                Severity = Severity.Error
-                Range = keyword
-                Fixes = []
-            }
-        )
-        |> Seq.toList
+    ranges
+    |> Seq.map (fun (keyword: range) ->
+        {
+            Type = Name
+            Message =
+                "Remove `private`. The signature file is the visibility boundary, so anything it does not list is already hidden."
+            Code = Code
+            Severity = Severity.Error
+            Range = keyword
+            Fixes = []
+        }
+    )
+    |> Seq.toList
 
 let cliAnalyzer (ctx: CliContext) : Async<Message list> =
     async { return analyze ctx.FileName ctx.ProjectOptions.SourceFiles ctx.ParseFileResults.ParseTree }

--- a/analyzers/Fantomas.Analyzers/PrivateAccessAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/PrivateAccessAnalyzer.fs
@@ -72,7 +72,8 @@ let analyze (fileName: string) (sourceFiles: string list) (parsedInput: ParsedIn
                 Severity = Severity.Error
                 Range = keyword
                 Fixes = []
-            })
+            }
+        )
         |> Seq.toList
 
 let cliAnalyzer (ctx: CliContext) : Async<Message list> =

--- a/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fs
@@ -57,7 +57,8 @@ let declaredInSignature
     (checkResults: FSharpCheckFileResults)
     (sourceText: ISourceText)
     (declaration: DocumentedDeclaration)
-    : bool =
+    : bool
+    =
     let line: int = declaration.NameRange.EndLine
 
     if line < 1 || line > sourceText.GetLineCount() then
@@ -69,7 +70,8 @@ let declaredInSignature
         |> Option.map (fun (symbolUse: FSharpSymbolUse) ->
             match symbolUse.Symbol.SignatureLocation, symbolUse.Symbol.DeclarationLocation with
             | Some signature, Some declaration -> signature.FileName <> declaration.FileName
-            | _ -> false)
+            | _ -> false
+        )
         |> Option.defaultValue false
 
 // Documentation comments that the signature file already carries.
@@ -83,7 +85,8 @@ let analyze
     (fileName: string)
     (sourceFiles: string list)
     (parsedInput: ParsedInput)
-    : Message list =
+    : Message list
+    =
     if not (hasSignatureFile fileName sourceFiles) then
         []
     else
@@ -139,7 +142,8 @@ let analyze
                 Severity = Severity.Warning
                 Range = declaration.DocRange
                 Fixes = []
-            })
+            }
+        )
         |> Seq.toList
 
 let cliAnalyzer (ctx: CliContext) : Async<Message list> =

--- a/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fs
@@ -64,15 +64,16 @@ let declaredInSignature
     if line < 1 || line > sourceText.GetLineCount() then
         false
     else
-        let lineText: string = sourceText.GetLineString(line - 1)
 
-        checkResults.GetSymbolUseAtLocation(line, declaration.NameRange.EndColumn, lineText, [ declaration.Name ])
-        |> Option.map (fun (symbolUse: FSharpSymbolUse) ->
-            match symbolUse.Symbol.SignatureLocation, symbolUse.Symbol.DeclarationLocation with
-            | Some signature, Some declaration -> signature.FileName <> declaration.FileName
-            | _ -> false
-        )
-        |> Option.defaultValue false
+    let lineText: string = sourceText.GetLineString(line - 1)
+
+    checkResults.GetSymbolUseAtLocation(line, declaration.NameRange.EndColumn, lineText, [ declaration.Name ])
+    |> Option.map (fun (symbolUse: FSharpSymbolUse) ->
+        match symbolUse.Symbol.SignatureLocation, symbolUse.Symbol.DeclarationLocation with
+        | Some signature, Some declaration -> signature.FileName <> declaration.FileName
+        | _ -> false
+    )
+    |> Option.defaultValue false
 
 // Documentation comments that the signature file already carries.
 //
@@ -91,65 +92,65 @@ let analyze
         []
     else
 
-        let documented: ResizeArray<DocumentedDeclaration> =
-            ResizeArray<DocumentedDeclaration>()
+    let documented: ResizeArray<DocumentedDeclaration> =
+        ResizeArray<DocumentedDeclaration>()
 
-        let collect (doc: PreXmlDoc) (name: Ident option) : unit =
-            match name with
-            | None -> ()
-            | Some ident ->
+    let collect (doc: PreXmlDoc) (name: Ident option) : unit =
+        match name with
+        | None -> ()
+        | Some ident ->
 
-            if not doc.IsEmpty then
-                documented.Add
-                    {
-                        DocRange = doc.Range
-                        Name = ident.idText
-                        NameRange = ident.idRange
-                    }
-
-        let walker: SyntaxCollectorBase =
-            { new SyntaxCollectorBase() with
-                override _.WalkBinding(_path: SyntaxVisitorPath, binding: SynBinding) : unit =
-                    match binding with
-                    | SynBinding(xmlDoc = doc; headPat = pat) -> collect doc (bindingName pat)
-
-                override _.WalkComponentInfo(_path: SyntaxVisitorPath, info: SynComponentInfo) : unit =
-                    match info with
-                    | SynComponentInfo(xmlDoc = doc; longId = ids) -> collect doc (List.tryLast ids)
-
-                override _.WalkUnionCase(_path: SyntaxVisitorPath, unionCase: SynUnionCase) : unit =
-                    match unionCase with
-                    | SynUnionCase(xmlDoc = doc; ident = SynIdent(ident, _)) -> collect doc (Some ident)
-
-                override _.WalkEnumCase(_path: SyntaxVisitorPath, enumCase: SynEnumCase) : unit =
-                    match enumCase with
-                    | SynEnumCase(xmlDoc = doc; ident = SynIdent(ident, _)) -> collect doc (Some ident)
-
-                override _.WalkField(_path: SyntaxVisitorPath, field: SynField) : unit =
-                    match field with
-                    | SynField(xmlDoc = doc; idOpt = idOpt) -> collect doc idOpt
-            }
-
-        walkAst walker parsedInput
-
-        documented
-        |> Seq.choose (fun (declaration: DocumentedDeclaration) ->
-            if not (declaredInSignature checkResults sourceText declaration) then
-                None
-            else
-
-            Some
+        if not doc.IsEmpty then
+            documented.Add
                 {
-                    Type = Name
-                    Message =
-                        "Move this documentation comment to the signature file. Keeping a copy in both is a second one to keep in step, and the signature is the one readers and tooling see."
-                    Code = Code
-                    Severity = Severity.Warning
-                    Range = declaration.DocRange
-                    Fixes = []
+                    DocRange = doc.Range
+                    Name = ident.idText
+                    NameRange = ident.idRange
                 }
-        )
-        |> Seq.toList
+
+    let walker: SyntaxCollectorBase =
+        { new SyntaxCollectorBase() with
+            override _.WalkBinding(_path: SyntaxVisitorPath, binding: SynBinding) : unit =
+                match binding with
+                | SynBinding(xmlDoc = doc; headPat = pat) -> collect doc (bindingName pat)
+
+            override _.WalkComponentInfo(_path: SyntaxVisitorPath, info: SynComponentInfo) : unit =
+                match info with
+                | SynComponentInfo(xmlDoc = doc; longId = ids) -> collect doc (List.tryLast ids)
+
+            override _.WalkUnionCase(_path: SyntaxVisitorPath, unionCase: SynUnionCase) : unit =
+                match unionCase with
+                | SynUnionCase(xmlDoc = doc; ident = SynIdent(ident, _)) -> collect doc (Some ident)
+
+            override _.WalkEnumCase(_path: SyntaxVisitorPath, enumCase: SynEnumCase) : unit =
+                match enumCase with
+                | SynEnumCase(xmlDoc = doc; ident = SynIdent(ident, _)) -> collect doc (Some ident)
+
+            override _.WalkField(_path: SyntaxVisitorPath, field: SynField) : unit =
+                match field with
+                | SynField(xmlDoc = doc; idOpt = idOpt) -> collect doc idOpt
+        }
+
+    walkAst walker parsedInput
+
+    documented
+    |> Seq.choose (fun (declaration: DocumentedDeclaration) ->
+        if not (declaredInSignature checkResults sourceText declaration) then
+            None
+        else
+
+        Some
+            {
+                Type = Name
+                Message =
+                    "Move this documentation comment to the signature file. Keeping a copy in both is a second one to keep in step, and the signature is the one readers and tooling see."
+                Code = Code
+                Severity = Severity.Warning
+                Range = declaration.DocRange
+                Fixes = []
+            }
+    )
+    |> Seq.toList
 
 let cliAnalyzer (ctx: CliContext) : Async<Message list> =
     async {

--- a/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fs
@@ -98,13 +98,14 @@ let analyze
             match name with
             | None -> ()
             | Some ident ->
-                if not doc.IsEmpty then
-                    documented.Add
-                        {
-                            DocRange = doc.Range
-                            Name = ident.idText
-                            NameRange = ident.idRange
-                        }
+
+            if not doc.IsEmpty then
+                documented.Add
+                    {
+                        DocRange = doc.Range
+                        Name = ident.idText
+                        NameRange = ident.idRange
+                    }
 
         let walker: SyntaxCollectorBase =
             { new SyntaxCollectorBase() with
@@ -132,17 +133,21 @@ let analyze
         walkAst walker parsedInput
 
         documented
-        |> Seq.filter (declaredInSignature checkResults sourceText)
-        |> Seq.map (fun (declaration: DocumentedDeclaration) ->
-            {
-                Type = Name
-                Message =
-                    "Move this documentation comment to the signature file. Keeping a copy in both is a second one to keep in step, and the signature is the one readers and tooling see."
-                Code = Code
-                Severity = Severity.Warning
-                Range = declaration.DocRange
-                Fixes = []
-            }
+        |> Seq.choose (fun (declaration: DocumentedDeclaration) ->
+            if not (declaredInSignature checkResults sourceText declaration) then
+                None
+            else
+
+            Some
+                {
+                    Type = Name
+                    Message =
+                        "Move this documentation comment to the signature file. Keeping a copy in both is a second one to keep in step, and the signature is the one readers and tooling see."
+                    Code = Code
+                    Severity = Severity.Warning
+                    Range = declaration.DocRange
+                    Fixes = []
+                }
         )
         |> Seq.toList
 

--- a/scripts/BuildAnalyzers.fsx
+++ b/scripts/BuildAnalyzers.fsx
@@ -309,22 +309,18 @@ let mergeSarifReports (reports: string list) (target: string) : unit =
 let localErrorRules: string list =
     [ "FANTOMAS-PIPEBACK-001"; "FANTOMAS-PRIVATE-001" ]
 
-/// The local analyzers that are kept out of the full run.
+/// The local analyzer that is kept out of the full run.
 ///
-/// Both report on debt that predates them, and a finding in `Analyze` becomes a code scanning alert
-/// on the pull request whatever its severity. `AnalyzeChanged` still runs them, over the files you
-/// touched, which is the scope those rules ask for. Drop one once its debt is gone.
-let localAdvisoryAnalyzers: string list =
-    [ "AnnotationAnalyzer"; "KeepIndentAnalyzer" ]
+/// It reports on debt that predates it, and a finding in `Analyze` becomes a code scanning alert on
+/// the pull request whatever its severity. `AnalyzeChanged` still runs it, over the files you
+/// touched, which is the scope the rule asks for. Drop this once the debt is gone.
+///
+/// `FANTOMAS-KEEPINDENT-001` is deliberately not here. It arrived with debt of its own, and that
+/// debt was cleared in the change that added it, so the full run has nothing old to report and
+/// anything it does report is something the change in front of you introduced.
+let localAdvisoryAnalyzers: string list = [ "AnnotationAnalyzer" ]
 
-/// The codes narrowed further still, to the lines the working tree touched.
-///
-/// A smaller set than the analyzers above, and deliberately so. `FANTOMAS-ANNOTATE-001` fires on
-/// every unannotated binding of a file, which one changed line should not surface all of.
-/// `FANTOMAS-KEEPINDENT-001` fires on an arm's body, which is rarely a line you touched: swapping
-/// two arms for `FANTOMAS-ARMORDER-001` changes the two lines carrying the `|` and none of the body
-/// it then asks you to de-indent. Narrowing that one would hide the finding the swap exists to
-/// reach.
+/// The code of that same rule, which is what a finding carries.
 let localAdvisoryCodes: Set<string> = set [ "FANTOMAS-ANNOTATE-001" ]
 
 /// Decides whether a finding is worth showing, from its rule, its file and its line. `Analyze`

--- a/scripts/BuildAnalyzers.fsx
+++ b/scripts/BuildAnalyzers.fsx
@@ -309,14 +309,22 @@ let mergeSarifReports (reports: string list) (target: string) : unit =
 let localErrorRules: string list =
     [ "FANTOMAS-PIPEBACK-001"; "FANTOMAS-PRIVATE-001" ]
 
-/// The local analyzer that is kept out of the full run.
+/// The local analyzers that are kept out of the full run.
 ///
-/// It reports on debt that predates it, and a finding in `Analyze` becomes a code scanning alert on
-/// the pull request whatever its severity. `AnalyzeChanged` still runs it, over the files you
-/// touched, which is the scope the rule asks for. Drop this once the debt is gone.
-let localAdvisoryAnalyzers: string list = [ "AnnotationAnalyzer" ]
+/// Both report on debt that predates them, and a finding in `Analyze` becomes a code scanning alert
+/// on the pull request whatever its severity. `AnalyzeChanged` still runs them, over the files you
+/// touched, which is the scope those rules ask for. Drop one once its debt is gone.
+let localAdvisoryAnalyzers: string list =
+    [ "AnnotationAnalyzer"; "KeepIndentAnalyzer" ]
 
-/// The code of that same rule, which is what a finding carries.
+/// The codes narrowed further still, to the lines the working tree touched.
+///
+/// A smaller set than the analyzers above, and deliberately so. `FANTOMAS-ANNOTATE-001` fires on
+/// every unannotated binding of a file, which one changed line should not surface all of.
+/// `FANTOMAS-KEEPINDENT-001` fires on an arm's body, which is rarely a line you touched: swapping
+/// two arms for `FANTOMAS-ARMORDER-001` changes the two lines carrying the `|` and none of the body
+/// it then asks you to de-indent. Narrowing that one would hide the finding the swap exists to
+/// reach.
 let localAdvisoryCodes: Set<string> = set [ "FANTOMAS-ANNOTATE-001" ]
 
 /// Decides whether a finding is worth showing, from its rule, its file and its line. `Analyze`

--- a/src/Fantomas.Client.Tests/DaemonCacheTests.fs
+++ b/src/Fantomas.Client.Tests/DaemonCacheTests.fs
@@ -62,8 +62,9 @@ let private expectOk (result: Result<'a, GetDaemonError>) : 'a =
     match result with
     | Ok value -> value
     | Error error ->
-        Assert.Fail $"Expected a daemon, got %A{error}"
-        failwith "unreachable"
+
+    Assert.Fail $"Expected a daemon, got %A{error}"
+    failwith "unreachable"
 
 [<Test>]
 let ``two folders on the same version share one daemon`` () =

--- a/src/Fantomas.Client.Tests/EndToEndTests.fs
+++ b/src/Fantomas.Client.Tests/EndToEndTests.fs
@@ -79,22 +79,23 @@ type EndToEndTests() =
             match failure with
             | Some error -> return Error error
             | None ->
-                let fsharpFile = Path.Combine(subDirectory.FullName, "File.fs")
-                File.Create(fsharpFile).Dispose()
 
-                // Create a .editorconfig file to override any parent configuration
-                let editorConfigPath = Path.Combine(subDirectory.FullName, ".editorconfig")
+            let fsharpFile = Path.Combine(subDirectory.FullName, "File.fs")
+            File.Create(fsharpFile).Dispose()
 
-                let editorConfigContent =
-                    """
+            // Create a .editorconfig file to override any parent configuration
+            let editorConfigPath = Path.Combine(subDirectory.FullName, ".editorconfig")
+
+            let editorConfigContent =
+                """
 root = true
 
 [*.fs]
 end_of_line = lf
 """
 
-                File.WriteAllText(editorConfigPath, editorConfigContent)
-                return Ok()
+            File.WriteAllText(editorConfigPath, editorConfigContent)
+            return Ok()
         }
 
     /// Installing from NuGet is the flaky part of these tests, so give it a couple of goes before

--- a/src/Fantomas.Client/FantomasToolLocator.fs
+++ b/src/Fantomas.Client/FantomasToolLocator.fs
@@ -79,15 +79,16 @@ let runToolListCmd (Folder workingDir: Folder) (globalFlag: bool) : Result<strin
     match startProcess ps with
     | Error err -> Error(DotNetToolListError.ProcessStartError err)
     | Ok p ->
-        p.WaitForExit()
-        let exitCode = p.ExitCode
 
-        if exitCode = 0 then
-            let output = readOutputStreamAsLines p.StandardOutput
-            Ok output
-        else
-            let error = p.StandardError.ReadToEnd()
-            Error(DotNetToolListError.ExitCodeNonZero(ps.FileName, ps.Arguments, exitCode, error))
+    p.WaitForExit()
+    let exitCode = p.ExitCode
+
+    if exitCode = 0 then
+        let output = readOutputStreamAsLines p.StandardOutput
+        Ok output
+    else
+        let error = p.StandardError.ReadToEnd()
+        Error(DotNetToolListError.ExitCodeNonZero(ps.FileName, ps.Arguments, exitCode, error))
 
 let packageSidVersionRegex = Regex(@"^Package\sId\s+Version.+$")
 
@@ -311,110 +312,111 @@ let createForVersion
     match startProcess processStart with
     | Error err -> Error err
     | Ok daemonProcess ->
-        // Standard error is redirected, so something has to read it. Left alone it fills the pipe
-        // the operating system gives the two processes, 4KB by default on Windows, and the daemon
-        // then blocks inside whatever it was doing when it wrote the line that did not fit. Keep
-        // the last of it for the failure message below and throw the rest away.
-        let recentStandardError = Queue<string>()
 
-        daemonProcess.ErrorDataReceived.Add(fun message ->
-            if not (isNull message.Data) then
-                lock
-                    recentStandardError
-                    (fun () ->
-                        recentStandardError.Enqueue message.Data
+    // Standard error is redirected, so something has to read it. Left alone it fills the pipe
+    // the operating system gives the two processes, 4KB by default on Windows, and the daemon
+    // then blocks inside whatever it was doing when it wrote the line that did not fit. Keep
+    // the last of it for the failure message below and throw the rest away.
+    let recentStandardError = Queue<string>()
 
-                        while recentStandardError.Count > 50 do
-                            recentStandardError.Dequeue() |> ignore
-                    )
+    daemonProcess.ErrorDataReceived.Add(fun message ->
+        if not (isNull message.Data) then
+            lock
+                recentStandardError
+                (fun () ->
+                    recentStandardError.Enqueue message.Data
+
+                    while recentStandardError.Count > 50 do
+                        recentStandardError.Dequeue() |> ignore
+                )
+    )
+
+    daemonProcess.BeginErrorReadLine()
+
+    let client =
+        new JsonRpc(daemonProcess.StandardInput.BaseStream, daemonProcess.StandardOutput.BaseStream)
+
+    let configurationWarnings = Event<ConfigurationWarning>()
+
+    // Has to happen before StartListening, for two reasons: StreamJsonRpc refuses to add local
+    // methods once the connection is listening, and a subscriber added before the daemon can
+    // send anything is a subscriber that cannot be raced by the first notification. A daemon
+    // that never sends these simply never triggers it.
+    client.AddLocalRpcMethod(
+        Methods.ConfigurationWarning,
+        Action<ConfigurationWarning>(fun warning ->
+            try
+                configurationWarnings.Trigger warning
+            with _ ->
+                // A subscriber that throws must not take the connection down with it. An
+                // exception out of a synchronous local method is not turned into an error
+                // response: it escapes the dispatcher and disconnects the client, which would
+                // fault every format request from then on over a message that only carries
+                // advice.
+                ()
         )
+    )
 
-        daemonProcess.BeginErrorReadLine()
+    do client.StartListening()
 
-        let client =
-            new JsonRpc(daemonProcess.StandardInput.BaseStream, daemonProcess.StandardOutput.BaseStream)
+    try
+        // Get the version first as a sanity check that connection is possible.
+        //
+        // Bounded, because this is what every caller waits behind: `LSPFantomasService` resolves
+        // daemons on one mailbox, so a process that starts and then never answers would hold up
+        // every format request for the rest of the session with nothing to show for it. Generous
+        // enough that a cold start on a loaded machine is not mistaken for a hang; a daemon that
+        // is still silent by then is one the cleanup below should get its hands on.
+        let _version =
+            client.InvokeAsync<string>(Fantomas.Client.Contracts.Methods.Version)
+            |> Async.AwaitTask
+            |> fun handshake -> Async.RunSynchronously(handshake, timeout = handshakeTimeoutInMs)
 
-        let configurationWarnings = Event<ConfigurationWarning>()
+        Ok
+            {
+                RpcClient = client
+                Process = daemonProcess
+                StartInfo = startInfo
+                ConfigurationWarnings = configurationWarnings.Publish
+            }
+    with ex ->
+        let error =
+            // A timeout says nothing about what was being waited for, so say it here. The next
+            // field report should carry a number someone can argue about rather than "it said
+            // something timed out".
+            if (ex :? TimeoutException) then
+                $"Daemon did not answer the version request within %i{handshakeTimeoutInMs} ms."
+            elif daemonProcess.HasExited then
+                // `HasExited` only says the process is gone; the handler above is fed
+                // asynchronously and can still be behind. `WaitForExit` with no timeout is the
+                // one overload that waits for the readers to drain too, so without it the
+                // message here would be missing the lines that explain the failure.
+                daemonProcess.WaitForExit()
 
-        // Has to happen before StartListening, for two reasons: StreamJsonRpc refuses to add local
-        // methods once the connection is listening, and a subscriber added before the daemon can
-        // send anything is a subscriber that cannot be raced by the first notification. A daemon
-        // that never sends these simply never triggers it.
-        client.AddLocalRpcMethod(
-            Methods.ConfigurationWarning,
-            Action<ConfigurationWarning>(fun warning ->
-                try
-                    configurationWarnings.Trigger warning
-                with _ ->
-                    // A subscriber that throws must not take the connection down with it. An
-                    // exception out of a synchronous local method is not turned into an error
-                    // response: it escapes the dispatcher and disconnects the client, which would
-                    // fault every format request from then on over a message that only carries
-                    // advice.
-                    ()
-            )
-        )
+                let stdErr =
+                    lock recentStandardError (fun () -> String.Join(Environment.NewLine, recentStandardError))
 
-        do client.StartListening()
+                $"Daemon std error: %s{stdErr}.\nJsonRpc exception:%s{ex.Message}"
+            else
+                ex.Message
+
+        // The handshake failed, so nothing will ever hand this daemon out and nothing will
+        // ever dispose it. Kill it here rather than leave the process running for the rest of
+        // the session with no way to reach it.
+        try
+            client.Dispose()
+        with _ ->
+            ()
 
         try
-            // Get the version first as a sanity check that connection is possible.
-            //
-            // Bounded, because this is what every caller waits behind: `LSPFantomasService` resolves
-            // daemons on one mailbox, so a process that starts and then never answers would hold up
-            // every format request for the rest of the session with nothing to show for it. Generous
-            // enough that a cold start on a loaded machine is not mistaken for a hang; a daemon that
-            // is still silent by then is one the cleanup below should get its hands on.
-            let _version =
-                client.InvokeAsync<string>(Fantomas.Client.Contracts.Methods.Version)
-                |> Async.AwaitTask
-                |> fun handshake -> Async.RunSynchronously(handshake, timeout = handshakeTimeoutInMs)
+            if not daemonProcess.HasExited then
+                daemonProcess.Kill()
 
-            Ok
-                {
-                    RpcClient = client
-                    Process = daemonProcess
-                    StartInfo = startInfo
-                    ConfigurationWarnings = configurationWarnings.Publish
-                }
-        with ex ->
-            let error =
-                // A timeout says nothing about what was being waited for, so say it here. The next
-                // field report should carry a number someone can argue about rather than "it said
-                // something timed out".
-                if (ex :? TimeoutException) then
-                    $"Daemon did not answer the version request within %i{handshakeTimeoutInMs} ms."
-                elif daemonProcess.HasExited then
-                    // `HasExited` only says the process is gone; the handler above is fed
-                    // asynchronously and can still be behind. `WaitForExit` with no timeout is the
-                    // one overload that waits for the readers to drain too, so without it the
-                    // message here would be missing the lines that explain the failure.
-                    daemonProcess.WaitForExit()
+            daemonProcess.Dispose()
+        with _ ->
+            ()
 
-                    let stdErr =
-                        lock recentStandardError (fun () -> String.Join(Environment.NewLine, recentStandardError))
-
-                    $"Daemon std error: %s{stdErr}.\nJsonRpc exception:%s{ex.Message}"
-                else
-                    ex.Message
-
-            // The handshake failed, so nothing will ever hand this daemon out and nothing will
-            // ever dispose it. Kill it here rather than leave the process running for the rest of
-            // the session with no way to reach it.
-            try
-                client.Dispose()
-            with _ ->
-                ()
-
-            try
-                if not daemonProcess.HasExited then
-                    daemonProcess.Kill()
-
-                daemonProcess.Dispose()
-            with _ ->
-                ()
-
-            Error(ProcessStartError.UnExpectedException(processStart.FileName, processStart.Arguments, error))
+        Error(ProcessStartError.UnExpectedException(processStart.FileName, processStart.Arguments, error))
 
 // Without a version to go on, ask the way every version there has ever been understands.
 let createFor (startInfo: FantomasToolStartInfo) : Result<RunningFantomasTool, ProcessStartError> =

--- a/src/Fantomas.Client/FantomasToolLocator.fs
+++ b/src/Fantomas.Client/FantomasToolLocator.fs
@@ -226,18 +226,20 @@ let findFantomasTool (workingDir: Folder) : Result<FantomasToolFound, FantomasTo
     | Ok(CompatibleTool version) -> Ok(FantomasToolFound(version, FantomasToolStartInfo.LocalTool workingDir))
     | Error err -> Error(FantomasToolError.DotNetListError err)
     | Ok _localToolListResult ->
-        let globalToolsListResult = runToolListCmd workingDir true
 
-        match globalToolsListResult with
-        | Ok(CompatibleTool version) -> Ok(FantomasToolFound(version, FantomasToolStartInfo.GlobalTool))
-        | Error err -> Error(FantomasToolError.DotNetListError err)
-        | Ok _nonCompatibleGlobalVersion ->
-            let fantomasOnPathVersion = fantomasVersionOnPath ()
+    let globalToolsListResult = runToolListCmd workingDir true
 
-            match fantomasOnPathVersion with
-            | Some(executableFile, FantomasVersion(CompatibleVersion version)) ->
-                Ok(FantomasToolFound((FantomasVersion(version)), FantomasToolStartInfo.ToolOnPath executableFile))
-            | _ -> Error FantomasToolError.NoCompatibleVersionFound
+    match globalToolsListResult with
+    | Ok(CompatibleTool version) -> Ok(FantomasToolFound(version, FantomasToolStartInfo.GlobalTool))
+    | Error err -> Error(FantomasToolError.DotNetListError err)
+    | Ok _nonCompatibleGlobalVersion ->
+
+    let fantomasOnPathVersion = fantomasVersionOnPath ()
+
+    match fantomasOnPathVersion with
+    | Some(executableFile, FantomasVersion(CompatibleVersion version)) ->
+        Ok(FantomasToolFound((FantomasVersion(version)), FantomasToolStartInfo.ToolOnPath executableFile))
+    | _ -> Error FantomasToolError.NoCompatibleVersionFound
 
 // Fantomas added `fantomas daemon` beside `fantomas --daemon` in 8.0.0-alpha-016, and both do the
 // same thing. The flag is kept working so that an older client can start a newer Fantomas, and this

--- a/src/Fantomas.Client/LSPFantomasService.fs
+++ b/src/Fantomas.Client/LSPFantomasService.fs
@@ -209,14 +209,15 @@ let isPathAbsolute (path: string) : bool =
     then
         false
     else
-        let pathRoot = Path.GetPathRoot path
-        // Accepts X:\ and \\UNC\PATH, rejects empty string, \ and X:, but accepts / to support Linux
-        if pathRoot.Length <= 2 && pathRoot <> "/" then
-            false
-        else if pathRoot.[0] <> '\\' || pathRoot.[1] <> '\\' then
-            true
-        else
-            pathRoot.Trim('\\').IndexOf('\\') <> -1 // A UNC server name without a share name (e.g "\\NAME" or "\\NAME\") is invalid
+
+    let pathRoot = Path.GetPathRoot path
+    // Accepts X:\ and \\UNC\PATH, rejects empty string, \ and X:, but accepts / to support Linux
+    if pathRoot.Length <= 2 && pathRoot <> "/" then
+        false
+    else if pathRoot.[0] <> '\\' || pathRoot.[1] <> '\\' then
+        true
+    else
+        pathRoot.Trim('\\').IndexOf('\\') <> -1 // A UNC server name without a share name (e.g "\\NAME" or "\\NAME\") is invalid
 
 let isCancellationRequested (requested: bool) : Result<unit, FantomasServiceError> =
     if requested then
@@ -344,83 +345,80 @@ let decodeFormatResult (inputFilePath: string) (json: JObject) : FantomasRespons
         if not (json.ContainsKey("Case")) || not (json.ContainsKey("Fields")) then
             mkError "Expected \"Case\" and \"Fields\" to be present in the response json"
         else
-            let caseName = json.["Case"].Value<string>()
-            let fields = json.["Fields"].Value<JArray>()
 
-            match caseName with
-            | "Formatted" when fields.Count = 2 ->
-                let fileName = fields.[0].Value<string>()
-                let formattedContent = fields.[1].Value<string>()
+        let caseName = json.["Case"].Value<string>()
+        let fields = json.["Fields"].Value<JArray>()
 
-                {
-                    Code = int FantomasResponseCode.Formatted
-                    FilePath = fileName
-                    Content = Some formattedContent
-                    SelectedRange = None
-                    Cursor = None
-                }
-            | "Formatted" when fields.Count = 3 ->
-                let fileName = fields.[0].Value<string>()
-                let formattedContent = fields.[1].Value<string>()
+        match caseName with
+        | "Formatted" when fields.Count = 2 ->
+            let fileName = fields.[0].Value<string>()
+            let formattedContent = fields.[1].Value<string>()
 
-                let cursor =
-                    if fields.[2].Type = JTokenType.Null then
-                        None
-                    else
-                        // This is wrapped as an option, the Case is "Some" here.
-                        // We need to extract the Line and Column from the first item in Fields
-                        let cursorObject = fields.[2].Value<JObject>()
-                        let cursorObject = cursorObject.["Fields"].[0].Value<JObject>()
+            {
+                Code = int FantomasResponseCode.Formatted
+                FilePath = fileName
+                Content = Some formattedContent
+                SelectedRange = None
+                Cursor = None
+            }
+        | "Formatted" when fields.Count = 3 ->
+            let fileName = fields.[0].Value<string>()
+            let formattedContent = fields.[1].Value<string>()
 
-                        Some(
-                            FormatCursorPosition(
-                                cursorObject.["Line"].Value<int>(),
-                                cursorObject.["Column"].Value<int>()
-                            )
-                        )
+            let cursor =
+                if fields.[2].Type = JTokenType.Null then
+                    None
+                else
 
-                {
-                    Code = int FantomasResponseCode.Formatted
-                    FilePath = fileName
-                    Content = Some formattedContent
-                    SelectedRange = None
-                    Cursor = cursor
-                }
+                // This is wrapped as an option, the Case is "Some" here.
+                // We need to extract the Line and Column from the first item in Fields
+                let cursorObject = fields.[2].Value<JObject>()
+                let cursorObject = cursorObject.["Fields"].[0].Value<JObject>()
 
-            | "Unchanged" when fields.Count = 1 ->
-                let fileName = fields.[0].Value<string>()
+                Some(FormatCursorPosition(cursorObject.["Line"].Value<int>(), cursorObject.["Column"].Value<int>()))
 
-                {
-                    Code = int FantomasResponseCode.UnChanged
-                    FilePath = fileName
-                    Content = None
-                    SelectedRange = None
-                    Cursor = None
-                }
-            | "Error" when fields.Count = 2 ->
-                let fileName = fields.[0].Value<string>()
-                let formattingError = fields.[1].Value<string>()
+            {
+                Code = int FantomasResponseCode.Formatted
+                FilePath = fileName
+                Content = Some formattedContent
+                SelectedRange = None
+                Cursor = cursor
+            }
 
-                {
-                    Code = int FantomasResponseCode.Error
-                    FilePath = fileName
-                    Content = Some formattingError
-                    SelectedRange = None
-                    Cursor = None
-                }
-            | "IgnoredFile" when fields.Count = 1 ->
-                let fileName = fields.[0].Value<string>()
+        | "Unchanged" when fields.Count = 1 ->
+            let fileName = fields.[0].Value<string>()
 
-                {
-                    Code = int FantomasResponseCode.Ignored
-                    FilePath = fileName
-                    Content = None
-                    SelectedRange = None
-                    Cursor = None
-                }
-            | _ ->
-                mkError
-                    $"Could not deserialize the message from the daemon, got unexpected case name %s{caseName} with %i{fields.Count} fields."
+            {
+                Code = int FantomasResponseCode.UnChanged
+                FilePath = fileName
+                Content = None
+                SelectedRange = None
+                Cursor = None
+            }
+        | "Error" when fields.Count = 2 ->
+            let fileName = fields.[0].Value<string>()
+            let formattingError = fields.[1].Value<string>()
+
+            {
+                Code = int FantomasResponseCode.Error
+                FilePath = fileName
+                Content = Some formattingError
+                SelectedRange = None
+                Cursor = None
+            }
+        | "IgnoredFile" when fields.Count = 1 ->
+            let fileName = fields.[0].Value<string>()
+
+            {
+                Code = int FantomasResponseCode.Ignored
+                FilePath = fileName
+                Content = None
+                SelectedRange = None
+                Cursor = None
+            }
+        | _ ->
+            mkError
+                $"Could not deserialize the message from the daemon, got unexpected case name %s{caseName} with %i{fields.Count} fields."
 
     with ex ->
         mkError $"Could not deserialize the message from the daemon, %s{ex.Message}"

--- a/src/Fantomas.Client/LSPFantomasService.fs
+++ b/src/Fantomas.Client/LSPFantomasService.fs
@@ -127,9 +127,10 @@ let rec resolveDaemon
                     match running with
                     | None -> startInfo
                     | Some daemon ->
-                        let asItWasStarted = (daemon :> IDaemon).StartInfo
-                        (daemon :> IDaemon).Dispose()
-                        asItWasStarted
+
+                    let asItWasStarted = (daemon :> IDaemon).StartInfo
+                    (daemon :> IDaemon).Dispose()
+                    asItWasStarted
 
                 startDaemon operations version startInfo folder state
         | Error FantomasToolError.NoCompatibleVersionFound -> Error GetDaemonError.InCompatibleVersionFound, state

--- a/src/Fantomas.Core.Tests/ASTTransformerTests.fs
+++ b/src/Fantomas.Core.Tests/ASTTransformerTests.fs
@@ -734,14 +734,15 @@ let ``_.Values[0] — indexed member arrives as one opaque segment with no termi
         | _ -> node.Children |> Array.tryPick search
 
     match search (Expr.Node expr) with
-    | Some chain ->
-        assertCount 1 chain.Segments
-
-        match chain.Segments with
-        | [ ChainSegment.DotMember(dot, _) ] -> assertText "." dot
-        | _ -> Assert.Fail $"Unexpected segments: %A{chain.Segments}"
-
-        match chain.Terminal with
-        | ChainTerminal.NoTerminal -> ()
-        | _ -> Assert.Fail $"Expected NoTerminal, got %A{chain.Terminal}"
     | None -> Assert.Fail "Expected to find the `_` dot-lambda chain"
+    | Some chain ->
+
+    assertCount 1 chain.Segments
+
+    match chain.Segments with
+    | [ ChainSegment.DotMember(dot, _) ] -> assertText "." dot
+    | _ -> Assert.Fail $"Unexpected segments: %A{chain.Segments}"
+
+    match chain.Terminal with
+    | ChainTerminal.NoTerminal -> ()
+    | _ -> Assert.Fail $"Expected NoTerminal, got %A{chain.Terminal}"

--- a/src/Fantomas.Core.Tests/ASTTransformerTests.fs
+++ b/src/Fantomas.Core.Tests/ASTTransformerTests.fs
@@ -18,8 +18,9 @@ let private getExprFromBinding (oak: Oak) =
     match oak.ModulesOrNamespaces.[0].Declarations.[0] with
     | ModuleDecl.TopLevelBinding binding -> binding.Expr
     | _ ->
-        Assert.Fail "Expected TopLevelBinding"
-        raise (System.Exception())
+
+    Assert.Fail "Expected TopLevelBinding"
+    raise (System.Exception())
 
 let private assertIdent (text: string) (expr: Expr) =
     match expr with
@@ -171,8 +172,9 @@ let ``_.Substring(0,16).ToLower() — DotLambda becomes NoSpaceAllowed terminal`
         | Expr.Chain node -> node
         | Expr.InfixApp app -> findChain app.RightHandSide
         | _ ->
-            Assert.Fail "Expected to find Chain in expression"
-            raise (System.Exception())
+
+        Assert.Fail "Expected to find Chain in expression"
+        raise (System.Exception())
 
     let chainNode = findChain expr
 

--- a/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
+++ b/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
@@ -264,11 +264,12 @@ let a =
 
             let genFunctionName =
                 match bindingNode.FunctionName with
-                | Choice1Of2 functionNameNode ->
-                    match functionNameNode.Content with
-                    | [ IdentifierOrDot.Ident node ] -> !-node.Text
-                    | _ -> !-"error"
                 | Choice2Of2 _ -> !-"error"
+                | Choice1Of2 functionNameNode ->
+
+                match functionNameNode.Content with
+                | [ IdentifierOrDot.Ident node ] -> !-node.Text
+                | _ -> !-"error"
 
             let genEq = !-bindingNode.Equals.Text
 

--- a/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
+++ b/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
@@ -315,10 +315,11 @@ let a =
                 match Seq.tryHead identNode.ContentBefore with
                 | None -> sepNone
                 | Some triviaNode ->
-                    // If found we check the content and try to print the comment text followed by a newline
-                    match triviaNode.Content with
-                    | CommentOnSingleLine comment -> !-comment +> sepNln
-                    | _ -> !-"error"
+
+                // If found we check the content and try to print the comment text followed by a newline
+                match triviaNode.Content with
+                | CommentOnSingleLine comment -> !-comment +> sepNln
+                | _ -> !-"error"
 
             firstComment +> !-identNode.Text
         | _ -> !-"error"

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -656,26 +656,26 @@ let (|ElIf|_|) expr =
                         let (_, prevElseKw, _, _, _) = rawEntries[i - 1]
 
                         match prevElseKw with
-                        | Some mElse ->
-                            match ifNode with
-                            | Choice1Of2 ifNode -> Choice2Of2(mElse, ifNode.Range)
-                            | Choice2Of2 _ ->
-                                invariantViolation
-                                    expr.Range
-                                    "cannot merge a second else keyword into existing else if"
                         | None -> ifNode
+                        | Some mElse ->
+
+                        match ifNode with
+                        | Choice1Of2 ifNode -> Choice2Of2(mElse, ifNode.Range)
+                        | Choice2Of2 _ ->
+                            invariantViolation expr.Range "cannot merge a second else keyword into existing else if"
 
                 (node, e1, thenKw, e2)
             )
 
         let elseInfo =
             match elseBody with
+            | None -> None
             | Some elseExpr ->
-                let (_, lastElseKw, _, _, _) = List.last rawEntries
 
-                match lastElseKw with
-                | Some elseKw -> Some(stn "else" elseKw, elseExpr)
-                | None -> None
+            let (_, lastElseKw, _, _, _) = List.last rawEntries
+
+            match lastElseKw with
+            | Some elseKw -> Some(stn "else" elseKw, elseExpr)
             | None -> None
 
         ValueSome(clauses, elseInfo)
@@ -2816,10 +2816,10 @@ let (|OpenL|_|) decls =
 
 let mkOpenNodeForImpl (creationAide: CreationAide) (target, range) : Open =
     match target with
+    | SynOpenDeclTarget.Type(typeName, _) -> OpenTargetNode(mkType creationAide typeName, range) |> Open.Target
     | SynOpenDeclTarget.ModuleOrNamespace(longId, _) ->
         OpenModuleOrNamespaceNode(mkSynLongIdent creationAide longId, range)
         |> Open.ModuleOrNamespace
-    | SynOpenDeclTarget.Type(typeName, _) -> OpenTargetNode(mkType creationAide typeName, range) |> Open.Target
 
 [<TailCall>]
 let rec visitHashDirectiveL acc decls =
@@ -3265,11 +3265,11 @@ let mkPropertyGetSetBinding
                 [
                     tuplePat
                     match List.tryLast ps with
+                    | Some indexerPat -> mkPat creationAide indexerPat
                     | None ->
                         invariantViolation
                             binding.RangeOfBindingWithRhs
                             "an indexed property setter has no indexer pattern"
-                    | Some indexerPat -> mkPat creationAide indexerPat
                 ]
             | [ SynPat.Tuple(false, [ p1; p2 ], _, _) ] -> [ mkPat creationAide p1; mkPat creationAide p2 ]
             | ps -> List.map (mkPat creationAide) ps
@@ -3362,6 +3362,7 @@ let mkMemberDefn (creationAide: CreationAide) (md: SynMemberDefn) =
     | SynMemberDefn.Member(memberDefn, _) -> mkBinding creationAide memberDefn None |> MemberDefn.Member
     | SynMemberDefn.Inherit(baseTypeOpt, _, _isInline, trivia) ->
         match baseTypeOpt with
+        | None -> invariantViolation md.Range "a successful parse produced an unfinished inherit member"
         | Some baseType ->
             MemberDefnInheritNode(
                 stn "inherit" trivia.InheritKeyword,
@@ -3369,7 +3370,6 @@ let mkMemberDefn (creationAide: CreationAide) (md: SynMemberDefn) =
                 memberDefinitionRange
             )
             |> MemberDefn.Inherit
-        | None -> invariantViolation md.Range "a successful parse produced an unfinished inherit member"
     | SynMemberDefn.ValField(f, _) -> mkSynField creationAide f |> MemberDefn.ValField
     | SynMemberDefn.LetBindings(
         bindings = [ SynBinding(
@@ -4222,11 +4222,12 @@ let mkFullTreeRange ast =
 
         let endPos =
             match List.tryLast modules with
-            | None ->
-                match List.tryLast directives with
-                | None -> RangeHelpers.absoluteZeroRange
-                | Some(ParsedHashDirective(range = r)) -> r
             | Some lastModule -> mkSynModuleOrNamespaceFullRange lastModule
+            | None ->
+
+            match List.tryLast directives with
+            | None -> RangeHelpers.absoluteZeroRange
+            | Some(ParsedHashDirective(range = r)) -> r
 
         let astRange = unionRanges startPos endPos
         includeTrivia astRange trivia
@@ -4242,11 +4243,12 @@ let mkFullTreeRange ast =
 
         let endPos =
             match List.tryLast modules with
-            | None ->
-                match List.tryLast directives with
-                | None -> RangeHelpers.absoluteZeroRange
-                | Some(ParsedHashDirective(range = r)) -> r
             | Some lastModule -> mkSynModuleOrNamespaceSigFullRange lastModule
+            | None ->
+
+            match List.tryLast directives with
+            | None -> RangeHelpers.absoluteZeroRange
+            | Some(ParsedHashDirective(range = r)) -> r
 
         let astRange = unionRanges startPos endPos
         includeTrivia astRange trivia

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -660,17 +660,18 @@ let (|ElIf|_|) expr =
                     if i = 0 then
                         ifNode
                     else
-                        // Get the previous entry's elseKw to merge into this entry
-                        let (_, prevElseKw, _, _, _) = rawEntries[i - 1]
 
-                        match prevElseKw with
-                        | None -> ifNode
-                        | Some mElse ->
+                    // Get the previous entry's elseKw to merge into this entry
+                    let (_, prevElseKw, _, _, _) = rawEntries[i - 1]
 
-                        match ifNode with
-                        | Choice1Of2 ifNode -> Choice2Of2(mElse, ifNode.Range)
-                        | Choice2Of2 _ ->
-                            invariantViolation expr.Range "cannot merge a second else keyword into existing else if"
+                    match prevElseKw with
+                    | None -> ifNode
+                    | Some mElse ->
+
+                    match ifNode with
+                    | Choice1Of2 ifNode -> Choice2Of2(mElse, ifNode.Range)
+                    | Choice2Of2 _ ->
+                        invariantViolation expr.Range "cannot merge a second else keyword into existing else if"
 
                 (node, e1, thenKw, e2)
             )
@@ -2295,9 +2296,10 @@ let mkBinding
             elif not attributes.IsEmpty then
                 attributes.Head.Range
             else
-                match trivia.LeadingKeyword, pat with
-                | SynLeadingKeyword.Member _, SynPat.LongIdent(extraId = Some _) -> pat.Range
-                | _ -> trivia.LeadingKeyword.Range
+
+            match trivia.LeadingKeyword, pat with
+            | SynLeadingKeyword.Member _, SynPat.LongIdent(extraId = Some _) -> pat.Range
+            | _ -> trivia.LeadingKeyword.Range
 
         let range = unionRanges start e.Range
 
@@ -2338,9 +2340,10 @@ let mkExternBinding
         if not xmlDoc.IsEmpty then
             unionRanges xmlDoc.Range pat.Range
         else
-            match attributes with
-            | [] -> range
-            | head :: _ -> unionRanges head.Range pat.Range
+
+        match attributes with
+        | [] -> range
+        | head :: _ -> unionRanges head.Range pat.Range
 
     let externNode =
         match trivia.LeadingKeyword with
@@ -2444,9 +2447,10 @@ let mkXmlDoc (px: PreXmlDoc) =
     if px.IsEmpty then
         None
     else
-        let xmlDoc = px.ToXmlDoc(false, None)
-        let lines = Array.map (sprintf "///%s") xmlDoc.UnprocessedLines
-        Some(XmlDocNode(lines, xmlDoc.Range))
+
+    let xmlDoc = px.ToXmlDoc(false, None)
+    let lines = Array.map (sprintf "///%s") xmlDoc.UnprocessedLines
+    Some(XmlDocNode(lines, xmlDoc.Range))
 
 let mkModuleName (SynComponentInfo(synType = synType; range = m) as info) : IdentListNode =
     match synType with
@@ -2790,9 +2794,9 @@ let mkType (creationAide: CreationAide) (t: SynType) : Type =
                     Type.Var(mkSynTypar typar), ts
                 | None ->
                     match ts with
+                    | head :: tail -> mkType creationAide head, tail
                     | [] ->
                         invariantViolation t.Range "a type intersection contains neither a typar nor any constraints"
-                    | head :: tail -> mkType creationAide head, tail
 
             assert (ts.Length = trivia.AmpersandRanges.Length)
 
@@ -2928,9 +2932,10 @@ let mkSynUnionCase
         if not xmlDoc.IsEmpty then
             m
         else
-            match trivia.BarRange with
-            | None -> m
-            | Some barRange -> unionRanges barRange m
+
+        match trivia.BarRange with
+        | None -> m
+        | Some barRange -> unionRanges barRange m
 
     let fields =
         match caseType with
@@ -3034,9 +3039,10 @@ let mkTypeDefn
                 elif leadingKeyword.Text = "and" then
                     leadingKeyword.Range
                 else
-                    match ats with
-                    | [] -> leadingKeyword.Range
-                    | firstAttr :: _ -> firstAttr.Range
+
+                match ats with
+                | [] -> leadingKeyword.Range
+                | firstAttr :: _ -> firstAttr.Range
 
             let endRange =
                 match trivia.EqualsRange with
@@ -3913,9 +3919,10 @@ let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRep
             if not px.IsEmpty then
                 unionRanges px.Range mIdentifierNode
             else
-                match ats with
-                | [] -> unionRanges leadingKeyword.Range mIdentifierNode
-                | firstAttr :: _ -> unionRanges firstAttr.Range mIdentifierNode
+
+            match ats with
+            | [] -> unionRanges leadingKeyword.Range mIdentifierNode
+            | firstAttr :: _ -> unionRanges firstAttr.Range mIdentifierNode
 
         TypeNameNode(
             mkXmlDoc px,

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -80,49 +80,52 @@ let mkSynIdent (creationAide: CreationAide) (SynIdent(ident, trivia)) =
     | Some(IdentTrivia.OriginalNotation text) -> stn text ident.idRange
     | Some(IdentTrivia.OriginalNotationWithParen(_, text, _)) -> stn $"(%s{text})" ident.idRange
     | Some(IdentTrivia.HasParenthesis _) ->
-        let width = ident.idRange.EndColumn - ident.idRange.StartColumn
 
-        let text =
-            if ident.idText.Length < width then
-                // preserve backticks inside the idText, e.g. the idText could be "|``Is Even``|``Is Odd``|"
-                creationAide.TextFromSource (fun () -> $"(%s{ident.idText})") ident.idRange
-            else
-                ident.idText
+    let width = ident.idRange.EndColumn - ident.idRange.StartColumn
 
-        stn $"(%s{text})" ident.idRange
+    let text =
+        if ident.idText.Length < width then
+            // preserve backticks inside the idText, e.g. the idText could be "|``Is Even``|``Is Odd``|"
+            creationAide.TextFromSource (fun () -> $"(%s{ident.idText})") ident.idRange
+        else
+            ident.idText
+
+    stn $"(%s{text})" ident.idRange
 
 let mkSynLongIdent (creationAide: CreationAide) (sli: SynLongIdent) =
     match sli.IdentsWithTrivia with
     | [] -> IdentListNode.Empty
     | [ single ] -> IdentListNode([ IdentifierOrDot.Ident(mkSynIdent creationAide single) ], sli.Range)
     | head :: tail ->
-        assert (tail.Length = sli.Dots.Length)
 
-        let rest =
-            (sli.Dots, tail)
-            ||> List.zip
-            |> List.collect (fun (dot, ident) ->
-                [
-                    IdentifierOrDot.KnownDot(stn "." dot)
-                    IdentifierOrDot.Ident(mkSynIdent creationAide ident)
-                ]
-            )
+    assert (tail.Length = sli.Dots.Length)
 
-        IdentListNode(IdentifierOrDot.Ident(mkSynIdent creationAide head) :: rest, sli.Range)
+    let rest =
+        (sli.Dots, tail)
+        ||> List.zip
+        |> List.collect (fun (dot, ident) ->
+            [
+                IdentifierOrDot.KnownDot(stn "." dot)
+                IdentifierOrDot.Ident(mkSynIdent creationAide ident)
+            ]
+        )
+
+    IdentListNode(IdentifierOrDot.Ident(mkSynIdent creationAide head) :: rest, sli.Range)
 
 let mkLongIdent (longIdent: LongIdent) : IdentListNode =
     match longIdent with
     | [] -> IdentListNode.Empty
     | [ single ] -> IdentListNode([ IdentifierOrDot.Ident(mkIdent single) ], single.idRange)
     | head :: tail ->
-        let rest =
-            tail
-            |> List.collect (fun ident -> [ IdentifierOrDot.UnknownDot; IdentifierOrDot.Ident(mkIdent ident) ])
 
-        let range =
-            longIdent |> List.map (fun ident -> ident.idRange) |> List.reduce unionRanges
+    let rest =
+        tail
+        |> List.collect (fun ident -> [ IdentifierOrDot.UnknownDot; IdentifierOrDot.Ident(mkIdent ident) ])
 
-        IdentListNode(IdentifierOrDot.Ident(mkIdent head) :: rest, range)
+    let range =
+        longIdent |> List.map (fun ident -> ident.idRange) |> List.reduce unionRanges
+
+    IdentListNode(IdentifierOrDot.Ident(mkIdent head) :: rest, range)
 
 let mkSynAccess (vis: SynAccess option) =
     match vis with
@@ -279,9 +282,10 @@ let mkAttributes (creationAide: CreationAide) (al: SynAttributeList list) : Mult
     match al with
     | [] -> None
     | _ ->
-        let attributeLists = List.map (mkAttributeList creationAide) al
-        let range = attributeLists |> List.map (fun al -> al.Range) |> combineRanges
-        Some(MultipleAttributeListNode(attributeLists, range))
+
+    let attributeLists = List.map (mkAttributeList creationAide) al
+    let range = attributeLists |> List.map (fun al -> al.Range) |> combineRanges
+    Some(MultipleAttributeListNode(attributeLists, range))
 
 /// Only used to get items of SynExpr.ArrayOrListComputed
 /// We can safely assume the SequentialTrivia.SeparatorRange is not going to be `then`.
@@ -332,13 +336,14 @@ let mkTuple (creationAide: CreationAide) (exprs: SynExpr list) (commas: range li
     match exprs with
     | [] -> invariantViolation m "a tuple expression has no elements"
     | head :: tail ->
-        let rest =
-            assert (tail.Length = commas.Length)
 
-            List.zip commas tail
-            |> List.collect (fun (c, e) -> [ yield Choice2Of2(stn "," c); yield Choice1Of2(mkExpr creationAide e) ])
+    let rest =
+        assert (tail.Length = commas.Length)
 
-        ExprTupleNode([ yield Choice1Of2(mkExpr creationAide head); yield! rest ], m)
+        List.zip commas tail
+        |> List.collect (fun (c, e) -> [ yield Choice2Of2(stn "," c); yield Choice1Of2(mkExpr creationAide e) ])
+
+    ExprTupleNode([ yield Choice1Of2(mkExpr creationAide head); yield! rest ], m)
 
 /// Unfold a list of let bindings
 /// Recursive and use properties have to be determined at this point
@@ -505,14 +510,16 @@ let (|MultipleConsInfixApps|_|) expr =
             match headAndLastOperator with
             | None -> visit rhs (Some(lhs, operator)) xs
             | Some(head, lastOperator) ->
-                xs.Enqueue(lastOperator, lhs)
-                visit rhs (Some(head, operator)) xs
+
+            xs.Enqueue(lastOperator, lhs)
+            visit rhs (Some(head, operator)) xs
         | e ->
             match headAndLastOperator with
             | None -> e, xs
             | Some(head, lastOperator) ->
-                xs.Enqueue(lastOperator, e)
-                head, xs
+
+            xs.Enqueue(lastOperator, e)
+            head, xs
 
     match expr with
     | ColonColonInfixApp _ ->
@@ -572,8 +579,9 @@ let (|SameInfixApps|_|) expr =
             match headAndLastOperator with
             | None -> e, xs
             | Some(head, lastOperator) ->
-                xs.Enqueue(lastOperator, e)
-                head, xs
+
+            xs.Enqueue(lastOperator, e)
+            head, xs
 
     match expr with
     | InfixApp(_, operator, _) ->
@@ -1949,12 +1957,13 @@ let mkExpr (creationAide: CreationAide) (e: SynExpr) : Expr =
                         | SynInterpolationFormatting.Printf _ -> mkExpr creationAide fillExpr, None
                         | SynInterpolationFormatting.DotNet(None, format) -> mkExpr creationAide fillExpr, format
                         | SynInterpolationFormatting.DotNet(Some alignment, format) ->
-                            let mComma =
-                                mkRange fillExpr.Range.FileName fillExpr.Range.End alignment.Range.Start
 
-                            let mTuple = unionRanges fillExpr.Range alignment.Range
+                        let mComma =
+                            mkRange fillExpr.Range.FileName fillExpr.Range.End alignment.Range.Start
 
-                            mkTuple creationAide [ fillExpr; alignment ] [ mComma ] mTuple |> Expr.Tuple, format
+                        let mTuple = unionRanges fillExpr.Range alignment.Range
+
+                        mkTuple creationAide [ fillExpr; alignment ] [ mComma ] mTuple |> Expr.Tuple, format
 
                     let m =
                         match format with
@@ -2078,16 +2087,17 @@ let mkTuplePat (creationAide: CreationAide) (pats: SynPat list) (commas: range l
     match pats with
     | [] -> invariantViolation m "a tuple pattern has no elements"
     | head :: tail ->
-        let rest =
-            if tail.Length <> commas.Length then
-                invariantViolation
-                    m
-                    $"Number of elements in tail of tuple (%i{tail.Length}) was not equal to number of commas (%i{commas.Length}), at range %O{m}."
 
-            List.zip commas tail
-            |> List.collect (fun (c, e) -> [ yield Choice2Of2(stn "," c); yield Choice1Of2(mkPat creationAide e) ])
+    let rest =
+        if tail.Length <> commas.Length then
+            invariantViolation
+                m
+                $"Number of elements in tail of tuple (%i{tail.Length}) was not equal to number of commas (%i{commas.Length}), at range %O{m}."
 
-        PatTupleNode([ yield Choice1Of2(mkPat creationAide head); yield! rest ], m)
+        List.zip commas tail
+        |> List.collect (fun (c, e) -> [ yield Choice2Of2(stn "," c); yield Choice1Of2(mkPat creationAide e) ])
+
+    PatTupleNode([ yield Choice1Of2(mkPat creationAide head); yield! rest ], m)
 
 let mkPat (creationAide: CreationAide) (p: SynPat) =
     let patternRange = p.Range
@@ -2962,8 +2972,9 @@ let mkImplicitCtor
         match self with
         | None -> None
         | Some(mAs, self) ->
-            let m = unionRanges mAs self.idRange
-            Some(AsSelfIdentifierNode(stn "as" mAs, mkIdent self, m))
+
+        let m = unionRanges mAs self.idRange
+        Some(AsSelfIdentifierNode(stn "as" mAs, mkIdent self, m))
 
     ImplicitConstructorNode(
         mkXmlDoc xmlDoc,
@@ -2990,62 +3001,63 @@ let mkTypeDefn
     let typeNameNode =
         match typeInfo with
         | SynComponentInfo(ats, tds, tcs, _, px, _preferPostfix, ao, _) ->
-            let identifierNode = mkComponentInfoName creationAide typeInfo
-            let mIdentifierNode = (Type.Node identifierNode).Range
 
-            let leadingKeyword =
-                match trivia.LeadingKeyword with
-                | SynTypeDefnLeadingKeyword.Type mType -> stn "type" mType
-                | SynTypeDefnLeadingKeyword.And mAnd -> stn "and" mAnd
-                | SynTypeDefnLeadingKeyword.StaticType _
-                | SynTypeDefnLeadingKeyword.Synthetic ->
-                    invariantViolationAbout
-                        range
-                        trivia.LeadingKeyword
-                        $"unexpected leading keyword %s{UnionCase.name trivia.LeadingKeyword}"
+        let identifierNode = mkComponentInfoName creationAide typeInfo
+        let mIdentifierNode = (Type.Node identifierNode).Range
 
-            let implicitConstructorNode =
-                match implicitConstructor with
-                | Some(SynMemberDefn.ImplicitCtor(vis, attrs, pats, self, xmlDoc, _, trivia)) ->
-                    let self =
-                        match self, trivia.AsKeyword with
-                        | Some self, Some mAs -> Some(mAs, self)
-                        | _ -> None
+        let leadingKeyword =
+            match trivia.LeadingKeyword with
+            | SynTypeDefnLeadingKeyword.Type mType -> stn "type" mType
+            | SynTypeDefnLeadingKeyword.And mAnd -> stn "and" mAnd
+            | SynTypeDefnLeadingKeyword.StaticType _
+            | SynTypeDefnLeadingKeyword.Synthetic ->
+                invariantViolationAbout
+                    range
+                    trivia.LeadingKeyword
+                    $"unexpected leading keyword %s{UnionCase.name trivia.LeadingKeyword}"
 
-                    mkImplicitCtor creationAide vis attrs pats self xmlDoc |> Some
-                | _ -> None
+        let implicitConstructorNode =
+            match implicitConstructor with
+            | Some(SynMemberDefn.ImplicitCtor(vis, attrs, pats, self, xmlDoc, _, trivia)) ->
+                let self =
+                    match self, trivia.AsKeyword with
+                    | Some self, Some mAs -> Some(mAs, self)
+                    | _ -> None
 
-            let m =
-                let startRange =
-                    if not px.IsEmpty then
-                        px.Range
-                    elif leadingKeyword.Text = "and" then
-                        leadingKeyword.Range
-                    else
-                        match ats with
-                        | [] -> leadingKeyword.Range
-                        | firstAttr :: _ -> firstAttr.Range
+                mkImplicitCtor creationAide vis attrs pats self xmlDoc |> Some
+            | _ -> None
 
-                let endRange =
-                    match trivia.EqualsRange with
-                    | None -> mIdentifierNode
-                    | Some mEq -> mEq
+        let m =
+            let startRange =
+                if not px.IsEmpty then
+                    px.Range
+                elif leadingKeyword.Text = "and" then
+                    leadingKeyword.Range
+                else
+                    match ats with
+                    | [] -> leadingKeyword.Range
+                    | firstAttr :: _ -> firstAttr.Range
 
-                unionRanges startRange endRange
+            let endRange =
+                match trivia.EqualsRange with
+                | None -> mIdentifierNode
+                | Some mEq -> mEq
 
-            TypeNameNode(
-                mkXmlDoc px,
-                mkAttributes creationAide ats,
-                leadingKeyword,
-                mkSynAccess ao,
-                identifierNode,
-                Option.map (mkSynTyparDecls creationAide) tds,
-                List.map (mkSynTypeConstraint creationAide) tcs,
-                implicitConstructorNode,
-                Option.map (stn "=") trivia.EqualsRange,
-                Option.map (stn "with") trivia.WithKeyword,
-                m
-            )
+            unionRanges startRange endRange
+
+        TypeNameNode(
+            mkXmlDoc px,
+            mkAttributes creationAide ats,
+            leadingKeyword,
+            mkSynAccess ao,
+            identifierNode,
+            Option.map (mkSynTyparDecls creationAide) tds,
+            List.map (mkSynTypeConstraint creationAide) tcs,
+            implicitConstructorNode,
+            Option.map (stn "=") trivia.EqualsRange,
+            Option.map (stn "with") trivia.WithKeyword,
+            m
+        )
 
     let members = List.map (mkMemberDefn creationAide) members
     let typeDefnRange = unionRanges typeNameNode.Range range
@@ -3181,32 +3193,33 @@ let mkWithGetSet
         | GetSetKeywords.Get mGet -> Some(MultipleTextsNode([ withNode; yield! visNodes visGet; stn "get" mGet ], m))
         | GetSetKeywords.Set mSet -> Some(MultipleTextsNode([ withNode; yield! visNodes visSet; stn "set" mSet ], m))
         | GetSetKeywords.GetSet(mGet, mSet) ->
-            if rangeBeforePos mGet mSet.Start then
-                Some(
-                    MultipleTextsNode(
-                        [
-                            withNode
-                            yield! visNodes visGet
-                            stn "get," mGet
-                            yield! visNodes visSet
-                            stn "set" mSet
-                        ],
-                        m
-                    )
+
+        if rangeBeforePos mGet mSet.Start then
+            Some(
+                MultipleTextsNode(
+                    [
+                        withNode
+                        yield! visNodes visGet
+                        stn "get," mGet
+                        yield! visNodes visSet
+                        stn "set" mSet
+                    ],
+                    m
                 )
-            else
-                Some(
-                    MultipleTextsNode(
-                        [
-                            withNode
-                            yield! visNodes visSet
-                            stn "set," mSet
-                            yield! visNodes visGet
-                            stn "get" mGet
-                        ],
-                        m
-                    )
+            )
+        else
+            Some(
+                MultipleTextsNode(
+                    [
+                        withNode
+                        yield! visNodes visSet
+                        stn "set," mSet
+                        yield! visNodes visGet
+                        stn "get" mGet
+                    ],
+                    m
                 )
+            )
     | _ -> None
 
 let mkPropertyGetSetBinding
@@ -3582,10 +3595,11 @@ let mkMemberDefn (creationAide: CreationAide) (md: SynMemberDefn) =
             match ao with
             | None -> None, None
             | Some ao ->
-                if rangeBeforePos ao.Range memberName.Range.Start then
-                    Some ao, None
-                else
-                    None, Some ao
+
+            if rangeBeforePos ao.Range memberName.Range.Start then
+                Some ao, None
+            else
+                None, Some ao
 
         match getKeyword, setKeyword with
         | Some getKeyword, None ->
@@ -3764,33 +3778,34 @@ let mkModuleOrNamespace
         match leadingKeyword with
         | None -> None
         | Some leadingKeyword ->
-            match name with
-            | None ->
-                let m = mkFileIndexRange range.FileIndex range.Start leadingKeyword.Range.End
 
-                ModuleOrNamespaceHeaderNode(
-                    mkXmlDoc xmlDoc,
-                    mkAttributes creationAide attribs,
-                    leadingKeyword,
-                    mkSynAccess accessibility,
-                    isRecursive,
-                    None,
-                    m
-                )
-                |> Some
-            | Some name ->
-                let m = mkFileIndexRange range.FileIndex range.Start name.Range.End
+        match name with
+        | None ->
+            let m = mkFileIndexRange range.FileIndex range.Start leadingKeyword.Range.End
 
-                ModuleOrNamespaceHeaderNode(
-                    mkXmlDoc xmlDoc,
-                    mkAttributes creationAide attribs,
-                    leadingKeyword,
-                    mkSynAccess accessibility,
-                    isRecursive,
-                    Some name,
-                    m
-                )
-                |> Some
+            ModuleOrNamespaceHeaderNode(
+                mkXmlDoc xmlDoc,
+                mkAttributes creationAide attribs,
+                leadingKeyword,
+                mkSynAccess accessibility,
+                isRecursive,
+                None,
+                m
+            )
+            |> Some
+        | Some name ->
+            let m = mkFileIndexRange range.FileIndex range.Start name.Range.End
+
+            ModuleOrNamespaceHeaderNode(
+                mkXmlDoc xmlDoc,
+                mkAttributes creationAide attribs,
+                leadingKeyword,
+                mkSynAccess accessibility,
+                isRecursive,
+                Some name,
+                m
+            )
+            |> Some
 
     let decls = mkModuleDecls creationAide decls id
 
@@ -3879,41 +3894,42 @@ let mkTypeDefnSig (creationAide: CreationAide) (SynTypeDefnSig(typeInfo, typeRep
     let typeNameNode =
         match typeInfo with
         | SynComponentInfo(ats, tds, tcs, _, px, _preferPostfix, ao, _) ->
-            let identifierNode = mkComponentInfoName creationAide typeInfo
-            let mIdentifierNode = (Type.Node identifierNode).Range
 
-            let leadingKeyword =
-                match trivia.LeadingKeyword with
-                | SynTypeDefnLeadingKeyword.Type mType -> stn "type" mType
-                | SynTypeDefnLeadingKeyword.And mAnd -> stn "and" mAnd
-                | SynTypeDefnLeadingKeyword.StaticType _
-                | SynTypeDefnLeadingKeyword.Synthetic ->
-                    invariantViolationAbout
-                        range
-                        trivia.LeadingKeyword
-                        $"unexpected leading keyword %s{UnionCase.name trivia.LeadingKeyword}"
+        let identifierNode = mkComponentInfoName creationAide typeInfo
+        let mIdentifierNode = (Type.Node identifierNode).Range
 
-            let m =
-                if not px.IsEmpty then
-                    unionRanges px.Range mIdentifierNode
-                else
-                    match ats with
-                    | [] -> unionRanges leadingKeyword.Range mIdentifierNode
-                    | firstAttr :: _ -> unionRanges firstAttr.Range mIdentifierNode
+        let leadingKeyword =
+            match trivia.LeadingKeyword with
+            | SynTypeDefnLeadingKeyword.Type mType -> stn "type" mType
+            | SynTypeDefnLeadingKeyword.And mAnd -> stn "and" mAnd
+            | SynTypeDefnLeadingKeyword.StaticType _
+            | SynTypeDefnLeadingKeyword.Synthetic ->
+                invariantViolationAbout
+                    range
+                    trivia.LeadingKeyword
+                    $"unexpected leading keyword %s{UnionCase.name trivia.LeadingKeyword}"
 
-            TypeNameNode(
-                mkXmlDoc px,
-                mkAttributes creationAide ats,
-                leadingKeyword,
-                mkSynAccess ao,
-                identifierNode,
-                Option.map (mkSynTyparDecls creationAide) tds,
-                List.map (mkSynTypeConstraint creationAide) tcs,
-                None,
-                Option.map (stn "=") trivia.EqualsRange,
-                Option.map (stn "with") trivia.WithKeyword,
-                m
-            )
+        let m =
+            if not px.IsEmpty then
+                unionRanges px.Range mIdentifierNode
+            else
+                match ats with
+                | [] -> unionRanges leadingKeyword.Range mIdentifierNode
+                | firstAttr :: _ -> unionRanges firstAttr.Range mIdentifierNode
+
+        TypeNameNode(
+            mkXmlDoc px,
+            mkAttributes creationAide ats,
+            leadingKeyword,
+            mkSynAccess ao,
+            identifierNode,
+            Option.map (mkSynTyparDecls creationAide) tds,
+            List.map (mkSynTypeConstraint creationAide) tcs,
+            None,
+            Option.map (stn "=") trivia.EqualsRange,
+            Option.map (stn "with") trivia.WithKeyword,
+            m
+        )
 
     let members = List.map (mkMemberSig creationAide) members
     let typeDefnRange = unionRanges typeNameNode.Range range
@@ -4113,33 +4129,34 @@ let mkModuleOrNamespaceSig
         match leadingKeyword with
         | None -> None
         | Some leadingKeyword ->
-            match name with
-            | None ->
-                let m = mkFileIndexRange range.FileIndex range.Start leadingKeyword.Range.End
 
-                ModuleOrNamespaceHeaderNode(
-                    mkXmlDoc xmlDoc,
-                    mkAttributes creationAide attribs,
-                    leadingKeyword,
-                    mkSynAccess accessibility,
-                    isRecursive,
-                    None,
-                    m
-                )
-                |> Some
-            | Some name ->
-                let m = mkFileIndexRange range.FileIndex range.Start name.Range.End
+        match name with
+        | None ->
+            let m = mkFileIndexRange range.FileIndex range.Start leadingKeyword.Range.End
 
-                ModuleOrNamespaceHeaderNode(
-                    mkXmlDoc xmlDoc,
-                    mkAttributes creationAide attribs,
-                    leadingKeyword,
-                    mkSynAccess accessibility,
-                    isRecursive,
-                    Some name,
-                    m
-                )
-                |> Some
+            ModuleOrNamespaceHeaderNode(
+                mkXmlDoc xmlDoc,
+                mkAttributes creationAide attribs,
+                leadingKeyword,
+                mkSynAccess accessibility,
+                isRecursive,
+                None,
+                m
+            )
+            |> Some
+        | Some name ->
+            let m = mkFileIndexRange range.FileIndex range.Start name.Range.End
+
+            ModuleOrNamespaceHeaderNode(
+                mkXmlDoc xmlDoc,
+                mkAttributes creationAide attribs,
+                leadingKeyword,
+                mkSynAccess accessibility,
+                isRecursive,
+                Some name,
+                m
+            )
+            |> Some
 
     ModuleOrNamespaceNode(header, decls, range)
 
@@ -4216,9 +4233,10 @@ let mkFullTreeRange ast =
             match directives with
             | ParsedHashDirective(range = r) :: _ -> r
             | [] ->
-                match modules with
-                | m :: _ -> mkSynModuleOrNamespaceFullRange m
-                | _ -> RangeHelpers.absoluteZeroRange
+
+            match modules with
+            | m :: _ -> mkSynModuleOrNamespaceFullRange m
+            | _ -> RangeHelpers.absoluteZeroRange
 
         let endPos =
             match List.tryLast modules with
@@ -4237,9 +4255,10 @@ let mkFullTreeRange ast =
             match directives with
             | ParsedHashDirective(range = r) :: _ -> r
             | [] ->
-                match modules with
-                | m :: _ -> mkSynModuleOrNamespaceSigFullRange m
-                | _ -> RangeHelpers.absoluteZeroRange
+
+            match modules with
+            | m :: _ -> mkSynModuleOrNamespaceSigFullRange m
+            | _ -> RangeHelpers.absoluteZeroRange
 
         let endPos =
             match List.tryLast modules with

--- a/src/Fantomas.Core/CodeFormatter.fs
+++ b/src/Fantomas.Core/CodeFormatter.fs
@@ -117,10 +117,11 @@ type CodeFormatter =
                 if List.isEmpty defines then
                     asts.[0]
                 else
-                    let sortedDefines = List.sort defines
 
-                    asts
-                    |> Array.find (fun (_, DefineCombination(d)) -> List.sort d = sortedDefines)
+                let sortedDefines = List.sort defines
+
+                asts
+                |> Array.find (fun (_, DefineCombination(d)) -> List.sort d = sortedDefines)
 
             let oak = ASTTransformer.mkOak (Some sourceText) ast
             let oak = Trivia.enrichTree config sourceText ast oak

--- a/src/Fantomas.Core/CodeFormatterImpl.fs
+++ b/src/Fantomas.Core/CodeFormatterImpl.fs
@@ -48,13 +48,14 @@ let parse (isSignature: bool) (source: ISourceText) : Async<(ParsedInput * Defin
                         if errors.IsEmpty then
                             return Ok(untypedTree, defineCombination)
                         else
-                            let defineNames =
-                                if defineCombination.Value.IsEmpty then
-                                    "no defines"
-                                else
-                                    defineCombination.Value |> String.concat ", "
 
-                            return Error defineNames
+                        let defineNames =
+                            if defineCombination.Value.IsEmpty then
+                                "no defines"
+                            else
+                                defineCombination.Value |> String.concat ", "
+
+                        return Error defineNames
                     }
                 )
                 |> Async.Parallel

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -2433,6 +2433,7 @@ let genSmallRecordBaseExpr genExtra (node: ExprRecordBaseNode) =
         node.Fields
         (fun _i item ->
             match item with
+            | ExprRecordFieldOrSpread.Spread node -> genExprSpreadNode node
             | ExprRecordFieldOrSpread.Field rf ->
                 genIdentListNode rf.FieldName
                 +> sepSpace
@@ -2440,7 +2441,6 @@ let genSmallRecordBaseExpr genExtra (node: ExprRecordBaseNode) =
                 +> sepSpace
                 +> genExpr rf.Expr
                 |> genNode rf
-            | ExprRecordFieldOrSpread.Spread node -> genExprSpreadNode node
         )
     +> addSpaceIfSpaceAroundDelimiter
     +> genSingleTextNode node.ClosingBrace
@@ -4233,11 +4233,12 @@ let inline (|ParameterWithTupleTypePattern|_|) (pat: Pattern) =
     match pat with
     | Pattern.Parameter parameterNode ->
         match parameterNode.Type with
-        | Some t ->
-            match t with
-            | Type.Tuple _ -> ValueSome()
-            | _ -> ValueNone
         | None -> ValueNone
+        | Some t ->
+
+        match t with
+        | Type.Tuple _ -> ValueSome()
+        | _ -> ValueNone
     | _ -> ValueNone
 
 /// Format a long parentheses parameter pattern in a binding or constructor.

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -150,20 +150,21 @@ let recordCursorNode f (node: Node) (ctx: Context) =
     match node.TryGetCursor with
     | None -> f ctx
     | Some cursor ->
-        // TODO: this currently assume the node fits on a single line.
-        // This won't be accurate in case of a multiline string.
-        let currentStartLine = ctx.WriterModel.LineCount + 1
-        let currentStartColumn = ctx.Column
 
-        let ctxAfter = f ctx
+    // TODO: this currently assume the node fits on a single line.
+    // This won't be accurate in case of a multiline string.
+    let currentStartLine = ctx.WriterModel.LineCount + 1
+    let currentStartColumn = ctx.Column
 
-        let formattedCursor =
-            let columnOffsetInSource = cursor.Column - node.Range.StartColumn
-            Fantomas.FCS.Text.Position.mkPos currentStartLine (currentStartColumn + columnOffsetInSource)
+    let ctxAfter = f ctx
 
-        { ctxAfter with
-            FormattedCursor = Some formattedCursor
-        }
+    let formattedCursor =
+        let columnOffsetInSource = cursor.Column - node.Range.StartColumn
+        Fantomas.FCS.Text.Position.mkPos currentStartLine (currentStartColumn + columnOffsetInSource)
+
+    { ctxAfter with
+        FormattedCursor = Some formattedCursor
+    }
 
 // Most nodes carry no trivia at all. `col` over an empty sequence returns the context unchanged,
 // so skipping it is equivalent to `sepNone` and saves allocating an enumerator per node.
@@ -339,24 +340,25 @@ let genOnelinerAttributes (n: MultipleAttributeListNode option) =
     match n with
     | None -> sepNone
     | Some n ->
-        let ats =
-            List.collect (fun (al: AttributeListNode) -> al.Attributes) n.AttributeLists
 
-        let openingToken =
-            List.tryHead n.AttributeLists
-            |> Option.map (fun (a: AttributeListNode) -> a.Opening)
+    let ats =
+        List.collect (fun (al: AttributeListNode) -> al.Attributes) n.AttributeLists
 
-        let closingToken =
-            List.tryLast n.AttributeLists
-            |> Option.map (fun (a: AttributeListNode) -> a.Closing)
+    let openingToken =
+        List.tryHead n.AttributeLists
+        |> Option.map (fun (a: AttributeListNode) -> a.Opening)
 
-        let genAttrs =
-            optSingle genSingleTextNode openingToken
-            +> genAttributesCore ats
-            +> optSingle genSingleTextNode closingToken
-            |> genNode n
+    let closingToken =
+        List.tryLast n.AttributeLists
+        |> Option.map (fun (a: AttributeListNode) -> a.Closing)
 
-        ifElse ats.IsEmpty sepNone (genAttrs +> sepSpace)
+    let genAttrs =
+        optSingle genSingleTextNode openingToken
+        +> genAttributesCore ats
+        +> optSingle genSingleTextNode closingToken
+        |> genNode n
+
+    ifElse ats.IsEmpty sepNone (genAttrs +> sepSpace)
 
 let genAttributes (node: MultipleAttributeListNode option) =
     match node with
@@ -774,12 +776,13 @@ let genTerminalSpace (node: ExprChain) (call: ChainCall) : Context -> Context =
     | ChainTerminal.NoTerminal -> sepNone
     | ChainTerminal.SpaceAllowed _ when not (isCalledOnPlainDottedName node) -> sepNone
     | ChainTerminal.SpaceAllowed _ ->
-        match List.tryLast node.Segments with
-        | Some(ChainSegment.DotMember(_, funcExpr)) ->
-            match call with
-            | ChainCall.Unit u -> sepSpaceBeforeParenInFuncInvocation funcExpr (Expr.Constant(Constant.Unit u))
-            | ChainCall.Paren parenNode -> sepSpaceBeforeParenInFuncInvocation funcExpr (Expr.Paren parenNode)
-        | _ -> sepNone
+
+    match List.tryLast node.Segments with
+    | Some(ChainSegment.DotMember(_, funcExpr)) ->
+        match call with
+        | ChainCall.Unit u -> sepSpaceBeforeParenInFuncInvocation funcExpr (Expr.Constant(Constant.Unit u))
+        | ChainCall.Paren parenNode -> sepSpaceBeforeParenInFuncInvocation funcExpr (Expr.Paren parenNode)
+    | _ -> sepNone
 
 /// The opener of the terminal call — the `(` and any space in front of it. This is the least
 /// the navigation before it has to leave room for.
@@ -824,17 +827,19 @@ let genTerminal (node: ExprChain) : Context -> Context =
     | ChainTerminal.NoTerminal -> sepNone
     | ChainTerminal.SpaceAllowed call
     | ChainTerminal.NoSpaceAllowed call ->
-        let addSpace: Context -> Context = genTerminalSpace node call
 
-        match call with
-        | ChainCall.Unit u -> addSpace +> genUnit u
-        | ChainCall.Paren parenNode ->
-            let short: Context -> Context = addSpace +> genExpr (Expr.Paren parenNode)
+    let addSpace: Context -> Context = genTerminalSpace node call
 
-            let long: Context -> Context =
-                addSpace +> genMultilineParenArg ChainCallPosition.Last parenNode
+    match call with
+    | ChainCall.Unit u -> addSpace +> genUnit u
+    | ChainCall.Paren parenNode ->
 
-            expressionFitsOnRestOfLine short long
+    let short: Context -> Context = addSpace +> genExpr (Expr.Paren parenNode)
+
+    let long: Context -> Context =
+        addSpace +> genMultilineParenArg ChainCallPosition.Last parenNode
+
+    expressionFitsOnRestOfLine short long
 
 /// Decide where a run of navigation steps breaks when it does not fit on one line.
 ///
@@ -1012,12 +1017,13 @@ let genChain (node: ExprChain) : Context -> Context =
             match steps with
             | [] -> onHeadLine, ctx
             | (segment, placement) :: rest ->
-                let stillOnHeadLine: bool =
-                    match placement with
-                    | ChainStepPlacement.OpensNewLine -> false
-                    | ChainStepPlacement.RidesOnCurrentLine -> onHeadLine
 
-                placeRun stillOnHeadLine rest (placeStep onHeadLine placement segment ctx)
+            let stillOnHeadLine: bool =
+                match placement with
+                | ChainStepPlacement.OpensNewLine -> false
+                | ChainStepPlacement.RidesOnCurrentLine -> onHeadLine
+
+            placeRun stillOnHeadLine rest (placeStep onHeadLine placement segment ctx)
 
         // onHeadLine — still on the receiver's line; no break has been emitted
         //              yet, so the first break must also `indent`.
@@ -1648,28 +1654,29 @@ let genExpr (e: Expr) =
             match node.SubsequentExpressions with
             | [] -> genExpr node.LeadingExpr
             | (operator, e2) :: es ->
-                let m =
-                    Fantomas.FCS.Text.Range.unionRanges (Expr.Node node.LeadingExpr).Range (Expr.Node e2).Range
 
-                genMultilineInfixExpr (ExprInfixAppNode(node.LeadingExpr, operator, e2, m))
-                +> sepNln
-                +> col
-                    sepNln
-                    es
-                    (fun (operator, e) ->
-                        genSingleTextNode operator
-                        +> sepNlnWhenWriteBeforeNewlineNotEmptyOr sepSpace
-                        +> (fun ctx ->
-                            match e with
-                            | Expr.Lambda _ when
-                                newLineInfixOps.Contains operator.Text
-                                && ctx.Config.IndentSize <= operator.Text.Length
-                                ->
-                                // Special measure to account for https://github.com/fsprojects/fantomas/issues/870
-                                (indent +> genExprInMultilineInfixExpr e +> unindent) ctx
-                            | _ -> genExprInMultilineInfixExpr e ctx
-                        )
+            let m =
+                Fantomas.FCS.Text.Range.unionRanges (Expr.Node node.LeadingExpr).Range (Expr.Node e2).Range
+
+            genMultilineInfixExpr (ExprInfixAppNode(node.LeadingExpr, operator, e2, m))
+            +> sepNln
+            +> col
+                sepNln
+                es
+                (fun (operator, e) ->
+                    genSingleTextNode operator
+                    +> sepNlnWhenWriteBeforeNewlineNotEmptyOr sepSpace
+                    +> (fun ctx ->
+                        match e with
+                        | Expr.Lambda _ when
+                            newLineInfixOps.Contains operator.Text
+                            && ctx.Config.IndentSize <= operator.Text.Length
+                            ->
+                            // Special measure to account for https://github.com/fsprojects/fantomas/issues/870
+                            (indent +> genExprInMultilineInfixExpr e +> unindent) ctx
+                        | _ -> genExprInMultilineInfixExpr e ctx
                     )
+                )
 
         let allExprs = node.LeadingExpr :: List.map snd node.SubsequentExpressions
 
@@ -2896,9 +2903,10 @@ let genControlExpressionStartCore
         match startKeyword with
         | Choice1Of2 node -> !-node.Text
         | Choice2Of2 ifKw ->
-            match ifKw with
-            | IfKeywordNode.SingleWord node -> !-node.Text
-            | IfKeywordNode.ElseIf _ -> !-"else if"
+
+        match ifKw with
+        | IfKeywordNode.SingleWord node -> !-node.Text
+        | IfKeywordNode.ElseIf _ -> !-"else if"
 
     let leaveStart =
         match startKeyword with
@@ -2996,27 +3004,28 @@ let genExprInMultilineInfixExpr (e: Expr) =
                     match statement with
                     | ComputationExpressionStatement.OtherStatement _ -> statement
                     | ComputationExpressionStatement.BindingStatement bindingNode ->
-                        let inKeyword = Some(SingleTextNode("in", bindingNode.Range.EndRange))
 
-                        let updatedBindingNode =
-                            BindingNode(
-                                bindingNode.XmlDoc,
-                                bindingNode.Attributes,
-                                bindingNode.LeadingKeyword,
-                                bindingNode.IsMutable,
-                                bindingNode.Inline,
-                                bindingNode.Accessibility,
-                                bindingNode.FunctionName,
-                                bindingNode.GenericTypeParameters,
-                                bindingNode.Parameters,
-                                bindingNode.ReturnType,
-                                bindingNode.Equals,
-                                bindingNode.Expr,
-                                inKeyword,
-                                bindingNode.Range
-                            )
+                    let inKeyword = Some(SingleTextNode("in", bindingNode.Range.EndRange))
 
-                        ComputationExpressionStatement.BindingStatement updatedBindingNode
+                    let updatedBindingNode =
+                        BindingNode(
+                            bindingNode.XmlDoc,
+                            bindingNode.Attributes,
+                            bindingNode.LeadingKeyword,
+                            bindingNode.IsMutable,
+                            bindingNode.Inline,
+                            bindingNode.Accessibility,
+                            bindingNode.FunctionName,
+                            bindingNode.GenericTypeParameters,
+                            bindingNode.Parameters,
+                            bindingNode.ReturnType,
+                            bindingNode.Equals,
+                            bindingNode.Expr,
+                            inKeyword,
+                            bindingNode.Range
+                        )
+
+                    ComputationExpressionStatement.BindingStatement updatedBindingNode
                 )
 
             let compExprBodyNode = ExprCompExprBodyNode(statements, node.Range)
@@ -3148,8 +3157,9 @@ let (|EndsWithSingleListApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
             | [] -> ValueNone
             | [ Expr.ArrayOrList singleList ] -> ValueSome(otherArgs.Close(), singleList)
             | arg :: args ->
-                otherArgs.Add(arg)
-                visit args
+
+            otherArgs.Add(arg)
+            visit args
 
         visit appNode.Arguments
 
@@ -3165,8 +3175,9 @@ let (|EndsWithSingleRecordApp|_|) (config: FormatConfig) (appNode: ExprAppNode) 
             | [] -> ValueNone
             | [ Expr.Record _ | Expr.AnonStructRecord _ as singleRecord ] -> ValueSome(otherArgs.Close(), singleRecord)
             | arg :: args ->
-                otherArgs.Add(arg)
-                visit args
+
+            otherArgs.Add(arg)
+            visit args
 
         visit appNode.Arguments
 
@@ -4220,13 +4231,15 @@ let sepNlnBetweenTypeAndMembers (node: ITypeDefn) (ctx: Context) : Context =
     match node.Members with
     | [] -> sepNone ctx
     | firstMember :: _ ->
-        match node.TypeName.WithKeyword with
-        | Some node when node.HasContentBefore -> enterNode node ctx
-        | _ ->
-            if ctx.Config.NewlineBetweenTypeDefinitionAndMembers then
-                sepNlnUnlessContentBefore (MemberDefn.Node firstMember) ctx
-            else
-                ctx
+
+    match node.TypeName.WithKeyword with
+    | Some node when node.HasContentBefore -> enterNode node ctx
+    | _ ->
+
+    if ctx.Config.NewlineBetweenTypeDefinitionAndMembers then
+        sepNlnUnlessContentBefore (MemberDefn.Node firstMember) ctx
+    else
+        ctx
 
 [<return: Struct>]
 let inline (|ParameterWithTupleTypePattern|_|) (pat: Pattern) =

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -183,15 +183,15 @@ let leaveNode<'n when 'n :> Node> (n: 'n) =
 let genNode<'n when 'n :> Node> (n: 'n) (f: Context -> Context) (ctx: Context) =
     // The NodeStart/NodeEnd payloads are only ever observed via CodeFormatter.GetWriterEventsAsync.
     // Keep them out of the default path entirely: building them costs a reflection call and a sprintf per node.
-    if ctx.DebugMode then
+    if not ctx.DebugMode then
+        (enterNode n +> recordCursorNode f n +> leaveNode n) ctx
+    else
         (writerEvent (NodeStart(n.GetType().Name, sprintf "%O" n.Range))
          +> enterNode n
          +> recordCursorNode f n
          +> leaveNode n
          +> writerEvent (NodeEnd(n.GetType().Name, sprintf "%O" n.Range)))
             ctx
-    else
-        (enterNode n +> recordCursorNode f n +> leaveNode n) ctx
 
 let genSingleTextNode (node: SingleTextNode) = !-node.Text |> genNode node
 
@@ -886,12 +886,13 @@ let balanceNavigationRun
         if low >= high then
             high
         else
-            let middle: ChainColumn = (low + high) / 2
 
-            if lineCount (fillAt middle) <= fewestLines then
-                narrowest low middle
-            else
-                narrowest (middle + 1) high
+        let middle: ChainColumn = (low + high) / 2
+
+        if lineCount (fillAt middle) <= fewestLines then
+            narrowest low middle
+        else
+            narrowest (middle + 1) high
 
     fillAt (narrowest 0 maxColumn)
 
@@ -1102,37 +1103,38 @@ let genChain (node: ExprChain) : Context -> Context =
                     if not sharesItsLastLine then
                         plainPlacements
                     else
-                        // Nothing after the run means the chain's terminal call rides there.
-                        let opener, whole =
-                            match afterRun with
-                            | [] -> genTerminalOpener node, genTerminalOnOneLine node
-                            | action :: _ -> genSegmentOpener action, genSegmentOnOneLine action
 
-                        // Charge the run's final step for `part` of the call that rides after it.
-                        let charge (part: Context -> Context) : ChainStepWidth list =
-                            let lastStep: int = List.length run - 1
-                            let callWidth: ChainStepWidth = widthOf part ctx
+                    // Nothing after the run means the chain's terminal call rides there.
+                    let opener, whole =
+                        match afterRun with
+                        | [] -> genTerminalOpener node, genTerminalOnOneLine node
+                        | action :: _ -> genSegmentOpener action, genSegmentOnOneLine action
 
-                            stepWidths
-                            |> List.mapi (fun i width -> if i = lastStep then width + callWidth else width)
+                    // Charge the run's final step for `part` of the call that rides after it.
+                    let charge (part: Context -> Context) : ChainStepWidth list =
+                        let lastStep: int = List.length run - 1
+                        let callWidth: ChainStepWidth = widthOf part ctx
 
-                        // Wrapping the navigation to make room for the arguments beats breaking
-                        // the arguments, so the call is charged whole whenever a line of the run
-                        // could hold it. When none can — the arguments are too wide however the
-                        // navigation wraps — only the opener has to fit and the arguments break
-                        // as usual.
-                        let chargingWhole: ChainStepWidth list = charge whole
+                        stepWidths
+                        |> List.mapi (fun i width -> if i = lastStep then width + callWidth else width)
 
-                        let wholeCallFitsOnALine: bool =
-                            not (fst (futureNlnCheckMem (whole, ctx)))
-                            && chargingWhole |> List.forall (fun width -> indentColumn + width <= maxColumn)
+                    // Wrapping the navigation to make room for the arguments beats breaking
+                    // the arguments, so the call is charged whole whenever a line of the run
+                    // could hold it. When none can — the arguments are too wide however the
+                    // navigation wraps — only the opener has to fit and the arguments break
+                    // as usual.
+                    let chargingWhole: ChainStepWidth list = charge whole
 
-                        decidePlacements (
-                            if wholeCallFitsOnALine then
-                                chargingWhole
-                            else
-                                charge opener
-                        )
+                    let wholeCallFitsOnALine: bool =
+                        not (fst (futureNlnCheckMem (whole, ctx)))
+                        && chargingWhole |> List.forall (fun width -> indentColumn + width <= maxColumn)
+
+                    decidePlacements (
+                        if wholeCallFitsOnALine then
+                            chargingWhole
+                        else
+                            charge opener
+                    )
 
                 let onHeadLine, ctx = placeRun onHeadLine (List.zip run placements) ctx
                 place onHeadLine false afterRun ctx
@@ -2022,15 +2024,16 @@ let genExpr (e: Expr) =
                 if isMultiline then
                     indentSepNlnUnindent (genExpr node.ThenExpr) ctx
                 else
-                    // Check if the entire expression is will still fit on one line, respecting MaxIfThenShortWidth
-                    let remainingMaxLength =
-                        ctx.Config.MaxIfThenShortWidth - (columnAfter - columnBefore)
 
-                    isShortExpression
-                        remainingMaxLength
-                        (sepSpace +> genExpr node.ThenExpr)
-                        (indentSepNlnUnindent (genExpr node.ThenExpr))
-                        ctx
+                // Check if the entire expression is will still fit on one line, respecting MaxIfThenShortWidth
+                let remainingMaxLength =
+                    ctx.Config.MaxIfThenShortWidth - (columnAfter - columnBefore)
+
+                isShortExpression
+                    remainingMaxLength
+                    (sepSpace +> genExpr node.ThenExpr)
+                    (indentSepNlnUnindent (genExpr node.ThenExpr))
+                    ctx
             )
         |> atCurrentColumnIndent
         |> genNode node
@@ -2055,20 +2058,21 @@ let genExpr (e: Expr) =
                 if isMultiline || thenExprIsIfThenElse then
                     long ctx
                 else
-                    // Check if the entire expression is will still fit on one line, respecting MaxIfThenShortWidth
-                    let remainingMaxLength =
-                        ctx.Config.MaxIfThenElseShortWidth - (columnAfter - columnBefore)
 
-                    isShortExpression
-                        remainingMaxLength
-                        (sepSpace
-                         +> genExpr node.ThenExpr
-                         +> sepSpace
-                         +> genSingleTextNode node.Else
-                         +> sepSpace
-                         +> genExpr node.ElseExpr)
-                        long
-                        ctx
+                // Check if the entire expression is will still fit on one line, respecting MaxIfThenShortWidth
+                let remainingMaxLength =
+                    ctx.Config.MaxIfThenElseShortWidth - (columnAfter - columnBefore)
+
+                isShortExpression
+                    remainingMaxLength
+                    (sepSpace
+                     +> genExpr node.ThenExpr
+                     +> sepSpace
+                     +> genSingleTextNode node.Else
+                     +> sepSpace
+                     +> genExpr node.ElseExpr)
+                    long
+                    ctx
             )
         |> atCurrentColumnIndent
         |> genNode node
@@ -2251,9 +2255,9 @@ let genExpr (e: Expr) =
             sepSpace
             node.Constraints
             (function
+            | StaticOptimizationConstraint.WhenTyparIsStruct t -> genSingleTextNode t
             | StaticOptimizationConstraint.WhenTyparTyconEqualsTycon n ->
                 genSingleTextNode n.TypeParameter +> sepColon +> sepSpace +> genType n.Type
-            | StaticOptimizationConstraint.WhenTyparIsStruct t -> genSingleTextNode t
             )
         +> sepEq
         +> sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth (genExpr node.Expr)
@@ -2586,8 +2590,9 @@ let genRecordExpression
     if requiresMultilineToPreserveSemantics fieldExprs then
         genNode node multilineRecordExpr ctx
     else
-        let size = getRecordSize ctx node.Fields
-        genNode node (isSmallExpression size smallRecordExpr multilineRecordExpr) ctx
+
+    let size = getRecordSize ctx node.Fields
+    genNode node (isSmallExpression size smallRecordExpr multilineRecordExpr) ctx
 
 let genArrayOrList (preferMultilineCramped: bool) (node: ExprArrayOrListNode) =
     if node.Elements.IsEmpty then
@@ -2642,8 +2647,9 @@ let genArrayOrList (preferMultilineCramped: bool) (node: ExprArrayOrListNode) =
             if requiresMultilineToPreserveSemantics node.Elements then
                 multilineExpression ctx
             else
-                let size = getListOrArrayExprSize ctx ctx.Config.MaxArrayOrListWidth node.Elements
-                isSmallExpression size smallExpression multilineExpression ctx
+
+            let size = getListOrArrayExprSize ctx ctx.Config.MaxArrayOrListWidth node.Elements
+            isSmallExpression size smallExpression multilineExpression ctx
         |> genNode node
 
 let genMultilineFunctionApplicationArguments (argExpr: Expr) =
@@ -2763,17 +2769,18 @@ let genLambdaAux (includeClosingParen: bool) (node: ExprLambdaNode) =
         let ctx =
             // In this check we want to write the lambda body in one line.
             // Depending on `includeClosingParen` we want to check if the closing parenthesis also still fits on the remainder of the current line.
+            if not includeClosingParen then
+                ctx
+            else
+
             // ...fun a -> expr)
             // This is to prevent the edge case where the lambda fits on one line but the closing parenthesis would go over the max_line_length.
-            if includeClosingParen then
-                { ctx with
-                    Config =
-                        { ctx.Config with
-                            MaxLineLength = maxLineLength - 1
-                        }
-                }
-            else
-                ctx
+            { ctx with
+                Config =
+                    { ctx.Config with
+                        MaxLineLength = maxLineLength - 1
+                    }
+            }
 
         if hasWriteBeforeNewlineContent ctx then
             indentSepNlnUnindent (genExpr node.Expr) ctx
@@ -2852,40 +2859,42 @@ let genClause (isLastItem: bool) (node: MatchClauseNode) =
                 if isMultiline then
                     indentSepNlnUnindent (genSingleTextNode node.Arrow +> sepNln +> genExpr node.BodyExpr) ctx
                 else
-                    let genKeepIndentInBranch =
-                        let long =
-                            let startNode =
-                                match node.Bar with
-                                | None -> Pattern.Node node.Pattern
-                                | Some bar -> bar
 
-                            genKeepIdentMatchClause startNode node.BodyExpr
+                let genKeepIndentInBranch =
+                    let long =
+                        let startNode =
+                            match node.Bar with
+                            | None -> Pattern.Node node.Pattern
+                            | Some bar -> bar
 
-                        expressionFitsOnRestOfLine (sepSpace +> genExpr node.BodyExpr) long
+                        genKeepIdentMatchClause startNode node.BodyExpr
 
-                    let sepArrow =
-                        if not node.Arrow.HasContentBefore then
-                            genSingleTextNodeWithSpaceSuffix sepSpace node.Arrow
-                        else
-                            // In the weird case where the arrow has content before it and there is no multiline whenExpr,
-                            // we need to ensure a space was written before the arrow to avoid offset errors.
-                            // See https://github.com/fsprojects/fantomas/issues/2888
-                            !- $" %s{node.Arrow.Text} " |> genNode node.Arrow
+                    expressionFitsOnRestOfLine (sepSpace +> genExpr node.BodyExpr) long
 
-                    (sepArrow
-                     +> ifElse
-                         (ctx.Config.ExperimentalKeepIndentInBranch && isLastItem)
-                         genKeepIndentInBranch
-                         (autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup genExpr node.BodyExpr))
-                        ctx
+                let sepArrow =
+                    if not node.Arrow.HasContentBefore then
+                        genSingleTextNodeWithSpaceSuffix sepSpace node.Arrow
+                    else
+                        // In the weird case where the arrow has content before it and there is no multiline whenExpr,
+                        // we need to ensure a space was written before the arrow to avoid offset errors.
+                        // See https://github.com/fsprojects/fantomas/issues/2888
+                        !- $" %s{node.Arrow.Text} " |> genNode node.Arrow
+
+                (sepArrow
+                 +> ifElse
+                     (ctx.Config.ExperimentalKeepIndentInBranch && isLastItem)
+                     genKeepIndentInBranch
+                     (autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup genExpr node.BodyExpr))
+                    ctx
             )
 
     let genPatAndBody ctx =
-        if isStroustrupStyleExpr ctx.Config node.BodyExpr then
-            let startColumn = ctx.Column
-            (genPatInClause node.Pattern +> atIndentLevel false startColumn genWhenAndBody) ctx
-        else
+        if not (isStroustrupStyleExpr ctx.Config node.BodyExpr) then
             (genPatInClause node.Pattern +> genWhenAndBody) ctx
+        else
+
+        let startColumn = ctx.Column
+        (genPatInClause node.Pattern +> atIndentLevel false startColumn genWhenAndBody) ctx
 
     genBar +> genPatAndBody |> genNode node
 
@@ -2966,10 +2975,11 @@ let genMultilineInfixExpr (node: ExprInfixAppNode) =
             if lastClauseIsSingleLine then
                 ctxAfterMatch
             else
-                // Last clause was multiline — discard the speculative output
-                // and re-format the match expression wrapped in parentheses.
-                ctx.WriterEvents.RollbackTo(backupPoint)
-                autoParenthesisIfExpressionExceedsPageWidth (genExpr node.LeftHandSide) ctx
+
+            // Last clause was multiline — discard the speculative output
+            // and re-format the match expression wrapped in parentheses.
+            ctx.WriterEvents.RollbackTo(backupPoint)
+            autoParenthesisIfExpressionExceedsPageWidth (genExpr node.LeftHandSide) ctx
         | lhsExpr -> genExpr lhsExpr ctx
 
     atCurrentColumn (
@@ -2998,38 +3008,39 @@ let genExprInMultilineInfixExpr (e: Expr) =
         if not hasBindings then
             genExpr e
         else
-            let statements =
-                node.Statements
-                |> List.map (fun statement ->
-                    match statement with
-                    | ComputationExpressionStatement.OtherStatement _ -> statement
-                    | ComputationExpressionStatement.BindingStatement bindingNode ->
 
-                    let inKeyword = Some(SingleTextNode("in", bindingNode.Range.EndRange))
+        let statements =
+            node.Statements
+            |> List.map (fun statement ->
+                match statement with
+                | ComputationExpressionStatement.OtherStatement _ -> statement
+                | ComputationExpressionStatement.BindingStatement bindingNode ->
 
-                    let updatedBindingNode =
-                        BindingNode(
-                            bindingNode.XmlDoc,
-                            bindingNode.Attributes,
-                            bindingNode.LeadingKeyword,
-                            bindingNode.IsMutable,
-                            bindingNode.Inline,
-                            bindingNode.Accessibility,
-                            bindingNode.FunctionName,
-                            bindingNode.GenericTypeParameters,
-                            bindingNode.Parameters,
-                            bindingNode.ReturnType,
-                            bindingNode.Equals,
-                            bindingNode.Expr,
-                            inKeyword,
-                            bindingNode.Range
-                        )
+                let inKeyword = Some(SingleTextNode("in", bindingNode.Range.EndRange))
 
-                    ComputationExpressionStatement.BindingStatement updatedBindingNode
-                )
+                let updatedBindingNode =
+                    BindingNode(
+                        bindingNode.XmlDoc,
+                        bindingNode.Attributes,
+                        bindingNode.LeadingKeyword,
+                        bindingNode.IsMutable,
+                        bindingNode.Inline,
+                        bindingNode.Accessibility,
+                        bindingNode.FunctionName,
+                        bindingNode.GenericTypeParameters,
+                        bindingNode.Parameters,
+                        bindingNode.ReturnType,
+                        bindingNode.Equals,
+                        bindingNode.Expr,
+                        inKeyword,
+                        bindingNode.Range
+                    )
 
-            let compExprBodyNode = ExprCompExprBodyNode(statements, node.Range)
-            atCurrentColumn (genExpr (Expr.CompExprBody compExprBodyNode))
+                ComputationExpressionStatement.BindingStatement updatedBindingNode
+            )
+
+        let compExprBodyNode = ExprCompExprBodyNode(statements, node.Range)
+        atCurrentColumn (genExpr (Expr.CompExprBody compExprBodyNode))
     | Expr.Paren parenNode ->
         match parenNode.Expr with
         | Expr.Match _ as mex ->
@@ -3132,54 +3143,57 @@ let (|EndsWithDualListApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
     if not (config.ExperimentalElmish || config.IsStroustrupStyle) then
         ValueNone
     else
-        let mutable otherArgs = ListCollector<Expr>()
 
-        let rec visit (args: Expr list) =
-            match args with
-            | [] -> ValueNone
-            | [ Expr.ArrayOrList firstList; Expr.ArrayOrList lastList ] ->
-                ValueSome(otherArgs.Close(), firstList, lastList)
-            | arg :: args ->
-                otherArgs.Add(arg)
-                visit args
+    let mutable otherArgs = ListCollector<Expr>()
 
-        visit appNode.Arguments
+    let rec visit (args: Expr list) =
+        match args with
+        | [] -> ValueNone
+        | [ Expr.ArrayOrList firstList; Expr.ArrayOrList lastList ] -> ValueSome(otherArgs.Close(), firstList, lastList)
+        | arg :: args ->
+
+        otherArgs.Add(arg)
+        visit args
+
+    visit appNode.Arguments
 
 [<return: Struct>]
 let (|EndsWithSingleListApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
     if not (config.ExperimentalElmish || config.IsStroustrupStyle) then
         ValueNone
     else
-        let mutable otherArgs = ListCollector<Expr>()
 
-        let rec visit (args: Expr list) =
-            match args with
-            | [] -> ValueNone
-            | [ Expr.ArrayOrList singleList ] -> ValueSome(otherArgs.Close(), singleList)
-            | arg :: args ->
+    let mutable otherArgs = ListCollector<Expr>()
 
-            otherArgs.Add(arg)
-            visit args
+    let rec visit (args: Expr list) =
+        match args with
+        | [] -> ValueNone
+        | [ Expr.ArrayOrList singleList ] -> ValueSome(otherArgs.Close(), singleList)
+        | arg :: args ->
 
-        visit appNode.Arguments
+        otherArgs.Add(arg)
+        visit args
+
+    visit appNode.Arguments
 
 [<return: Struct>]
 let (|EndsWithSingleRecordApp|_|) (config: FormatConfig) (appNode: ExprAppNode) =
     if not config.IsStroustrupStyle then
         ValueNone
     else
-        let mutable otherArgs = ListCollector<Expr>()
 
-        let rec visit (args: Expr list) =
-            match args with
-            | [] -> ValueNone
-            | [ Expr.Record _ | Expr.AnonStructRecord _ as singleRecord ] -> ValueSome(otherArgs.Close(), singleRecord)
-            | arg :: args ->
+    let mutable otherArgs = ListCollector<Expr>()
 
-            otherArgs.Add(arg)
-            visit args
+    let rec visit (args: Expr list) =
+        match args with
+        | [] -> ValueNone
+        | [ Expr.Record _ | Expr.AnonStructRecord _ as singleRecord ] -> ValueSome(otherArgs.Close(), singleRecord)
+        | arg :: args ->
 
-        visit appNode.Arguments
+        otherArgs.Add(arg)
+        visit args
+
+    visit appNode.Arguments
 
 let genAppWithLambda sep (node: ExprAppWithLambdaNode) =
     let short =
@@ -3851,12 +3865,13 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
                 if isMultiline then
                     indentSepNlnUnindent body
                 else
-                    let short = sepSpace +> body
 
-                    let long =
-                        indentSepNlnUnindentUnlessStroustrup (fun e -> sepSpace +> genExpr e) b.Expr
+                let short = sepSpace +> body
 
-                    isShortExpression ctx.Config.MaxFunctionBindingWidth short long
+                let long =
+                    indentSepNlnUnindentUnlessStroustrup (fun e -> sepSpace +> genExpr e) b.Expr
+
+                isShortExpression ctx.Config.MaxFunctionBindingWidth short long
 
             (genXml b.XmlDoc
              +> genAttrIsFirstChild
@@ -4474,17 +4489,18 @@ let genTypeDefn (td: TypeDefn) =
             if hasMembers then
                 multilineExpression
             else
-                let smallExpression =
-                    sepSpace
-                    +> genAccessOpt node.Accessibility
-                    +> sepSpace
-                    +> genSingleTextNode node.OpeningBrace
-                    +> addSpaceIfSpaceAroundDelimiter
-                    +> col sepSemi node.Fields genTypeDefnRecordFieldOrSpread
-                    +> addSpaceIfSpaceAroundDelimiter
-                    +> genSingleTextNode node.ClosingBrace
 
-                isSmallExpression size smallExpression multilineExpression
+            let smallExpression =
+                sepSpace
+                +> genAccessOpt node.Accessibility
+                +> sepSpace
+                +> genSingleTextNode node.OpeningBrace
+                +> addSpaceIfSpaceAroundDelimiter
+                +> col sepSemi node.Fields genTypeDefnRecordFieldOrSpread
+                +> addSpaceIfSpaceAroundDelimiter
+                +> genSingleTextNode node.ClosingBrace
+
+            isSmallExpression size smallExpression multilineExpression
 
         let genTypeDefinition (ctx: Context) =
             let size = getRecordSize ctx node.Fields
@@ -4979,15 +4995,16 @@ let addFinalNewline (ctx: Context) =
         if ctx.Config.InsertFinalNewline then
             ctx
         else
-            // Due to trivia the last event is a newline, if insert_final_newline is false, we need to remove it.
-            ctx.WriterEvents.Remove(lastTailNode)
 
-            { ctx with
-                WriterModel =
-                    { ctx.WriterModel with
-                        LineCount = max 0 (ctx.WriterModel.LineCount - 1)
-                    }
-            }
+        // Due to trivia the last event is a newline, if insert_final_newline is false, we need to remove it.
+        ctx.WriterEvents.Remove(lastTailNode)
+
+        { ctx with
+            WriterModel =
+                { ctx.WriterModel with
+                    LineCount = max 0 (ctx.WriterModel.LineCount - 1)
+                }
+        }
     | _ ->
         if not ctx.Config.InsertFinalNewline then
             ctx

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -149,12 +149,13 @@ module WriterModel =
                     }
                 )
 
-            if List.exists (fun i -> i.ConfirmedMultiline) updatedInfos then
-                { m with
-                    Mode = ShortExpression(updatedInfos)
-                }
-            else
+            if not (List.exists (fun i -> i.ConfirmedMultiline) updatedInfos) then
                 updateCmd cmd
+            else
+
+            { m with
+                Mode = ShortExpression(updatedInfos)
+            }
 
 module WriterEvents =
     let normalize ev =
@@ -252,12 +253,13 @@ type Context =
             if List.exists (fun i -> i = info) infos then
                 x
             else
-                { x with
-                    WriterModel =
-                        { x.WriterModel with
-                            Mode = ShortExpression(info :: infos)
-                        }
-                }
+
+            { x with
+                WriterModel =
+                    { x.WriterModel with
+                        Mode = ShortExpression(info :: infos)
+                    }
+            }
         | _ ->
             { x with
                 WriterModel =
@@ -555,10 +557,11 @@ let sepSpace (ctx: Context) =
     if ctx.WriterModel.IsDummy then
         (!-" ") ctx
     else
-        match lastWriteEventOnLastLine ctx with
-        | Some w when (String.endsWithOrdinal " " w || String.endsWithOrdinal Environment.NewLine w) -> ctx
-        | None -> ctx
-        | _ -> (!-" ") ctx
+
+    match lastWriteEventOnLastLine ctx with
+    | Some w when (String.endsWithOrdinal " " w || String.endsWithOrdinal Environment.NewLine w) -> ctx
+    | None -> ctx
+    | _ -> (!-" ") ctx
 
 // add actual spaces until the target column is reached, regardless of previous content
 // use with care
@@ -795,66 +798,69 @@ let findTrailingTriviaNewline (events: EventList) : EventNode =
     if isNull current then
         null
     else
-        match current.Event with
-        | WriteLineBecauseOfTrivia ->
-            let mutable check = current.Prev
-            let mutable foundTrivia = false
 
-            while not (isNull check) && not foundTrivia do
-                match check.Event with
-                // Block comment internals — keep walking
-                | WriteLineInsideTrivia -> check <- check.Prev
-                // Single-line comment, block comment, XML doc, or directive
-                | WriteTrivia _ -> foundTrivia <- true
-                // Hit something that isn't part of trivia — stop
-                | _ -> check <- null
+    match current.Event with
+    | WriteLineBecauseOfTrivia ->
+        let mutable check = current.Prev
+        let mutable foundTrivia = false
 
-            if foundTrivia then current else null
-        | _ -> null
+        while not (isNull check) && not foundTrivia do
+            match check.Event with
+            // Block comment internals — keep walking
+            | WriteLineInsideTrivia -> check <- check.Prev
+            // Single-line comment, block comment, XML doc, or directive
+            | WriteTrivia _ -> foundTrivia <- true
+            // Hit something that isn't part of trivia — stop
+            | _ -> check <- null
+
+        if foundTrivia then current else null
+    | _ -> null
 
 let indentSepNlnWithTriviaAwareness (ctx: Context) =
     let indentAmount = ctx.Config.IndentSize
     let triviaNewline = findTrailingTriviaNewline ctx.WriterEvents
 
-    if not (isNull triviaNewline) then
-        // Find the start of the trivia block — walk backward from the trivia newline
-        // past trivia events to find where the block begins.
-        let mutable start = triviaNewline
-
-        while not (isNull start.Prev)
-              && (
-                  match start.Prev.Event with
-                  | WriteTrivia _
-                  | WriteLineInsideTrivia
-                  | WriteLineBecauseOfTrivia -> true
-                  | _ -> false
-              ) do
-            start <- start.Prev
-
-        // Splice IndentBy before the trivia block — the trivia's newline acts as sepNln
-        ctx.WriterEvents.InsertBefore(start, IndentBy indentAmount) |> ignore
-
-        { ctx with
-            WriterModel = WriterModel.update ctx.Config.MaxLineLength (IndentBy indentAmount) ctx.WriterModel
-        }
-    else
+    if isNull triviaNewline then
         (indent +> sepNln) ctx
+    else
+
+    // Find the start of the trivia block — walk backward from the trivia newline
+    // past trivia events to find where the block begins.
+    let mutable start = triviaNewline
+
+    while not (isNull start.Prev)
+          && (
+              match start.Prev.Event with
+              | WriteTrivia _
+              | WriteLineInsideTrivia
+              | WriteLineBecauseOfTrivia -> true
+              | _ -> false
+          ) do
+        start <- start.Prev
+
+    // Splice IndentBy before the trivia block — the trivia's newline acts as sepNln
+    ctx.WriterEvents.InsertBefore(start, IndentBy indentAmount) |> ignore
+
+    { ctx with
+        WriterModel = WriterModel.update ctx.Config.MaxLineLength (IndentBy indentAmount) ctx.WriterModel
+    }
 
 let unindentWithTriviaAwareness (ctx: Context) =
     let unindentAmount = ctx.Config.IndentSize
     let triviaNewline = findTrailingTriviaNewline ctx.WriterEvents
 
-    if not (isNull triviaNewline) then
-        // Splice the UnIndentBy into the DLL before the trailing trivia newline,
-        // and update the WriterModel using the same logic as WriterModel.update.
-        ctx.WriterEvents.InsertBefore(triviaNewline, UnIndentBy unindentAmount)
-        |> ignore
-
-        { ctx with
-            WriterModel = WriterModel.update ctx.Config.MaxLineLength (UnIndentBy unindentAmount) ctx.WriterModel
-        }
-    else
+    if isNull triviaNewline then
         writerEvent (UnIndentBy unindentAmount) ctx
+    else
+
+    // Splice the UnIndentBy into the DLL before the trailing trivia newline,
+    // and update the WriterModel using the same logic as WriterModel.update.
+    ctx.WriterEvents.InsertBefore(triviaNewline, UnIndentBy unindentAmount)
+    |> ignore
+
+    { ctx with
+        WriterModel = WriterModel.update ctx.Config.MaxLineLength (UnIndentBy unindentAmount) ctx.WriterModel
+    }
 
 let indentSepNlnUnindent f =
     indentSepNlnWithTriviaAwareness +> f +> unindentWithTriviaAwareness
@@ -940,10 +946,11 @@ let futureNlnCheckMem (f, ctx: Context) =
     if ctx.WriterModel.IsDummy then
         (false, false)
     else
-        let dummyResult = ctx.WithDummy(f, keepPageWidth = true)
-        let isMultiline = dummyResult.WriterModel.LineCount > ctx.WriterModel.LineCount
-        let isLong = dummyResult.Column > ctx.Config.MaxLineLength
-        isMultiline, isLong
+
+    let dummyResult = ctx.WithDummy(f, keepPageWidth = true)
+    let isMultiline = dummyResult.WriterModel.LineCount > ctx.WriterModel.LineCount
+    let isLong = dummyResult.Column > ctx.Config.MaxLineLength
+    isMultiline, isLong
 
 let futureNlnCheck f (ctx: Context) =
     let isMultiLine, isLong = futureNlnCheckMem (f, ctx)
@@ -983,10 +990,11 @@ let sepColon (ctx: Context) =
     if ctx.WriterModel.IsDummy then
         defaultExpr ctx
     else
-        match lastWriteEventOnLastLine ctx with
-        | Some w when String.endsWithOrdinal " " w -> !- ": " ctx
-        | None -> !- ": " ctx
-        | _ -> defaultExpr ctx
+
+    match lastWriteEventOnLastLine ctx with
+    | Some w when String.endsWithOrdinal " " w -> !- ": " ctx
+    | None -> !- ": " ctx
+    | _ -> defaultExpr ctx
 
 let sepColonFixed = !-":"
 

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -663,10 +663,11 @@ let isSmallExpression size (smallExpression: Context -> Context) fallbackExpress
     match size with
     | CharacterWidth maxWidth -> isShortExpression maxWidth smallExpression fallbackExpression ctx
     | NumberOfItems(items, maxItems) ->
-        if items > maxItems then
-            fallbackExpression ctx
-        else
-            expressionFitsOnRestOfLine smallExpression fallbackExpression ctx
+
+    if items > maxItems then
+        fallbackExpression ctx
+    else
+        expressionFitsOnRestOfLine smallExpression fallbackExpression ctx
 
 let leadingExpressionResult leadingExpression continuationExpression (ctx: Context) =
     let lineCountBefore, columnBefore =
@@ -865,19 +866,20 @@ let expressionExceedsPageWidthWithLayout (layout: LongExpressionLayout) (addSpac
     | NewlineOnly -> expressionExceedsPageWidth beforeShort sepNone sepNln sepNone expr ctx
     | IndentAndUnindent
     | DoubleIndentAndUnindent ->
-        let beforeLong =
-            match layout with
-            | IndentAndUnindent -> indent +> sepNln
-            | DoubleIndentAndUnindent -> indent +> indent +> sepNln
-            | NewlineOnly -> sepNln
 
-        let afterLong =
-            match layout with
-            | IndentAndUnindent -> unindentWithTriviaAwareness
-            | DoubleIndentAndUnindent -> unindentWithTriviaAwareness +> unindentWithTriviaAwareness
-            | NewlineOnly -> sepNone
+    let beforeLong =
+        match layout with
+        | IndentAndUnindent -> indent +> sepNln
+        | DoubleIndentAndUnindent -> indent +> indent +> sepNln
+        | NewlineOnly -> sepNln
 
-        expressionExceedsPageWidth beforeShort sepNone beforeLong afterLong expr ctx
+    let afterLong =
+        match layout with
+        | IndentAndUnindent -> unindentWithTriviaAwareness
+        | DoubleIndentAndUnindent -> unindentWithTriviaAwareness +> unindentWithTriviaAwareness
+        | NewlineOnly -> sepNone
+
+    expressionExceedsPageWidth beforeShort sepNone beforeLong afterLong expr ctx
 
 let autoIndentAndNlnIfExpressionExceedsPageWidth expr (ctx: Context) =
     expressionExceedsPageWidthWithLayout IndentAndUnindent false expr ctx
@@ -1168,55 +1170,57 @@ let colWithNlnWhenItemIsMultiline (items: ColMultilineItem list) (ctx: Context) 
     | [] -> ctx
     | [ (ColMultilineItem(expr, _)) ] -> expr ctx
     | ColMultilineItem(initialExpr, _) :: items ->
-        let result =
-            // The first item can be written as is.
-            let initialIsMultiline, initialCtx = isMultilineItem initialExpr ctx
 
-            let itemsState =
+    let result =
+        // The first item can be written as is.
+        let initialIsMultiline, initialCtx = isMultilineItem initialExpr ctx
+
+        let itemsState =
+            {
+                Context = initialCtx
+                LastBlockMultiline = initialIsMultiline
+            }
+
+        let rec loop (acc: ColMultilineItemsState) (items: ColMultilineItem list) =
+            match items with
+            | [] -> acc.Context
+            | ColMultilineItem(expr, sepNlnItem) :: rest ->
+
+            // Optimistic path: assume the item (or its predecessor) is multiline,
+            // so emit an extra blank line separator before running the expression.
+            // If both turn out to be single-line, we roll back and replay without the extra blank line.
+            let backupPoint = acc.Context.WriterEvents.CreateBackupPoint()
+
+            let ctxAfterNln =
+                (ifElseCtx
+                    hasBlankLineBeforeLastWrite
+                    sepNone // don't add extra newline if there already is a full blank line at the end of the stream.
+                    sepNlnUnlessLastEventIsNewline // trivia may have already produced a newline
+                 +> sepNlnItem)
+                    acc.Context
+
+            let isMultiline, nextCtx = isMultilineItem expr ctxAfterNln
+
+            let nextCtx =
+                if not isMultiline && not acc.LastBlockMultiline then
+                    // Both the previous and current items are single-line.
+                    // The optimistic blank line was wrong — roll back those events
+                    // and replay with just the regular separator.
+                    acc.Context.WriterEvents.RollbackTo(backupPoint)
+                    (sepNlnUnlessLastEventIsNewline +> expr) acc.Context
+                else
+                    nextCtx
+
+            loop
                 {
-                    Context = initialCtx
-                    LastBlockMultiline = initialIsMultiline
+                    Context = nextCtx
+                    LastBlockMultiline = isMultiline
                 }
+                rest
 
-            let rec loop (acc: ColMultilineItemsState) (items: ColMultilineItem list) =
-                match items with
-                | [] -> acc.Context
-                | ColMultilineItem(expr, sepNlnItem) :: rest ->
-                    // Optimistic path: assume the item (or its predecessor) is multiline,
-                    // so emit an extra blank line separator before running the expression.
-                    // If both turn out to be single-line, we roll back and replay without the extra blank line.
-                    let backupPoint = acc.Context.WriterEvents.CreateBackupPoint()
+        loop itemsState items
 
-                    let ctxAfterNln =
-                        (ifElseCtx
-                            hasBlankLineBeforeLastWrite
-                            sepNone // don't add extra newline if there already is a full blank line at the end of the stream.
-                            sepNlnUnlessLastEventIsNewline // trivia may have already produced a newline
-                         +> sepNlnItem)
-                            acc.Context
-
-                    let isMultiline, nextCtx = isMultilineItem expr ctxAfterNln
-
-                    let nextCtx =
-                        if not isMultiline && not acc.LastBlockMultiline then
-                            // Both the previous and current items are single-line.
-                            // The optimistic blank line was wrong — roll back those events
-                            // and replay with just the regular separator.
-                            acc.Context.WriterEvents.RollbackTo(backupPoint)
-                            (sepNlnUnlessLastEventIsNewline +> expr) acc.Context
-                        else
-                            nextCtx
-
-                    loop
-                        {
-                            Context = nextCtx
-                            LastBlockMultiline = isMultiline
-                        }
-                        rest
-
-            loop itemsState items
-
-        result
+    result
 
 let colWithNlnWhenItemIsMultilineUsingConfig (items: ColMultilineItem list) (ctx: Context) =
     if ctx.Config.BlankLinesAroundNestedMultilineExpressions then

--- a/src/Fantomas.Core/Defines.fs
+++ b/src/Fantomas.Core/Defines.fs
@@ -17,11 +17,12 @@ module private DefineCombinationSolver =
         match f e with
         | Some x -> x
         | None ->
-            match e with
-            | IfDirectiveExpression.Not e -> IfDirectiveExpression.Not(map f e)
-            | IfDirectiveExpression.And(e1, e2) -> IfDirectiveExpression.And(map f e1, map f e2)
-            | IfDirectiveExpression.Or(e1, e2) -> IfDirectiveExpression.Or(map f e1, map f e2)
-            | _ -> e
+
+        match e with
+        | IfDirectiveExpression.Not e -> IfDirectiveExpression.Not(map f e)
+        | IfDirectiveExpression.And(e1, e2) -> IfDirectiveExpression.And(map f e1, map f e2)
+        | IfDirectiveExpression.Or(e1, e2) -> IfDirectiveExpression.Or(map f e1, map f e2)
+        | _ -> e
 
     let rec forall f e =
         f e

--- a/src/Fantomas.Core/Defines.fs
+++ b/src/Fantomas.Core/Defines.fs
@@ -139,53 +139,55 @@ module private DefineCombinationSolver =
         if groupedLiterals enforcedLit |> List.exists (fun (_, g) -> List.length g > 1) then
             Unsatisfiable
         else
-            let singletons, toSolve =
-                groupedLiterals allLiterals |> List.partition (fun (_, g) -> List.length g = 1)
 
-            let singletonsLit = singletons |> List.collect snd
-            let solvedSet = set (enforcedLit @ singletonsLit)
+        let singletons, toSolve =
+            groupedLiterals allLiterals |> List.partition (fun (_, g) -> List.length g = 1)
 
-            let toSolve =
-                toSolve
-                |> List.filter (fun (k, _) ->
-                    not (Set.contains (Positive k) solvedSet || Set.contains (Negative k) solvedSet)
-                )
+        let singletonsLit = singletons |> List.collect snd
+        let solvedSet = set (enforcedLit @ singletonsLit)
 
-            let rec genCombinations groups =
-                seq {
-                    match groups with
-                    | [] -> yield []
-                    | g :: gs -> yield! genCombinations gs |> Seq.collect (fun l -> g |> Seq.map (fun x -> x :: l))
-                }
+        let toSolve =
+            toSolve
+            |> List.filter (fun (k, _) ->
+                not (Set.contains (Positive k) solvedSet || Set.contains (Negative k) solvedSet)
+            )
 
-            let solve vals groups =
-                let combinations = genCombinations (groups |> List.map snd)
+        let rec genCombinations groups =
+            seq {
+                match groups with
+                | [] -> yield []
+                | g :: gs -> yield! genCombinations gs |> Seq.collect (fun l -> g |> Seq.map (fun x -> x :: l))
+            }
 
-                combinations
-                |> Seq.mapi (fun i comb ->
-                    if i > maxSteps then
-                        Some Unconclusive
-                    else
-                        let vals = vals @ comb
+        let solve vals groups =
+            let combinations = genCombinations (groups |> List.map snd)
 
-                        if eval cnf vals then
-                            Some(
-                                Satisfiable(
-                                    vals
-                                    |> List.choose (
-                                        function
-                                        | Positive x -> Some x
-                                        | _ -> None
-                                    )
-                                )
+            combinations
+            |> Seq.mapi (fun i comb ->
+                if i > maxSteps then
+                    Some Unconclusive
+                else
+
+                let vals = vals @ comb
+
+                if not (eval cnf vals) then
+                    None
+                else
+                    Some(
+                        Satisfiable(
+                            vals
+                            |> List.choose (
+                                function
+                                | Positive x -> Some x
+                                | _ -> None
                             )
-                        else
-                            None
-                )
-                |> Seq.tryPick id
-                |> Option.defaultValue Unsatisfiable
+                        )
+                    )
+            )
+            |> Seq.tryPick id
+            |> Option.defaultValue Unsatisfiable
 
-            solve (Seq.toList solvedSet) toSolve
+        solve (Seq.toList solvedSet) toSolve
 
     let mergeBoolExprs maxSolveSteps exprs =
         let solve e =

--- a/src/Fantomas.Core/MultipleDefineCombinations.fs
+++ b/src/Fantomas.Core/MultipleDefineCombinations.fs
@@ -96,15 +96,16 @@ type CodeFragment =
                 elif not hasOwnContent && hasOtherContent then
                     -1
                 else
-                    // This only really tailors to #1026
-                    // The shortest content is chosen because it will lead to the branch with less indentation.
-                    // This is again very specific to that exact unit test.
-                    let ownLength = ownContent.Length
-                    let otherLength = otherContent.Length
 
-                    if ownLength < otherLength then 1
-                    elif ownLength > otherLength then -1
-                    else 0
+                // This only really tailors to #1026
+                // The shortest content is chosen because it will lead to the branch with less indentation.
+                // This is again very specific to that exact unit test.
+                let ownLength = ownContent.Length
+                let otherLength = otherContent.Length
+
+                if ownLength < otherLength then 1
+                elif ownLength > otherLength then -1
+                else 0
             // This is an unexpected situation.
             // You should never enter the case where you need to compare a hash line with something other than a hash line.
             | x, other -> failwith $"Cannot compare %A{x} with %A{other}"
@@ -256,8 +257,9 @@ Please raise an issue at https://fsprojects.github.io/fantomas-tools/#/fantomas/
         if List.isEmpty headItems then
             continuation []
         else
-            let max = List.max headItems
-            traverseFragments (List.map List.tail input) (fun xs -> max :: xs |> continuation)
+
+        let max = List.max headItems
+        traverseFragments (List.map List.tail input) (fun xs -> max :: xs |> continuation)
 
     let selectedFragments: CodeFragment list =
         traverseFragments (allInFragments |> List.map (fun r -> r.Fragments)) id

--- a/src/Fantomas.Core/Queue.fs
+++ b/src/Fantomas.Core/Queue.fs
@@ -42,12 +42,13 @@ type Queue<'T>(data: 'T array list, length: int) =
         if Array.isEmpty head then
             x
         else
-            let newHead = Array.skip 1 head
 
-            if Array.isEmpty newHead then
-                Queue(tail, length - 1)
-            else
-                Queue(newHead :: tail, length - 1)
+        let newHead = Array.skip 1 head
+
+        if Array.isEmpty newHead then
+            Queue(tail, length - 1)
+        else
+            Queue(newHead :: tail, length - 1)
 
     member x.IsEmpty = length = 0
 
@@ -65,35 +66,38 @@ type Queue<'T>(data: 'T array list, length: int) =
         if n >= length then
             false
         else
-            let mutable i = length - n // how many items at end
-            let mutable r = false
 
-            let rec dataToEnd acc =
-                function
-                | hd: _ array :: tl ->
-                    if i > hd.Length then
-                        i <- i - hd.Length
-                        dataToEnd (hd :: acc) tl
-                    else
-                        i <- hd.Length - i // index in first array
-                        hd :: acc
-                | [] -> acc
+        let mutable i = length - n // how many items at end
+        let mutable r = false
 
-            let rec exists xs =
-                match xs with
-                | arr: _ array :: tl ->
-                    while not r && i < arr.Length do
-                        if f arr.[i] then
-                            r <- true
+        let rec dataToEnd acc =
+            function
+            | [] -> acc
+            | hd: _ array :: tl ->
 
-                        i <- i + 1
+            if i > hd.Length then
+                i <- i - hd.Length
+                dataToEnd (hd :: acc) tl
+            else
+                i <- hd.Length - i // index in first array
+                hd :: acc
 
-                    i <- 0
-                    if r then true else exists tl
-                | [] -> r
+        let rec exists xs =
+            match xs with
+            | [] -> r
+            | arr: _ array :: tl ->
 
-            let d = dataToEnd [] data
-            d |> List.skipWhile p |> exists
+            while not r && i < arr.Length do
+                if f arr.[i] then
+                    r <- true
+
+                i <- i + 1
+
+            i <- 0
+            if r then true else exists tl
+
+        let d = dataToEnd [] data
+        d |> List.skipWhile p |> exists
 
     interface System.Collections.Generic.IReadOnlyCollection<'T> with
         member x.Count = x.Length

--- a/src/Fantomas.Core/Queue.fs
+++ b/src/Fantomas.Core/Queue.fs
@@ -38,15 +38,16 @@ type Queue<'T>(data: 'T array list, length: int) =
         match data with
         | [] -> x
         | head :: tail ->
-            if Array.isEmpty head then
-                x
-            else
-                let newHead = Array.skip 1 head
 
-                if Array.isEmpty newHead then
-                    Queue(tail, length - 1)
-                else
-                    Queue(newHead :: tail, length - 1)
+        if Array.isEmpty head then
+            x
+        else
+            let newHead = Array.skip 1 head
+
+            if Array.isEmpty newHead then
+                Queue(tail, length - 1)
+            else
+                Queue(newHead :: tail, length - 1)
 
     member x.IsEmpty = length = 0
 

--- a/src/Fantomas.Core/Queue.fs
+++ b/src/Fantomas.Core/Queue.fs
@@ -7,15 +7,16 @@ type Queue<'T>(data: 'T array list, length: int) =
 
     override x.GetHashCode() =
         match hashCode with
-        | None ->
-            let mutable hash = 1
-
-            for x' in x do
-                hash <- 31 * hash + Unchecked.hash x'
-
-            hashCode <- Some hash
-            hash
         | Some hash -> hash
+        | None ->
+
+        let mutable hash: int = 1
+
+        for x' in x do
+            hash <- 31 * hash + Unchecked.hash x'
+
+        hashCode <- Some hash
+        hash
 
     override x.Equals(other) =
         match other with

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -12,25 +12,26 @@ let correctSelection (fileIndex: int) (sourceText: ISourceText) (selection: rang
             if idx < 0 then
                 None
             else
-                let line = sourceText.GetLineString(idx)
 
-                if String.isNotNullOrWhitespace line then
-                    Some(lineNumber, line)
-                else
-                    None
+            let line = sourceText.GetLineString(idx)
+
+            if String.isNotNullOrWhitespace line then
+                Some(lineNumber, line)
+            else
+                None
         )
 
     match Array.tryHead lines, Array.tryLast lines with
     | Some(startLineNumber, startLine), Some(endLineNumber, endLine) ->
         let startColumn =
-            // The selection is on the same line as the code but appears to be inside whitespace
-            if startLineNumber = selection.StartLine then
+            // The selection is on a different line than the code, take first non-whitespace character
+            if startLineNumber <> selection.StartLine then
+                Seq.takeWhile System.Char.IsWhiteSpace startLine |> Seq.length
+            else
+                // The selection is on the same line as the code but appears to be inside whitespace
                 Seq.takeWhile System.Char.IsWhiteSpace startLine
                 |> Seq.length
                 |> fun firstCharOnLine -> System.Math.Max(firstCharOnLine, selection.StartColumn)
-            else
-                // The selection is on a different line than the code, take first non-whitespace character
-                Seq.takeWhile System.Char.IsWhiteSpace startLine |> Seq.length
 
         let endColumn =
             // The selection is on the same line as the code but appears to be inside whitespace

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -383,41 +383,41 @@ let formatSelection
         match treeWithSelection with
         | None -> return raise (FormatException("No suitable AST node was found for the given selection."))
         | Some tree ->
-            let maxLineLength = config.MaxLineLength - selection.StartColumn
 
-            let selectionConfig =
-                { config with
-                    InsertFinalNewline = false
-                    MaxLineLength = maxLineLength
-                }
+        let maxLineLength = config.MaxLineLength - selection.StartColumn
 
-            let formattedSelection =
-                let context = Context.Context.Create selectionConfig
+        let selectionConfig =
+            { config with
+                InsertFinalNewline = false
+                MaxLineLength = maxLineLength
+            }
 
-                match tree with
-                | TreeForSelection.Unsupported ->
-                    raise (FormatException("The current selection is not supported right now."))
-                | TreeForSelection.Standalone tree ->
-                    let enrichedTree = Trivia.enrichTree selectionConfig sourceText baseUntypedTree tree
+        let formattedSelection =
+            let context = Context.Context.Create selectionConfig
 
-                    CodePrinter.genFile enrichedTree context
-                    |> Context.dump true
-                    |> fun result -> result.Code
-                | TreeForSelection.RequiresExtraction(tree, t) ->
-                    let enrichedTree = Trivia.enrichTree selectionConfig sourceText baseUntypedTree tree
+            match tree with
+            | TreeForSelection.Unsupported ->
+                raise (FormatException("The current selection is not supported right now."))
+            | TreeForSelection.Standalone tree ->
+                let enrichedTree = Trivia.enrichTree selectionConfig sourceText baseUntypedTree tree
 
-                    let { Code = formattedCode } =
-                        CodePrinter.genFile enrichedTree context |> Context.dump true
+                CodePrinter.genFile enrichedTree context
+                |> Context.dump true
+                |> fun result -> result.Code
+            | TreeForSelection.RequiresExtraction(tree, t) ->
+                let enrichedTree = Trivia.enrichTree selectionConfig sourceText baseUntypedTree tree
 
-                    let source = SourceText.ofString formattedCode
-                    let formattedAST, _ = Fantomas.FCS.Parse.parseFile isSignature source []
-                    let formattedTree = ASTTransformer.mkOak (Some source) formattedAST
-                    let rangeOfSelection = findRangeOf t formattedTree
+                let { Code = formattedCode } =
+                    CodePrinter.genFile enrichedTree context |> Context.dump true
 
-                    match rangeOfSelection with
-                    | Some m -> source.GetSubTextFromRange m
-                    | None ->
-                        raise (FormatException("No suitable AST node could be extracted from formatted selection."))
+                let source = SourceText.ofString formattedCode
+                let formattedAST, _ = Fantomas.FCS.Parse.parseFile isSignature source []
+                let formattedTree = ASTTransformer.mkOak (Some source) formattedAST
+                let rangeOfSelection = findRangeOf t formattedTree
 
-            return formattedSelection.TrimEnd([| '\r'; '\n' |]), selection
+                match rangeOfSelection with
+                | Some m -> source.GetSubTextFromRange m
+                | None -> raise (FormatException("No suitable AST node could be extracted from formatted selection."))
+
+        return formattedSelection.TrimEnd([| '\r'; '\n' |]), selection
     }

--- a/src/Fantomas.Core/Selection.fs
+++ b/src/Fantomas.Core/Selection.fs
@@ -415,9 +415,9 @@ let formatSelection
                     let rangeOfSelection = findRangeOf t formattedTree
 
                     match rangeOfSelection with
+                    | Some m -> source.GetSubTextFromRange m
                     | None ->
                         raise (FormatException("No suitable AST node could be extracted from formatted selection."))
-                    | Some m -> source.GetSubTextFromRange m
 
             return formattedSelection.TrimEnd([| '\r'; '\n' |]), selection
     }

--- a/src/Fantomas.Core/SyntaxOak.fs
+++ b/src/Fantomas.Core/SyntaxOak.fs
@@ -84,15 +84,16 @@ let private hasLayoutAffectingTrivia (nodes: Queue<TriviaNode>) =
     if nodes.Count = 0 then
         false
     else
-        let mutable found = false
-        let mutable e = nodes.GetEnumerator()
 
-        while not found && e.MoveNext() do
-            match e.Current.Content with
-            | Cursor -> ()
-            | _ -> found <- true
+    let mutable found = false
+    let mutable e = nodes.GetEnumerator()
 
-        found
+    while not found && e.MoveNext() do
+        match e.Current.Content with
+        | Cursor -> ()
+        | _ -> found <- true
+
+    found
 
 /// Base implementation of <see cref="Node"/> shared by all concrete Oak node types.
 /// Manages the mutable trivia queues (<c>ContentBefore</c> / <c>ContentAfter</c>) and
@@ -133,40 +134,41 @@ type NodeBase(range: range) =
         let hasContentAfter = not (Seq.isEmpty x.ContentAfter)
         let hasContent = hasContentBefore || hasChildren || hasContentAfter
 
-        if hasContent then
-            sb.AppendLine() |> ignore
-
-            if hasContentBefore then
-                for tn in x.ContentBefore do
-                    sb.Append(contentIndent).Append("▼ ").Append(tn.ToString()).AppendLine()
-                    |> ignore
-
-            if hasChildren then
-                for n in x.Children do
-                    match n with
-                    | :? SingleTextNode as stn ->
-                        for tn in stn.ContentBefore do
-                            sb.Append(contentIndent).Append("▼ ").Append(tn.ToString()).AppendLine()
-                            |> ignore
-
-                        sb.Append(contentIndent).Append(stn.ToString()).AppendLine() |> ignore
-
-                        for tn in stn.ContentAfter do
-                            sb.Append(contentIndent).Append("▲ ").Append(tn.ToString()).AppendLine()
-                            |> ignore
-                    | :? NodeBase as nb ->
-                        nb.AppendToStringWithIndent(sb, depth + 1)
-                        sb.AppendLine() |> ignore
-                    | _ -> sb.Append(contentIndent).Append(n.ToString()).AppendLine() |> ignore
-
-            if hasContentAfter then
-                for tn in x.ContentAfter do
-                    sb.Append(contentIndent).Append("▲ ").Append(tn.ToString()).AppendLine()
-                    |> ignore
-
-            sb.Append(indent).Append(")") |> ignore
-        else
+        if not hasContent then
             sb.Append(")") |> ignore
+        else
+
+        sb.AppendLine() |> ignore
+
+        if hasContentBefore then
+            for tn in x.ContentBefore do
+                sb.Append(contentIndent).Append("▼ ").Append(tn.ToString()).AppendLine()
+                |> ignore
+
+        if hasChildren then
+            for n in x.Children do
+                match n with
+                | :? SingleTextNode as stn ->
+                    for tn in stn.ContentBefore do
+                        sb.Append(contentIndent).Append("▼ ").Append(tn.ToString()).AppendLine()
+                        |> ignore
+
+                    sb.Append(contentIndent).Append(stn.ToString()).AppendLine() |> ignore
+
+                    for tn in stn.ContentAfter do
+                        sb.Append(contentIndent).Append("▲ ").Append(tn.ToString()).AppendLine()
+                        |> ignore
+                | :? NodeBase as nb ->
+                    nb.AppendToStringWithIndent(sb, depth + 1)
+                    sb.AppendLine() |> ignore
+                | _ -> sb.Append(contentIndent).Append(n.ToString()).AppendLine() |> ignore
+
+        if hasContentAfter then
+            for tn in x.ContentAfter do
+                sb.Append(contentIndent).Append("▲ ").Append(tn.ToString()).AppendLine()
+                |> ignore
+
+        sb.Append(indent).Append(")") |> ignore
 
     member private x.ToStringWithIndent(depth: int) =
         let sb = StringBuilder()

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -280,10 +280,11 @@ let rec findNodeBeforeWithMatchingColumn (node: Node) (triviaRange: range) : Nod
         match deeperMatch with
         | Some _ -> deeperMatch
         | None ->
-            if child.Range.StartColumn = triviaColumn then
-                Some child
-            else
-                None
+
+        if child.Range.StartColumn = triviaColumn then
+            Some child
+        else
+            None
     )
 
 /// Assigns a trivia node (comment, blank line, directive) to the appropriate child
@@ -458,14 +459,15 @@ let addToTree (tree: Oak) (trivia: TriviaNode array) =
         match smallestNodeThatContainsTrivia with
         | None -> triviaBeforeOrAfterEntireTree tree trivia
         | Some parentNode ->
-            match trivia.Content with
-            | LineCommentAfterSourceCode _ -> lineCommentAfterSourceCodeToTriviaInstruction parentNode trivia
-            | CommentOnSingleLine _
-            | CommentOnSingleLineWithLeadingNewlines _
-            | Newline
-            | Directive _ -> assignTriviaToTriviaInstruction parentNode trivia
-            | BlockComment _
-            | Cursor -> blockCommentToTriviaInstruction parentNode trivia
+
+        match trivia.Content with
+        | LineCommentAfterSourceCode _ -> lineCommentAfterSourceCodeToTriviaInstruction parentNode trivia
+        | CommentOnSingleLine _
+        | CommentOnSingleLineWithLeadingNewlines _
+        | Newline
+        | Directive _ -> assignTriviaToTriviaInstruction parentNode trivia
+        | BlockComment _
+        | Cursor -> blockCommentToTriviaInstruction parentNode trivia
 
 let internal collectCommentTextsFromAST (sourceText: ISourceText) (ast: ParsedInput) : Set<TriviaContent> =
     let parsedTrivia =

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -26,40 +26,41 @@ let internal collectTriviaFromCodeComments
         if not (RangeHelpers.rangeContainsRange codeRange ct.Range) then
             None
         else
-            match ct with
-            | CommentTrivia.BlockComment r ->
-                let content = source.GetSubTextFromRange r
-                let startLine = source.GetLineString(r.StartLine - 1)
-                let endLine = source.GetLineString(r.EndLine - 1)
 
-                let contentBeforeComment =
-                    startLine.Substring(0, r.StartColumn).TrimStart(' ', ';').Length
+        match ct with
+        | CommentTrivia.BlockComment r ->
+            let content = source.GetSubTextFromRange r
+            let startLine = source.GetLineString(r.StartLine - 1)
+            let endLine = source.GetLineString(r.EndLine - 1)
 
-                let contentAfterComment = endLine.Substring(r.EndColumn).TrimEnd(' ', ';').Length
+            let contentBeforeComment =
+                startLine.Substring(0, r.StartColumn).TrimStart(' ', ';').Length
 
-                let content =
-                    if contentBeforeComment = 0 && contentAfterComment = 0 then
-                        CommentOnSingleLine content
-                    else
-                        BlockComment(content, false, false)
+            let contentAfterComment = endLine.Substring(r.EndColumn).TrimEnd(' ', ';').Length
 
-                Some(TriviaNode(content, r))
-            | CommentTrivia.LineComment r ->
-                let content = source.GetSubTextFromRange r
-                let index = r.StartLine - 1
-                let line = source.GetLineString index
+            let content =
+                if contentBeforeComment = 0 && contentAfterComment = 0 then
+                    CommentOnSingleLine content
+                else
+                    BlockComment(content, false, false)
 
-                let content =
-                    let trimmedLine = line.TrimStart(' ', ';')
+            Some(TriviaNode(content, r))
+        | CommentTrivia.LineComment r ->
+            let content = source.GetSubTextFromRange r
+            let index = r.StartLine - 1
+            let line = source.GetLineString index
 
-                    if index = 0 && String.startsWithOrdinal "#!" trimmedLine then // shebang
-                        CommentOnSingleLine content
-                    else if String.startsWithOrdinal "//" trimmedLine then
-                        CommentOnSingleLine content
-                    else
-                        LineCommentAfterSourceCode content
+            let content =
+                let trimmedLine = line.TrimStart(' ', ';')
 
-                Some(TriviaNode(content, r))
+                if index = 0 && String.startsWithOrdinal "#!" trimmedLine then // shebang
+                    CommentOnSingleLine content
+                else if String.startsWithOrdinal "//" trimmedLine then
+                    CommentOnSingleLine content
+                else
+                    LineCommentAfterSourceCode content
+
+            Some(TriviaNode(content, r))
     )
 
 let internal collectTriviaFromBlankLines
@@ -74,70 +75,73 @@ let internal collectTriviaFromBlankLines
         // weird edge cases where there is no source code but only hash defines
         []
     else
-        let fileIndex = codeRange.FileIndex
 
-        let captureLinesIfMultiline (r: range) =
-            if r.StartLine = r.EndLine then
-                []
-            else
-                [ r.StartLine .. r.EndLine ]
+    let fileIndex = codeRange.FileIndex
 
-        let multilineStringsLines =
-            let rec visit (node: Node) (finalContinuation: int list -> int list) =
-                let continuations: ((int list -> int list) -> int list) list =
-                    Array.toList node.Children |> List.map visit
+    let captureLinesIfMultiline (r: range) =
+        if r.StartLine = r.EndLine then
+            []
+        else
+            [ r.StartLine .. r.EndLine ]
 
-                let currentLines =
-                    match node with
-                    | :? StringNode as node -> captureLinesIfMultiline node.Range
-                    | _ -> []
+    let multilineStringsLines =
+        let rec visit (node: Node) (finalContinuation: int list -> int list) =
+            let continuations: ((int list -> int list) -> int list) list =
+                Array.toList node.Children |> List.map visit
 
-                let finalContinuation (lines: int list list) : int list =
-                    List.collect id (currentLines :: lines) |> finalContinuation
+            let currentLines =
+                match node with
+                | :? StringNode as node -> captureLinesIfMultiline node.Range
+                | _ -> []
 
-                Continuation.sequence continuations finalContinuation
+            let finalContinuation (lines: int list list) : int list =
+                List.collect id (currentLines :: lines) |> finalContinuation
 
-            visit rootNode id
+            Continuation.sequence continuations finalContinuation
 
-        let blockCommentLines =
-            codeComments
-            |> List.collect (
-                function
-                | CommentTrivia.BlockComment r -> captureLinesIfMultiline r
-                | CommentTrivia.LineComment _ -> []
-            )
+        visit rootNode id
 
-        let ignoreLines =
-            Set(
-                seq {
-                    yield! multilineStringsLines
-                    yield! blockCommentLines
-                }
-            )
-
-        let min = System.Math.Max(0, codeRange.StartLine - 1)
-
-        let max = System.Math.Min(source.Length - 1, codeRange.EndLine - 1)
-
-        (min, [ min..max ])
-        ||> List.chooseState (fun count idx ->
-            if ignoreLines.Contains(idx + 1) then
-                0, None
-            else
-                let line = source.GetLineString(idx)
-
-                if String.isNotNullOrWhitespace line then
-                    0, None
-                else
-                    let range =
-                        let p = Position.mkPos (idx + 1) 0
-                        Range.mkFileIndexRange fileIndex p p
-
-                    if count < config.KeepMaxNumberOfBlankLines then
-                        (count + 1), Some(TriviaNode(Newline, range))
-                    else
-                        count, None
+    let blockCommentLines =
+        codeComments
+        |> List.collect (
+            function
+            | CommentTrivia.BlockComment r -> captureLinesIfMultiline r
+            | CommentTrivia.LineComment _ -> []
         )
+
+    let ignoreLines =
+        Set(
+            seq {
+                yield! multilineStringsLines
+                yield! blockCommentLines
+            }
+        )
+
+    let min = System.Math.Max(0, codeRange.StartLine - 1)
+
+    let max = System.Math.Min(source.Length - 1, codeRange.EndLine - 1)
+
+    (min, [ min..max ])
+    ||> List.chooseState (fun count idx ->
+        if ignoreLines.Contains(idx + 1) then
+            0, None
+        else
+
+        let line = source.GetLineString(idx)
+
+        if String.isNotNullOrWhitespace line then
+            0, None
+        else
+
+        let range =
+            let p = Position.mkPos (idx + 1) 0
+            Range.mkFileIndexRange fileIndex p p
+
+        if count < config.KeepMaxNumberOfBlankLines then
+            (count + 1), Some(TriviaNode(Newline, range))
+        else
+            count, None
+    )
 
 type ConditionalDirectiveTrivia with
 
@@ -159,9 +163,10 @@ let internal collectTriviaFromDirectiveRanges
         if not (RangeHelpers.rangeContainsRange codeRange directiveRange) then
             None
         else
-            let text = (source.GetSubTextFromRange directiveRange).TrimEnd()
-            let content = Directive text
-            Some(TriviaNode(content, directiveRange))
+
+        let text = (source.GetSubTextFromRange directiveRange).TrimEnd()
+        let content = Directive text
+        Some(TriviaNode(content, directiveRange))
     )
 
 let rec findNodeWhereRangeFitsIn (root: Node) (range: range) : Node option =
@@ -170,12 +175,13 @@ let rec findNodeWhereRangeFitsIn (root: Node) (range: range) : Node option =
     if not doesSelectionFitInNode then
         None
     else
-        // The more specific the node fits the selection, the better
-        let betterChildNode =
-            root.Children
-            |> Array.tryPick (fun childNode -> findNodeWhereRangeFitsIn childNode range)
 
-        betterChildNode |> Option.orElseWith (fun () -> Some root)
+    // The more specific the node fits the selection, the better
+    let betterChildNode =
+        root.Children
+        |> Array.tryPick (fun childNode -> findNodeWhereRangeFitsIn childNode range)
+
+    betterChildNode |> Option.orElseWith (fun () -> Some root)
 
 let triviaBeforeOrAfterEntireTree (rootNode: Node) (trivia: TriviaNode) : unit =
     let isBefore = trivia.Range.EndLine < rootNode.Range.StartLine

--- a/src/Fantomas.Core/Utils.fs
+++ b/src/Fantomas.Core/Utils.fs
@@ -13,8 +13,9 @@ module UnionCase =
         if isNull (box value) || not (FSharpType.IsUnion unionType) then
             unionType.Name
         else
-            let case, _ = FSharpValue.GetUnionFields(value, unionType)
-            $"%s{unionType.Name}.%s{case.Name}"
+
+        let case, _ = FSharpValue.GetUnionFields(value, unionType)
+        $"%s{unionType.Name}.%s{case.Name}"
 
 [<RequireQualifiedAccess>]
 module String =
@@ -67,11 +68,12 @@ module List =
     let partitionWhile (f: int -> 'a -> bool) (xs: 'a list) : 'a list * 'a list =
         let rec go i before after =
             match after with
-            | head :: tail ->
-                match f i head with
-                | true -> go (i + 1) (head :: before) tail
-                | false -> List.rev before, after
             | [] -> List.rev before, after
+            | head :: tail ->
+
+            match f i head with
+            | true -> go (i + 1) (head :: before) tail
+            | false -> List.rev before, after
 
         go 0 [] xs
 

--- a/src/Fantomas.Tests/EditorConfigReportTests.fs
+++ b/src/Fantomas.Tests/EditorConfigReportTests.fs
@@ -31,13 +31,14 @@ let ``every problem is named, and the origin with them`` () =
     match report with
     | None -> Assert.Fail "Expected a report"
     | Some report ->
-        Assert.That(report, Does.Contain "/repo/.editorconfig")
-        Assert.That(report, Does.Contain "'fsharp_wibble' is not a Fantomas setting")
 
-        Assert.That(
-            report,
-            Does.Contain "'fsharp_experimental_elmish' does not accept the value 'yes', so the default is used instead"
-        )
+    Assert.That(report, Does.Contain "/repo/.editorconfig")
+    Assert.That(report, Does.Contain "'fsharp_wibble' is not a Fantomas setting")
+
+    Assert.That(
+        report,
+        Does.Contain "'fsharp_experimental_elmish' does not accept the value 'yes', so the default is used instead"
+    )
 
 [<Test>]
 let ``a misspelling is answered with the spelling that works`` () =
@@ -60,8 +61,9 @@ let ``the settings list is not written out for a value that could not be read`` 
     match describe "/repo/.editorconfig" [ unrecognized ("fsharp_max_record_width", "banana") ] with
     | None -> Assert.Fail "Expected a report"
     | Some report ->
-        Assert.That(report, Does.Not.Contain "--verbosity d")
-        Assert.That(report, Does.Not.Contain "fsharp_multiline_bracket_style")
+
+    Assert.That(report, Does.Not.Contain "--verbosity d")
+    Assert.That(report, Does.Not.Contain "fsharp_multiline_bracket_style")
 
 [<Test>]
 let ``a setting Fantomas does not have points at where the whole list is`` () =

--- a/src/Fantomas.Tests/EditorConfigurationTests.fs
+++ b/src/Fantomas.Tests/EditorConfigurationTests.fs
@@ -51,12 +51,13 @@ type ConfigurationFile
         match content with
         | Some c -> c
         | None ->
-            let root =
-                match isRoot with
-                | Some true -> "root=true"
-                | _ -> String.empty
 
-            $"%s{root}\n\n%s{header}\n%s{EditorConfig.configToEditorConfig config}"
+        let root =
+            match isRoot with
+            | Some true -> "root=true"
+            | _ -> String.empty
+
+        $"%s{root}\n\n%s{header}\n%s{EditorConfig.configToEditorConfig config}"
 
     do File.WriteAllText(editorConfigPath, content)
 

--- a/src/Fantomas.Tests/EditorConfigurationTests.fs
+++ b/src/Fantomas.Tests/EditorConfigurationTests.fs
@@ -35,14 +35,15 @@ type ConfigurationFile
 
     let editorConfigPath =
         match subFolder with
-        | Some sf ->
-            let dirPath = Path.Join(rootDir, sf)
-
-            if not (Directory.Exists(dirPath)) then
-                Directory.CreateDirectory(dirPath) |> ignore
-
-            Path.Join(rootDir, sf, ".editorconfig")
         | None -> Path.Join(rootDir, ".editorconfig")
+        | Some sf ->
+
+        let dirPath = Path.Join(rootDir, sf)
+
+        if not (Directory.Exists(dirPath)) then
+            Directory.CreateDirectory(dirPath) |> ignore
+
+        Path.Join(rootDir, sf, ".editorconfig")
 
     let header = Option.defaultValue "[*.fs]" editorConfigHeader
 
@@ -81,14 +82,15 @@ type FSharpFile
 
     let fsharpFilePath =
         match subFolder with
-        | Some sf ->
-            let dirPath = Path.Join(rootDir, sf)
-
-            if not (Directory.Exists(dirPath)) then
-                Directory.CreateDirectory(dirPath) |> ignore
-
-            Path.Join(rootDir, sf, fsharpFile)
         | None -> Path.Join(rootDir, fsharpFile)
+        | Some sf ->
+
+        let dirPath = Path.Join(rootDir, sf)
+
+        if not (Directory.Exists(dirPath)) then
+            Directory.CreateDirectory(dirPath) |> ignore
+
+        Path.Join(rootDir, sf, fsharpFile)
 
     let content = Option.defaultValue String.empty content
     do File.WriteAllText(fsharpFilePath, content)

--- a/src/Fantomas.Tests/Integration/DaemonTests.fs
+++ b/src/Fantomas.Tests/Integration/DaemonTests.fs
@@ -118,9 +118,10 @@ let private runWithDaemonCollectingWarnings
                 if (before > 0 && steadyFor >= 2) || attemptsLeft = 0 then
                     return ()
                 else
-                    do! Async.Sleep 50
-                    let steadyFor = if count () = before then steadyFor + 1 else 0
-                    return! settle (attemptsLeft - 1) steadyFor
+
+                do! Async.Sleep 50
+                let steadyFor = if count () = before then steadyFor + 1 else 0
+                return! settle (attemptsLeft - 1) steadyFor
             }
 
         try

--- a/src/Fantomas.Tests/Integration/DaemonTests.fs
+++ b/src/Fantomas.Tests/Integration/DaemonTests.fs
@@ -144,8 +144,9 @@ let private theOnlyWarning (warnings: ConfigurationWarning list) : Configuration
     match warnings with
     | [ warning ] -> warning
     | otherwise ->
-        Assert.Fail $"Expected exactly one configuration warning, got %A{otherwise}"
-        failwith "unreachable"
+
+    Assert.Fail $"Expected exactly one configuration warning, got %A{otherwise}"
+    failwith "unreachable"
 
 let private problemsOf (warning: ConfigurationWarning) : (int * int * string * string) array =
     warning.Problems

--- a/src/Fantomas.Tests/JsonReportTests.fs
+++ b/src/Fantomas.Tests/JsonReportTests.fs
@@ -633,12 +633,13 @@ let ``a setting an .editorconfig set names the file that set it`` () =
             Settings =
                 plain.Settings
                 |> List.map (fun (setting: Fantomas.EditorConfig.ResolvedSetting) ->
-                    if setting.Setting = "max_line_length" then
-                        { setting with
-                            SetBy = Some "/repo/.editorconfig"
-                        }
-                    else
+                    if setting.Setting <> "max_line_length" then
                         setting
+                    else
+
+                    { setting with
+                        SetBy = Some "/repo/.editorconfig"
+                    }
                 )
         }
 

--- a/src/Fantomas.Tests/ReportTests.fs
+++ b/src/Fantomas.Tests/ReportTests.fs
@@ -914,12 +914,13 @@ let ``the settings line names the .editorconfig it means, absolutely`` () =
             Settings =
                 plain.Settings
                 |> List.map (fun (setting: Fantomas.EditorConfig.ResolvedSetting) ->
-                    if setting.Setting = "max_line_length" then
-                        { setting with
-                            SetBy = Some "/repo/.editorconfig"
-                        }
-                    else
+                    if setting.Setting <> "max_line_length" then
                         setting
+                    else
+
+                    { setting with
+                        SetBy = Some "/repo/.editorconfig"
+                    }
                 )
         }
 
@@ -955,12 +956,13 @@ let ``the settings an .editorconfig set are set apart from the defaults by a bla
             Settings =
                 resolved.Settings
                 |> List.map (fun (setting: Fantomas.EditorConfig.ResolvedSetting) ->
-                    if setting.Setting = "max_line_length" then
-                        { setting with
-                            SetBy = Some "/repo/.editorconfig"
-                        }
-                    else
+                    if setting.Setting <> "max_line_length" then
                         setting
+                    else
+
+                    { setting with
+                        SetBy = Some "/repo/.editorconfig"
+                    }
                 )
         }
 

--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -37,9 +37,10 @@ type TemporaryFileCodeSample
         match subFolders with
         | Some sf -> Some sf
         | None ->
-            match subFolder with
-            | Some sf -> Array.singleton sf |> Some
-            | None -> None
+
+        match subFolder with
+        | Some sf -> Array.singleton sf |> Some
+        | None -> None
 
     let filename =
         let name =
@@ -52,12 +53,13 @@ type TemporaryFileCodeSample
         match internalSubFolders with
         | None -> Path.Join(Path.GetTempPath(), sprintf "%s.%s" name extension)
         | Some sf ->
-            let tempFolder = Path.Join(Path.GetTempPath(), Path.Join(sf))
 
-            if not (Directory.Exists(tempFolder)) then
-                Directory.CreateDirectory(tempFolder) |> ignore
+        let tempFolder = Path.Join(Path.GetTempPath(), Path.Join(sf))
 
-            Path.Join(tempFolder, sprintf "%s.%s" name extension)
+        if not (Directory.Exists(tempFolder)) then
+            Directory.CreateDirectory(tempFolder) |> ignore
+
+        Path.Join(tempFolder, sprintf "%s.%s" name extension)
 
     do
         (if hasByteOrderMark then

--- a/src/Fantomas/Arguments.fs
+++ b/src/Fantomas/Arguments.fs
@@ -206,20 +206,22 @@ let parse (argv: string array) : Result<Arguments list, ArgumentProblem> =
         match tryFindFlag name with
         | None -> problem <- Some(ArgumentProblem.UnknownFlag(name, flagSuggestion name))
         | Some flag ->
-            match flag.Kind, attached with
-            | FlagKind.Switch argument, None -> given.Add argument
-            | FlagKind.Switch _, Some value -> problem <- Some(ArgumentProblem.UnexpectedValue(name, value))
-            | FlagKind.Valued build, Some value -> given.Add(build value)
-            | FlagKind.Valued build, None ->
-                // A token beginning with a dash is never swallowed as a value: `--out --check` is
-                // a missing output path, not an output path named `--check`.
-                if index < argv.Length && not (isFlagToken argv.[index]) then
-                    given.Add(build argv.[index])
-                    index <- index + 1
-                else
-                    let found: string option = if index < argv.Length then Some argv.[index] else None
 
-                    problem <- Some(ArgumentProblem.MissingValue(name, found))
+        match flag.Kind, attached with
+        | FlagKind.Switch argument, None -> given.Add argument
+        | FlagKind.Switch _, Some value -> problem <- Some(ArgumentProblem.UnexpectedValue(name, value))
+        | FlagKind.Valued build, Some value -> given.Add(build value)
+        | FlagKind.Valued build, None ->
+
+        // A token beginning with a dash is never swallowed as a value: `--out --check` is
+        // a missing output path, not an output path named `--check`.
+        if index < argv.Length && not (isFlagToken argv.[index]) then
+            given.Add(build argv.[index])
+            index <- index + 1
+        else
+            let found: string option = if index < argv.Length then Some argv.[index] else None
+
+            problem <- Some(ArgumentProblem.MissingValue(name, found))
 
     match problem with
     | Some problem -> Error problem
@@ -337,13 +339,14 @@ let classifyInputPath (fs: IFileSystem) (maybeInput: string list option) : Input
         match missing with
         | Some x -> InputPath.NotFound x
         | None ->
-            // Every path here is known to exist, so which of the two it is can be asked rather
-            // than guessed from whether it carries an extension. Guessing called a folder named
-            // `my.stuff` a file, and a file with no extension a folder.
-            let folders, files =
-                inputs |> List.partition (fun (path: string) -> fs.Directory.Exists path)
 
-            InputPath.Multiple(files, folders)
+        // Every path here is known to exist, so which of the two it is can be asked rather
+        // than guessed from whether it carries an extension. Guessing called a folder named
+        // `my.stuff` a file, and a file with no extension a folder.
+        let folders, files =
+            inputs |> List.partition (fun (path: string) -> fs.Directory.Exists path)
+
+        InputPath.Multiple(files, folders)
 
 let tryOut (given: Arguments list) : string option =
     given

--- a/src/Fantomas/CheckCommand.fs
+++ b/src/Fantomas/CheckCommand.fs
@@ -73,22 +73,23 @@ let runCheckCommand (env: CliEnvironment) (inputPath: InputPath) : CheckCommandR
         match plan env.FileSystem env.Log env.FindIgnoreFile inputPath OutputPath.NotKnown with
         | Error problem -> CheckCommandResult.InvalidInput problem
         | Ok items ->
-            let ignored: string list =
-                items
-                |> List.choose (fun item ->
-                    match item with
-                    | WorkItem.Ignored file -> Some file
-                    | WorkItem.Format _ -> None
-                )
 
-            let toCheck: string list =
-                items
-                |> List.choose (fun item ->
-                    match item with
-                    | WorkItem.Ignored _ -> None
-                    | WorkItem.Format(inputFile, _) -> Some inputFile
-                )
+        let ignored: string list =
+            items
+            |> List.choose (fun item ->
+                match item with
+                | WorkItem.Ignored file -> Some file
+                | WorkItem.Format _ -> None
+            )
 
-            CheckCommandResult.Completed(ignored, Async.RunSynchronously(checkCode env toCheck))
+        let toCheck: string list =
+            items
+            |> List.choose (fun item ->
+                match item with
+                | WorkItem.Ignored _ -> None
+                | WorkItem.Format(inputFile, _) -> Some inputFile
+            )
+
+        CheckCommandResult.Completed(ignored, Async.RunSynchronously(checkCode env toCheck))
     with exn ->
         CheckCommandResult.Failed exn

--- a/src/Fantomas/Daemon.fs
+++ b/src/Fantomas/Daemon.fs
@@ -278,18 +278,19 @@ type FantomasDaemon(sender: Stream, reader: Stream, environment: DaemonEnvironme
                                         if formatResponse.Code = request.SourceCode then
                                             return FormatDocumentResponse.Unchanged request.FilePath
                                         else
-                                            let cursor =
-                                                formatResponse.Cursor
-                                                |> Option.map (fun cursorPos ->
-                                                    FormatCursorPosition(cursorPos.Line, cursorPos.Column)
-                                                )
 
-                                            return
-                                                FormatDocumentResponse.Formatted(
-                                                    request.FilePath,
-                                                    formatResponse.Code,
-                                                    cursor
-                                                )
+                                        let cursor =
+                                            formatResponse.Cursor
+                                            |> Option.map (fun cursorPos ->
+                                                FormatCursorPosition(cursorPos.Line, cursorPos.Column)
+                                            )
+
+                                        return
+                                            FormatDocumentResponse.Formatted(
+                                                request.FilePath,
+                                                formatResponse.Code,
+                                                cursor
+                                            )
                                     }
                                 )
                                 (fun message -> FormatDocumentResponse.Error(request.FilePath, message))

--- a/src/Fantomas/Daemon.fs
+++ b/src/Fantomas/Daemon.fs
@@ -61,8 +61,9 @@ let configurationFor
         match requestConfig with
         | None -> config, []
         | Some properties ->
-            let config, problems = parseOptionsFromEditorConfig config properties
-            config, List.map (toConfigurationProblem ConfigurationProblemSource.Request) problems
+
+        let config, problems = parseOptionsFromEditorConfig config properties
+        config, List.map (toConfigurationProblem ConfigurationProblemSource.Request) problems
 
     let problems = List.toArray (fromEditorConfig @ fromRequest)
 

--- a/src/Fantomas/Diagnostics.fs
+++ b/src/Fantomas/Diagnostics.fs
@@ -96,22 +96,23 @@ let snippet (theme: Theme) (lines: string array) (range: range) : string list =
     if range.StartLine < 1 || range.StartLine > lines.Length then
         []
     else
-        let firstLine = max 1 (range.StartLine - contextLines)
-        let lastLine = min lines.Length (range.StartLine + contextLines)
-        let gutter = String.length (string<int> lastLine)
 
-        let blankGutter: string = muted theme (String.Concat(String(' ', gutter), " |"))
+    let firstLine = max 1 (range.StartLine - contextLines)
+    let lastLine = min lines.Length (range.StartLine + contextLines)
+    let gutter = String.length (string<int> lastLine)
 
-        [
-            for number in firstLine..lastLine do
-                let lineNumber: string = (string<int> number).PadLeft(gutter)
-                let numberedGutter: string = muted theme (String.Concat(lineNumber, " |"))
-                yield String.Concat(numberedGutter, " ", expandTabs lines.[number - 1])
+    let blankGutter: string = muted theme (String.Concat(String(' ', gutter), " |"))
 
-                if number = range.StartLine then
-                    let indent, carets = caretRun lines.[number - 1] range
-                    yield String.Concat(blankGutter, " ", indent, negative theme carets)
-        ]
+    [
+        for number in firstLine..lastLine do
+            let lineNumber: string = (string<int> number).PadLeft(gutter)
+            let numberedGutter: string = muted theme (String.Concat(lineNumber, " |"))
+            yield String.Concat(numberedGutter, " ", expandTabs lines.[number - 1])
+
+            if number = range.StartLine then
+                let indent, carets = caretRun lines.[number - 1] range
+                yield String.Concat(blankGutter, " ", indent, negative theme carets)
+    ]
 
 // Where to draw the caret. The first error by position, since in an offside cascade that is the
 // line that caused it rather than the innocent line the parser gave up on. Falling back to the
@@ -224,8 +225,9 @@ let renderInvariantViolation
         if not verbose || String.IsNullOrWhiteSpace violation.SyntaxNode then
             []
         else
-            [ ""; "Syntax tree node:"; "" ]
-            @ List.ofArray (violation.SyntaxNode.Split('\n'))
+
+        [ ""; "Syntax tree node:"; "" ]
+        @ List.ofArray (violation.SyntaxNode.Split('\n'))
 
     let reportIt: string = reportAsBug theme "the snippet above"
 
@@ -300,13 +302,14 @@ let renderInvalidOutput
         if List.isEmpty ordered then
             []
         else
-            [
-                yield ""
-                yield "This is what the parser made of that output. The lines below are the output, not your file."
-                yield ""
-                yield! List.map (outputHeadline theme) ordered
-                yield! snippetFor theme output (caretTarget ordered)
-            ]
+
+        [
+            yield ""
+            yield "This is what the parser made of that output. The lines below are the output, not your file."
+            yield ""
+            yield! List.map (outputHeadline theme) ordered
+            yield! snippetFor theme output (caretTarget ordered)
+        ]
 
     [
         yield $"%s{link theme file} could not be formatted by Fantomas:"

--- a/src/Fantomas/Diagnostics.fs
+++ b/src/Fantomas/Diagnostics.fs
@@ -137,15 +137,16 @@ let snippetFor (theme: Theme) (source: string) (target: range option) : string l
     match target with
     | None -> []
     | Some range ->
-        if String.IsNullOrEmpty source then
-            []
-        else
 
-        let lines: string array = source.Replace("\r\n", "\n").Split('\n')
+    if String.IsNullOrEmpty source then
+        []
+    else
 
-        match snippet theme lines range with
-        | [] -> []
-        | snippetLines -> "" :: snippetLines
+    let lines: string array = source.Replace("\r\n", "\n").Split('\n')
+
+    match snippet theme lines range with
+    | [] -> []
+    | snippetLines -> "" :: snippetLines
 
 let renderParseFailure
     (theme: Theme)

--- a/src/Fantomas/DoctorCommand.fs
+++ b/src/Fantomas/DoctorCommand.fs
@@ -205,30 +205,31 @@ let askIgnore (env: CliEnvironment) (file: string) : IgnoreStep =
     match env.FindIgnoreFile file with
     | None -> IgnoreStep.NoIgnoreFile
     | Some ignoreFile ->
-        // Each one above asked the same two questions the governing file is asked, so that what is
-        // reported of it is what would have been reported had it been the one that applies. An
-        // ignore file described in weaker terms than the one beside it reads as the lesser fact,
-        // and which of the two governs is the whole point being made.
-        let shadowed: ShadowedIgnoreFile list =
-            env.FindIgnoreFilesAbove ignoreFile
-            |> List.map (fun (above: IgnoreFile) ->
-                {
-                    Path = above.Location.FullName
-                    WouldIgnore = IgnoreFile.isIgnoredFile env.Log (Some above) file
-                    Matches = IgnoreFile.matchingLines above file
-                }
-            )
 
-        // The verdict comes from the same function every run uses, and the lines are the same
-        // question asked one pattern at a time. The verdict is the one to report: it is what
-        // decides what happens to the file, and a disagreement between the two is this command's
-        // to survive rather than to resolve.
-        IgnoreStep.Governed(
-            ignoreFile.Location.FullName,
-            IgnoreFile.isIgnoredFile env.Log (Some ignoreFile) file,
-            IgnoreFile.matchingLines ignoreFile file,
-            shadowed
+    // Each one above asked the same two questions the governing file is asked, so that what is
+    // reported of it is what would have been reported had it been the one that applies. An
+    // ignore file described in weaker terms than the one beside it reads as the lesser fact,
+    // and which of the two governs is the whole point being made.
+    let shadowed: ShadowedIgnoreFile list =
+        env.FindIgnoreFilesAbove ignoreFile
+        |> List.map (fun (above: IgnoreFile) ->
+            {
+                Path = above.Location.FullName
+                WouldIgnore = IgnoreFile.isIgnoredFile env.Log (Some above) file
+                Matches = IgnoreFile.matchingLines above file
+            }
         )
+
+    // The verdict comes from the same function every run uses, and the lines are the same
+    // question asked one pattern at a time. The verdict is the one to report: it is what
+    // decides what happens to the file, and a disagreement between the two is this command's
+    // to survive rather than to resolve.
+    IgnoreStep.Governed(
+        ignoreFile.Location.FullName,
+        IgnoreFile.isIgnoredFile env.Log (Some ignoreFile) file,
+        IgnoreFile.matchingLines ignoreFile file,
+        shadowed
+    )
 
 let formatOnce (isSignature: bool) (config: FormatConfig) (content: string) : string =
     CodeFormatter.FormatDocumentAsync(isSignature, content, config)
@@ -268,10 +269,11 @@ let walkFormatting
         match firstDifference original after with
         | Some line -> FormatChange.Reformatted(line, after.Length)
         | None ->
-            if content <> formatted then
-                FormatChange.LineEndingsOnly
-            else
-                FormatChange.Nothing
+
+        if content <> formatted then
+            FormatChange.LineEndingsOnly
+        else
+            FormatChange.Nothing
 
     let report: DoctorReport =
         { report with
@@ -305,13 +307,14 @@ let walkFormatting
             match firstDifference first second with
             | None -> IdempotencyStep.Idempotent
             | Some line ->
-                let at (source: string array) : string =
-                    if line <= source.Length then
-                        source.[line - 1]
-                    else
-                        String.Empty
 
-                IdempotencyStep.NotIdempotent(line, at first, at second)
+            let at (source: string array) : string =
+                if line <= source.Length then
+                    source.[line - 1]
+                else
+                    String.Empty
+
+            IdempotencyStep.NotIdempotent(line, at first, at second)
         with error ->
             IdempotencyStep.Failed error
 

--- a/src/Fantomas/EditorConfig.fs
+++ b/src/Fantomas/EditorConfig.fs
@@ -213,13 +213,15 @@ let parseOptionsFromEditorConfig
             match properties.TryGetValue setting with
             | false, _ -> defaultValue
             | true, struct (written, value) ->
-                match parseSettingValue defaultValue value with
-                | Some parsed -> parsed
-                | None ->
-                    if not (isSpecDefinedNonValue setting value) then
-                        unrecognizedValues.Add(written, value)
 
-                    defaultValue
+            match parseSettingValue defaultValue value with
+            | Some parsed -> parsed
+            | None ->
+
+            if not (isSpecDefinedNonValue setting value) then
+                unrecognizedValues.Add(written, value)
+
+            defaultValue
         )
 
     let config =

--- a/src/Fantomas/EditorConfig.fs
+++ b/src/Fantomas/EditorConfig.fs
@@ -274,20 +274,21 @@ let tryReadConfiguration (fsharpFile: string) : EditorConfigResult option =
     if editorConfigSettings.Properties.Count = 0 then
         None
     else
-        let config, problems =
-            parseOptionsFromEditorConfig FormatConfig.Default editorConfigSettings.Properties
 
-        let editorConfigFiles =
-            editorConfigSettings.EditorConfigFiles
-            |> Seq.map editorConfigFilePath
-            |> Seq.toList
+    let config, problems =
+        parseOptionsFromEditorConfig FormatConfig.Default editorConfigSettings.Properties
 
-        Some
-            {
-                Config = config
-                EditorConfigFiles = editorConfigFiles
-                Problems = problems
-            }
+    let editorConfigFiles =
+        editorConfigSettings.EditorConfigFiles
+        |> Seq.map editorConfigFilePath
+        |> Seq.toList
+
+    Some
+        {
+            Config = config
+            EditorConfigFiles = editorConfigFiles
+            Problems = problems
+        }
 
 type ResolvedSetting =
     {

--- a/src/Fantomas/EditorConfigReport.fs
+++ b/src/Fantomas/EditorConfigReport.fs
@@ -50,26 +50,27 @@ let describe (origin: string) (problems: EditorConfigProblem list) : string opti
     if List.isEmpty problems then
         None
     else
-        let namesAnyUnknownSetting =
-            problems
-            |> List.exists (fun problem ->
-                match problem with
-                | EditorConfigProblem.UnknownSetting _ -> true
-                | EditorConfigProblem.UnrecognizedValue _ -> false
-            )
 
-        [
-            yield ""
-            yield $"Fantomas cannot use some settings from %s{origin}:"
-            for problem in problems do
-                yield String.Concat("  ", describeProblem problem)
-            if namesAnyUnknownSetting then
-                yield
-                    $"Run fantomas with --verbosity d to see every .editorconfig setting fantomas %s{fantomasVersion} supports."
-            yield ""
-        ]
-        |> String.concat Environment.NewLine
-        |> Some
+    let namesAnyUnknownSetting =
+        problems
+        |> List.exists (fun problem ->
+            match problem with
+            | EditorConfigProblem.UnknownSetting _ -> true
+            | EditorConfigProblem.UnrecognizedValue _ -> false
+        )
+
+    [
+        yield ""
+        yield $"Fantomas cannot use some settings from %s{origin}:"
+        for problem in problems do
+            yield String.Concat("  ", describeProblem problem)
+        if namesAnyUnknownSetting then
+            yield
+                $"Run fantomas with --verbosity d to see every .editorconfig setting fantomas %s{fantomasVersion} supports."
+        yield ""
+    ]
+    |> String.concat Environment.NewLine
+    |> Some
 
 let describeSupportedSettings () : string =
     [

--- a/src/Fantomas/EditorConfigReport.fs
+++ b/src/Fantomas/EditorConfigReport.fs
@@ -94,30 +94,32 @@ let createReporter (log: ILogger) : EditorConfigReporter =
         match describe origin problems with
         | None -> ()
         | Some report ->
-            if reported.TryAdd(report, ()) then
-                // The report carries what someone wrote in their `.editorconfig`, so it travels as
-                // a property rather than as the message template: a `{` in a value would otherwise
-                // be read as the start of one.
-                log.Warning("{EditorConfigReport}", report)
 
-            if
-                log.IsEnabled LogEventLevel.Debug
-                && Threading.Interlocked.Exchange(&supportedSettingsWritten.contents, 1) = 0
-            then
-                log.Debug("{SupportedEditorConfigSettings}", describeSupportedSettings ())
+        if reported.TryAdd(report, ()) then
+            // The report carries what someone wrote in their `.editorconfig`, so it travels as
+            // a property rather than as the message template: a `{` in a value would otherwise
+            // be read as the start of one.
+            log.Warning("{EditorConfigReport}", report)
+
+        if
+            log.IsEnabled LogEventLevel.Debug
+            && Threading.Interlocked.Exchange(&supportedSettingsWritten.contents, 1) = 0
+        then
+            log.Debug("{SupportedEditorConfigSettings}", describeSupportedSettings ())
 
 let readConfiguration (report: EditorConfigReporter) (fsharpFile: string) : FormatConfig =
     match tryReadConfiguration fsharpFile with
     | None -> FormatConfig.Default
     | Some result ->
-        let origin =
-            match result.EditorConfigFiles with
-            // The editorconfig library only reports settings it read from a file, so it should
-            // always name at least one. Keep a way through anyway, because that is its invariant
-            // and not ours, but do not name the F# file as the origin: nothing is wrong with it,
-            // and pointing at it sends someone looking in the wrong place.
-            | [] -> $"the .editorconfig that applies to %s{fsharpFile}"
-            | files -> String.concat ", " files
 
-        report origin result.Problems
-        result.Config
+    let origin =
+        match result.EditorConfigFiles with
+        // The editorconfig library only reports settings it read from a file, so it should
+        // always name at least one. Keep a way through anyway, because that is its invariant
+        // and not ours, but do not name the F# file as the origin: nothing is wrong with it,
+        // and pointing at it sends someone looking in the wrong place.
+        | [] -> $"the .editorconfig that applies to %s{fsharpFile}"
+        | files -> String.concat ", " files
+
+    report origin result.Problems
+    result.Config

--- a/src/Fantomas/FormatCommand.fs
+++ b/src/Fantomas/FormatCommand.fs
@@ -41,28 +41,30 @@ let formatContentAsync (formatParams: FormatParams) (originalContent: string) : 
                 CodeFormatter.FormatDocumentAsync(isSignatureFile, originalContent, formatParams.Config)
 
             let contentChanged: bool =
-                if formatParams.CompareWithoutLineEndings then
-                    let stripNewlines (s: string) : string = carriageReturn.Replace(s, String.Empty)
-
-                    (stripNewlines originalContent) <> (stripNewlines formattedContent)
-                else
+                if not formatParams.CompareWithoutLineEndings then
                     originalContent <> formattedContent
-
-            if contentChanged then
-                let! (validation: ValidationResult) =
-                    CodeFormatter.ValidateFSharpCodeAsync(isSignatureFile, formattedContent)
-
-                if not validation.IsValid then
-                    return
-                        FormatResult.InvalidCode(
-                            filename = formatParams.File,
-                            formattedContent = formattedContent,
-                            diagnostics = validation.Diagnostics
-                        )
                 else
-                    return FormatResult.Formatted(filename = formatParams.File, formattedContent = formattedContent)
-            else
+
+                let stripNewlines (s: string) : string = carriageReturn.Replace(s, String.Empty)
+
+                (stripNewlines originalContent) <> (stripNewlines formattedContent)
+
+            if not contentChanged then
                 return FormatResult.Unchanged(filename = formatParams.File)
+            else
+
+            let! (validation: ValidationResult) =
+                CodeFormatter.ValidateFSharpCodeAsync(isSignatureFile, formattedContent)
+
+            if validation.IsValid then
+                return FormatResult.Formatted(filename = formatParams.File, formattedContent = formattedContent)
+            else
+                return
+                    FormatResult.InvalidCode(
+                        filename = formatParams.File,
+                        formattedContent = formattedContent,
+                        diagnostics = validation.Diagnostics
+                    )
         with ex ->
             return FormatResult.Error(formatParams.File, ex)
     }
@@ -178,12 +180,12 @@ let processFile
                 if not inPlace then
                     ensureParentFolderExists fs outputFile
 
-                if source.HasByteOrderMark then
+                if not source.HasByteOrderMark then
+                    do! fs.File.WriteAllTextAsync(outputFile, contents) |> Async.AwaitTask
+                else
                     do!
                         fs.File.WriteAllTextAsync(outputFile, contents, Encoding.UTF8)
                         |> Async.AwaitTask
-                else
-                    do! fs.File.WriteAllTextAsync(outputFile, contents) |> Async.AwaitTask
 
                 env.Log.Debug $"%s{outputFile} has been written."
 

--- a/src/Fantomas/HelpPage.fs
+++ b/src/Fantomas/HelpPage.fs
@@ -216,8 +216,9 @@ let writeFlag
     match description with
     | [] -> write left
     | first :: rest ->
-        writeRow write descriptionColumn left first
-        List.iter (writeContinuation write descriptionColumn) rest
+
+    writeRow write descriptionColumn left first
+    List.iter (writeContinuation write descriptionColumn) rest
 
 let writeExample
     (write: string -> unit)
@@ -236,8 +237,9 @@ let writeLink (write: string -> unit) (theme: Theme) (label: string, urls: strin
     match urls with
     | [] -> ()
     | first :: rest ->
-        writeRow write linkColumn label (link theme first)
-        List.iter (fun (url: string) -> writeContinuation write linkColumn (link theme url)) rest
+
+    writeRow write linkColumn label (link theme first)
+    List.iter (fun (url: string) -> writeContinuation write linkColumn (link theme url)) rest
 
 let renderOverview (theme: Theme) (invocation: string) : string list =
     let lines: ResizeArray<string> = ResizeArray()

--- a/src/Fantomas/IgnoreFile.fs
+++ b/src/Fantomas/IgnoreFile.fs
@@ -149,22 +149,23 @@ module IgnoreFile =
         match ignoreFile with
         | None -> false
         | Some ignoreFile ->
-            let fs: IFileSystem = ignoreFile.Location.FileSystem
-            let fullPath: AbsoluteFilePath = AbsoluteFilePath.Create fs file
 
-            try
-                ignoreFile.IsIgnored fullPath
-            with ex ->
-                // Matching a path against the ignore file is not something that should fail. If it
-                // does, say which file and which ignore file could not be told apart, and go on to
-                // format the file rather than abandon the run over it.
-                log.Error
-                    $"Could not tell whether '%s{file}' is matched by %s{ignoreFile.Location.FullName}: %s{ex.Message}"
+        let fs: IFileSystem = ignoreFile.Location.FileSystem
+        let fullPath: AbsoluteFilePath = AbsoluteFilePath.Create fs file
 
-                // The line above is the one to act on; this keeps the type and the stack trace for
-                // whoever asks for detail.
-                log.Debug $"%A{ex}"
-                false
+        try
+            ignoreFile.IsIgnored fullPath
+        with ex ->
+            // Matching a path against the ignore file is not something that should fail. If it
+            // does, say which file and which ignore file could not be told apart, and go on to
+            // format the file rather than abandon the run over it.
+            log.Error
+                $"Could not tell whether '%s{file}' is matched by %s{ignoreFile.Location.FullName}: %s{ex.Message}"
+
+            // The line above is the one to act on; this keeps the type and the stack trace for
+            // whoever asks for detail.
+            log.Debug $"%A{ex}"
+            false
 
     let matchingLines (ignoreFile: IgnoreFile) (file: string) : IgnoreMatch list =
         let fs: IFileSystem = ignoreFile.Location.FileSystem

--- a/src/Fantomas/IgnoreFile.fs
+++ b/src/Fantomas/IgnoreFile.fs
@@ -45,17 +45,19 @@ module IgnoreFile =
             if isNull currentDirectory then
                 None
             else
-                let potentialFile =
-                    fs.Path.Combine(currentDirectory.FullName, IgnoreFileName) |> fs.FileInfo.New
 
-                if potentialFile.Exists then
-                    {
-                        Location = potentialFile
-                        IsIgnored = loadIgnoreList potentialFile.FullName
-                    }
-                    |> Some
-                else
-                    walkUp currentDirectory.Parent
+            let potentialFile =
+                fs.Path.Combine(currentDirectory.FullName, IgnoreFileName) |> fs.FileInfo.New
+
+            if not potentialFile.Exists then
+                walkUp currentDirectory.Parent
+            else
+
+            {
+                Location = potentialFile
+                IsIgnored = loadIgnoreList potentialFile.FullName
+            }
+            |> Some
 
         walkUp (fs.FileInfo.New(filePath).Directory)
 
@@ -103,20 +105,21 @@ module IgnoreFile =
             if isNull currentDirectory then
                 List.rev found
             else
-                let potentialFile: IFileInfo =
-                    fs.Path.Combine(currentDirectory.FullName, IgnoreFileName) |> fs.FileInfo.New
 
-                let found: IgnoreFile list =
-                    if potentialFile.Exists then
-                        {
-                            Location = potentialFile
-                            IsIgnored = loadIgnoreList potentialFile.FullName
-                        }
-                        :: found
-                    else
-                        found
+            let potentialFile: IFileInfo =
+                fs.Path.Combine(currentDirectory.FullName, IgnoreFileName) |> fs.FileInfo.New
 
-                walkUp currentDirectory.Parent found
+            let found: IgnoreFile list =
+                if not potentialFile.Exists then
+                    found
+                else
+                    {
+                        Location = potentialFile
+                        IsIgnored = loadIgnoreList potentialFile.FullName
+                    }
+                    :: found
+
+            walkUp currentDirectory.Parent found
 
         // Every one above rather than the next one up. Two ignore files above the nearest is not a
         // layout anybody sets out to build, and it is exactly the layout where the reader has the

--- a/src/Fantomas/Invocation.fs
+++ b/src/Fantomas/Invocation.fs
@@ -10,13 +10,15 @@ let nameOf (processPath: string option) : string =
     match processPath with
     | None -> "fantomas"
     | Some path ->
-        match Path.GetFileNameWithoutExtension path with
-        | "" -> "fantomas"
-        | executable ->
-            if String.Equals(executable, "dotnet", StringComparison.OrdinalIgnoreCase) then
-                "dotnet fantomas"
-            else
-                executable
+
+    match Path.GetFileNameWithoutExtension path with
+    | "" -> "fantomas"
+    | executable ->
+
+    if String.Equals(executable, "dotnet", StringComparison.OrdinalIgnoreCase) then
+        "dotnet fantomas"
+    else
+        executable
 
 let name () : string =
     nameOf (Option.ofObj Environment.ProcessPath)

--- a/src/Fantomas/JsonReport.fs
+++ b/src/Fantomas/JsonReport.fs
@@ -155,33 +155,34 @@ let checkReport (workingDirectory: string) (result: CheckCommandResult) : RunRep
         | CheckCommandResult.Failed error -> Some error.Message, []
         | CheckCommandResult.InvalidInput problem -> Some(describeInputProblem problem), []
         | CheckCommandResult.Completed(_, checkResult) ->
-            // A file that could not be formatted is counted as changed as well as errored, so it
-            // would otherwise be listed twice under two different answers.
-            let failed: Set<string> = checkResult.Errors |> List.map fst |> Set.ofList
 
-            let files: FileReport list =
-                [
-                    for file, error in checkResult.Errors do
+        // A file that could not be formatted is counted as changed as well as errored, so it
+        // would otherwise be listed twice under two different answers.
+        let failed: Set<string> = checkResult.Errors |> List.map fst |> Set.ofList
+
+        let files: FileReport list =
+            [
+                for file, error in checkResult.Errors do
+                    {
+                        Path = file
+                        Outcome = describeFileFailure file error
+                    }
+
+                for file in checkResult.Formatted do
+                    if not (Set.contains file failed) then
                         {
                             Path = file
-                            Outcome = describeFileFailure file error
+                            Outcome = FileOutcome.NeedsFormatting
                         }
 
-                    for file in checkResult.Formatted do
-                        if not (Set.contains file failed) then
-                            {
-                                Path = file
-                                Outcome = FileOutcome.NeedsFormatting
-                            }
+                for file in checkResult.Unchanged do
+                    {
+                        Path = file
+                        Outcome = FileOutcome.Unchanged
+                    }
+            ]
 
-                    for file in checkResult.Unchanged do
-                        {
-                            Path = file
-                            Outcome = FileOutcome.Unchanged
-                        }
-                ]
-
-            None, sortByPath files
+        None, sortByPath files
 
     {
         Command = Command.Check
@@ -198,27 +199,28 @@ let profileReport (workingDirectory: string) (result: ProfileCommand.ProfileComm
         | ProfileCommand.ProfileCommandResult.Failed error -> Some error.Message, None, []
         | ProfileCommand.ProfileCommandResult.InvalidInput problem -> Some(describeInputProblem problem), None, []
         | ProfileCommand.ProfileCommandResult.Completed profile ->
-            let files: FileReport list =
-                [
-                    for file, error in profile.Errors do
-                        {
-                            Path = file
-                            Outcome = describeFileFailure file error
-                        }
 
-                    for timing in profile.Timings do
-                        {
-                            Path = timing.File
-                            Outcome =
-                                FileOutcome.Timed(
-                                    timing.LineCount,
-                                    timing.DefineCombinations,
-                                    int (round timing.TimeTaken.TotalMilliseconds)
-                                )
-                        }
-                ]
+        let files: FileReport list =
+            [
+                for file, error in profile.Errors do
+                    {
+                        Path = file
+                        Outcome = describeFileFailure file error
+                    }
 
-            None, Some(int (round profile.Elapsed.TotalMilliseconds)), sortByPath files
+                for timing in profile.Timings do
+                    {
+                        Path = timing.File
+                        Outcome =
+                            FileOutcome.Timed(
+                                timing.LineCount,
+                                timing.DefineCombinations,
+                                int (round timing.TimeTaken.TotalMilliseconds)
+                            )
+                    }
+            ]
+
+        None, Some(int (round profile.Elapsed.TotalMilliseconds)), sortByPath files
 
     {
         Command = Command.Profile
@@ -389,41 +391,42 @@ let writeDoctorIgnore (json: Utf8JsonWriter) (step: IgnoreStep option) : unit =
     match step with
     | None -> json.WriteNull "ignore"
     | Some step ->
-        json.WriteStartObject "ignore"
 
-        match step with
-        | IgnoreStep.NoIgnoreFile ->
-            json.WriteString("status", "no-ignore-file")
-            json.WriteNull "ignoreFile"
+    json.WriteStartObject "ignore"
+
+    match step with
+    | IgnoreStep.NoIgnoreFile ->
+        json.WriteString("status", "no-ignore-file")
+        json.WriteNull "ignoreFile"
+        json.WriteStartArray "matches"
+        json.WriteEndArray()
+        json.WriteStartArray "shadowed"
+        json.WriteEndArray()
+    | IgnoreStep.Governed(ignoreFile, isIgnored, matches, shadowed) ->
+        json.WriteString("status", (if isIgnored then "ignored" else "not-ignored"))
+        json.WriteString("ignoreFile", ignoreFile)
+        json.WriteStartArray "matches"
+        List.iter (writeIgnoreMatch json) matches
+        json.WriteEndArray()
+
+        // Every ignore file above the one that governs the file, whether or not it would have
+        // decided anything, rather than only the ones that disagree. The reader of the document
+        // is a program, which can filter on `wouldIgnore` itself and cannot ask for the ones
+        // that were left out.
+        json.WriteStartArray "shadowed"
+
+        for above in shadowed do
+            json.WriteStartObject()
+            json.WriteString("path", above.Path)
+            json.WriteBoolean("wouldIgnore", above.WouldIgnore)
             json.WriteStartArray "matches"
+            List.iter (writeIgnoreMatch json) above.Matches
             json.WriteEndArray()
-            json.WriteStartArray "shadowed"
-            json.WriteEndArray()
-        | IgnoreStep.Governed(ignoreFile, isIgnored, matches, shadowed) ->
-            json.WriteString("status", (if isIgnored then "ignored" else "not-ignored"))
-            json.WriteString("ignoreFile", ignoreFile)
-            json.WriteStartArray "matches"
-            List.iter (writeIgnoreMatch json) matches
-            json.WriteEndArray()
+            json.WriteEndObject()
 
-            // Every ignore file above the one that governs the file, whether or not it would have
-            // decided anything, rather than only the ones that disagree. The reader of the document
-            // is a program, which can filter on `wouldIgnore` itself and cannot ask for the ones
-            // that were left out.
-            json.WriteStartArray "shadowed"
+        json.WriteEndArray()
 
-            for above in shadowed do
-                json.WriteStartObject()
-                json.WriteString("path", above.Path)
-                json.WriteBoolean("wouldIgnore", above.WouldIgnore)
-                json.WriteStartArray "matches"
-                List.iter (writeIgnoreMatch json) above.Matches
-                json.WriteEndArray()
-                json.WriteEndObject()
-
-            json.WriteEndArray()
-
-        json.WriteEndObject()
+    json.WriteEndObject()
 
 let writeEditorConfigProblem (json: Utf8JsonWriter) (problem: EditorConfigProblem) : unit =
     json.WriteStartObject()
@@ -447,67 +450,69 @@ let writeDoctorConfiguration (json: Utf8JsonWriter) (resolved: ResolvedConfig op
     match resolved with
     | None -> json.WriteNull "configuration"
     | Some resolved ->
-        json.WriteStartObject "configuration"
 
-        json.WriteStartArray "editorConfigFiles"
+    json.WriteStartObject "configuration"
 
-        for file in resolved.EditorConfigFiles do
-            json.WriteStringValue file
+    json.WriteStartArray "editorConfigFiles"
 
-        json.WriteEndArray()
+    for file in resolved.EditorConfigFiles do
+        json.WriteStringValue file
 
-        json.WriteStartArray "problems"
-        List.iter (writeEditorConfigProblem json) resolved.Problems
-        json.WriteEndArray()
+    json.WriteEndArray()
 
-        json.WriteStartArray "settings"
+    json.WriteStartArray "problems"
+    List.iter (writeEditorConfigProblem json) resolved.Problems
+    json.WriteEndArray()
 
-        for setting in resolved.Settings do
-            json.WriteStartObject()
-            json.WriteString("setting", setting.Setting)
-            json.WriteString("value", setting.Value)
+    json.WriteStartArray "settings"
 
-            match setting.SetBy with
-            | None -> json.WriteNull "setBy"
-            | Some file -> json.WriteString("setBy", file)
+    for setting in resolved.Settings do
+        json.WriteStartObject()
+        json.WriteString("setting", setting.Setting)
+        json.WriteString("value", setting.Value)
 
-            json.WriteEndObject()
+        match setting.SetBy with
+        | None -> json.WriteNull "setBy"
+        | Some file -> json.WriteString("setBy", file)
 
-        json.WriteEndArray()
         json.WriteEndObject()
+
+    json.WriteEndArray()
+    json.WriteEndObject()
 
 let writeDoctorFormat (json: Utf8JsonWriter) (path: string) (step: FormatStep option) : unit =
     match step with
     | None -> json.WriteNull "format"
     | Some step ->
-        json.WriteStartObject "format"
 
-        match step with
-        | FormatStep.Produced(_, FormatChange.Nothing) -> json.WriteString("status", "unchanged")
-        // No line of the file changes and the file is still rewritten. `status` is what tells this
-        // apart from a file that needs nothing, which is why there is no count here to read instead.
-        | FormatStep.Produced(_, FormatChange.LineEndingsOnly) -> json.WriteString("status", "line-endings")
-        | FormatStep.Produced(_, FormatChange.Reformatted(firstChangedLine, lineCountAfter)) ->
-            json.WriteString("status", "changed")
-            json.WriteNumber("firstChangedLine", firstChangedLine)
-            json.WriteNumber("lineCountAfter", lineCountAfter)
-        | FormatStep.Failed error ->
-            json.WriteString("status", "failed")
+    json.WriteStartObject "format"
 
-            match describeFileFailure path error with
-            | FileOutcome.Failed(message, diagnostics) ->
-                json.WriteString("message", message)
-                json.WriteStartArray "diagnostics"
-                List.iter (writeDiagnostic json) diagnostics
-                json.WriteEndArray()
-            // `describeFileFailure` answers with nothing else. Named rather than swept up by a
-            // wildcard, so that a case added to it has to be placed here deliberately.
-            | FileOutcome.Formatted
-            | FileOutcome.Unchanged
-            | FileOutcome.NeedsFormatting
-            | FileOutcome.Timed _ -> ()
+    match step with
+    | FormatStep.Produced(_, FormatChange.Nothing) -> json.WriteString("status", "unchanged")
+    // No line of the file changes and the file is still rewritten. `status` is what tells this
+    // apart from a file that needs nothing, which is why there is no count here to read instead.
+    | FormatStep.Produced(_, FormatChange.LineEndingsOnly) -> json.WriteString("status", "line-endings")
+    | FormatStep.Produced(_, FormatChange.Reformatted(firstChangedLine, lineCountAfter)) ->
+        json.WriteString("status", "changed")
+        json.WriteNumber("firstChangedLine", firstChangedLine)
+        json.WriteNumber("lineCountAfter", lineCountAfter)
+    | FormatStep.Failed error ->
+        json.WriteString("status", "failed")
 
-        json.WriteEndObject()
+        match describeFileFailure path error with
+        | FileOutcome.Failed(message, diagnostics) ->
+            json.WriteString("message", message)
+            json.WriteStartArray "diagnostics"
+            List.iter (writeDiagnostic json) diagnostics
+            json.WriteEndArray()
+        // `describeFileFailure` answers with nothing else. Named rather than swept up by a
+        // wildcard, so that a case added to it has to be placed here deliberately.
+        | FileOutcome.Formatted
+        | FileOutcome.Unchanged
+        | FileOutcome.NeedsFormatting
+        | FileOutcome.Timed _ -> ()
+
+    json.WriteEndObject()
 
 // The diagnostics of invalid output are positions in output that was thrown away rather than in the
 // file at `path`, exactly as they are for a format run, and the same warning applies: a caller
@@ -516,39 +521,41 @@ let writeDoctorValidity (json: Utf8JsonWriter) (step: ValidityStep option) : uni
     match step with
     | None -> json.WriteNull "validity"
     | Some step ->
-        json.WriteStartObject "validity"
 
-        match step with
-        | ValidityStep.Valid ->
-            json.WriteString("status", "valid")
-            json.WriteStartArray "diagnostics"
-            json.WriteEndArray()
-        | ValidityStep.Invalid diagnostics ->
-            json.WriteString("status", "invalid")
-            json.WriteStartArray "diagnostics"
-            List.iter (writeDiagnostic json) (List.map describeDiagnostic diagnostics)
-            json.WriteEndArray()
+    json.WriteStartObject "validity"
 
-        json.WriteEndObject()
+    match step with
+    | ValidityStep.Valid ->
+        json.WriteString("status", "valid")
+        json.WriteStartArray "diagnostics"
+        json.WriteEndArray()
+    | ValidityStep.Invalid diagnostics ->
+        json.WriteString("status", "invalid")
+        json.WriteStartArray "diagnostics"
+        List.iter (writeDiagnostic json) (List.map describeDiagnostic diagnostics)
+        json.WriteEndArray()
+
+    json.WriteEndObject()
 
 let writeDoctorIdempotency (json: Utf8JsonWriter) (step: IdempotencyStep option) : unit =
     match step with
     | None -> json.WriteNull "idempotency"
     | Some step ->
-        json.WriteStartObject "idempotency"
 
-        match step with
-        | IdempotencyStep.Idempotent -> json.WriteString("status", "idempotent")
-        | IdempotencyStep.Failed error ->
-            json.WriteString("status", "failed")
-            json.WriteString("message", error.Message)
-        | IdempotencyStep.NotIdempotent(line, afterFirstPass, afterSecondPass) ->
-            json.WriteString("status", "not-idempotent")
-            json.WriteNumber("line", line)
-            json.WriteString("afterFirstPass", afterFirstPass)
-            json.WriteString("afterSecondPass", afterSecondPass)
+    json.WriteStartObject "idempotency"
 
-        json.WriteEndObject()
+    match step with
+    | IdempotencyStep.Idempotent -> json.WriteString("status", "idempotent")
+    | IdempotencyStep.Failed error ->
+        json.WriteString("status", "failed")
+        json.WriteString("message", error.Message)
+    | IdempotencyStep.NotIdempotent(line, afterFirstPass, afterSecondPass) ->
+        json.WriteString("status", "not-idempotent")
+        json.WriteNumber("line", line)
+        json.WriteString("afterFirstPass", afterFirstPass)
+        json.WriteString("afterSecondPass", afterSecondPass)
+
+    json.WriteEndObject()
 
 let writeDoctorDocument (json: Utf8JsonWriter) (workingDirectory: string) (result: DoctorCommandResult) : unit =
     json.WriteStartObject()

--- a/src/Fantomas/Report.fs
+++ b/src/Fantomas/Report.fs
@@ -217,11 +217,12 @@ let reportError (env: CliEnvironment) (verbosity: VerbosityLevel) (file: string,
     match describeItself env.ErrorTheme file source verbose error with
     | Some report -> env.Log.Error(String.Concat(glyphs.Errored, " ", report))
     | None ->
-        env.Log.Error(describeOther ())
 
-        // The line above is the one to act on; this keeps the type and the stack trace for whoever
-        // asks for detail, rather than replacing the message with them.
-        env.Log.Debug $"%A{error}"
+    env.Log.Error(describeOther ())
+
+    // The line above is the one to act on; this keeps the type and the stack trace for whoever
+    // asks for detail, rather than replacing the message with them.
+    env.Log.Debug $"%A{error}"
 
 // A single named file is answered on its own terms: the caller asked about this file, so every
 // state it can be in is said out loud, and there is no summary to add to one line.
@@ -541,8 +542,9 @@ let reportCheckResults
     match List.choose id [ summary; fix ] with
     | [] -> ()
     | lines ->
-        env.Log.Information ""
-        env.Log.Information(String.concat " " lines)
+
+    env.Log.Information ""
+    env.Log.Information(String.concat " " lines)
 
 // What is printed and what the process ends with are decided apart from each other, so that this
 // reporter and the JSON one cannot end the same run with different codes.
@@ -664,16 +666,17 @@ let describeDoctorFile (theme: Theme) (glyphs: StatusGlyphs) (step: FileStep) : 
         match file.UnreachableUnder with
         | None -> doctorRow glyphs.Formatted "File" says
         | Some folder ->
-            // Not a failure: naming the file, which is what this run did, formats it. It is the
-            // answer to the question that brings somebody here with a file under `obj`, and the
-            // ignore file they were about to go and read has nothing to do with it.
-            { doctorRow glyphs.NeedsFormatting "File" says with
-                Detail =
-                    [
-                        $"It sits under %s{link theme folder}, which Fantomas never opens, so a run over a"
-                        "folder above it does not reach this file. Naming the file itself, as here, does."
-                    ]
-            }
+
+        // Not a failure: naming the file, which is what this run did, formats it. It is the
+        // answer to the question that brings somebody here with a file under `obj`, and the
+        // ignore file they were about to go and read has nothing to do with it.
+        { doctorRow glyphs.NeedsFormatting "File" says with
+            Detail =
+                [
+                    $"It sits under %s{link theme folder}, which Fantomas never opens, so a run over a"
+                    "folder above it does not reach this file. Naming the file itself, as here, does."
+                ]
+        }
 
 let describeIgnoreMatch (theme: Theme) (matched: IgnoreMatch) : string =
     String.Concat("line ", string<int> matched.LineNumber, ": ", flagName theme matched.Pattern)
@@ -682,115 +685,117 @@ let describeDoctorIgnore (theme: Theme) (glyphs: StatusGlyphs) (verbose: bool) (
     match step with
     | IgnoreStep.NoIgnoreFile -> doctorRow glyphs.Formatted "Ignore" "No .fantomasignore at or above this file."
     | IgnoreStep.Governed(ignoreFile, isIgnored, matches, shadowed) ->
-        let deciding: IgnoreMatch option = List.tryLast matches
 
-        // A path is somewhere the reader can go and a pattern is something they can type, here as
-        // in the lines below. A sentence is no reason for either to lose its colour.
-        let ignoreFile: string = link theme ignoreFile
-        let pattern (matched: IgnoreMatch) : string = flagName theme matched.Pattern
+    let deciding: IgnoreMatch option = List.tryLast matches
 
-        let says: string =
-            match isIgnored, deciding with
-            | true, Some matched -> $"Matched by %s{ignoreFile}, line %d{matched.LineNumber}: %s{pattern matched}"
-            | true, None ->
-                // The ignore library said yes and no pattern of the file says so on its own. That
-                // should not happen, and if it does the verdict is the one that decides what
-                // happens to the file, so the verdict is what is reported.
-                $"Matched by %s{ignoreFile}. Which pattern matched could not be worked out."
-            | false, Some matched when matched.Negated ->
-                $"Not matched: line %d{matched.LineNumber} of %s{ignoreFile}, %s{pattern matched}, takes it back out."
-            | false, _ -> $"Governed by %s{ignoreFile}, and no pattern in it matches."
+    // A path is somewhere the reader can go and a pattern is something they can type, here as
+    // in the lines below. A sentence is no reason for either to lose its colour.
+    let ignoreFile: string = link theme ignoreFile
+    let pattern (matched: IgnoreMatch) : string = flagName theme matched.Pattern
 
-        // Read out one at a time only where there is more than one, since a single match is
-        // already quoted in the line above. Several is where it earns its space: what decided is
-        // the last of them, and a `!` line further down is exactly the case nobody spots by eye.
-        let listed: string list =
-            if List.length matches > 1 then
-                List.map (describeIgnoreMatch theme) matches @ [ "The last of these decides." ]
-            else
-                []
+    let says: string =
+        match isIgnored, deciding with
+        | true, Some matched -> $"Matched by %s{ignoreFile}, line %d{matched.LineNumber}: %s{pattern matched}"
+        | true, None ->
+            // The ignore library said yes and no pattern of the file says so on its own. That
+            // should not happen, and if it does the verdict is the one that decides what
+            // happens to the file, so the verdict is what is reported.
+            $"Matched by %s{ignoreFile}. Which pattern matched could not be worked out."
+        | false, Some matched when matched.Negated ->
+            $"Not matched: line %d{matched.LineNumber} of %s{ignoreFile}, %s{pattern matched}, takes it back out."
+        | false, _ -> $"Governed by %s{ignoreFile}, and no pattern in it matches."
 
-        // An ignore file further up that would have skipped this file, where the one that governs
-        // it does not. The only arrangement of ignore files worth interrupting the report for, and
-        // the one somebody arrives with: a pattern written in a repository's ignore file that had
-        // no effect, and an ignore file in a subfolder they had forgotten writing.
-        //
-        // The other direction says nothing. Where the governing file already skips the file, what
-        // one further up would have made of it changes neither the outcome nor what the reader is
-        // puzzled by, and the line that names the pattern which decided is already there.
-        let overruled: ShadowedIgnoreFile list =
-            if isIgnored then
-                []
-            else
-                List.filter (fun (above: ShadowedIgnoreFile) -> above.WouldIgnore) shadowed
+    // Read out one at a time only where there is more than one, since a single match is
+    // already quoted in the line above. Several is where it earns its space: what decided is
+    // the last of them, and a `!` line further down is exactly the case nobody spots by eye.
+    let listed: string list =
+        if List.length matches > 1 then
+            List.map (describeIgnoreMatch theme) matches @ [ "The last of these decides." ]
+        else
+            []
 
-        let overruledLines: string list =
-            match overruled with
-            | [] -> []
-            | files ->
-                [
-                    for file in files do
-                        let path: string = link theme file.Path
+    // An ignore file further up that would have skipped this file, where the one that governs
+    // it does not. The only arrangement of ignore files worth interrupting the report for, and
+    // the one somebody arrives with: a pattern written in a repository's ignore file that had
+    // no effect, and an ignore file in a subfolder they had forgotten writing.
+    //
+    // The other direction says nothing. Where the governing file already skips the file, what
+    // one further up would have made of it changes neither the outcome nor what the reader is
+    // puzzled by, and the line that names the pattern which decided is already there.
+    let overruled: ShadowedIgnoreFile list =
+        if isIgnored then
+            []
+        else
+            List.filter (fun (above: ShadowedIgnoreFile) -> above.WouldIgnore) shadowed
 
-                        match List.tryLast file.Matches with
-                        | Some matched ->
-                            $"%s{path} is above it and has no say: line %d{matched.LineNumber}, %s{pattern matched}, would have skipped this file."
-                        | None ->
-                            // Same disagreement between the verdict and the lines that the
-                            // governing file can have, and survived the same way.
-                            $"%s{path} is above it and has no say. It would have skipped this file."
+    let overruledLines: string list =
+        match overruled with
+        | [] -> []
+        | files ->
 
-                    "Fantomas reads the nearest .fantomasignore and no other, where .gitignore applies"
-                    "every one above the file as well."
-                ]
+        [
+            for file in files do
+                let path: string = link theme file.Path
 
-        // The rest of the chain, for whoever asked for detail. Named rather than described: none of
-        // them decided anything, and the one that would have is already spelled out above.
-        let alsoAbove: string list =
-            // The complement of `overruled`, said the same way round rather than by subtracting one
-            // list from the other, which would ask an equality of the record that nothing else
-            // needs.
-            let quiet: string list =
-                shadowed
-                |> List.choose (fun (above: ShadowedIgnoreFile) ->
-                    if isIgnored || not above.WouldIgnore then
-                        Some(link theme above.Path)
-                    else
-                        None
-                )
+                match List.tryLast file.Matches with
+                | Some matched ->
+                    $"%s{path} is above it and has no say: line %d{matched.LineNumber}, %s{pattern matched}, would have skipped this file."
+                | None ->
+                    // Same disagreement between the verdict and the lines that the
+                    // governing file can have, and survived the same way.
+                    $"%s{path} is above it and has no say. It would have skipped this file."
 
-            if verbose && not (List.isEmpty quiet) then
-                [ $"Also above it, with no say: %s{andList quiet}." ]
-            else
-                []
+            "Fantomas reads the nearest .fantomasignore and no other, where .gitignore applies"
+            "every one above the file as well."
+        ]
 
-        // The difference from `.gitignore` that catches people out, said to whoever asked for
-        // detail rather than on every run. Not said twice: where an ignore file above was actually
-        // overruled, the lines that report it carry the rule already.
-        let nearestOnly: string list =
-            if verbose && List.isEmpty overruled then
-                [
-                    "This is the nearest .fantomasignore at or above the file and the only one that"
-                    "applies. Unlike .gitignore, Fantomas does not merge in the ones above it."
-                ]
-            else
-                []
+    // The rest of the chain, for whoever asked for detail. Named rather than described: none of
+    // them decided anything, and the one that would have is already spelled out above.
+    let alsoAbove: string list =
+        // The complement of `overruled`, said the same way round rather than by subtracting one
+        // list from the other, which would ask an equality of the record that nothing else
+        // needs.
+        let quiet: string list =
+            shadowed
+            |> List.choose (fun (above: ShadowedIgnoreFile) ->
+                if isIgnored || not above.WouldIgnore then
+                    Some(link theme above.Path)
+                else
+                    None
+            )
 
-        { doctorRow glyphs.Ignored "Ignore" says with
-            Detail = listed @ overruledLines @ alsoAbove @ nearestOnly
-        }
-        |> fun (row: DoctorRow) ->
-            if isIgnored then
-                row
-            elif not (List.isEmpty overruled) then
-                // Not a failure, and not the plain answer either: the file is formatted, and an
-                // ignore file the reader may well have meant to apply says it should not be. The
-                // same mark a file under a folder no walk opens carries, for the same reason.
-                { row with
-                    Glyph = glyphs.NeedsFormatting
-                }
-            else
-                { row with Glyph = glyphs.Formatted }
+        if verbose && not (List.isEmpty quiet) then
+            [ $"Also above it, with no say: %s{andList quiet}." ]
+        else
+            []
+
+    // The difference from `.gitignore` that catches people out, said to whoever asked for
+    // detail rather than on every run. Not said twice: where an ignore file above was actually
+    // overruled, the lines that report it carry the rule already.
+    let nearestOnly: string list =
+        if verbose && List.isEmpty overruled then
+            [
+                "This is the nearest .fantomasignore at or above the file and the only one that"
+                "applies. Unlike .gitignore, Fantomas does not merge in the ones above it."
+            ]
+        else
+            []
+
+    { doctorRow glyphs.Ignored "Ignore" says with
+        Detail = listed @ overruledLines @ alsoAbove @ nearestOnly
+    }
+    |> fun (row: DoctorRow) ->
+        if isIgnored then
+            row
+        elif not (List.isEmpty overruled) then
+            // Not a failure, and not the plain answer either: the file is formatted, and an
+            // ignore file the reader may well have meant to apply says it should not be. The
+            // same mark a file under a folder no walk opens carries, for the same reason.
+            { row with
+                Glyph = glyphs.NeedsFormatting
+            }
+        else
+            { row with Glyph = glyphs.Formatted }
 
 let describeDoctorSettings (theme: Theme) (glyphs: StatusGlyphs) (resolved: ResolvedConfig) : DoctorRow =
     let fromEditorConfig: ResolvedSetting list = resolved.FromEditorConfig
@@ -825,11 +830,12 @@ let describeDoctorSettings (theme: Theme) (glyphs: StatusGlyphs) (resolved: Reso
         | [], _ -> $"No .editorconfig applies. All %d{total} settings are Fantomas defaults."
         | files, [] -> $"All %d{total} settings are Fantomas defaults: %s{named files} sets nothing Fantomas reads."
         | _, set ->
-            let count: int = List.length set
 
-            // Named, and named absolutely, as every path this report prints is. `.editorconfig` on
-            // its own is the one thing somebody reading this cannot go and open.
-            $"%d{count} of %d{total} settings come from %s{named contributing}, the rest are Fantomas defaults."
+        let count: int = List.length set
+
+        // Named, and named absolutely, as every path this report prints is. `.editorconfig` on
+        // its own is the one thing somebody reading this cannot go and open.
+        $"%d{count} of %d{total} settings come from %s{named contributing}, the rest are Fantomas defaults."
 
     let written (setting: ResolvedSetting) : string =
         String.Concat(setting.Setting, " = ", setting.Value)
@@ -1049,8 +1055,9 @@ let reportDoctorReport (env: CliEnvironment) (settings: CliSettings) (report: Do
     match footer with
     | None -> ()
     | Some report ->
-        blank ()
-        write report
+
+    blank ()
+    write report
 
 let reportDoctorCommand (env: CliEnvironment) (settings: CliSettings) (result: DoctorCommandResult) : int =
     match result with

--- a/src/Fantomas/Report.fs
+++ b/src/Fantomas/Report.fs
@@ -130,11 +130,12 @@ let reportIgnored
     let mutable saidOutLoud: bool = false
 
     for file in List.sort ignored do
-        if Set.contains file named then
-            saidOutLoud <- true
-            env.Log.Information(fileLine theme glyphs.Ignored file "was ignored by .fantomasignore.")
-        else
+        if not (Set.contains file named) then
             env.Log.Debug $"'%s{file}' was ignored"
+        else
+
+        saidOutLoud <- true
+        env.Log.Information(fileLine theme glyphs.Ignored file "was ignored by .fantomasignore.")
 
     saidOutLoud
 
@@ -156,11 +157,11 @@ let summaryLine (theme: Theme) (counts: (int * string) list) : string =
             // one that carries the noun. Asking the line what it has so far is what lets the states
             // at zero be dropped, the separator be placed and the noun be put in front of exactly
             // one of them without walking the list three times to find out.
-            if line.Length = 0 then
+            if line.Length <> 0 then
+                line.Append(", ").Append(heading theme (string<int> count)) |> ignore
+            else
                 line.Append(heading theme (string<int> count)).Append(' ').Append(plural count "file" "files")
                 |> ignore
-            else
-                line.Append(", ").Append(heading theme (string<int> count)) |> ignore
 
             line.Append(' ').Append(label) |> ignore
 
@@ -502,16 +503,17 @@ let reportCheckResults
         if needing = 0 then
             None
         else
-            let subject: string = if needing = 1 then "it" else "them"
 
-            Some(
-                String.Concat(
-                    "Run ",
-                    muted theme env.Invocation,
-                    flagName theme (String.Concat(" ", describeInputPaths inputPath)),
-                    $" to format %s{subject}."
-                )
+        let subject: string = if needing = 1 then "it" else "them"
+
+        Some(
+            String.Concat(
+                "Run ",
+                muted theme env.Invocation,
+                flagName theme (String.Concat(" ", describeInputPaths inputPath)),
+                $" to format %s{subject}."
             )
+        )
 
     // Counted whenever the run found anything, rather than only when something needs formatting: an
     // error is a finding too, and a check that reported one used to end without saying how many

--- a/src/Fantomas/Suggestion.fs
+++ b/src/Fantomas/Suggestion.fs
@@ -11,23 +11,24 @@ let editDistance (limit: int) (left: string) (right: string) : int =
     if abs (left.Length - right.Length) > limit then
         limit + 1
     else
-        let mutable previous: int array = Array.init (right.Length + 1) id
-        let mutable current: int array = Array.zeroCreate<int>(right.Length + 1)
 
-        for row in 1 .. left.Length do
-            current[0] <- row
+    let mutable previous: int array = Array.init (right.Length + 1) id
+    let mutable current: int array = Array.zeroCreate<int>(right.Length + 1)
 
-            for column in 1 .. right.Length do
-                let substitution: int =
-                    previous[column - 1] + (if left[row - 1] = right[column - 1] then 0 else 1)
+    for row in 1 .. left.Length do
+        current[0] <- row
 
-                current[column] <- min (min (current[column - 1] + 1) (previous[column] + 1)) substitution
+        for column in 1 .. right.Length do
+            let substitution: int =
+                previous[column - 1] + (if left[row - 1] = right[column - 1] then 0 else 1)
 
-            let swap: int array = previous
-            previous <- current
-            current <- swap
+            current[column] <- min (min (current[column - 1] + 1) (previous[column] + 1)) substitution
 
-        min previous[right.Length] (limit + 1)
+        let swap: int array = previous
+        previous <- current
+        current <- swap
+
+    min previous[right.Length] (limit + 1)
 
 let nearest (limit: int) (candidates: string list) (term: string) : string option =
     candidates


### PR DESCRIPTION
fsharp_experimental_keep_indent_in_branch only preserves a de-indented
branch body, it never produces one: the body stays where the source put
it, so the style depends on somebody writing it first. That is the other
half of what FANTOMAS-ARMORDER-001 starts, and nothing asked for it.

The rule reports the last arm of a match, match! or function whose body
is a block sitting a level past the bar. It speaks only where the reshape
cannot change meaning: the body has to be on a line of its own already
and span more than one line, and nothing may follow the match in the same
block, since de-indenting moves the body's offside line out to the bar
and would take that following code into the arm. It stays quiet on a when
guard and on a conditional directive, and offers no fix, because
re-indenting a block means leaving the multiline strings inside it alone.

KeepIndentAnalyzer gets its own file beside ArmOrderAnalyzer, and the
trivia both rules read moves to Common.

It runs in AnalyzeChanged only, like FANTOMAS-ANNOTATE-001, because 166
sites predate it. Unlike that rule it is not narrowed to the lines git
diff reports: swapping two arms touches the lines carrying the bar and
none of the body it then asks to de-indent, which is the finding the swap
exists to reach.

The .editorconfig section now covers analyzers as well as src, so the
setting is on everywhere the pipelines analyze and a finding is never one
the formatter would undo. Six analyzer files reformat as a result.
