### PR TITLE
Analyze redundant parentheses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,17 +66,10 @@ asks for the whole project, because what it compiles is no longer what it compil
 Scoping it to the changed files is what makes this quick: analyzing one file of
 `Fantomas.Core.Tests` takes seconds where the whole project takes minutes.
 
-Nothing here fails the run, and everything it reports is a finding in a file `git status` names as
-changed. A finding in a file you did not touch is dropped, whatever its rule: without that, a
-changed `.fsproj` pulling in the whole project buries the two files you added under the project's
-existing debt.
-
-Within a file that did change, `FANTOMAS-ANNOTATE-001` is narrowed further to the lines `git diff`
-says you touched. A file is a much coarser scope than that rule asks for: one line changed in
-`ASTTransformer.fs` otherwise surfaces every unannotated binding in it. Every other rule reports
-wherever it fires in a file you edited, including `FANTOMAS-KEEPINDENT-001`, which also reports on
-pre-existing debt but means an arm's body rather than the `|` lines a swap touches. A file git has
-never seen is new in its entirety, so everything in it is reported.
+Everything it reports is about the code in front of you: findings in files you did not touch are
+dropped, and a few rules that report on pre-existing debt are narrowed to the lines `git diff` says
+you touched. Which rules and why is in `scripts/BuildAnalyzers.fsx`, and you do not need to know it
+to act on a run. What comes out is the thing to fix.
 
 ```bash
 dotnet fsi build.fsx -- -p Analyze
@@ -94,8 +87,8 @@ The findings also land in `analysis.sarif` in the repo root, merged from the per
 `analysisreports/`. Both files hold the last run and nothing more, so after `AnalyzeChanged` they
 cover only the files it looked at. **Read one of them afterwards.** `AnalyzeChanged` exits 0
 whatever it found, so a run finishing tells you nothing. `Analyze` does fail on a finding at error
-severity, which today means the two local rules that carry it. GitHub raises everything else as
-code scanning alerts on the pull request, which is a slower way to learn about them.
+severity. GitHub raises everything else as code scanning alerts on the pull request, which is a
+slower way to learn about them.
 
 When you read the SARIF, read the results for every project you touched. Filtering the paths down
 to `src/Fantomas/` looks right and silently drops `src/Fantomas.Tests/`, which does not contain

--- a/analyzers/AGENTS.md
+++ b/analyzers/AGENTS.md
@@ -5,16 +5,17 @@ feedback arrives while you work instead of in review. They are ordinary F# analy
 `FSharp.Analyzers.SDK`, and the `Analyze` and `AnalyzeChanged` pipelines run them alongside
 `Ionide.Analyzers` and `G-Research.FSharp.Analyzers`.
 
-| Code | Rule | Severity | Runs in |
-| --- | --- | --- | --- |
-| [`FANTOMAS-PIPEBACK-001`](#fantomas-pipeback-001) | No backward pipe | Error | both pipelines |
-| [`FANTOMAS-PRIVATE-001`](#fantomas-private-001) | No `let private` beside a signature file | Error | both pipelines |
-| [`FANTOMAS-ARMORDER-001`](#fantomas-armorder-001) | Shortest match arm first | Warning | both pipelines |
-| [`FANTOMAS-BRANCHORDER-001`](#fantomas-branchorder-001) | Shortest `if` branch first | Warning | both pipelines |
-| [`FANTOMAS-KEEPINDENT-001`](#fantomas-keepindent-001) | Last branch keeps the indentation | Warning | both pipelines |
-| [`FANTOMAS-ANNOTATE-001`](#fantomas-annotate-001) | Annotate every `let` binding | Warning | `AnalyzeChanged` only |
-| [`FANTOMAS-XMLDOC-001`](#fantomas-xmldoc-001) | No doc comment the signature file already carries | Warning | both pipelines |
-| [`FANTOMAS-OPENS-001`](#fantomas-opens-001) | No `open` nothing in the file uses | Warning | both pipelines |
+| Code | Rule |
+| --- | --- |
+| [`FANTOMAS-PIPEBACK-001`](#fantomas-pipeback-001) | No backward pipe |
+| [`FANTOMAS-PRIVATE-001`](#fantomas-private-001) | No `let private` beside a signature file |
+| [`FANTOMAS-ARMORDER-001`](#fantomas-armorder-001) | Shortest match arm first |
+| [`FANTOMAS-BRANCHORDER-001`](#fantomas-branchorder-001) | Shortest `if` branch first |
+| [`FANTOMAS-KEEPINDENT-001`](#fantomas-keepindent-001) | Last branch keeps the indentation |
+| [`FANTOMAS-ANNOTATE-001`](#fantomas-annotate-001) | Annotate every `let` binding |
+| [`FANTOMAS-XMLDOC-001`](#fantomas-xmldoc-001) | No doc comment the signature file already carries |
+| [`FANTOMAS-OPENS-001`](#fantomas-opens-001) | No `open` nothing in the file uses |
+| [`FANTOMAS-PARENS-001`](#fantomas-parens-001) | No parentheses the code parses the same without |
 
 ## FANTOMAS-PIPEBACK-001
 
@@ -202,10 +203,9 @@ name holds. Modules with a signature file already state this at the boundary; an
 implementation as well. This applies inside a function as much as at the top level: a local `let` in
 a long body is exactly where a reader loses track of what something is.
 
-It is guidance for code you are writing or revisiting, not a reason to sweep the codebase, which is
-why the rule runs in `AnalyzeChanged` and not in the full `Analyze`. When you touch a binding for
-some other reason, add the annotations it is missing. Leave the bindings you had no reason to open
-alone.
+It is guidance for code you are writing or revisiting, not a reason to sweep the codebase. When you
+touch a binding for some other reason, add the annotations it is missing. Leave the bindings you had
+no reason to open alone.
 
 A tuple parameter counts as annotated when every element of it is, so `(a: int, b: string)` is
 accepted and does not have to be rewritten as `((a, b): int * string)`. Both state the type of
@@ -275,37 +275,55 @@ and `--include-files` are mutually exclusive in the tool, which drops the former
 both are given. `AnalyzeChanged` therefore ignores the exclusion, and does not need it: it includes
 the files the working tree changed, and a generated file under `obj` is never one of them.
 
-## Severity and scope
+## FANTOMAS-PARENS-001
 
-Severity and scope are separate levers. Severity decides whether the run fails: the tool exits
-non-zero on any finding at error severity, so the two error rules fail `Analyze` and fail CI. Scope
-decides who has to look: a rule excluded from `Analyze` is absent from CI and from GitHub code
-scanning whatever its severity, and still reports locally.
+Remove a pair of parentheses the code parses the same without. It is a pair of characters the reader
+has to match to find out that it says nothing, and the thing inside it reads as though it had been
+grouped for a reason.
 
-`FANTOMAS-ANNOTATE-001` is excluded from `Analyze` because it reports on debt that predates it.
-`AnalyzeChanged` runs it, and narrows it further to the lines `git diff` says you touched: a file is
-a much coarser scope than that rule asks for, and one line changed in a file of several thousand
-otherwise surfaces every unannotated binding in it. Every other rule reports wherever it fires in a
-file you edited, because a finding from one of those is worth seeing.
+```fsharp
+let indent: int = ctx.Config.IndentSize * depth
+```
 
-`FANTOMAS-KEEPINDENT-001` and `FANTOMAS-OPENS-001` each arrived with debt of their own and are both
-in both pipelines, because that debt was cleared in the change that added them. The unused-open
-count was the thing to measure before deciding: eight findings in hand-written source, all of them
-real, which is small enough to fix outright rather than carry in the advisory lists. The full run therefore has nothing old to report, and
-anything it does report is something the change in front of you introduced, which is the state to
-keep it in: a new case is cheap to fix while you are writing it and becomes a code scanning alert if
-you do not.
+rather than
 
-The narrowing reads the tool's own output format and fails open, so anything it cannot parse is
-kept. A change upstream makes it stop narrowing rather than start hiding.
+```fsharp
+let indent: int = (ctx.Config.IndentSize * depth)
+```
 
-`AnalyzeChanged` also demotes the two error rules to warnings, because the run you do while working
-should report everything and stop for nothing.
+The compiler answers whether a pair is needed, through `SynExpr.shouldBeParenthesizedInContext` and
+`SynPat.shouldBeParenthesizedInContext`, which is the same pair of calls FsAutoComplete makes for
+the diagnostic it raises as `FSAC0004`. Both read only the untyped tree, so the rule needs no check
+results and says the same thing in the editor as on the command line. Asking the compiler is what
+makes the rule trustworthy on the pairs that look removable and are not: `-(f 1)` keeps its
+parentheses because `- f 1` would negate `f` and then apply the result, and `f (-1)` loses them
+because `f -1` really does apply `f` to a negative literal.
 
-All four severities print at the tool's default verbosity, so choosing a lower one does not hide a
-finding, it only stops the run failing. `Info` and `Hint` are real options for a rule that should be
-seen but never block. What they do change is how GitHub code scanning classifies the alert, so the
-scope column above is still the lever for a rule with existing debt.
+Expressions and patterns are both reported, under the one code. `let f (x) = x` is the same question
+as `let x = (1)` and the same answer, and the only thing that differs is what to watch for while
+editing, which is what the message says.
+
+**A parenthesis written against what comes before it is passed over.** `Some(x)`,
+`new StringBuilder(64)`, `Dictionary<int, string>(comparer)` and `s.TrimEnd('\n')` are all removable
+in the compiler's sense, and `Some x` and `new StringBuilder 64` do compile, but that pair is how
+this repository writes a union case, a constructor and a method call. Reporting them would make the
+rule a request to restyle the codebase rather than a rule about parentheses that say nothing, and
+they were half of everything it had to say. The same call with a space in front of it, `Some (1)`,
+is reported, which makes the guard a question about the text rather than about the tree: the tree
+cannot tell the two apart and they are written for different reasons.
+
+**The reported range spans the opening parenthesis through the closing one**, so it says exactly what
+to delete. There is no fix attached, for the reason every other rule here has none, and here the
+reason is the sharpest: `FSharp.Analyzers.Cli` has no handling of `Fix` at all, so a fix would be
+written for the editor alone. What the deletion does not do for you is re-indent a body that spans
+more than one line, whose offside line moves when the opening parenthesis goes. This is the Fantomas
+repository, so `FormatChanged` puts right whatever you get wrong there, which is not a reason to
+skip reading the diff. What you never have to think about is two tokens ending up against each
+other, because a parenthesis with nothing but whitespace in front of it is the only kind reported.
+
+The rule reports debt that predates it, so it is guidance for code you are writing or revisiting
+rather than a reason to sweep the codebase. Remove the pairs in the code you touch. Leave the ones
+you had no reason to open alone.
 
 ## Suppressing a finding
 
@@ -356,9 +374,9 @@ rather than that the run succeeded.
 
 Every rule is registered twice, as a `CliAnalyzer` and as an `EditorAnalyzer`, with both attributes
 in the signature file. The pipelines use the first; the second is what makes the rule show up in
-Ionide as you type. Four of the five rules read only `ctx.FileName`, `ctx.ProjectOptions.SourceFiles`
-and `ctx.ParseFileResults.ParseTree`, all of which `EditorContext` carries as well as `CliContext`
-does.
+Ionide as you type. Most of them read only `ctx.FileName`, `ctx.ProjectOptions.SourceFiles`,
+`ctx.SourceText` and `ctx.ParseFileResults.ParseTree`, all of which `EditorContext` carries as well
+as `CliContext` does.
 
 `FANTOMAS-XMLDOC-001` and `FANTOMAS-OPENS-001` also read `ctx.CheckFileResults`, because the untyped
 tree can say neither whether the signature file declares the same binding nor what a name resolved
@@ -373,6 +391,12 @@ test that builds its sources in memory has no filesystem to look at.
 
 A new rule needs a section above, because `HelpUri` links to it. Anything a person is told to do
 belongs there rather than only in the message.
+
+Severity decides whether a finding fails the run, not whether it prints, and a rule that arrives
+with debt behind it has to be kept out of the full `Analyze` or every old finding becomes a code
+scanning alert. Both decisions are made in `scripts/BuildAnalyzers.fsx`, in lists that say why
+beside each entry. Measure what a new rule reports over `src` before deciding: debt small enough to
+clear in the same change is better cleared.
 
 Tests live in `Fantomas.Analyzers.Tests` and go through `cliAnalyzer`, using
 `FSharp.Analyzers.SDK.Testing` to build a real `CliContext`. That is deliberately the entry point
@@ -408,7 +432,7 @@ dotnet msbuild src/Fantomas.Core/Fantomas.Core.fsproj -t:CoreCompile \
   -p:BuildProjectReferences=false -p:DesignTimeBuild=true -getItem:FscCommandLineArgs
 ```
 
-None of this is currently load bearing for the four rules that read only the untyped tree. Parsing
+None of this is currently load bearing for the rules that read only the untyped tree. Parsing
 every file of `Fantomas.Core` under the default options, both define sets, `--strict-indentation+`
 and `--langversion:preview` produces identical findings from them, which is what you would expect.
 `FANTOMAS-XMLDOC-001` and `FANTOMAS-OPENS-001` read the typed tree and so do depend on the project

--- a/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
+++ b/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="AnnotationAnalyzerTests.fs" />
     <Compile Include="XmlDocAnalyzerTests.fs" />
     <Compile Include="UnusedOpensAnalyzerTests.fs" />
+    <Compile Include="UnnecessaryParensAnalyzerTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.Analyzers\Fantomas.Analyzers.fsproj" />

--- a/analyzers/Fantomas.Analyzers.Tests/UnnecessaryParensAnalyzerTests.fs
+++ b/analyzers/Fantomas.Analyzers.Tests/UnnecessaryParensAnalyzerTests.fs
@@ -1,0 +1,181 @@
+module Fantomas.Analyzers.Tests.UnnecessaryParensAnalyzerTests
+
+open NUnit.Framework
+open Fantomas.Analyzers.Tests.TestHelpers
+open Fantomas.Analyzers.UnnecessaryParensAnalyzer
+
+[<Test>]
+let ``parentheses around the body of a binding are reported`` () =
+    let source: string =
+        """module M
+
+let x: int = (1 + 2)"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 3 ]
+
+[<Test>]
+let ``parentheses that hold an operand together are not reported`` () =
+    let source: string =
+        """module M
+
+let x: int = (1 + 2) * 3"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``parentheses around a parameter name are reported`` () =
+    let source: string =
+        """module M
+
+let f (x) = x"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 3 ]
+
+[<Test>]
+let ``parentheses around an annotated parameter are not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int) = x"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``parentheses around the condition of an if are reported`` () =
+    let source: string =
+        """module M
+
+let a: bool = true
+let b: int = if (a) then 1 else 2"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 4 ]
+
+[<Test>]
+let ``parentheses around an argument that is itself an application are not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int) : int = x
+let y: int = f (f 1)"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``parentheses around an argument that is a single name are reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int) : int = x
+let y: int = 1
+let z: int = f (y)"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 5 ]
+
+/// `- f 1` would negate `f` and then apply the result, so the pair is load bearing and the rule
+/// stays quiet. This is the guard `shouldBeParenthesizedInContext` provides and the reason the rule
+/// asks the compiler rather than looking for a paren whose contents parse on their own.
+[<Test>]
+let ``parentheses a unary minus needs are not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int) : int = x
+let z: int = -(f 1)"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+/// The other way round, and a surprise worth pinning: `f -1` applies `f` to a negative literal
+/// rather than subtracting, so the pair really is unnecessary and the rule says so.
+[<Test>]
+let ``parentheses around a negative literal argument are reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int) : int = x
+let y: int = f (-1)"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 4 ]
+
+[<Test>]
+let ``parentheses written against a union case are not reported`` () =
+    let source: string =
+        """module M
+
+let x: int option = Some(1)"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``parentheses written against a constructor are not reported`` () =
+    let source: string =
+        """module M
+
+open System.Text
+
+let sb: StringBuilder = StringBuilder(64)"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+[<Test>]
+let ``parentheses written against a type application are not reported`` () =
+    let source: string =
+        """module M
+
+open System.Collections.Generic
+
+let d: Dictionary<int, string> = Dictionary<int, string>(HashIdentity.Structural)"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+/// The same call with a space in front of the parenthesis is a different thing to write and is
+/// reported, which is what makes the guard a question about the text rather than about the tree.
+[<Test>]
+let ``parentheses set off from the name they apply to are reported`` () =
+    let source: string =
+        """module M
+
+let x: int option = Some (1)"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 3 ]
+
+[<Test>]
+let ``parentheses written against a union case pattern are not reported`` () =
+    let source: string =
+        """module M
+
+let f (x: int option) : int =
+    match x with
+    | None -> 0
+    | Some(y) -> y"""
+
+    analyzeSource cliAnalyzer source |> assertLines []
+
+/// The case the agent has to re-indent. The rule says nothing about the edit, so the test says
+/// nothing about it either: what is asserted is that the pair is found at all.
+[<Test>]
+let ``parentheses around a body spanning several lines are reported`` () =
+    let source: string =
+        """module M
+
+let a: bool = true
+
+let x: int =
+    (if a then
+        1
+     else
+        2)"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 6 ]
+
+/// Two findings in one file, to pin the order they arrive in. The fold reaches a node before the
+/// nodes under it and says nothing about siblings, so without the sort this is whatever a
+/// dictionary happens to enumerate.
+[<Test>]
+let ``findings are reported in the order the file reads`` () =
+    let source: string =
+        """module M
+
+let f (x) = x
+let y: int = (1 + 2)"""
+
+    analyzeSource cliAnalyzer source |> assertLines [ 3; 4 ]

--- a/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
+++ b/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
@@ -43,6 +43,8 @@
     <Compile Include="XmlDocAnalyzer.fs" />
     <Compile Include="UnusedOpensAnalyzer.fsi" />
     <Compile Include="UnusedOpensAnalyzer.fs" />
+    <Compile Include="UnnecessaryParensAnalyzer.fsi" />
+    <Compile Include="UnnecessaryParensAnalyzer.fs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Must track the fsharp-analyzers version pinned in .config/dotnet-tools.json. -->

--- a/analyzers/Fantomas.Analyzers/UnnecessaryParensAnalyzer.fs
+++ b/analyzers/Fantomas.Analyzers/UnnecessaryParensAnalyzer.fs
@@ -1,0 +1,111 @@
+module Fantomas.Analyzers.UnnecessaryParensAnalyzer
+
+open System.Collections.Generic
+open FSharp.Analyzers.SDK
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
+
+[<Literal>]
+let Code: string = "FANTOMAS-PARENS-001"
+
+[<Literal>]
+let Name: string = "UnnecessaryParensAnalyzer"
+
+[<Literal>]
+let ShortDescription: string =
+    "Detects parentheses that can be removed without changing how the code parses, which are a pair of characters the reader has to match for nothing."
+
+[<Literal>]
+let HelpUri: string =
+    "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-parens-001"
+
+// What the two messages have to say beyond "remove them" is different, because the two edits are:
+// an expression can span more than one line and have to be moved left, where a parenthesized
+// pattern is a name and a pair of characters around it.
+[<Literal>]
+let ExpressionMessage: string =
+    "Remove these parentheses. The expression parses the same without them. Re-indent the body if it spans more than one line."
+
+[<Literal>]
+let PatternMessage: string =
+    "Remove these parentheses. The pattern parses the same without them, so `let f (x) = x` becomes `let f x = x`."
+
+// Whether the opening parenthesis is written against whatever comes before it, which is how a call
+// writes its argument list: `Some(x)`, `new StringBuilder(64)`, `s.TrimEnd('\n')`,
+// `Dictionary<int, string>(comparer)`.
+//
+// Those pairs are removable and the rule stays quiet about them anyway. `Some x` and
+// `new StringBuilder 64` compile, but the parentheses are how this repository writes a union case
+// or a constructor, and half of what the rule would otherwise report is that shape. Reporting them
+// turns the rule into a request to restyle the codebase, which is not what it is for.
+//
+// This is a question about text rather than about the tree, because the tree cannot tell
+// `Some(x)` from `Some (x)` and the two are written for different reasons.
+let isApplicationParen (sourceText: ISourceText) (range: range) : bool =
+    let line: string = sourceText.GetLineString(range.StartLine - 1)
+
+    if range.StartColumn = 0 || range.StartColumn > line.Length then
+        false
+    else
+
+    // Everything that can end the thing being called: a name, the `>` closing a type application,
+    // and the closing bracket of the call before it in a chain.
+    let preceding: char = line[range.StartColumn - 1]
+    System.Char.IsLetterOrDigit preceding || "_'`>)]".Contains preceding
+
+// Every pair of parentheses the code parses the same without, mapped to what to say about it.
+//
+// Whether a pair is needed at all is `shouldBeParenthesizedInContext`, which is the same pair of
+// calls FsAutoComplete makes for its own version of this diagnostic. The expression overload wants a
+// one-based line getter where `ISourceText` counts from zero, and it consults those lines for the
+// cases it cannot answer from the tree alone, so getting the bridge wrong makes the rule judge the
+// wrong line rather than fail.
+//
+// The keys are ranges spanning the opening parenthesis through the closing one, which is the thing
+// to delete. `rightParenRange` has to be there: a pair that was never closed is broken source, and
+// nothing is gained by speaking about it.
+let unnecessaryParens (sourceText: ISourceText) (parsedInput: ParsedInput) : Dictionary<range, string> =
+    let getSourceLineStr (lineNumber: int) : string =
+        sourceText.GetLineString(lineNumber - 1)
+
+    (Dictionary<range, string>(Range.comparer), parsedInput)
+    ||> ParsedInput.fold (fun (found: Dictionary<range, string>) (path: SyntaxVisitorPath) (node: SyntaxNode) ->
+        match node with
+        | SyntaxNode.SynExpr(SynExpr.Paren(expr = inner; rightParenRange = Some _; range = range)) when
+            not (isApplicationParen sourceText range)
+            && not (SynExpr.shouldBeParenthesizedInContext getSourceLineStr path inner)
+            ->
+            found[range] <- ExpressionMessage
+            found
+        | SyntaxNode.SynPat(SynPat.Paren(inner, range)) when
+            not (isApplicationParen sourceText range)
+            && not (SynPat.shouldBeParenthesizedInContext path inner)
+            ->
+            found[range] <- PatternMessage
+            found
+        | _ -> found
+    )
+
+let analyze (sourceText: ISourceText) (parsedInput: ParsedInput) : Message list =
+    unnecessaryParens sourceText parsedInput
+    // The fold reaches a node before the nodes under it but says nothing about the order of
+    // siblings, and a dictionary says nothing about order at all. Sorting here is what makes the
+    // findings read down the file the way the file does.
+    |> Seq.sortBy (fun (pair: KeyValuePair<range, string>) -> pair.Key.StartLine, pair.Key.StartColumn)
+    |> Seq.map (fun (pair: KeyValuePair<range, string>) ->
+        {
+            Type = Name
+            Message = pair.Value
+            Code = Code
+            Severity = Severity.Warning
+            Range = pair.Key
+            Fixes = []
+        }
+    )
+    |> Seq.toList
+
+let cliAnalyzer (ctx: CliContext) : Async<Message list> =
+    async { return analyze ctx.SourceText ctx.ParseFileResults.ParseTree }
+
+let editorAnalyzer (ctx: EditorContext) : Async<Message list> =
+    async { return analyze ctx.SourceText ctx.ParseFileResults.ParseTree }

--- a/analyzers/Fantomas.Analyzers/UnnecessaryParensAnalyzer.fsi
+++ b/analyzers/Fantomas.Analyzers/UnnecessaryParensAnalyzer.fsi
@@ -1,0 +1,31 @@
+module Fantomas.Analyzers.UnnecessaryParensAnalyzer
+
+open FSharp.Analyzers.SDK
+
+[<Literal>]
+val Code: string = "FANTOMAS-PARENS-001"
+
+[<Literal>]
+val Name: string = "UnnecessaryParensAnalyzer"
+
+[<Literal>]
+val ShortDescription: string =
+    "Detects parentheses that can be removed without changing how the code parses, which are a pair of characters the reader has to match for nothing."
+
+[<Literal>]
+val HelpUri: string = "https://github.com/fsprojects/fantomas/blob/main/analyzers/AGENTS.md#fantomas-parens-001"
+
+/// Reports a pair of parentheses, around an expression or around a pattern, that the code parses
+/// the same without. The reported range spans the opening parenthesis through the closing one, so
+/// it says exactly what to delete.
+///
+/// The compiler answers whether a pair is needed, through
+/// `SynExpr.shouldBeParenthesizedInContext` and `SynPat.shouldBeParenthesizedInContext`, which is
+/// the same pair of calls FsAutoComplete makes for the diagnostic it raises as `FSAC0004`. Both
+/// read only the untyped tree, so the rule says the same thing in the editor as on the command
+/// line.
+[<CliAnalyzer(Name, ShortDescription, HelpUri)>]
+val cliAnalyzer: ctx: CliContext -> Async<Message list>
+
+[<EditorAnalyzer(Name, ShortDescription, HelpUri)>]
+val editorAnalyzer: ctx: EditorContext -> Async<Message list>

--- a/scripts/BuildAnalyzers.fsx
+++ b/scripts/BuildAnalyzers.fsx
@@ -309,19 +309,22 @@ let mergeSarifReports (reports: string list) (target: string) : unit =
 let localErrorRules: string list =
     [ "FANTOMAS-PIPEBACK-001"; "FANTOMAS-PRIVATE-001" ]
 
-/// The local analyzer that is kept out of the full run.
+/// The local analyzers that are kept out of the full run.
 ///
-/// It reports on debt that predates it, and a finding in `Analyze` becomes a code scanning alert on
-/// the pull request whatever its severity. `AnalyzeChanged` still runs it, over the files you
-/// touched, which is the scope the rule asks for. Drop this once the debt is gone.
+/// They report on debt that predates them, and a finding in `Analyze` becomes a code scanning alert
+/// on the pull request whatever its severity. `AnalyzeChanged` still runs them, over the files you
+/// touched, which is the scope both rules ask for. Drop one of these once its debt is gone.
 ///
-/// `FANTOMAS-KEEPINDENT-001` is deliberately not here. It arrived with debt of its own, and that
-/// debt was cleared in the change that added it, so the full run has nothing old to report and
-/// anything it does report is something the change in front of you introduced.
-let localAdvisoryAnalyzers: string list = [ "AnnotationAnalyzer" ]
+/// `FANTOMAS-KEEPINDENT-001` and `FANTOMAS-OPENS-001` are deliberately not here. Both arrived with
+/// debt of their own, and both times that debt was cleared in the change that added the rule, so
+/// the full run has nothing old to report and anything it does report is something the change in
+/// front of you introduced.
+let localAdvisoryAnalyzers: string list =
+    [ "AnnotationAnalyzer"; "UnnecessaryParensAnalyzer" ]
 
-/// The code of that same rule, which is what a finding carries.
-let localAdvisoryCodes: Set<string> = set [ "FANTOMAS-ANNOTATE-001" ]
+/// The codes of those same rules, which is what a finding carries.
+let localAdvisoryCodes: Set<string> =
+    set [ "FANTOMAS-ANNOTATE-001"; "FANTOMAS-PARENS-001" ]
 
 /// Decides whether a finding is worth showing, from its rule, its file and its line. `Analyze`
 /// shows all of them; only `AnalyzeChanged` narrows.
@@ -338,11 +341,11 @@ let everyFinding: FindingFilter = fun _ _ _ -> true
 /// under the project's existing debt, and a run whose findings you have to hand-filter is a run that
 /// tells you nothing.
 ///
-/// **And, for the advisory rule, is it on a line that changed?** A file is a much coarser scope than
-/// it asks for: one line changed in a file of several thousand otherwise surfaces every unannotated
-/// binding in it, and the annotation rule explicitly says to leave alone the bindings you had no
-/// reason to open. Every other rule reports anywhere in a file you edited, which is the scope those
-/// rules do ask for.
+/// **And, for the advisory rules, is it on a line that changed?** A file is a much coarser scope
+/// than they ask for: one line changed in a file of several thousand otherwise surfaces every
+/// unannotated binding and every stray pair of parentheses in it, and both rules are guidance for
+/// the code you are writing rather than a reason to sweep the file. Every other rule reports
+/// anywhere in a file you edited, which is the scope those rules do ask for.
 ///
 /// A file git has never seen is new in its entirety, so everything in it is worth reporting.
 let keepFinding (scopes: Map<string, ChangedLines>) : FindingFilter =
@@ -354,11 +357,11 @@ let keepFinding (scopes: Map<string, ChangedLines>) : FindingFilter =
 
 /// Drops the advisory findings that sit on lines the working tree did not touch.
 ///
-/// `AnalyzeChanged` scopes itself to the files you edited, which for the annotation rule is much
-/// coarser than the rule asks for: one line changed in a file of several thousand surfaces every
-/// unannotated binding in it, and the rule explicitly says to leave the bindings you had no reason
-/// to open alone. The other rules are left alone, because a finding from one of those is worth
-/// seeing wherever it is.
+/// `AnalyzeChanged` scopes itself to the files you edited, which for the two advisory rules is much
+/// coarser than they ask for: one line changed in a file of several thousand surfaces every
+/// unannotated binding and every stray pair of parentheses in it, where both rules are about the
+/// code you are writing. The other rules are left alone, because a finding from one of those is
+/// worth seeing wherever it is.
 ///
 /// Reads the tool's own output format. Anything it cannot parse is kept, so a change upstream makes
 /// this stop narrowing rather than start hiding.

--- a/src/Fantomas.Client/FantomasToolLocator.fs
+++ b/src/Fantomas.Client/FantomasToolLocator.fs
@@ -239,7 +239,7 @@ let findFantomasTool (workingDir: Folder) : Result<FantomasToolFound, FantomasTo
 
     match fantomasOnPathVersion with
     | Some(executableFile, FantomasVersion(CompatibleVersion version)) ->
-        Ok(FantomasToolFound((FantomasVersion(version)), FantomasToolStartInfo.ToolOnPath executableFile))
+        Ok(FantomasToolFound(FantomasVersion(version), FantomasToolStartInfo.ToolOnPath executableFile))
     | _ -> Error FantomasToolError.NoCompatibleVersionFound
 
 // Fantomas added `fantomas daemon` beside `fantomas --daemon` in 8.0.0-alpha-016, and both do the
@@ -384,7 +384,7 @@ let createForVersion
             // A timeout says nothing about what was being waited for, so say it here. The next
             // field report should carry a number someone can argue about rather than "it said
             // something timed out".
-            if (ex :? TimeoutException) then
+            if ex :? TimeoutException then
                 $"Daemon did not answer the version request within %i{handshakeTimeoutInMs} ms."
             elif daemonProcess.HasExited then
                 // `HasExited` only says the process is gone; the handler above is fed


### PR DESCRIPTION
**tl;dr** another analyzer we run on newly added/changed code in this repository.
Not new functionality in Fantomas itself.

Also, thank you @brianrourkeboll 🥰, this is based off all your hard work in the compiler!

---

Ports the detection behind the diagnostic FsAutoComplete raises as FSAC0004: SynExpr.shouldBeParenthesizedInContext and SynPat.shouldBeParenthesizedInContext answer whether a pair is needed, so the rule reads only the untyped tree and registers in the editor as well as the CLI. The reported range spans the opening parenthesis through the closing one, and no fix is attached, because FSharp.Analyzers.Cli has no handling of Fix at all.

A parenthesis written against what precedes it is passed over. Some(x), new StringBuilder(64) and s.TrimEnd('\n') are all removable in the compiler's sense, but that pair is how this repository writes a union case, a constructor and a method call, and it was half of the 363 findings over src. Reporting them would make the rule a request to restyle the codebase rather than a rule about parentheses that group nothing. The same call with a space in front of it, Some (1), is still reported. This also means a reported pair always has whitespace before it, so removing one can never glue two tokens together.

The rule reports debt that predates it, so it goes in the advisory lists in scripts/BuildAnalyzers.fsx alongside FANTOMAS-ANNOTATE-001: out of the full Analyze, and narrowed by AnalyzeChanged to the lines git diff says you touched.

Clears the two findings in Fantomas.Client.

Both AGENTS.md files lose the prose that named which rules run in which pipeline. That is decided in one place, scripts/BuildAnalyzers.fsx, which already says why beside each list, and it is not something you need to know in order to act on a run.

