### PR TITLE
Name the daemon that raised a configuration warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,22 @@ front of you.
 
 When updating `CHANGELOG.md`, add new entries to the **end** of the relevant section (e.g. `### Fixed`), not the top. One entry per issue.
 
+An entry ends in a link to the issue it closes, and to the pull request only when no issue lies
+behind the change. `docs/docs/contributors/Pull request ground rules.md` is where that convention
+is written down.
+
+A pull request has no number until it is opened, so an entry that needs one is written last, in a
+commit of its own:
+
+1. Commit the work, leaving every `CHANGELOG.md` out of it.
+2. Push, and open the pull request.
+3. Write the entry against that pull request's URL, and commit it on its own.
+
+Wait for the URL rather than guessing the number. An entry that links an issue needs none of this
+and can be written with the work.
+
+`src/Fantomas.Client/CHANGELOG.md` is a second changelog, covering that package alone.
+
 ## Post-task Steps
 
 Run these after completing a task rather than during iterative development.

--- a/docs/docs/end-users/FantomasClient.md
+++ b/docs/docs/end-users/FantomasClient.md
@@ -79,7 +79,7 @@ service.ConfigurationWarnings.Add(fun warning ->
         warning.Problems
         |> Array.map (fun problem ->
             if problem.Code = int ConfigurationProblemCode.UnknownSetting then
-                $"%s{problem.Setting} is not a Fantomas setting"
+                $"Fantomas %s{warning.Version} does not have the setting %s{problem.Setting}"
             else
                 $"%s{problem.Setting} does not accept the value %s{problem.Value}")
         |> showWarnings warning.FilePath warning.EditorConfigFiles)
@@ -104,6 +104,13 @@ Worth knowing:
   setting rather than trying to point at it.
 - `Source` tells you whether the setting came from a `.editorconfig` on disk or from the `Config`
   dictionary your own tool sent along with the request.
+- `Version` is the Fantomas that raised the warning, such as `8.0.0-alpha-022`, ready to show to a
+  user: no `Fantomas` in front, no leading `v`, and no `+<commit>` on the end. Say it, because a
+  `fsharp_` setting that does nothing is more often a Fantomas older than the setting than it is a
+  typo, and a message that does not name a version invites exactly that question. Do not ask
+  `VersionAsync` for it: that is a round trip for something you were already handed, and it races
+  `ClearCache`, so a user who has just installed a newer Fantomas gets told the wrong one ignored
+  their setting.
 - Only Fantomas 8 daemons send these. Against an older one the event simply never fires, so no
   version check is needed.
 - The event is raised on whichever thread the daemon's message arrived on, never on the thread that
@@ -130,7 +137,9 @@ goes on the wire byte for byte:
 `Code` is `1` for a setting Fantomas does not have and `2` for a value it cannot parse; `Source` is
 `1` for a `.editorconfig` on disk and `2` for the `Config` dictionary sent with the request.
 `Value` is `null` for `Code` `1`, because no value was ever read. `EditorConfigFiles` is empty when
-`Problems` is empty.
+`Problems` is empty. There is no `Version` on the wire: `Fantomas.Client` fills that in for the
+daemon it started, which is how it can name daemons released before the field existed, and driving
+the daemon yourself you already know which version you launched.
 
 ## Seeing which Fantomas was used
 

--- a/src/Fantomas.Client/CHANGELOG.md
+++ b/src/Fantomas.Client/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This is the changelog for the Fantomas.Client package specifically. It's distinct from that of the overall libraries and command-line tool.
 
+## [0.12.0-beta-002] - 2026-08-28
+
+### Added
+- `ConfigurationWarning.Version`, the Fantomas that raised the warning, such as `8.0.0-alpha-022`. A `fsharp_` setting that silently does nothing is more often an older Fantomas than a typo, so a message about one wants to name the version, and asking `VersionAsync` for it was both a round trip for something the cache already knew and a race against `ClearCache`, which could name whichever daemon answered second. It arrives in the shape `FantomasVersion` guarantees, with no `Fantomas` in front, no leading `v` and no `+<commit>` on the end, rather than the longer form `VersionAsync` answers with. Stamped on by this package from the version the daemon answered its handshake with, so it needs no wire change and works against every Fantomas 8 daemon that already exists; `RunningFantomasTool.ConfigurationWarnings` carries it too. [#3441](https://github.com/fsprojects/fantomas/issues/3441)
+
+### Changed
+- Breaking: `ConfigurationWarning` gained the `Version` field. Source-breaking only for code that *constructs* one, which is a daemon rather than a client; reading a warning needs no source change. [#3441](https://github.com/fsprojects/fantomas/issues/3441)
+
 ## [0.12.0-beta-001] - 2026-08-28
 
 ### Added

--- a/src/Fantomas.Client/Contracts.fs
+++ b/src/Fantomas.Client/Contracts.fs
@@ -99,6 +99,7 @@ type ConfigurationProblem =
 [<NoComparison>]
 type ConfigurationWarning =
     {
+        Version: string
         FilePath: string
         EditorConfigFiles: string array
         Problems: ConfigurationProblem array

--- a/src/Fantomas.Client/Contracts.fsi
+++ b/src/Fantomas.Client/Contracts.fsi
@@ -23,7 +23,8 @@ module Methods =
     /// naming the settings in the resolved configuration that Fantomas could not act on. Purely
     /// informational: the request still succeeds, using defaults for whatever could not be read.
     ///
-    /// The notification carries one `ConfigurationWarning`, serialized as it is written here:
+    /// The notification carries one `ConfigurationWarning`, serialized as it is written here
+    /// except for `Version`, which the daemon does not send:
     /// `{"FilePath": "...", "EditorConfigFiles": ["..."], "Problems": [{"Code": 1, "Source": 1,
     /// "Setting": "fsharp_bogus_option", "Value": null}]}`.
     [<Literal>]
@@ -141,6 +142,16 @@ type ConfigurationProblem =
 [<NoComparison>]
 type ConfigurationWarning =
     {
+        /// The Fantomas that raised this, in the shape `dotnet tool list` writes: no `Fantomas` in
+        /// front, no leading `v`, no `+<commit>` on the end, such as `8.0.0-alpha-022`. Ready to
+        /// put in front of a user, which is the one thing this is here for.
+        ///
+        /// Filled in by `Fantomas.Client` from the daemon that raised the warning, rather than
+        /// sent by the daemon: that is what lets it name every Fantomas 8 daemon there already is
+        /// rather than only the ones released after this. Talking to a daemon yourself, this
+        /// arrives as `null` and you already know which version you started.
+        Version: string
+
         /// The file that was being formatted, echoed back from the request unchanged.
         /// Absolute, because `Fantomas.Client` rejects a relative path before sending the request.
         FilePath: string
@@ -183,6 +194,10 @@ type FantomasService =
     ///
     /// Only Fantomas 8 daemons send these; an older one never raises it, so no version check is
     /// needed.
+    ///
+    /// `Version` names the daemon that raised the warning, so reporting one needs no separate
+    /// `VersionAsync` call. Asking afterwards would also be a race against `ClearCache`, which can
+    /// leave a newly installed daemon answering for a warning the one it replaced raised.
     abstract ConfigurationWarnings: IEvent<ConfigurationWarning>
 
     abstract ConfigurationAsync: filePath: string * ?cancellationToken: CancellationToken -> Task<FantomasResponse>

--- a/src/Fantomas.Client/FantomasToolLocator.fs
+++ b/src/Fantomas.Client/FantomasToolLocator.fs
@@ -441,17 +441,29 @@ let createForVersion
         // every format request for the rest of the session with nothing to show for it. Generous
         // enough that a cold start on a loaded machine is not mistaken for a hang; a daemon that
         // is still silent by then is one the cleanup below should get its hands on.
-        let _version =
+        let printedVersion: string =
             client.InvokeAsync<string>(Fantomas.Client.Contracts.Methods.Version)
             |> Async.AwaitTask
             |> fun handshake -> Async.RunSynchronously(handshake, timeout = handshakeTimeoutInMs)
+
+        // What the daemon answered rather than the version it was started for, because `createFor`
+        // starts one without knowing which version that is, and a warning has to name the Fantomas
+        // that raised it. Read through `FantomasVersion`, so what a consumer shows a user is
+        // `8.0.0-alpha-022` rather than the `+<commit>` form `fantomas --version` prints.
+        let daemonVersion: string =
+            string<FantomasVersion>(FantomasVersion.Create printedVersion)
 
         Ok
             {
                 RpcClient = client
                 Process = daemonProcess
                 StartInfo = startInfo
-                ConfigurationWarnings = configurationWarnings.Publish
+                // Stamped as the warning is forwarded, so every one that leaves this package names
+                // its daemon whichever way a caller started it. The daemon does not send a version,
+                // which means this works against every Fantomas 8 daemon there already is.
+                ConfigurationWarnings =
+                    configurationWarnings.Publish
+                    |> Event.map (fun warning -> { warning with Version = daemonVersion })
             }
     with ex ->
         let error =

--- a/src/Fantomas.Client/LSPFantomasServiceTypes.fsi
+++ b/src/Fantomas.Client/LSPFantomasServiceTypes.fsi
@@ -81,6 +81,9 @@ type RunningFantomasTool =
         /// message arrived on. Subscribed to by `createFor` before the connection starts
         /// listening, so no notification can outrun a subscriber added there. A daemon older than
         /// Fantomas 8 does not send these, so the event simply never fires.
+        ///
+        /// `Version` is stamped on from the version this daemon answered the handshake with, so a
+        /// warning names the Fantomas that raised it even when the daemon was started without one.
         ConfigurationWarnings: IEvent<ConfigurationWarning>
     }
 

--- a/src/Fantomas.Tests/Integration/DaemonTests.fs
+++ b/src/Fantomas.Tests/Integration/DaemonTests.fs
@@ -3,6 +3,7 @@ module Fantomas.Tests.Integration.DaemonTests
 open System
 open System.Threading.Tasks
 open Fantomas
+open Fantomas.Client
 open Fantomas.Client.LSPFantomasServiceTypes
 open Fantomas.Daemon
 open NUnit.Framework
@@ -882,3 +883,72 @@ let a =
             | otherResponse -> Assert.Fail $"Unexpected response %A{otherResponse}"
         }
     )
+
+// The one thing a warning is for is telling a user which settings their Fantomas ignored, and the
+// version is the load-bearing part of that: a `fsharp_` setting that does nothing is more often an
+// older Fantomas than a typo. It is not on the wire, so this covers the whole of the path that puts
+// it there, which is `Fantomas.Client` starting a real daemon and reading the version it answers
+// with. `createFor` is the harder half of that: it starts a daemon without being told which version
+// it is, so nothing but the handshake can name it.
+[<Test>]
+let ``a warning forwarded by Fantomas.Client names the daemon that raised it`` () =
+    use codeFile = new TemporaryFileCodeSample("module Foo\n\nlet add a  b = a + b")
+
+    let tool =
+        match
+            FantomasToolLocator.createFor (
+                FantomasToolStartInfo.ToolOnPath(FantomasExecutableFile(fantomasExecutable ()))
+            )
+        with
+        | Ok tool -> tool
+        | Error error -> failwith $"Could not start the daemon under test: %A{error}"
+
+    use _tool = tool :> IDisposable
+
+    let warnings = ResizeArray<ConfigurationWarning>()
+    tool.ConfigurationWarnings.Add(fun warning -> lock warnings (fun () -> warnings.Add warning))
+
+    let request =
+        {
+            SourceCode = "module Foo\n\nlet add a  b = a + b"
+            FilePath = codeFile.Filename
+            Config = Some(readOnlyDict [ "fsharp_bogus_option", "true" ])
+            Cursor = None
+        }
+
+    tool.RpcClient.InvokeAsync<FormatDocumentResponse>(Methods.FormatDocument, request)
+    |> Async.AwaitTask
+    |> Async.RunSynchronously
+    |> ignore<FormatDocumentResponse>
+
+    // The notification is one-way, so it can still be in flight when the response arrives.
+    let rec settle (attemptsLeft: int) : unit =
+        if lock warnings (fun () -> warnings.Count) = 0 && attemptsLeft > 0 then
+            System.Threading.Thread.Sleep 50
+            settle (attemptsLeft - 1)
+
+    settle 100
+
+    // What the daemon prints for itself, minus the build metadata nobody reading a notification
+    // needs. The tool's own version request answers with that longer form, which is the thing this
+    // saves a consumer from having to trim.
+    let expected: string =
+        let printed = CodeFormatter.GetVersion()
+
+        match printed.IndexOf '+' with
+        | -1 -> printed
+        | plus -> printed.Substring(0, plus)
+
+    let warning = theOnlyWarning (List.ofSeq warnings)
+
+    problemsOf warning
+    |> should
+        equal
+        [|
+            int ConfigurationProblemCode.UnknownSetting,
+            int ConfigurationProblemSource.Request,
+            "fsharp_bogus_option",
+            null
+        |]
+
+    warning.Version |> should equal expected

--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -4,6 +4,7 @@ open System
 open System.Diagnostics
 open System.IO
 open System.IO.Abstractions
+open System.Runtime.InteropServices
 open System.Text
 open Serilog
 open Serilog.Core
@@ -298,7 +299,10 @@ type FantomasToolResult =
         Error: string
     }
 
-let getFantomasToolStartInfo (arguments: string list) : ProcessStartInfo =
+/// Where this build put the tool. Resolved from where this file sits rather than from where the
+/// test assembly is running, because those are not the same place under a coverage run: AltCover
+/// executes the tests from an instrumented copy of the output folder.
+let private fantomasOutputFile (fileName: string) : string =
     let configuration: string =
 #if DEBUG
         "debug"
@@ -306,12 +310,27 @@ let getFantomasToolStartInfo (arguments: string list) : ProcessStartInfo =
         "release"
 #endif
 
-    // Resolved from where this file sits rather than from where the test assembly is running,
-    // because those are not the same place under a coverage run: AltCover executes the tests from
-    // an instrumented copy of the output folder.
-    let fantomasDll: string =
-        Path.Combine(__SOURCE_DIRECTORY__, "..", "..", "artifacts", "bin", "Fantomas", configuration, "fantomas.dll")
-        |> Path.GetFullPath
+    Path.Combine(__SOURCE_DIRECTORY__, "..", "..", "artifacts", "bin", "Fantomas", configuration, fileName)
+    |> Path.GetFullPath
+
+/// The executable beside the dll the tests below run, for a test that hands a real fantomas to
+/// something that starts the process itself.
+let fantomasExecutable () : string =
+    let fileName: string =
+        if RuntimeInformation.IsOSPlatform OSPlatform.Windows then
+            "fantomas.exe"
+        else
+            "fantomas"
+
+    let executable: string = fantomasOutputFile fileName
+
+    if not (File.Exists executable) then
+        failwithf $"The fantomas executable at \"%s{executable}\" does not exist!"
+
+    executable
+
+let getFantomasToolStartInfo (arguments: string list) : ProcessStartInfo =
+    let fantomasDll: string = fantomasOutputFile "fantomas.dll"
 
     if not (File.Exists fantomasDll) then
         failwithf $"The fantomas dll at \"%s{fantomasDll}\" does not exist!"

--- a/src/Fantomas/Daemon.fs
+++ b/src/Fantomas/Daemon.fs
@@ -69,6 +69,10 @@ let configurationFor
 
     config,
     {
+        // Filled in by Fantomas.Client for the daemon that sent this. A daemon has no reason to
+        // name itself here: the client already knows which one it started, and stamping it there
+        // is what lets it name daemons released before this field existed.
+        Version = null
         FilePath = filePath
         // Only worth sending when there is something to point at. It is the same list on every
         // request for a file, and a client has nothing to do with it while nothing is wrong.
@@ -82,6 +86,7 @@ let configurationFor
 
 let noConfigurationProblems (filePath: string) : ConfigurationWarning =
     {
+        Version = null
         FilePath = filePath
         EditorConfigFiles = Array.empty
         Problems = Array.empty


### PR DESCRIPTION
A warning says a setting was ignored, and the question that follows is by which Fantomas. A `fsharp_` setting that silently does nothing is more often a Fantomas older than the setting than it is a typo, so a message that cannot name a version invites exactly the question it ought to be answering.

`ConfigurationWarning` carries a `Version` now. Reporting one no longer needs a `VersionAsync` call, which was a round trip for something the cache already knew and a race against `ClearCache`: a user who has just installed a newer Fantomas could be told that one ignored their setting.

Stamped on by `Fantomas.Client` as the warning is forwarded, from the version the daemon answered its handshake with, so it needs no wire change and works against every Fantomas 8 daemon that already exists. It is stamped in the locator rather than in the service, because `RunningFantomasTool.ConfigurationWarnings` is a surface of its own and `createFor` starts a daemon without being told which version it is, so there the handshake is the only thing that can name it. Read through `FantomasVersion`, so a consumer is handed `8.0.0-alpha-022` rather than the `+<commit>` form the version request answers with.

Source-breaking for code that constructs a `ConfigurationWarning`, which is a daemon rather than a client.

Fixes #3441 