### PR TITLE
Apply stroustrup bracket style to object expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [8.0.0-alpha-026] - 2026-08-29
+
+### Changed
+
+- `fsharp_multiline_bracket_style = stroustrup` now applies to object expressions, so `{` stays on the line that opens the binding and `new T with` moves below it. Up to now object expressions were printed by the `aligned` branch whatever the setting said, which left `{ new T with` on one line and made stroustrup the only bracket style that did not reach every bracket it names. The [Microsoft style guide](https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting#formatting-object-expressions) writes the form out under "Formatting object expressions" and Fantomas now produces it character for character. This was left alone in the belief that the layout was an offside error waiting to happen; it is not, and the compiler accepts it in a binding, a list item, a function argument, a lambda body, a match clause and a nested `let` alike. An object expression under stroustrup now lands where a record already landed in each of those positions. `aligned`, which is the default since `8.0.0-alpha-002`, and `cramped` are untouched. [#2990](https://github.com/fsprojects/fantomas/issues/2990)
+- `fsharp_multiline_bracket_style = stroustrup` now survives a binding whose signature broke across lines, and a match clause under `fsharp_experimental_keep_indent_in_branch`. Both were printed by branches written before stroustrup existed and never given a stroustrup-aware counterpart, so the setting was quietly overruled in each: a `let` whose parameters wrapped left its `=` alone on a line and indented the bracket below it, and a match clause under keep-indent did the same below the arrow. They now read `= {` and `| _ -> {`, with the items one level in and the closing bracket back at the column the binding or the clause started from, which is what the same code already produced when the signature fitted on one line or the setting was off. This reaches every bracket the setting names, so records, update records, anonymous records, anonymous structs, lists and arrays move with the object expressions of the entry above rather than behind them. The closing bracket of a match clause stays two columns right of the bar, because on the bar's own column the `|` of the next clause no longer parses. [#3450](https://github.com/fsprojects/fantomas/pull/3450)
+
 ## [8.0.0-alpha-025] - 2026-08-28
 
 ### Fixed

--- a/src/Fantomas.Core.Tests/Stroustrup/DotIndexedSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/DotIndexedSetExpressionTests.fs
@@ -144,6 +144,27 @@ myMutable.[x] <- [|
 """
 
 [<Test>]
+let ``dotIndexedSet with object expression`` () =
+    formatSourceString
+        """
+myMutable.[x] <-
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+myMutable.[x] <- {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
+"""
+
+[<Test>]
 let ``application unit dotIndexedSet with record instance `` () =
     formatSourceString
         """
@@ -278,6 +299,27 @@ app().[x] <- [|
 // See https://github.com/fsprojects/fantomas/issues/1999
 
 [<Test>]
+let ``application unit dotIndexedSet with object expression`` () =
+    formatSourceString
+        """
+app().[x] <-
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+app().[x] <- {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
+"""
+
+[<Test>]
 let ``application parenthesis expr dotIndexedSet with record instance `` () =
     formatSourceString
         """
@@ -407,4 +449,25 @@ app(meh).[x] <- [|
     itemFour
     itemFive
 |]
+"""
+
+[<Test>]
+let ``application parenthesis expr dotIndexedSet with object expression`` () =
+    formatSourceString
+        """
+app(meh).[x] <-
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+app(meh).[x] <- {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
 """

--- a/src/Fantomas.Core.Tests/Stroustrup/DotSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/DotSetExpressionTests.fs
@@ -165,3 +165,24 @@ App().foo <- [|
     itemFive
 |]
 """
+
+[<Test>]
+let ``dotSet with object expression`` () =
+    formatSourceString
+        """
+App().foo <-
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+App().foo <- {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
+"""

--- a/src/Fantomas.Core.Tests/Stroustrup/KeepIndentInBranchExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/KeepIndentInBranchExpressionTests.fs
@@ -33,12 +33,11 @@ match x with
         equal
         """
 match x with
-| _ ->
-    {
-        A = longTypeName
-        B = someOtherVariable
-        C = ziggyBarX
-    }
+| _ -> {
+    A = longTypeName
+    B = someOtherVariable
+    C = ziggyBarX
+  }
 """
 
 [<Test>]
@@ -55,11 +54,10 @@ match x with
         equal
         """
 match x with
-| _ ->
-    {
-        astContext with
-            IsInsideMatchClausePattern = true
-    }
+| _ -> {
+    astContext with
+        IsInsideMatchClausePattern = true
+  }
 """
 
 [<Test>]
@@ -78,12 +76,11 @@ match x with
         equal
         """
 match x with
-| _ ->
-    {|
-        A = longTypeName
-        B = someOtherVariable
-        C = ziggyBarX
-    |}
+| _ -> {|
+    A = longTypeName
+    B = someOtherVariable
+    C = ziggyBarX
+  |}
 """
 
 [<Test>]
@@ -103,12 +100,11 @@ match x with
         equal
         """
 match x with
-| _ ->
-    struct {|
-        A = longTypeName
-        B = someOtherVariable
-        C = ziggyBarX
-    |}
+| _ -> struct {|
+    A = longTypeName
+    B = someOtherVariable
+    C = ziggyBarX
+  |}
 """
 
 [<Test>]
@@ -153,14 +149,13 @@ match x with
         equal
         """
 match x with
-| _ ->
-    [
-        itemOne
-        itemTwo
-        itemThree
-        itemFour
-        itemFive
-    ]
+| _ -> [
+    itemOne
+    itemTwo
+    itemThree
+    itemFour
+    itemFive
+  ]
 """
 
 [<Test>]
@@ -181,12 +176,34 @@ match x with
         equal
         """
 match x with
+| _ -> [|
+    itemOne
+    itemTwo
+    itemThree
+    itemFour
+    itemFive
+  |]
+"""
+
+[<Test>]
+let ``synMatchClause in match expression with object expression`` () =
+    formatSourceString
+        """
+match x with
 | _ ->
-    [|
-        itemOne
-        itemTwo
-        itemThree
-        itemFour
-        itemFive
-    |]
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+match x with
+| _ -> {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+  }
 """

--- a/src/Fantomas.Core.Tests/Stroustrup/LambdaExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/LambdaExpressionTests.fs
@@ -144,6 +144,27 @@ fun x -> [|
 """
 
 [<Test>]
+let ``lambda with object expression`` () =
+    formatSourceString
+        """
+fun x ->
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+fun x -> {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
+"""
+
+[<Test>]
 let ``paren lambda with record instance `` () =
     formatSourceString
         """
@@ -276,6 +297,27 @@ let ``paren lambda with array`` () =
 """
 
 [<Test>]
+let ``paren lambda with object expression`` () =
+    formatSourceString
+        """
+(fun x ->
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable })
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(fun x -> {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+})
+"""
+
+[<Test>]
 let ``app paren lambda with record instance `` () =
     formatSourceString
         """
@@ -405,6 +447,27 @@ List.map (fun x -> [|
     itemFour
     itemFive
 |])
+"""
+
+[<Test>]
+let ``app paren lambda with object expression`` () =
+    formatSourceString
+        """
+List.map (fun x ->
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable })
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+List.map (fun x -> {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+})
 """
 
 [<Test>]
@@ -553,6 +616,30 @@ List.map
         itemFour
         itemFive
     |])
+    b
+    c
+"""
+
+[<Test>]
+let ``app paren lambda with object expression and other args`` () =
+    formatSourceString
+        """
+List.map (fun x ->
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }) b c
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+List.map
+    (fun x -> {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    })
     b
     c
 """
@@ -708,5 +795,27 @@ Bar
         itemFour
         itemFive
     |])
+    .Bar()
+"""
+
+[<Test>]
+let ``dotGetApp with lambda with object expression`` () =
+    formatSourceString
+        """
+Bar.Foo(fun x -> { new IFoo with
+                     member _.Bar() = longTypeName
+                     member _.Baz() = someOtherVariable }).Bar()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+Bar
+    .Foo(fun x -> {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    })
     .Bar()
 """

--- a/src/Fantomas.Core.Tests/Stroustrup/LetOrUseBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/LetOrUseBangExpressionTests.fs
@@ -191,3 +191,32 @@ collect {
     return items
 }
 """
+
+[<Test>]
+let ``letOrUseBang with object expression`` () =
+    formatSourceString
+        """
+opt {
+    let! foo =
+        { new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable }
+
+    ()
+}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+opt {
+    let! foo = {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    }
+
+    ()
+}
+"""

--- a/src/Fantomas.Core.Tests/Stroustrup/LongIdentSetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/LongIdentSetExpressionTests.fs
@@ -142,3 +142,24 @@ myMutable <- [|
     itemFive
 |]
 """
+
+[<Test>]
+let ``longIdentSet with object expression`` () =
+    formatSourceString
+        """
+myMutable <-
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+myMutable <- {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
+"""

--- a/src/Fantomas.Core.Tests/Stroustrup/MultiLineLambdaClosingNewlineExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/MultiLineLambdaClosingNewlineExpressionTests.fs
@@ -145,6 +145,27 @@ let ``paren lambda with array`` () =
 """
 
 [<Test>]
+let ``paren lambda with object expression`` () =
+    formatSourceString
+        """
+(fun x ->
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable })
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+(fun x -> {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+})
+"""
+
+[<Test>]
 let ``app paren lambda with record instance `` () =
     formatSourceString
         """
@@ -274,6 +295,27 @@ List.map (fun x -> [|
     itemFour
     itemFive
 |])
+"""
+
+[<Test>]
+let ``app paren lambda with object expression`` () =
+    formatSourceString
+        """
+List.map (fun x ->
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable })
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+List.map (fun x -> {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+})
 """
 
 [<Test>]
@@ -422,6 +464,30 @@ List.map
         itemFour
         itemFive
     |])
+    b
+    c
+"""
+
+[<Test>]
+let ``app paren lambda with object expression and other args`` () =
+    formatSourceString
+        """
+List.map (fun x ->
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }) b c
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+List.map
+    (fun x -> {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    })
     b
     c
 """
@@ -577,6 +643,28 @@ Bar
         itemFour
         itemFive
     |])
+    .Bar()
+"""
+
+[<Test>]
+let ``dotGetApp with lambda with object expression`` () =
+    formatSourceString
+        """
+Bar.Foo(fun x -> { new IFoo with
+                     member _.Bar() = longTypeName
+                     member _.Baz() = someOtherVariable }).Bar()
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+Bar
+    .Foo(fun x -> {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    })
     .Bar()
 """
 

--- a/src/Fantomas.Core.Tests/Stroustrup/NamedArgumentExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/NamedArgumentExpressionTests.fs
@@ -185,6 +185,33 @@ let v =
 """
 
 [<Test>]
+let ``synExprApp with named argument with object expression`` () =
+    formatSourceString
+        """
+let v =
+    SomeConstructor(
+        v =
+            { new IFoo with
+                member _.Bar() = longTypeName
+                member _.Baz() = someOtherVariable }
+    )
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    SomeConstructor(
+        v = {
+            new IFoo with
+                member _.Bar() = longTypeName
+                member _.Baz() = someOtherVariable
+        }
+    )
+"""
+
+[<Test>]
 let ``synExprApp with multiple named arguments`` () =
     formatSourceString
         """
@@ -400,6 +427,33 @@ let v =
             itemFour
             itemFive
         |]
+    )
+"""
+
+[<Test>]
+let ``synExprNew with named argument with object expression`` () =
+    formatSourceString
+        """
+let v =
+    new FooBar(
+        v =
+            { new IFoo with
+                member _.Bar() = longTypeName
+                member _.Baz() = someOtherVariable }
+    )
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let v =
+    new FooBar(
+        v = {
+            new IFoo with
+                member _.Bar() = longTypeName
+                member _.Baz() = someOtherVariable
+        }
     )
 """
 

--- a/src/Fantomas.Core.Tests/Stroustrup/SetExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SetExpressionTests.fs
@@ -142,3 +142,24 @@ myMutable[x] <- [|
     itemFive
 |]
 """
+
+[<Test>]
+let ``set with object expression`` () =
+    formatSourceString
+        """
+myMutable[x] <-
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+myMutable[x] <- {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
+"""

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionExpressionTests.fs
@@ -156,6 +156,27 @@ let x y = [|
 """
 
 [<Test>]
+let ``synbinding function with object expression`` () =
+    formatSourceString
+        """
+let x y =
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x y = {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
+"""
+
+[<Test>]
 let ``type member function with record instance`` () =
     formatSourceString
         """
@@ -296,6 +317,29 @@ type Foo() =
         itemFour
         itemFive
     |]
+"""
+
+[<Test>]
+let ``type member function with object expression`` () =
+    formatSourceString
+        """
+type Foo() =
+    member this.Bar x =
+        { new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Foo() =
+    member this.Bar x = {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    }
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionLongPatternExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionLongPatternExpressionTests.fs
@@ -42,12 +42,11 @@ let private addTaskToScheduler
     prio
     (task: unit -> unit)
     groupName
-    =
-    {
-        A = longTypeName
-        B = someOtherVariable
-        C = ziggyBarX
-    }
+    = {
+    A = longTypeName
+    B = someOtherVariable
+    C = ziggyBarX
+}
 """
 
 [<Test>]
@@ -76,11 +75,10 @@ let private addTaskToScheduler
     prio
     (task: unit -> unit)
     groupName
-    =
-    {
-        astContext with
-            IsInsideMatchClausePattern = true
-    }
+    = {
+    astContext with
+        IsInsideMatchClausePattern = true
+}
 """
 
 [<Test>]
@@ -111,12 +109,11 @@ let private addTaskToScheduler
     prio
     (task: unit -> unit)
     groupName
-    =
-    {|
-        A = longTypeName
-        B = someOtherVariable
-        C = ziggyBarX
-    |}
+    = {|
+    A = longTypeName
+    B = someOtherVariable
+    C = ziggyBarX
+|}
 """
 
 [<Test>]
@@ -185,14 +182,13 @@ let private addTaskToScheduler
     prio
     (task: unit -> unit)
     groupName
-    =
-    [
-        itemOne
-        itemTwo
-        itemThree
-        itemFour
-        itemFive
-    ]
+    = [
+    itemOne
+    itemTwo
+    itemThree
+    itemFour
+    itemFive
+]
 """
 
 [<Test>]
@@ -225,14 +221,48 @@ let private addTaskToScheduler
     prio
     (task: unit -> unit)
     groupName
+    = [|
+    itemOne
+    itemTwo
+    itemThree
+    itemFour
+    itemFive
+|]
+"""
+
+[<Test>]
+let ``synbinding function with object expression`` () =
+    formatSourceString
+        """
+let private addTaskToScheduler
+    (scheduler: IScheduler)
+    taskName
+    taskCron
+    prio
+    (task: unit -> unit)
+    groupName
     =
-    [|
-        itemOne
-        itemTwo
-        itemThree
-        itemFour
-        itemFive
-    |]
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let private addTaskToScheduler
+    (scheduler: IScheduler)
+    taskName
+    taskCron
+    prio
+    (task: unit -> unit)
+    groupName
+    = {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
 """
 
 [<Test>]
@@ -265,12 +295,11 @@ type Foo() =
         prio
         (task: unit -> unit)
         groupName
-        =
-        {
-            A = longTypeName
-            B = someOtherVariable
-            C = ziggyBarX
-        }
+        = {
+        A = longTypeName
+        B = someOtherVariable
+        C = ziggyBarX
+    }
 """
 
 [<Test>]
@@ -300,11 +329,10 @@ type Foo() =
         prio
         (task: unit -> unit)
         groupName
-        =
-        {
-            astContext with
-                IsInsideMatchClausePattern = true
-        }
+        = {
+        astContext with
+            IsInsideMatchClausePattern = true
+    }
 """
 
 [<Test>]
@@ -337,12 +365,11 @@ type Foo() =
         prio
         (task: unit -> unit)
         groupName
-        =
-        {|
-            A = longTypeName
-            B = someOtherVariable
-            C = ziggyBarX
-        |}
+        = {|
+        A = longTypeName
+        B = someOtherVariable
+        C = ziggyBarX
+    |}
 """
 
 [<Test>]
@@ -376,12 +403,11 @@ type Foo() =
         prio
         (task: unit -> unit)
         groupName
-        =
-        struct {|
-            A = longTypeName
-            B = someOtherVariable
-            C = ziggyBarX
-        |}
+        = struct {|
+        A = longTypeName
+        B = someOtherVariable
+        C = ziggyBarX
+    |}
 """
 
 [<Test>]
@@ -454,14 +480,13 @@ type Foo() =
         prio
         (task: unit -> unit)
         groupName
-        =
-        [
-            itemOne
-            itemTwo
-            itemThree
-            itemFour
-            itemFive
-        ]
+        = [
+        itemOne
+        itemTwo
+        itemThree
+        itemFour
+        itemFive
+    ]
 """
 
 [<Test>]
@@ -496,12 +521,48 @@ type Foo() =
         prio
         (task: unit -> unit)
         groupName
+        = [|
+        itemOne
+        itemTwo
+        itemThree
+        itemFour
+        itemFive
+    |]
+"""
+
+[<Test>]
+let ``type member function with object expression`` () =
+    formatSourceString
+        """
+type Foo() =
+    member this.addTaskToScheduler
+        (scheduler: IScheduler)
+        taskName
+        taskCron
+        prio
+        (task: unit -> unit)
+        groupName
         =
-        [|
-            itemOne
-            itemTwo
-            itemThree
-            itemFour
-            itemFive
-        |]
+        { new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Foo() =
+    member this.addTaskToScheduler
+        (scheduler: IScheduler)
+        taskName
+        taskCron
+        prio
+        (task: unit -> unit)
+        groupName
+        = {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    }
 """

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionWithReturnTypeExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingFunctionWithReturnTypeExpressionTests.fs
@@ -122,6 +122,27 @@ let x y : int array = [|
 """
 
 [<Test>]
+let ``synbinding function with object expression`` () =
+    formatSourceString
+        """
+let x y : IFoo =
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x y : IFoo = {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
+"""
+
+[<Test>]
 let ``type member function with record instance`` () =
     formatSourceString
         """
@@ -262,4 +283,27 @@ type Foo() =
         itemFour
         itemFive
     |]
+"""
+
+[<Test>]
+let ``type member function with object expression`` () =
+    formatSourceString
+        """
+type Foo() =
+    member this.Bar x : IFoo =
+        { new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Foo() =
+    member this.Bar x : IFoo = {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    }
 """

--- a/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynBindingValueExpressionTests.fs
@@ -168,6 +168,27 @@ let t = [|
 """
 
 [<Test>]
+let ``synbinding value with object expression`` () =
+    formatSourceString
+        """
+let x =
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+let x = {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
+"""
+
+[<Test>]
 let ``nested synbinding value with record`` () =
     formatSourceString
         """
@@ -334,6 +355,29 @@ type Foo() =
         itemFour
         itemFive
     |]
+"""
+
+[<Test>]
+let ``type member value with object expression`` () =
+    formatSourceString
+        """
+type Foo() =
+    member this.Bar =
+        { new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+type Foo() =
+    member this.Bar = {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    }
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/SynExprAndBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynExprAndBangExpressionTests.fs
@@ -210,3 +210,35 @@ collect {
     return items
 }
 """
+
+[<Test>]
+let ``andBang with object expression`` () =
+    formatSourceString
+        """
+opt {
+    let! abc = def ()
+    and! foo =
+        { new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable }
+
+    ()
+}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+opt {
+    let! abc = def ()
+
+    and! foo = {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    }
+
+    ()
+}
+"""

--- a/src/Fantomas.Core.Tests/Stroustrup/SynMatchClauseExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/SynMatchClauseExpressionTests.fs
@@ -159,6 +159,29 @@ match x with
 // Similar to long patterns in synbinding functions.
 
 [<Test>]
+let ``synMatchClause in match expression with object expression`` () =
+    formatSourceString
+        """
+match x with
+| _ ->
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+match x with
+| _ -> {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+  }
+"""
+
+[<Test>]
 let ``synMatchClause in match expression with long when expression with record instance `` () =
     formatSourceString
         """
@@ -348,6 +371,31 @@ with ex -> [|
     itemFour
     itemFive
 |]
+"""
+
+[<Test>]
+let ``synMatchClause in try/with expression with object expression`` () =
+    formatSourceString
+        """
+try
+    foo()
+with ex ->
+    { new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable }
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+try
+    foo ()
+with ex -> {
+    new IFoo with
+        member _.Bar() = longTypeName
+        member _.Baz() = someOtherVariable
+}
 """
 
 [<Test>]

--- a/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnBangExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnBangExpressionTests.fs
@@ -239,3 +239,38 @@ myComp {
     |]
 }
 """
+
+[<Test>]
+let ``yieldOrReturnBang with object expression`` () =
+    formatSourceString
+        """
+myComp {
+    yield!
+        { new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable }
+    return!
+        { new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable }
+}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+myComp {
+    yield! {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    }
+
+    return! {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    }
+}
+"""

--- a/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnExpressionTests.fs
+++ b/src/Fantomas.Core.Tests/Stroustrup/YieldOrReturnExpressionTests.fs
@@ -239,3 +239,38 @@ myComp {
     |]
 }
 """
+
+[<Test>]
+let ``yieldOrReturn with object expression`` () =
+    formatSourceString
+        """
+myComp {
+    yield
+        { new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable }
+    return
+        { new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable }
+}
+"""
+        config
+    |> prepend newline
+    |> should
+        equal
+        """
+myComp {
+    yield {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    }
+
+    return {
+        new IFoo with
+            member _.Bar() = longTypeName
+            member _.Baz() = someOtherVariable
+    }
+}
+"""

--- a/src/Fantomas.Core/CodePrinter.fs
+++ b/src/Fantomas.Core/CodePrinter.fs
@@ -1436,7 +1436,7 @@ let genExpr (e: Expr) =
                 +> sepNlnBeforeInterfaces
                 +> colEx sepNlnUnlessContentBefore node.Interfaces genInterfaceImpl
 
-            let genObjExpr =
+            let genObjExprCramped: Context -> Context =
                 genSingleTextNode node.OpeningBrace
                 +> addSpaceIfSpaceAroundDelimiter
                 +> atCurrentColumn (
@@ -1451,7 +1451,7 @@ let genExpr (e: Expr) =
                 +> addSpaceIfSpaceAroundDelimiter
                 +> genSingleTextNode node.ClosingBrace
 
-            let genObjExprAlignBrackets =
+            let genObjExprAlignBrackets: Context -> Context =
                 let genObjExpr =
                     atCurrentColumn (
                         genSingleTextNode node.New
@@ -1471,7 +1471,25 @@ let genExpr (e: Expr) =
                     +> genSingleTextNode node.ClosingBrace
                 )
 
-            ifAlignOrStroustrupBrackets genObjExprAlignBrackets genObjExpr
+            let genObjExprStroustrup: Context -> Context =
+                genSingleTextNode node.OpeningBrace
+                +> indentSepNlnUnindent (
+                    genSingleTextNode node.New
+                    +> sepSpace
+                    +> genType node.Type
+                    +> param
+                    +> sepSpace
+                    +> optSingle genSingleTextNode node.With
+                    +> genBody
+                )
+                +> sepNln
+                +> genSingleTextNode node.ClosingBrace
+
+            fun ctx ->
+                match ctx.Config.MultilineBracketStyle with
+                | Stroustrup -> genObjExprStroustrup ctx
+                | Aligned -> genObjExprAlignBrackets ctx
+                | Cramped -> genObjExprCramped ctx
         |> genNode node
     | Expr.While node ->
         atCurrentColumn (
@@ -2907,7 +2925,9 @@ let genClause (isLastItem: bool) (node: MatchClauseNode) =
 
                 (sepArrow
                  +> ifElse
-                     (ctx.Config.ExperimentalKeepIndentInBranch && isLastItem)
+                     (ctx.Config.ExperimentalKeepIndentInBranch
+                      && isLastItem
+                      && not (isStroustrupStyleExpr ctx.Config node.BodyExpr))
                      genKeepIndentInBranch
                      (autoIndentAndNlnIfExpressionExceedsPageWidthUnlessStroustrup genExpr node.BodyExpr))
                     ctx
@@ -2918,6 +2938,9 @@ let genClause (isLastItem: bool) (node: MatchClauseNode) =
             (genPatInClause node.Pattern +> genWhenAndBody) ctx
         else
 
+        // The column is taken after the bar, so a stroustrup closing bracket lands strictly right of
+        // it. On the bar's own column the `|` of the next clause no longer parses, and giving only
+        // the last clause the bar's column would leave two columns in one match. See #2990.
         let startColumn = ctx.Column
         (genPatInClause node.Pattern +> atIndentLevel false startColumn genWhenAndBody) ctx
 
@@ -3887,7 +3910,7 @@ let genBinding (b: BindingNode) (ctx: Context) : Context =
 
             let genExpr isMultiline =
                 if isMultiline then
-                    indentSepNlnUnindent body
+                    indentSepNlnUnindentUnlessStroustrup (fun e -> sepSpace +> genExpr e) b.Expr
                 else
 
                 let short = sepSpace +> body

--- a/src/Fantomas.Core/Context.fs
+++ b/src/Fantomas.Core/Context.fs
@@ -905,6 +905,7 @@ let isStroustrupStyleExpr (config: FormatConfig) (e: Expr) =
     match e with
     | Expr.Record _
     | Expr.AnonStructRecord _
+    | Expr.ObjExpr _
     | Expr.ArrayOrList _ -> isStroustrupEnabled
     | Expr.NamedComputation _ -> not config.NewlineBeforeMultilineComputationExpression
     | _ -> false


### PR DESCRIPTION
Object expressions were printed by the aligned branch whatever MultilineBracketStyle said, so `{ new T with` stayed on one line and stroustrup was the only bracket style that did not reach every bracket it names. They now have a branch of their own, and Expr.ObjExpr counts as a stroustrup-style expression, so the brace stays on the line that opens the binding and `new T with` moves below it. This is the form the Microsoft style guide writes out under "Formatting object expressions". It was left alone in the belief that the layout produced an offside error, which no compiler back to F# 6 agrees with.

Two places that were overriding stroustrup are lifted along with it, for every bracket kind rather than for object expressions alone. A match clause governed by ExperimentalKeepIndentInBranch no longer takes the decision away from a stroustrup body, and a binding whose signature broke across lines now gets the stroustrup body layout that the single-line path already had.

The closing bracket of a stroustrup body in a match clause stays two columns right of the bar. On the bar's own column the `|` of the next clause no longer parses, and giving only the last clause the bar's column would leave two columns in one match; a comment records both.

Fixes #2990 