### PR TITLE
Add analyzer for unused opens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,19 +27,10 @@ The style rules for this repository are analyzers rather than prose, so the feed
 you work instead of in review. They live in `analyzers/`, and the `Analyze` and `AnalyzeChanged`
 pipelines run them alongside the two analyzer packages.
 
-| Code | Rule | Severity |
-| --- | --- | --- |
-| `FANTOMAS-PIPEBACK-001` | No backward pipe | Error |
-| `FANTOMAS-PRIVATE-001` | No `let private` beside a signature file | Error |
-| `FANTOMAS-ARMORDER-001` | Shortest match arm first | Warning |
-| `FANTOMAS-BRANCHORDER-001` | Shortest `if` branch first | Warning |
-| `FANTOMAS-KEEPINDENT-001` | Last branch keeps the indentation | Warning |
-| `FANTOMAS-ANNOTATE-001` | Annotate every `let` binding | Warning |
-| `FANTOMAS-XMLDOC-001` | No doc comment the signature file already carries | Warning |
-
-[analyzers/AGENTS.md](analyzers/AGENTS.md) has what each one asks for and why, how to suppress a
-finding, and what to know before writing another. `dotnet fsi build.fsx -- -p AnalyzeChanged` will
-tell you the same thing about the code in front of you.
+[analyzers/AGENTS.md](analyzers/AGENTS.md) lists them and has what each one asks for and why, how to
+suppress a finding, and what to know before writing another. Every finding links to its own section
+there. `dotnet fsi build.fsx -- -p AnalyzeChanged` will tell you the same thing about the code in
+front of you.
 
 ## Changelog
 

--- a/analyzers/AGENTS.md
+++ b/analyzers/AGENTS.md
@@ -14,6 +14,7 @@ feedback arrives while you work instead of in review. They are ordinary F# analy
 | [`FANTOMAS-KEEPINDENT-001`](#fantomas-keepindent-001) | Last branch keeps the indentation | Warning | both pipelines |
 | [`FANTOMAS-ANNOTATE-001`](#fantomas-annotate-001) | Annotate every `let` binding | Warning | `AnalyzeChanged` only |
 | [`FANTOMAS-XMLDOC-001`](#fantomas-xmldoc-001) | No doc comment the signature file already carries | Warning | both pipelines |
+| [`FANTOMAS-OPENS-001`](#fantomas-opens-001) | No `open` nothing in the file uses | Warning | both pipelines |
 
 ## FANTOMAS-PIPEBACK-001
 
@@ -237,6 +238,43 @@ falls back to the declaration itself, so it is `Some` for every symbol and `IsSo
 What separates the two is which file it points at — into the `.fsi` for a symbol the signature
 declares, back at the `.fs` for one it does not.
 
+## FANTOMAS-OPENS-001
+
+Remove an `open` that nothing in the file resolves through. It is a name the reader has to hold
+while reading everything below it, and it says the file depends on something it does not.
+
+The compiler answers this rather than the rule: `FSharp.Compiler.EditorServices.UnusedOpens`, which
+is the same call FsAutoComplete makes for the diagnostic it raises as `FSAC0001`. It walks every
+symbol use of the file and keeps the opens that were needed to write a name the way it is written,
+so an open kept only to shorten a type annotation counts as used. That is a question about the typed
+tree, which is why the rule reads `ctx.CheckFileResults` and is quiet in the editor without them.
+
+**The reported range is the module identifier, not the declaration.** `open System` reports
+`System` alone, columns 5 to 11. What has to go is the whole line, including its linebreak, so no
+blank line is left where the declaration was. There is no fix attached, for the reason every other
+rule here has none, and here it costs the least: deleting a line needs no re-indentation and cannot
+glue two tokens together.
+
+It runs on signature files as well as implementation files. An `open` in an `.fsi` that no `val` or
+type in it resolves through is unused in exactly the same sense, and the compiler answers it the
+same way.
+
+Two things it does not see, both inherited from the compiler's own detection: an `open` that only
+brings an operator into scope, and one that only brings a type extension into scope. FsAutoComplete
+ships this analyzer disabled by default where it ships the parentheses one enabled, which is the
+clearest available signal about how far to trust it. Nothing in this repository triggers either gap
+today: every finding of the first full run was real, and the whole solution still built with all
+eight of them removed. But a finding that looks wrong is worth checking against the build before
+acting on it, because deleting a needed `open` breaks the build rather than failing quietly.
+
+Generated sources are excluded rather than reported. `scripts/BuildAnalyzers.fsx` passes
+`**/*.AssemblyInfo.fs` to `--exclude-files`: MSBuild writes one per project under `obj`, opening
+`System` and `System.Reflection` and then writing every attribute out fully qualified, so the rule
+has two true things to say about each of them and nowhere to say them. Note that `--exclude-files`
+and `--include-files` are mutually exclusive in the tool, which drops the former with a warning when
+both are given. `AnalyzeChanged` therefore ignores the exclusion, and does not need it: it includes
+the files the working tree changed, and a generated file under `obj` is never one of them.
+
 ## Severity and scope
 
 Severity and scope are separate levers. Severity decides whether the run fails: the tool exits
@@ -250,8 +288,10 @@ a much coarser scope than that rule asks for, and one line changed in a file of 
 otherwise surfaces every unannotated binding in it. Every other rule reports wherever it fires in a
 file you edited, because a finding from one of those is worth seeing.
 
-`FANTOMAS-KEEPINDENT-001` arrived with debt of its own and is still in both pipelines, because that
-debt was cleared in the change that added it. The full run therefore has nothing old to report, and
+`FANTOMAS-KEEPINDENT-001` and `FANTOMAS-OPENS-001` each arrived with debt of their own and are both
+in both pipelines, because that debt was cleared in the change that added them. The unused-open
+count was the thing to measure before deciding: eight findings in hand-written source, all of them
+real, which is small enough to fix outright rather than carry in the advisory lists. The full run therefore has nothing old to report, and
 anything it does report is something the change in front of you introduced, which is the state to
 keep it in: a new case is cheap to fix while you are writing it and becomes a code scanning alert if
 you do not.
@@ -320,8 +360,9 @@ Ionide as you type. Four of the five rules read only `ctx.FileName`, `ctx.Projec
 and `ctx.ParseFileResults.ParseTree`, all of which `EditorContext` carries as well as `CliContext`
 does.
 
-`FANTOMAS-XMLDOC-001` also reads `ctx.CheckFileResults`, because the untyped tree cannot say whether
-the signature file declares the same binding. That does not cost the editor registration:
+`FANTOMAS-XMLDOC-001` and `FANTOMAS-OPENS-001` also read `ctx.CheckFileResults`, because the untyped
+tree can say neither whether the signature file declares the same binding nor what a name resolved
+through. That does not cost the editor registration:
 `EditorContext` carries check results too, as an option rather than outright, so the editor analyzer
 matches on it and says nothing when they are absent. A rule that needs the typed tree is fine; one
 that cannot answer without it has to be quiet in the editor rather than wrong there.
@@ -338,7 +379,8 @@ Tests live in `Fantomas.Analyzers.Tests` and go through `cliAnalyzer`, using
 the pipelines use, so the wiring is covered rather than bypassed: read `ctx.FileName` or
 `ctx.ProjectOptions.SourceFiles` wrongly and a test notices. `analyzeSource` covers a single
 snippet, `analyzeWithSignature` builds an implementation with a signature file beside it, which is
-what the two rules keyed on the signature file need. A snippet has to begin with a module
+what the two rules keyed on the signature file need, and `analyzeSignature` builds the same pair and
+analyzes the `.fsi` of it instead, which is how `FANTOMAS-OPENS-001` is held to what it does there. A snippet has to begin with a module
 declaration, because the harness type checks it as part of a project and raises on any compiler
 error. Give every rule a test for the finding and a test for each shape that looks like it but is
 not.
@@ -369,6 +411,6 @@ dotnet msbuild src/Fantomas.Core/Fantomas.Core.fsproj -t:CoreCompile \
 None of this is currently load bearing for the four rules that read only the untyped tree. Parsing
 every file of `Fantomas.Core` under the default options, both define sets, `--strict-indentation+`
 and `--langversion:preview` produces identical findings from them, which is what you would expect.
-`FANTOMAS-XMLDOC-001` reads the typed tree and so does depend on the project options resolving, which
-is another reason the fixture checks they came back non-empty. The defines are the only option that could change a verdict, since they decide which branch of
+`FANTOMAS-XMLDOC-001` and `FANTOMAS-OPENS-001` read the typed tree and so do depend on the project
+options resolving, which is another reason the fixture checks they came back non-empty. The defines are the only option that could change a verdict, since they decide which branch of
 an `#if` reaches the tree, and `DEBUG` in `Selection.fs` is the only one in real source anywhere.

--- a/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
+++ b/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="BranchOrderAnalyzerTests.fs" />
     <Compile Include="AnnotationAnalyzerTests.fs" />
     <Compile Include="XmlDocAnalyzerTests.fs" />
+    <Compile Include="UnusedOpensAnalyzerTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Analyzers\Fantomas.Analyzers.fsproj" />

--- a/analyzers/Fantomas.Analyzers.Tests/TestHelpers.fs
+++ b/analyzers/Fantomas.Analyzers.Tests/TestHelpers.fs
@@ -49,9 +49,15 @@ let analyzeSource (analyzer: Analyzer<CliContext>) (source: string) : Message li
     let ctx: CliContext = getContext projectOptions source
     analyzer ctx |> Async.RunSynchronously
 
-/// Runs an analyzer over an implementation file that has a signature file beside it, which is what
-/// the rules keyed on the signature file need in order to see one.
-let analyzeWithSignature (analyzer: Analyzer<CliContext>) (signature: string) (implementation: string) : Message list =
+/// Builds a context over a signature file and its implementation, analyzing whichever of the two
+/// `target` names. A signature file cannot be type checked on its own, so both are always compiled
+/// and only the file under analysis changes.
+let private contextForPair
+    (signature: string)
+    (implementation: string)
+    (target: SourceFile -> SourceFile -> SourceFile)
+    : CliContext
+    =
     let signatureFile: SourceFile =
         {
             FileName = "M.fsi"
@@ -64,13 +70,25 @@ let analyzeWithSignature (analyzer: Analyzer<CliContext>) (signature: string) (i
             Source = implementation
         }
 
+    getContextFor
+        (AnalyzerProjectOptions.BackgroundCompilerOptions projectOptions)
+        [ signatureFile; implementationFile ]
+        (target signatureFile implementationFile)
+    |> Async.AwaitTask
+    |> Async.RunSynchronously
+
+/// Runs an analyzer over an implementation file that has a signature file beside it, which is what
+/// the rules keyed on the signature file need in order to see one.
+let analyzeWithSignature (analyzer: Analyzer<CliContext>) (signature: string) (implementation: string) : Message list =
     let ctx: CliContext =
-        getContextFor
-            (AnalyzerProjectOptions.BackgroundCompilerOptions projectOptions)
-            [ signatureFile; implementationFile ]
-            implementationFile
-        |> Async.AwaitTask
-        |> Async.RunSynchronously
+        contextForPair signature implementation (fun _ implementationFile -> implementationFile)
+
+    analyzer ctx |> Async.RunSynchronously
+
+/// Runs an analyzer over the signature file of such a pair rather than over its implementation.
+let analyzeSignature (analyzer: Analyzer<CliContext>) (signature: string) (implementation: string) : Message list =
+    let ctx: CliContext =
+        contextForPair signature implementation (fun signatureFile _ -> signatureFile)
 
     analyzer ctx |> Async.RunSynchronously
 

--- a/analyzers/Fantomas.Analyzers.Tests/UnusedOpensAnalyzerTests.fs
+++ b/analyzers/Fantomas.Analyzers.Tests/UnusedOpensAnalyzerTests.fs
@@ -1,0 +1,102 @@
+module Fantomas.Analyzers.Tests.UnusedOpensAnalyzerTests
+
+open NUnit.Framework
+open FSharp.Analyzers.SDK
+open Fantomas.Analyzers.Tests.TestHelpers
+open Fantomas.Analyzers.UnusedOpensAnalyzer
+
+[<Test>]
+let ``an open nothing uses is reported`` () =
+    let source: string =
+        """module M
+
+open System
+
+let y: int = 42"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 3 ]
+
+[<Test>]
+let ``an open something uses is not reported`` () =
+    let source: string =
+        """module M
+
+open System
+
+let y: int = Int32.MaxValue"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``only the unused one of two opens is reported`` () =
+    let source: string =
+        """module M
+
+open System
+open System.Collections.Generic
+
+let y: int = Dictionary<string, int>().Count"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 3 ]
+
+[<Test>]
+let ``an open used only from a nested module is not reported`` () =
+    let source: string =
+        """module M
+
+open System.Collections.Generic
+
+module Inner =
+    let y: int = Dictionary<string, int>().Count"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``the reported range covers the module identifier alone`` () =
+    let source: string =
+        """module M
+
+open System
+
+let y: int = 42"""
+
+    let message: Message = analyzeSource cliAnalyzer source |> List.exactlyOne
+
+    // `open System` puts `System` at columns 5 to 11. The range names the module rather than the
+    // whole declaration, so what gets deleted is the line the range sits on and not the range.
+    Assert.That(
+        (message.Range.StartLine, message.Range.StartColumn, message.Range.EndLine, message.Range.EndColumn),
+        Is.EqualTo((3, 5, 3, 11))
+    )
+
+[<Test>]
+let ``an unused open in a signature file is reported`` () =
+    let signature: string =
+        """module M
+
+open System
+
+val y: int"""
+
+    let implementation: string =
+        """module M
+
+let y: int = 42"""
+
+    analyzeSignature cliAnalyzer signature implementation |> assertLines [ 3 ]
+
+[<Test>]
+let ``an open a signature file uses is not reported`` () =
+    let signature: string =
+        """module M
+
+open System
+
+val y: Int32"""
+
+    let implementation: string =
+        """module M
+
+let y: System.Int32 = 42"""
+
+    analyzeSignature cliAnalyzer signature implementation |> assertLines []

--- a/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
+++ b/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
@@ -41,6 +41,8 @@
     <Compile Include="AnnotationAnalyzer.fs" />
     <Compile Include="XmlDocAnalyzer.fsi" />
     <Compile Include="XmlDocAnalyzer.fs" />
+    <Compile Include="UnusedOpensAnalyzer.fsi" />
+    <Compile Include="UnusedOpensAnalyzer.fs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Must track the fsharp-analyzers version pinned in .config/dotnet-tools.json. -->

--- a/analyzers/Fantomas.Analyzers/UnusedOpensAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/UnusedOpensAnalyzer.fs
@@ -1,0 +1,60 @@
+module Fantomas.Analyzers.UnusedOpensAnalyzer
+
+open FSharp.Analyzers.SDK
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.EditorServices
+open FSharp.Compiler.Text
+
+[<Literal>]
+let Code: string = "FANTOMAS-OPENS-001"
+
+[<Literal>]
+let Name: string = "UnusedOpensAnalyzer"
+
+[<Literal>]
+let ShortDescription: string =
+    "Detects an open declaration that nothing in the file needs, which is a name the reader has to hold and a dependency the file does not have."
+
+[<Literal>]
+let HelpUri: string =
+    "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-opens-001"
+
+// The opens no symbol use of the file resolves through.
+//
+// All of the work is `UnusedOpens.getUnusedOpens`, which is the same call FsAutoComplete makes for
+// its own version of this diagnostic. It wants a one-based line getter where `ISourceText` counts
+// from zero, and it reads those lines to find where each open's declaration starts, so getting the
+// bridge wrong moves every reported range by a line rather than failing.
+let analyze (checkResults: FSharpCheckFileResults) (sourceText: ISourceText) : Async<Message list> =
+    async {
+        let getSourceLineStr (lineNumber: int) : string =
+            sourceText.GetLineString(lineNumber - 1)
+
+        let! unused: range list = UnusedOpens.getUnusedOpens (checkResults, getSourceLineStr)
+
+        return
+            unused
+            |> List.map (fun (range: range) ->
+                {
+                    Type = Name
+                    Message =
+                        "Remove this `open` declaration. Nothing in the file resolves through it, so it is a name the reader has to hold and a dependency the file does not have."
+                    Code = Code
+                    Severity = Severity.Warning
+                    Range = range
+                    Fixes = []
+                }
+            )
+    }
+
+let cliAnalyzer (ctx: CliContext) : Async<Message list> =
+    analyze ctx.CheckFileResults ctx.SourceText
+
+// Without check results there is no symbol use to walk, and an open cannot be told from an unused
+// one. It says nothing rather than guessing.
+let editorAnalyzer (ctx: EditorContext) : Async<Message list> =
+    async {
+        match ctx.CheckFileResults with
+        | None -> return []
+        | Some checkResults -> return! analyze checkResults ctx.SourceText
+    }

--- a/analyzers/Fantomas.Analyzers/UnusedOpensAnalyzer.fsi
+++ b/analyzers/Fantomas.Analyzers/UnusedOpensAnalyzer.fsi
@@ -1,0 +1,27 @@
+module Fantomas.Analyzers.UnusedOpensAnalyzer
+
+open FSharp.Analyzers.SDK
+
+[<Literal>]
+val Code: string = "FANTOMAS-OPENS-001"
+
+[<Literal>]
+val Name: string = "UnusedOpensAnalyzer"
+
+[<Literal>]
+val ShortDescription: string =
+    "Detects an open declaration that nothing in the file needs, which is a name the reader has to hold and a dependency the file does not have."
+
+[<Literal>]
+val HelpUri: string = "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-opens-001"
+
+/// Reports an `open` declaration that no symbol in the file resolves through.
+///
+/// The compiler answers this, through `FSharp.Compiler.EditorServices.UnusedOpens`, which walks
+/// every symbol use of the file and keeps the opens that were needed to write a name the way it is
+/// written. The untyped tree cannot say any of that, so the rule is quiet without check results.
+[<CliAnalyzer(Name, ShortDescription, HelpUri)>]
+val cliAnalyzer: ctx: CliContext -> Async<Message list>
+
+[<EditorAnalyzer(Name, ShortDescription, HelpUri)>]
+val editorAnalyzer: ctx: EditorContext -> Async<Message list>

--- a/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/XmlDocAnalyzer.fs
@@ -3,7 +3,6 @@ module Fantomas.Analyzers.XmlDocAnalyzer
 open FSharp.Analyzers.SDK
 open FSharp.Analyzers.SDK.ASTCollecting
 open FSharp.Compiler.CodeAnalysis
-open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open FSharp.Compiler.Xml

--- a/scripts/BuildAnalyzers.fsx
+++ b/scripts/BuildAnalyzers.fsx
@@ -486,10 +486,17 @@ let analyzeTargets (extraArguments: string list) (keep: FindingFilter) (targets:
                 let arguments =
                     [
                         "fsharp-analyzers"
-                        // The test SDK generates this entry point into the compilation from the
-                        // package cache. It is part of what gets type checked but it is not ours.
+                        // Neither of these is source anybody wrote. The test SDK generates its
+                        // entry point into the compilation from the package cache, and MSBuild
+                        // generates an `AssemblyInfo` per project under `obj`. Both are part of
+                        // what gets type checked, and a finding in either is not a finding about
+                        // this repository. `AssemblyInfo` earns its place here because it opens
+                        // `System` and `System.Reflection` and then writes every attribute out
+                        // fully qualified, so `FANTOMAS-OPENS-001` has two true things to say
+                        // about each of them and nowhere to say them.
                         "--exclude-files"
                         "**/Microsoft.NET.Test.Sdk.Program.fs"
+                        "**/*.AssemblyInfo.fs"
                         for analyzer in analyzers do
                             "--analyzers-path"
                             analyzer

--- a/src/Fantomas.Core/Defines.fs
+++ b/src/Fantomas.Core/Defines.fs
@@ -1,7 +1,6 @@
 namespace Fantomas.Core
 
 open Fantomas.FCS.SyntaxTrivia
-open Fantomas.Core
 
 type internal DefineCombination =
     | DefineCombination of defines: string list

--- a/src/Fantomas.Tests/EditorConfigReportTests.fs
+++ b/src/Fantomas.Tests/EditorConfigReportTests.fs
@@ -1,7 +1,6 @@
 module Fantomas.Tests.EditorConfigReportTests
 
 open NUnit.Framework
-open Fantomas
 open Fantomas.EditorConfig
 open Fantomas.EditorConfigReport
 open Fantomas.Tests.TestHelpers

--- a/src/Fantomas.Tests/ProfileCommandTests.fs
+++ b/src/Fantomas.Tests/ProfileCommandTests.fs
@@ -1,6 +1,5 @@
 module Fantomas.Tests.ProfileCommandTests
 
-open System
 open System.IO.Abstractions
 open System.IO.Abstractions.TestingHelpers
 open NUnit.Framework

--- a/src/Fantomas/CommandResult.fs
+++ b/src/Fantomas/CommandResult.fs
@@ -3,7 +3,6 @@ module Fantomas.CommandResult
 open System
 open Fantomas.Core
 open Fantomas.FCS.Parse
-open Fantomas.Theme
 
 [<RequireQualifiedAccess; NoComparison>]
 type FormatResult =

--- a/src/Fantomas/FormatCommand.fs
+++ b/src/Fantomas/FormatCommand.fs
@@ -5,8 +5,6 @@ open System.IO
 open System.IO.Abstractions
 open System.Text
 open Fantomas.Core
-open Fantomas
-open Fantomas.Logging
 open Fantomas.Arguments
 open Fantomas.Cli
 open Fantomas.CommandResult

--- a/src/Fantomas/Report.fs
+++ b/src/Fantomas/Report.fs
@@ -3,7 +3,6 @@ module Fantomas.Report
 open System
 open System.IO.Abstractions
 open System.Text
-open Serilog
 // Fantomas.Core has a FormatResult of its own. Opening Fantomas last is what makes the
 // FormatResult named here the one this project defines.
 open Fantomas.Core


### PR DESCRIPTION
Ported from the diagnostic FsAutoComplete raises as FSAC0001. Detection is a
single call to FSharp.Compiler.EditorServices.UnusedOpens, which walks every
symbol use of the file and keeps the opens a name was written through, so the
rule reads check results and is quiet in the editor without them.
