### PR TITLE
Compile the signature file fslex generates for lex.fsl

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "fantomas": {
-      "version": "8.0.0-alpha-022",
+      "version": "8.0.0-alpha-025",
       "commands": [
         "fantomas"
       ],

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,8 +7,8 @@
     </ItemGroup>
 
     <!--
-      Overrides the CallFsYacc target from the FsLexYacc package. This file is imported after the
-      package's targets, so this definition is the one that runs.
+      Overrides the CallFsLex and CallFsYacc targets from the FsLexYacc package. This file is
+      imported after the package's targets, so these definitions are the ones that run.
 
       fsyacc prints every shift/reduce and reduce/reduce conflict it finds, unconditionally: there
       is no quiet or nowarn flag. For pars.fsy that is over 1400 lines of conflict reports on every
@@ -27,8 +27,26 @@
         2. The FileWrites ItemGroup is a copy-paste of the one in CallFsLex and registers the fslex
            output paths, so the generated parsers are never removed by dotnet clean.
 
-      Once those are fixed and released, this override can go away.
+      Bug 1 applies to CallFsLex too, and it is the reason that target is overridden here as well:
+      every generated .fsi is a Compile item, so deleting one on its own leaves the build unable to
+      find a source file it was told to compile, and no rebuild puts it back. CallFsLex needs the
+      Outputs fix alone; its FileWrites group already names the fslex paths. fslex is quiet, so
+      that Exec keeps the default output importance.
+
+      Once those are fixed and released, these overrides can go away.
     -->
+    <Target Name="CallFsLex"
+            Inputs="@(FsLex)"
+            Outputs="@(FsLex->'$(FsLexOutputFolder)%(Filename).fs');@(FsLex->'$(FsLexOutputFolder)%(Filename).fsi')"
+            Condition="'@(FsLex)'!=''"
+            BeforeTargets="CoreCompile">
+        <MakeDir Directories="$(FsLexOutputFolder)" />
+        <Exec Command="$(FsLexYaccToolRunner)&quot;$(FsLexToolPath)\$(FsLexToolExe)&quot; -o &quot;$(FsLexOutputFolder)%(FsLex.Filename).fs&quot; %(FsLex.OtherFlags) %(FsLex.Identity)" />
+        <ItemGroup>
+            <FileWrites Include="$(FsLexOutputFolder)%(FsLex.Filename).fs;$(FsLexOutputFolder)%(FsLex.Filename).fsi" />
+        </ItemGroup>
+    </Target>
+
     <Target Name="CallFsYacc"
             Inputs="@(FsYacc)"
             Outputs="@(FsYacc->'$(FsYaccOutputFolder)%(Filename).fs');@(FsYacc->'$(FsYaccOutputFolder)%(Filename).fsi')"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
         <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.6" />
         <PackageVersion Include="System.Memory" Version="4.6.3" />
         <PackageVersion Include="System.Runtime" Version="4.3.1" />
-        <PackageVersion Include="FsLexYacc" Version="11.3.0" />
+        <PackageVersion Include="FsLexYacc" Version="11.4.1" />
 
         <!-- Hosts the vendored FSharpEmbedResourceText MSBuild task, see Fantomas.FCS.BuildTasks. -->
         <PackageVersion Include="Microsoft.Build.Framework" Version="18.0.2" />

--- a/src/Fantomas.FCS/Fantomas.FCS.fsproj
+++ b/src/Fantomas.FCS/Fantomas.FCS.fsproj
@@ -347,9 +347,9 @@
     <Compile Include="$(FsYaccOutputFolder)pplex.fs">
       <Link>SyntaxTree\FsLexOutput\pplex.fs</Link>
     </Compile>
-<!--    <Compile Include="$(FsYaccOutputFolder)\lex.fsi">-->
-<!--      <Link>SyntaxTree\FsLexOutput\lex.fsi</Link>-->
-<!--    </Compile>-->
+    <Compile Include="$(FsYaccOutputFolder)\lex.fsi">
+      <Link>SyntaxTree\FsLexOutput\lex.fsi</Link>
+    </Compile>
     <Compile Include="$(FsYaccOutputFolder)\lex.fs">
       <Link>SyntaxTree\FsLexOutput\lex.fs</Link>
     </Compile>

--- a/src/Fantomas.FCS/packages.lock.json
+++ b/src/Fantomas.FCS/packages.lock.json
@@ -16,12 +16,12 @@
       },
       "FsLexYacc": {
         "type": "Direct",
-        "requested": "[11.3.0, )",
-        "resolved": "11.3.0",
-        "contentHash": "v0Q3/c0tizN8vRZ72Tdo+OKU767Yjul0wRJgG1/W15H4tK/9qHne/mylw/gTEIC8FV2zgiDlAudhQpdZXYG3IA==",
+        "requested": "[11.4.1, )",
+        "resolved": "11.4.1",
+        "contentHash": "t77MbPw80ndxR0GGkoFByCl27/oWW5jtLN7S4aYQ21IfoBnskXNdtOlxt7cJw/F9aD2dd8kqCrRbpMuE0cDyaQ==",
         "dependencies": {
           "FSharp.Core": "4.6.2",
-          "FsLexYacc.Runtime": "11.3.0"
+          "FsLexYacc.Runtime": "11.4.1"
         }
       },
       "G-Research.FSharp.Analyzers": {
@@ -94,8 +94,8 @@
       },
       "FsLexYacc.Runtime": {
         "type": "Transitive",
-        "resolved": "11.3.0",
-        "contentHash": "36b+4G+85WXU3kmbtq9hFSMGCLkn1nLzJoPgNaLUusnjXrC5ndAyS+hl13H6frpLCS3DB1wAmx/1SGYDe0avMw==",
+        "resolved": "11.4.1",
+        "contentHash": "BNLDgkJMztlyUgVV2SuECN5nPZK1C70g06r/dMKmyG7BbbLnQjTuCjAjrde0A5PLEKuVobIQAhuS7ljpoDX9aA==",
         "dependencies": {
           "FSharp.Core": "4.6.2"
         }


### PR DESCRIPTION
lex.fsi was the one generated signature left out of the build. lex.fsl's header defines a nested module, and fslex copied that module declaration into the signature while dropping its body, producing a file that would not compile. FsLexYacc 11.4.1 fixes that (fsprojects/FsLexYacc#240), so bump the pin and take the Compile item out of comments.

Compiling it exposes the missing .fsi in the package's CallFsLex Outputs, the fslex side of the bug CallFsYacc is already overridden for. Every generated .fsi is a Compile item, so deleting one on its own left the build asking for a source file that no rebuild would put back. Override CallFsLex the same way.

The CallFsYacc override stays: 11.4.1 ships none of the fixes it carries.
