### PR TITLE
Ensure dots on next line in chains are indented far enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [8.0.0-alpha-024] - 2026-08-28
+
+### Fixed
+
+- The dots of a chain that breaks are indented past the head of the chain, instead of landing on the head's own column or to the left of it. A dot on the head's column reads as a new item rather than as the chain continuing, and inside a parenthesis the parser refuses the output outright: `let v = ((someObject.First(a).Second(b).Third(c)))` at two-space indentation produced code Fantomas would not accept from itself, so the file was left unformatted with a bug report on the console. The dots now step one indent level at a time until they clear the head, which keeps every column a multiple of the indent size; a chain whose dots already cleared its head is untouched. This replaces a branch that anchored a parenthesised chain on its opening parenthesis, written when only a real dot chain reached it. Since `8.0.0-alpha-014` a dotted long identifier is a chain too, so it also fired for the likes of `Seq.map`, which never breaks, and moved a lambda written behind such a call three columns for no reason. [#3445](https://github.com/fsprojects/fantomas/pull/3445)
+
 ## [8.0.0-alpha-023] - 2026-08-28
 
 ### Fixed
@@ -297,6 +303,7 @@
 ### Changed
 
 - Update FCS to 'Remove LetOrUseKeyword from SynExprLetOrUseTrivia', commit 43932b4c7984d6562e91e5f1484868cd4f5befcf [#3167](https://github.com/fsprojects/fantomas/pull/3167)
+- `let!` and `use!` answer to `fsharp_max_value_binding_width`, as `let` and `use` always did, so a binding whose right-hand side is wider than that setting breaks after the `=` instead of holding one line up to the page width. The two of them were printed by a branch of their own that consulted the page width and nothing else, and the FCS update above is what let that branch go: once the parser stopped carrying the leading keyword in `SynExprLetOrUseTrivia`, a `let!` was built the way a `let` is and could be printed by the same code, which took three cases of `ComputationExpressionStatement` down to one. On default settings the two widths are 80 and 120, so a line of 110 characters carrying a body of 86 moves where it used to stay put. Code written in computation expressions is where this is felt. [#3167](https://github.com/fsprojects/fantomas/pull/3167)
 
 ## [7.0.6] - 2026-08-19
 

--- a/src/Fantomas.Core.Tests/ChainTests.fs
+++ b/src/Fantomas.Core.Tests/ChainTests.fs
@@ -888,3 +888,131 @@ let a =
     config // note
         .Settings.GetValue(key)
 """
+
+// ── A chain inside parentheses and the offside rule ─────────────────────────
+//
+// A segment that lands on the chain head's own column reads as a new item rather than
+// as a continuation. Inside a parenthesis the parser agrees and refuses the output,
+// because the parenthesis opened its offside context at that very column. `genChain`
+// compares the head's column with the column a fresh line would land on and adds a
+// level of indentation when they meet, whatever encloses the chain. The collision
+// depends on the indent size, so both 4 and 2 are covered here.
+
+[<Test>]
+let ``chain inside parentheses indents its segments past the head`` () =
+    formatSourceString
+        """
+let a xs =
+    xs
+    |> (someObject.First(one).Second(two).Third(three).Fourth(four).Fifth(five).Sixth(six))
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let a xs =
+    xs
+    |> (someObject
+            .First(one)
+            .Second(two)
+            .Third(three)
+            .Fourth(four)
+            .Fifth(five)
+            .Sixth(six))
+"""
+
+[<Test>]
+let ``chain that stays on one line inside parentheses does not indent what follows it`` () =
+    formatSourceString
+        """
+let b xs =
+    xs
+    |> (Seq.map (fun line -> transformTheLine line otherArgument finalArgument extraArgument))
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let b xs =
+    xs
+    |> (Seq.map (fun line ->
+        transformTheLine line otherArgument finalArgument extraArgument))
+"""
+
+[<Test>]
+let ``chain segments are moved off the head's column with no parenthesis in sight`` () =
+    formatSourceString
+        """
+let c xs =
+    xs
+    |>> someObject.First(one).Second(two).Third(three).Fourth(four).Fifth(five).Sixth(six)
+"""
+        { config with MaxLineLength = 80 }
+    |> prepend newline
+    |> should
+        equal
+        """
+let c xs =
+    xs
+    |>> someObject
+            .First(one)
+            .Second(two)
+            .Third(three)
+            .Fourth(four)
+            .Fifth(five)
+            .Sixth(six)
+"""
+
+[<Test>]
+let ``chain inside parentheses indents its segments past the head at two space indentation`` () =
+    formatSourceString
+        """
+let d =
+  ((someObject.First(one).Second(two).Third(three).Fourth(four).Fifth(five).Sixth(six)))
+"""
+        { config with
+            MaxLineLength = 80
+            IndentSize = 2
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let d =
+  ((someObject
+      .First(one)
+      .Second(two)
+      .Third(three)
+      .Fourth(four)
+      .Fifth(five)
+      .Sixth(six)))
+"""
+
+[<Test>]
+let ``chain inside parentheses clears a head that a pipe pushed to the right`` () =
+    formatSourceString
+        """
+let e xs =
+  xs
+  |> (someObject.First(one).Second(two).Third(three).Fourth(four).Fifth(five).Sixth(six))
+"""
+        { config with
+            MaxLineLength = 80
+            IndentSize = 2
+        }
+    |> prepend newline
+    |> should
+        equal
+        """
+let e xs =
+  xs
+  |> (someObject
+        .First(one)
+        .Second(two)
+        .Third(three)
+        .Fourth(four)
+        .Fifth(five)
+        .Sixth(six))
+"""

--- a/src/Fantomas.Core.Tests/QuotationTests.fs
+++ b/src/Fantomas.Core.Tests/QuotationTests.fs
@@ -123,10 +123,10 @@ test
             .Replace("8.12", "8.13") // CRAP score rounding
             .Replace("4.12", "4.13") // CRAP score rounding
             .Trim([| '\u00FF' |]) = expected
-                .Replace('\r', '\u00FF')
-                .Replace('\n', '\u00FF')
-                .Replace("\u00FF\u00FF", "\u00FF")
-                .Trim([| '\u00FF' |])
+                                        .Replace('\r', '\u00FF')
+                                        .Replace('\n', '\u00FF')
+                                        .Replace("\u00FF\u00FF", "\u00FF")
+                                        .Trim([| '\u00FF' |])
     @>
 """
 

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1213,7 +1213,32 @@ let genChain (node: ExprChain) : Context -> Context =
         if terminalIsCall && everySegmentIsLight && headIsSimple && headAndSegmentsFit then
             genChainKeptTogether ctx
         else
+
+        // Put the dots of the chain further right than where the chain started:
+        //
+        //     |> (someObject
+        //             .First(one)
+        //             .Second(two))
+        //
+        // A dot level with the head, or left of it, reads as a new item rather than as the
+        // chain continuing. Inside a parenthesis the parser agrees and refuses the output.
+
+        // Nothing is written yet, so this is the column the head will start on.
+        let headColumn: ChainColumn = ctx.Column
+
+        // Where a dot would land if we indented and broke the line right here.
+        let segmentColumn: ChainColumn =
+            ctx.WithDummy(indent +> sepNln, keepPageWidth = true).Column
+
+        if segmentColumn > headColumn then
             genLeadingDotPipeline ctx
+        else
+
+        // One whole level at a time until the dots clear the head, so every column stays a
+        // multiple of the indent size.
+        let levels: int = (headColumn - segmentColumn) / ctx.Config.IndentSize + 1
+
+        (rep levels indent +> genLeadingDotPipeline +> rep levels unindent) ctx
 
     // Try the whole chain on one line first; otherwise `long` decides between keeping the
     // chain together (with wrapped arguments) and the leading-dot pipeline.
@@ -3064,7 +3089,6 @@ let genExprInMultilineInfixExpr (e: Expr) =
             match infixNode.LeftHandSide with
             | Expr.Chain _ -> atCurrentColumnIndent (genExpr e)
             | _ -> genExpr e
-        | Expr.Chain _
         | Expr.Record _ -> atCurrentColumnIndent (genExpr e)
         | _ -> genExpr e
     | Expr.MatchLambda matchLambdaNode ->

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -58,7 +58,10 @@ type WriterModel =
         | _ -> false
 
 module WriterModel =
-    let init =
+    /// A function rather than a value: a module-level value is a static field, and a thread
+    /// reading it while the module is still initializing sees null. Every context starts from
+    /// a fresh record anyway, so there is nothing to share.
+    let init () =
         {
             LineCount = 0
             Indent = 0
@@ -203,7 +206,7 @@ type Context =
     static member Default =
         {
             Config = FormatConfig.Default
-            WriterModel = WriterModel.init
+            WriterModel = WriterModel.init ()
             WriterEvents = EventList()
             FormattedCursor = None
             DebugMode = false


### PR DESCRIPTION
## Where this came from

Formatting [Fable](https://github.com/fable-compiler/Fable) with the v8 alphas, as an upgrade trial against a real code base. One file came back with a change nobody asked for:

```fsharp
// 7.0.6
File.ReadLines packageJsonPath
|> (Seq.map (fun line ->
    if line.Contains originalPackageName then
        line.Replace(originalPackageName, newPackageName)
    else
        line
))

// 8.0.0-alpha-023
File.ReadLines packageJsonPath
|> (Seq.map (fun line ->
       if line.Contains originalPackageName then
           line.Replace(originalPackageName, newPackageName)
       else
           line
   ))
```

The body moved three columns, to a column anchored to nothing a reader can see: not the `|>`, not `Seq.map`, not `(fun`. Bisecting the published alphas put it in `8.0.0-alpha-014`, which is almost entirely #3385, the chain redesign.

## What was actually wrong

`genExprInMultilineInfixExpr` wraps a parenthesised right-hand side in `atCurrentColumnIndent` when the parentheses hold a chain. The branch dates to the original chain proof of concept and was written for `DotGetApp`, which meant a real dot chain:

```fsharp
| Paren (_, InfixApp (_, _, DotGet _, _, _), _, _)
| Paren (_, DotGetApp _, _, _) -> atCurrentColumnIndent (genExpr e)
```

#3385 made a dotted long identifier an `Expr.Chain`, so `Seq.map` began reaching a branch meant for fluent code. The condition kept its shape and lost its meaning.

The writer events show what it costs. `atCurrentColumnIndent` does not add an indent, it replaces the base indent with an absolute column, and nothing is written between that and the lambda's own `IndentBy`:

```
Write "|>"
SetAtColumn 7              the right side of the pipe
SetIndent 7                the base indent is now an absolute 7
  ExprParenNode, "(", ExprChain (Seq . map), "(", ExprLambdaNode, "fun", "->"
IndentBy 4                 the lambda, measured from 7 and not from 4
WriteLine                  the first newline since SetIndent
```

The reposition exists so that a chain that breaks lands where the parser accepts it. `Seq.map` never breaks, so it protected nothing and only moved the base that the lambda then indented from.

## Why the branch existed at all

Not style. Remove it and format a chain that does break, and Fantomas produces output it then refuses:

```
    |> (someObject
        .FirstMethodName(argumentOne)

error FS0010: Unexpected symbol '.' in expression
```

Measured with `fsc --parseonly`, the rule is an inequality rather than a minimum. A dot may sit left of the head; it may not sit on it:

| Shape | Head column | Dot column | Result |
| --- | --- | --- | --- |
| `\|> (chain` | 8 | 7 | parses |
| `\|> (chain` | 8 | 8 | **refused** |
| `\|> (chain` | 8 | 9 | parses |
| `\|>> chain`, no parentheses | 8 | 8 | parses |
| `\|> ((chain` | 9 | 9 | **refused** |

A parenthesis opens an offside context at the first token inside it, which is the chain's own head. A dot on that column starts a new item there instead of continuing the chain.

## A second bug the old branch never covered

The branch only ever ran for the right-hand side of a multiline infix. It never saw a `let` binding, so this was broken and unnoticed. On `8.0.0-alpha-023`, at two-space indentation:

```fsharp
let d =
  ((someObject.First(a).Second(b).Third(c).Fourth(d).Fifth(e).Sixth(f)))
```

produces invalid F# and is thrown away, leaving the file unformatted with a bug report on the console. This PR fixes that too.

## The fix

The constraint is a relation between the head's column and the dots' column. Both belong to the chain, so the rule lives in `genChain` rather than in one of its callers, which also means it can be asked only when the chain actually breaks:

```fsharp
// Nothing is written yet, so this is the column the head will start on.
let headColumn: ChainColumn = ctx.Column

// Where a dot would land if we indented and broke the line right here.
let segmentColumn: ChainColumn =
    ctx.WithDummy(indent +> sepNln, keepPageWidth = true).Column

if segmentColumn > headColumn then
    genLeadingDotPipeline ctx
else

// One whole level at a time until the dots clear the head, so every column stays a
// multiple of the indent size.
let levels: int = (headColumn - segmentColumn) / ctx.Config.IndentSize + 1

(rep levels indent +> genLeadingDotPipeline +> rep levels unindent) ctx
```

No absolute column is set, so `atIndentLevel` and `atCurrentColumnIndent` are gone from this path and every column stays a multiple of the indent size. The correction is stepped in whole levels, and a chain whose dots already clear the head takes the untouched path. The `Expr.Chain` case in `genExprInMultilineInfixExpr` is deleted.

This also matches what the F# style guide asks for under formatting chained expressions, "indent the subsequent links in the chain by one level after the leading link".

## Validation

- `Fantomas.Core.Tests` green. Five new tests in `ChainTests.fs`, one per shape, covering indent sizes 4 and 2. Four of them fail without the fix, including the one the parser refuses.
- **Fable**: one file changes out of 245, and it is exactly the regression above reverting to its 7.0.6 shape.
- **FsAutoComplete**: `src/` is byte-identical to `8.0.0-alpha-023`.

## One test to look at again: the `=` operator

`should preserve comments in quotation, 2535` had to be updated, and it is the one change here that does not look good:

```fsharp
            .Trim([| 'ÿ' |]) = expected
                                        .Replace('\r', 'ÿ')
```

The head `expected` trails a long `= ` at the end of its line, so clearing it means column 40. Every other affected chain stays where it was, because its dots already cleared its head.

That is not a chain problem. It is the no-break infix operator problem: `=`, `>`, `<`, `%` and `%%` cannot move down with their right-hand side, so the right-hand side stays beside them and whatever follows starts far to the right. [fslang-design#836](https://github.com/fsharp/fslang-design/issues/836) proposes giving that right-hand side a line of its own, which would put `expected` at a column the indent size explains and bring the dots back with it. #3434 is the implementation of that.

So this test changing is a fairly direct sign that #3434 is worth landing. Until then the expectation records what Fantomas actually does.
