### PR TITLE
Space an operator that starts with a star

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [8.0.0-alpha-023] - 2026-08-28
+
+### Fixed
+
+- An operator that starts with a star keeps a space on either side of it inside the parentheses wherever its name is written, so `val inline ( *. ): ...` and `abstract member ( *. ): ...` survive formatting. Only `let ( *. ) a b = ...` was spaced before; a `val` in a signature file and an abstract member in either kind of file came out as `(*.)`, which opens a block comment and swallows the rest of the file. Multiplication is unaffected, because `(*)` is a token the lexer knows. [#3443](https://github.com/fsprojects/fantomas/pull/3443)
+
 ## [8.0.0-alpha-022] - 2026-08-27
 
 ### Added

--- a/src/Fantomas.Core.Tests/OperatorTests.fs
+++ b/src/Fantomas.Core.Tests/OperatorTests.fs
@@ -1710,3 +1710,21 @@ let v =
             "ffffffffff"
         ]
 """
+
+[<Test>]
+let ``abstract member for operator starting with a star keeps the space inside the parentheses, 3442`` () =
+    formatSourceString
+        """
+type Foo =
+    abstract member ( *.) : int * int -> int
+    abstract member (.*) : int * int -> int
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Foo =
+    abstract member ( *. ): int * int -> int
+    abstract member (.*): int * int -> int
+"""

--- a/src/Fantomas.Core.Tests/SignatureTests.fs
+++ b/src/Fantomas.Core.Tests/SignatureTests.fs
@@ -2262,3 +2262,25 @@ val repro: '``QuotedWithIllegalChar<'T>`` -> unit
         """
 val repro: '``QuotedWithIllegalChar<'T>`` -> unit
 """
+
+[<Test>]
+let ``val for operator starting with a star keeps the space inside the parentheses, 3442`` () =
+    formatSignatureString
+        """
+module MahSignature
+
+val inline (.*)  : (unit -> ^a) -> ^b           -> unit -> ^c
+val inline ( *.) : ^a           -> (unit -> ^b) -> unit -> ^c
+val inline (.*.) : (unit -> ^a) -> (unit -> ^b) -> unit -> ^c
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+module MahSignature
+
+val inline (.*): (unit -> ^a) -> ^b -> unit -> ^c
+val inline ( *. ): ^a -> (unit -> ^b) -> unit -> ^c
+val inline (.*.): (unit -> ^a) -> (unit -> ^b) -> unit -> ^c
+"""

--- a/src/Fantomas.Core/ASTTransformer.fs
+++ b/src/Fantomas.Core/ASTTransformer.fs
@@ -74,11 +74,22 @@ let mkIdent (ident: Ident) =
 
     stn text ident.idRange
 
+/// Whether an operator written between parentheses needs a space on either side of it.
+///
+/// A leading star would otherwise open a comment: `( *. )` printed as `(*.)` swallows the rest of
+/// the file. Multiplication is the exception, because `(*)` is a token the lexer knows.
+let operatorNeedsSpaceInsideParens (text: string) : bool =
+    text.Length > 1 && String.startsWithOrdinal "*" text
+
 let mkSynIdent (creationAide: CreationAide) (SynIdent(ident, trivia)) =
     match trivia with
     | None -> mkIdent ident
     | Some(IdentTrivia.OriginalNotation text) -> stn text ident.idRange
-    | Some(IdentTrivia.OriginalNotationWithParen(_, text, _)) -> stn $"(%s{text})" ident.idRange
+    | Some(IdentTrivia.OriginalNotationWithParen(_, text, _)) ->
+        if operatorNeedsSpaceInsideParens text then
+            stn $"( %s{text} )" ident.idRange
+        else
+            stn $"(%s{text})" ident.idRange
     | Some(IdentTrivia.HasParenthesis _) ->
 
     let width = ident.idRange.EndColumn - ident.idRange.StartColumn
@@ -2067,7 +2078,7 @@ let mkExprQuote creationAide isRaw e range : ExprQuoteNode =
 let (|ParenStarSynIdent|_|) =
     function
     | IdentTrivia.OriginalNotationWithParen(lpr, originalNotation, rpr) ->
-        if originalNotation.Length > 1 && String.startsWithOrdinal "*" originalNotation then
+        if operatorNeedsSpaceInsideParens originalNotation then
             ValueSome(lpr, originalNotation, rpr)
         else
             ValueNone


### PR DESCRIPTION
`mkSynIdent` printed a parenthesised operator tight, so an operator starting with a star came out as `(*.)`. That opens a block comment and swallows the rest of the file. Only `let ( *. ) a b = ...` was spaced before, through a separate check in `mkBinding`, which left a `val` in a signature file and an abstract member in either kind of file broken.

The condition now lives in one predicate that both `mkSynIdent` and `ParenStarSynIdent` use, so the name carries its own spacing and CodePrinter has nothing to decide. Multiplication is unaffected: `(*)` is a token the lexer knows, and the predicate keeps the existing length check that excludes it.

Fixes #3442
