### PR TITLE
Add more useful doc comments in signature files

### DIFF
--- a/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
+++ b/src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs
@@ -40,6 +40,7 @@ let ``+> will compose two functions`` () =
 
     // (+>) is very similar to `>>` in F#
     // There is an implementation detail but conceptually it is the same.
+    // The detail is shown in `+> stops composing once a short expression attempt is confirmed multiline` below.
     let h (context: Context) : Context =
         // This is the equivalent of `g (f context)`
         (f +> g) context
@@ -202,7 +203,7 @@ let ``trying multiple code paths`` () =
     Assert.AreEqual("This fits on\ntwo lines", code)
 
 // There are other various helper functions for code path fallback.
-// `isShortExpression`, `sepSpaceIfShortExpressionOrAddIndentAndNewline`, `leadingExpressionIsMultiline`, ...
+// `isShortExpression`, `sepSpaceOrIndentAndNlnIfExpressionExceedsPageWidth`, `leadingExpressionIsMultiline`, ...
 
 [<Test>]
 let ``printing trivia instructions`` () =
@@ -1104,3 +1105,73 @@ let ``autoIndentAndNlnIfExpressionExceedsPageWidth without trailing trivia still
         |> dump
 
     Assert.AreEqual("let x =\n    a long expression that does not fit\nnext", code)
+
+// ============================================================================
+// What a layout attempt costs
+// These tests show two things the signatures cannot: `+>` is not plain composition,
+// and every fallback runs the expression again.
+// ============================================================================
+
+[<Test>]
+let ``+> stops composing once a short expression attempt is confirmed multiline`` () =
+    // Inside a single-line attempt the WriterModel runs in ShortExpression mode.
+    // The first newline confirms that the attempt failed, and from then on `+>` no longer
+    // calls its right-hand side. The rest of the expression is never printed, which is what
+    // keeps a failed attempt cheap.
+    let mutable rightHandSideCalls = 0
+
+    let neverReached (ctx: Context) =
+        rightHandSideCalls <- rightHandSideCalls + 1
+        !- "never reached" ctx
+
+    let short = !-"first" +> sepNln +> neverReached
+    let fallback = !-"fallback"
+    let code = expressionFitsOnRestOfLine short fallback (mkLfCtx ()) |> dump
+
+    Assert.AreEqual("fallback", code)
+    Assert.AreEqual(0, rightHandSideCalls)
+
+    // In Standard mode `+>` always runs both sides, so the same function prints everything.
+    let code = short (mkLfCtx ()) |> dump
+    Assert.AreEqual("first\nnever reached", code)
+    Assert.AreEqual(1, rightHandSideCalls)
+
+[<Test>]
+let ``every fallback layer runs the expression once more`` () =
+    // A page width helper first prints the expression as a single-line attempt.
+    // When that fails, the events are rolled back and the expression is printed again as the long layout.
+    // A helper nested inside another helper is part of the outer attempt as well, so the innermost
+    // expression is printed once per layer that falls back, plus once for the outer attempt.
+    // A subtree wrapped in n of these helpers can therefore be printed n + 1 times.
+    // Decide the layout once, as high in the tree as possible, rather than at every level.
+    let mutable leafCalls = 0
+
+    let leaf (ctx: Context) =
+        leafCalls <- leafCalls + 1
+        !- "a leaf that is far too long for the page" ctx
+
+    let ctx () =
+        { mkLfCtx () with
+            Config =
+                { (mkLfCtx ()).Config with
+                    MaxLineLength = 20
+                }
+        }
+
+    // One helper: the attempt and the fallback.
+    let _ = autoIndentAndNlnIfExpressionExceedsPageWidth leaf (ctx ())
+    Assert.AreEqual(2, leafCalls)
+
+    // Two helpers: the outer attempt, then the inner attempt and the inner fallback.
+    leafCalls <- 0
+
+    let nested =
+        autoIndentAndNlnIfExpressionExceedsPageWidth (!-"x = " +> autoIndentAndNlnIfExpressionExceedsPageWidth leaf)
+
+    let _ = nested (ctx ())
+    Assert.AreEqual(3, leafCalls)
+
+    // A probe such as `futureNlnCheck` is a full run as well. Asking and then printing is two runs.
+    leafCalls <- 0
+    let _ = ifElseCtx (futureNlnCheck leaf) leaf leaf (ctx ())
+    Assert.AreEqual(2, leafCalls)

--- a/src/Fantomas.Core.Tests/DefinesTests.fs
+++ b/src/Fantomas.Core.Tests/DefinesTests.fs
@@ -1,4 +1,4 @@
-module Fantomas.Core.Tests.TokenParserTests
+module Fantomas.Core.Tests.DefinesTests
 
 open NUnit.Framework
 open FsUnit

--- a/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
+++ b/src/Fantomas.Core.Tests/Fantomas.Core.Tests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="UtilsTests.fs" />
     <Compile Include="QueueTests.fs" />
     <Compile Include="DefinesTests.fs" />
+    <Compile Include="TriviaAssignmentTests.fs" />
     <Compile Include="StringTests.fs" />
     <Compile Include="CommentTests.fs" />
     <Compile Include="ShebangTests.fs" />

--- a/src/Fantomas.Core.Tests/TriviaAssignmentTests.fs
+++ b/src/Fantomas.Core.Tests/TriviaAssignmentTests.fs
@@ -1,0 +1,162 @@
+module Fantomas.Core.Tests.TriviaAssignmentTests
+
+open NUnit.Framework
+open Fantomas.Core
+open Fantomas.Core.SyntaxOak
+
+// This test suite illustrates where `Trivia.enrichTree` attaches comments and blank lines.
+// Each test parses a small source, walks to a node, and asserts which trivia sits before or after it.
+// Debug these when a comment ends up in the wrong place after formatting.
+
+let private parseOak (source: string) : Oak =
+    CodeFormatter.ParseOakAsync(false, source)
+    |> Async.RunSynchronously
+    |> Array.head
+    |> fst
+
+let private declarations (oak: Oak) : ModuleDecl list =
+    oak.ModulesOrNamespaces.[0].Declarations
+
+let private binding (decl: ModuleDecl) : BindingNode =
+    match decl with
+    | ModuleDecl.TopLevelBinding node -> node
+    | other -> failwith $"Expected a binding, got %A{other}"
+
+let private contentsBefore (node: Node) : TriviaContent list =
+    node.ContentBefore |> Seq.map _.Content |> Seq.toList
+
+let private contentsAfter (node: Node) : TriviaContent list =
+    node.ContentAfter |> Seq.map _.Content |> Seq.toList
+
+let private assertTrivia (expected: TriviaContent list) (actual: TriviaContent list) : unit =
+    Assert.That(actual, Is.EqualTo<TriviaContent list>(expected))
+
+[<Test>]
+let ``a comment on its own line goes before the next sibling`` () =
+    let oak =
+        parseOak
+            """
+let a = 1
+// about b
+let b = 2
+"""
+
+    let b = declarations oak |> List.item 1 |> binding
+    assertTrivia [ CommentOnSingleLine "// about b" ] (contentsBefore b)
+    // The comment is not attached to `a`, the sibling it follows.
+    let a = declarations oak |> List.head |> binding
+    assertTrivia List.empty<TriviaContent> (contentsAfter a)
+
+[<Test>]
+let ``a comment after code on the same line goes after the last node on that line`` () =
+    let oak =
+        parseOak
+            """
+let a = 1 // trailing
+let b = 2
+"""
+
+    // The container is the module, and the child that ends on the comment's line is the binding `a`.
+    // The trivia is pushed down to the last node of that binding, the literal `1`, so that the
+    // printer emits the comment right after the code that was on the line, not after the whole binding.
+    let a = declarations oak |> List.head |> binding
+
+    match a.Expr with
+    | Expr.Constant(Constant.FromText literal) ->
+        assertTrivia [ LineCommentAfterSourceCode "// trailing" ] (contentsAfter literal)
+    | other -> Assert.Fail $"Expected a constant, got %A{other}"
+
+    assertTrivia List.empty<TriviaContent> (contentsAfter a)
+
+[<Test>]
+let ``a comment before a closing bracket goes after the last element`` () =
+    let oak =
+        parseOak
+            """
+let xs = [
+    1
+    // after the last element
+]
+"""
+
+    // The next sibling is the closing bracket, and a bracket never owns a comment.
+    let xs = declarations oak |> List.head |> binding
+
+    match xs.Expr with
+    | Expr.ArrayOrList list ->
+        assertTrivia List.empty<TriviaContent> (contentsBefore list.Closing)
+
+        match list.Elements with
+        | [ Expr.Constant(Constant.FromText one) ] ->
+            assertTrivia [ CommentOnSingleLine "// after the last element" ] (contentsAfter one)
+        | other -> Assert.Fail $"Expected one element, got %A{other}"
+    | other -> Assert.Fail $"Expected a list, got %A{other}"
+
+[<Test>]
+let ``an indented comment stays with the sibling at its column`` () =
+    let oak =
+        parseOak
+            """
+let x =
+    try foo () with _ -> ()
+    // still about the try
+let y = 1
+"""
+
+    // The next sibling in the module, `y`, starts at column 0 and the comment at column 4.
+    // The comment therefore goes after the deepest earlier node that starts at column 4, the try-with.
+    let x = declarations oak |> List.head |> binding
+    let y = declarations oak |> List.item 1 |> binding
+    assertTrivia List.empty<TriviaContent> (contentsBefore y)
+
+    match x.Expr with
+    | Expr.TryWithSingleClause tryWith ->
+        assertTrivia [ CommentOnSingleLine "// still about the try" ] (contentsAfter tryWith)
+    | other -> Assert.Fail $"Expected a try-with, got %A{other}"
+
+[<Test>]
+let ``a blank line is a Newline trivia before the node that follows it`` () =
+    let oak =
+        parseOak
+            """
+let a = 1
+
+let b = 2
+"""
+
+    let b = declarations oak |> List.item 1 |> binding
+    assertTrivia [ Newline ] (contentsBefore b)
+
+[<Test>]
+let ``blank lines before an indented comment travel with the comment`` () =
+    let oak =
+        parseOak
+            """
+let f () =
+    let a = 1
+
+    // about b
+    let b = 2
+    a + b
+"""
+
+    // The blank line is at column 0 and the comment at column 4. Kept apart, they would be assigned
+    // through different rules and could land on different nodes. Together they are one trivia that
+    // records how many blank lines preceded the comment.
+    let f = declarations oak |> List.head |> binding
+
+    match f.Expr with
+    | Expr.CompExprBody body ->
+        match body.Statements with
+        | [ _; ComputationExpressionStatement.BindingStatement b; _ ] ->
+            assertTrivia [ CommentOnSingleLineWithLeadingNewlines(1, "// about b") ] (contentsBefore b)
+        | other -> Assert.Fail $"Expected three statements, got %A{other}"
+    | other -> Assert.Fail $"Expected a computation expression body, got %A{other}"
+
+[<Test>]
+let ``trivia outside every node is attached to the root`` () =
+    let oak = parseOak "let a = 1\n// the end"
+
+    // Nothing in the tree spans the final comment, so it is content after the module node.
+    let moduleNode = oak.ModulesOrNamespaces.[0]
+    assertTrivia [ CommentOnSingleLine "// the end" ] (contentsAfter moduleNode)

--- a/src/Fantomas.Core/ASTTransformer.fsi
+++ b/src/Fantomas.Core/ASTTransformer.fsi
@@ -4,4 +4,12 @@ open Fantomas.FCS.Text
 open Fantomas.FCS.Syntax
 open Fantomas.Core.SyntaxOak
 
+/// Build the Oak for a parsed file.
+///
+/// `sourceText` is where the text of literals is taken from. The parser keeps the value of a string,
+/// number or interpolation, not the characters that spelled it, so `1_000`, `0x10` or a verbatim
+/// string cannot be recovered from the tree alone. With the source, the node carries the original
+/// spelling; with `None` it carries a fallback rendered from the value. Pass `None` only when the
+/// tree did not come from text, as `CodeFormatter.TransformAST` without a source does.
+/// The Oak comes back without trivia. `Trivia.enrichTree` adds it, and needs the source as well.
 val mkOak: sourceText: ISourceText option -> ast: ParsedInput -> Oak

--- a/src/Fantomas.Core/CodeFormatter.fsi
+++ b/src/Fantomas.Core/CodeFormatter.fsi
@@ -9,10 +9,14 @@ type CodeFormatter =
     /// Parse a source string using given config
     static member ParseAsync: isSignature: bool * source: string -> Async<(ParsedInput * string list) array>
 
-    /// Format an abstract syntax tree
+    /// Format an abstract syntax tree.
+    /// Without the source, comments and blank lines are not in the tree and cannot be printed, and
+    /// literals are re-rendered from their values rather than kept as they were spelled.
     static member FormatASTAsync: ast: ParsedInput -> Async<string>
 
-    /// Format an abstract syntax tree using a given config
+    /// Format an abstract syntax tree using a given config.
+    /// Without the source, comments and blank lines are not in the tree and cannot be printed, and
+    /// literals are re-rendered from their values rather than kept as they were spelled.
     static member FormatASTAsync: ast: ParsedInput * config: FormatConfig -> Async<string>
 
     /// Format an abstract syntax tree with the original source for trivia processing
@@ -81,10 +85,11 @@ type CodeFormatter =
     /// Parse a source string to SyntaxOak
     static member ParseOakAsync: isSignature: bool * source: string -> Async<(Oak * string list) array>
 
-    /// Transform a ParsedInput to an Oak
+    /// Transform a ParsedInput to an Oak without trivia; the source is needed to attach comments and
+    /// blank lines and to keep the spelling of literals.
     static member TransformAST: ast: ParsedInput -> Oak
 
-    /// Transform a ParsedInput to an Oak
+    /// Transform a ParsedInput to an Oak, with the trivia found in the source attached to its nodes.
     static member TransformAST: ast: ParsedInput * source: string -> Oak
 
     /// Format SyntaxOak to string

--- a/src/Fantomas.Core/CodeFormatterImpl.fsi
+++ b/src/Fantomas.Core/CodeFormatterImpl.fsi
@@ -1,4 +1,4 @@
-﻿[<RequireQualifiedAccess>]
+[<RequireQualifiedAccess>]
 module internal Fantomas.Core.CodeFormatterImpl
 
 open Fantomas.FCS.Syntax
@@ -6,11 +6,19 @@ open Fantomas.FCS.Text
 
 val getSourceText: source: string -> ISourceText
 
-/// Format an abstract syntax tree using given config
+/// Format one abstract syntax tree using the given config.
+/// With `sourceText` the Oak keeps the original spelling of literals and is enriched with trivia;
+/// without it, comments and blank lines are gone and literals are re-rendered from their values.
+/// `cursor` is inserted into the Oak before printing and reported back in the result.
 val formatAST:
     ast: ParsedInput -> sourceText: ISourceText option -> config: FormatConfig -> cursor: pos option -> FormatResult
 
+/// Parse the source once per define combination. A source without conditional directives yields
+/// a single tree with the empty combination. Raises `FormatException` when any parse has an
+/// invalidating diagnostic.
 val parse: isSignature: bool -> source: ISourceText -> Async<(ParsedInput * DefineCombination) array>
 
+/// The full pipeline: parse per define combination, format each tree in parallel with the source
+/// and cursor, and merge the results into one when there was more than one.
 val formatDocument:
     config: FormatConfig -> isSignature: bool -> source: ISourceText -> cursor: pos option -> Async<FormatResult>

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -52,6 +52,8 @@ type Context =
         Config: FormatConfig
         WriterModel: WriterModel
         WriterEvents: EventList
+        /// Where the cursor inserted by `Trivia.insertCursor` ended up in the output, once the
+        /// printer has passed it. Reported as `FormatResult.Cursor` by `dump`.
         FormattedCursor: pos option
         /// When enabled, genNode emits NodeStart/NodeEnd WriterEvents around each Oak node.
         /// Only used by CodeFormatter.GetWriterEventsAsync for diagnostic output.

--- a/src/Fantomas.Core/Context.fsi
+++ b/src/Fantomas.Core/Context.fsi
@@ -1,3 +1,5 @@
+/// The helpers in this module are illustrated, with the events they emit and the code they produce,
+/// in src/Fantomas.Core.Tests/CodePrinterHelperFunctionsTests.fs. Read that file before this one.
 module internal Fantomas.Core.Context
 
 open Fantomas.FCS.Text
@@ -35,7 +37,8 @@ type WriterModel =
         AtColumn: int
         /// text to be written before next newline
         WriteBeforeNewline: string
-        /// dummy = "fake" writer used in `autoNln`, `autoNlnByFuture`
+        /// Dummy is the probing writer used by `WithDummy` and the helpers built on it (`futureNlnCheck`, `exceedsWidth`).
+        /// ShortExpression is the single-line attempt made by `isShortExpression` and `expressionFitsOnRestOfLine`.
         Mode: WriteModelMode
         /// current length of last line of output
         Column: int

--- a/src/Fantomas.Core/Defines.fsi
+++ b/src/Fantomas.Core/Defines.fsi
@@ -1,5 +1,8 @@
-﻿namespace Fantomas.Core
+namespace Fantomas.Core
 
+/// One set of defines the source is parsed and formatted under, such as `[ "DEBUG"; "NET" ]`.
+/// A file with conditional directives is formatted once per combination and the results merged,
+/// see `MultipleDefineCombinations`.
 type internal DefineCombination =
     | DefineCombination of defines: string list
 
@@ -10,4 +13,7 @@ type internal DefineCombination =
 module internal Defines =
     open Fantomas.FCS.SyntaxTrivia
 
+    /// The combinations that together make every branch of every `#if` active at least once.
+    /// Always the empty set first, then sets a solver derived from the directive expressions,
+    /// then each define on its own. Illustrated in src/Fantomas.Core.Tests/DefinesTests.fs.
     val getDefineCombination: hashDirectives: ConditionalDirectiveTrivia list -> DefineCombination list

--- a/src/Fantomas.Core/MultipleDefineCombinations.fsi
+++ b/src/Fantomas.Core/MultipleDefineCombinations.fsi
@@ -3,4 +3,13 @@ module internal Fantomas.Core.MultipleDefineCombinations
 /// When conditional defines were found in the source code, we format the code using all possible combinations.
 /// Depending on the values of each combination, code will either be produced or not.
 /// In this function, we try to piece back all the active code fragments.
+///
+/// The merge works on the formatted text, not on the tree. Each result is split into fragments at
+/// its `#if`, `#else` and `#endif` lines, so every result must have the same number of fragments;
+/// when they do not, the merge raises `FormatException`. Fragments are then compared position by
+/// position and the one with the most lines wins, an empty branch losing to a non-empty one.
+/// The cursor, if any, is taken from the result whose winning fragment contained it.
+///
+/// Because the split is by line, CodePrinter has to print a directive on a line of its own and may
+/// not move code across one. Illustrated in src/Fantomas.Core.Tests/MultipleDefineCombinationsTests.fs.
 val mergeMultipleFormatResults: config: FormatConfig -> results: (DefineCombination * FormatResult) list -> FormatResult

--- a/src/Fantomas.Core/RangeHelpers.fsi
+++ b/src/Fantomas.Core/RangeHelpers.fsi
@@ -7,12 +7,22 @@ module RangeHelpers =
     /// Checks if Range B is fully contained by Range A
     val rangeContainsRange: a: Range -> b: Range -> bool
     val rangeEq: (range -> range -> bool)
+    /// Whether `r2` starts exactly where `r1` ends, on the same line and in the same file.
+    /// Nothing, not even a space, sits between them.
     val isAdjacentTo: r1: Range -> r2: Range -> bool
     /// Range.range0 starts at line 1, column 0
     /// This range starts at line 0, column 0
     val absoluteZeroRange: Range
 
+/// Split the range of a node into the ranges of the tokens that delimit it, so the transformer can
+/// give an opening or closing token a `SingleTextNode` of its own. `size` is the length of the
+/// token in characters: 1 for `(`, 2 for `[|` or `{|`. The ranges are computed from the ends of the
+/// node's range, not looked up, so they are only right when the token really is the first or last
+/// thing in the node.
 module RangePatterns =
+    /// The opening token, the whole range, and the closing token, both tokens `size` long.
     val (|StartEndRange|): size: int -> range: range -> range * range * range
+    /// The opening token, `size` long, and the whole range.
     val (|StartRange|): size: int -> range: range -> range * range
+    /// The closing token, `size` long, and the whole range.
     val (|EndRange|): size: int -> range: range -> range * range

--- a/src/Fantomas.Core/Selection.fsi
+++ b/src/Fantomas.Core/Selection.fsi
@@ -2,5 +2,19 @@ module internal Fantomas.Core.Selection
 
 open Fantomas.FCS.Text
 
+/// Format one node of the source and return its formatted text with the range it replaces.
+///
+/// The selection is first trimmed to the code inside it: leading and trailing whitespace lines are
+/// dropped and the columns moved to the first and last non-blank character. The trimmed range has
+/// to match a node exactly; it is that trimmed range which is returned, not the one passed in.
+///
+/// The node is then formatted on its own. Most nodes are wrapped in a synthetic module. Nodes that
+/// cannot stand alone, a type or a pattern, are placed in a synthetic binding, and the formatted
+/// node is cut back out of the result by parsing it again. The page width is reduced by the start
+/// column so the result fits where it came from, and the final newline is left off.
+///
+/// Raises `FormatException` when the source does not parse, when no node matches the trimmed
+/// selection, when the node kind is not supported, or when the node cannot be found again in the
+/// formatted synthetic tree. Illustrated in src/Fantomas.Core.Tests/FormattingSelectionOnlyTests.fs.
 val formatSelection:
     config: FormatConfig -> isSignature: bool -> selection: range -> sourceText: ISourceText -> Async<string * range>

--- a/src/Fantomas.Core/Trivia.fsi
+++ b/src/Fantomas.Core/Trivia.fsi
@@ -4,10 +4,33 @@ open Fantomas.FCS.Syntax
 open Fantomas.FCS.Text
 open Fantomas.Core.SyntaxOak
 
+/// The smallest node whose range contains `range`, found by descending into the first child that
+/// still contains it. This is the node trivia and selections are resolved against.
 val findNodeWhereRangeFitsIn: root: Node -> range: range -> Node option
+
+/// The text of every comment in the source, normalised, so that the comments of the input and of
+/// the output can be compared to prove none was lost.
 val collectCommentTextsFromAST: sourceText: ISourceText -> ast: ParsedInput -> Set<TriviaContent>
+
+/// Attach everything the Oak does not represent, comments, blank lines and directives, to the
+/// nodes it belongs with. Mutates `tree` in place and returns it.
+///
+/// Comments and directives come from the trivia the parser recorded; blank lines are read from the
+/// source text. Each piece is attached to the smallest node whose range contains it, as
+/// `ContentBefore` of the child that follows it or `ContentAfter` of the child that precedes it.
+///
+/// Which side wins depends on the kind of trivia. A comment after code on the same line goes after
+/// the last node on that line. A comment on its own line goes before the next sibling, unless that
+/// sibling is a closing bracket, or the comment is indented to the column of the previous sibling
+/// while the next one is not. Blank lines before an indented comment travel with the comment.
+/// Trivia outside every node is attached to the root.
+///
+/// The choices are illustrated in src/Fantomas.Core.Tests/TriviaAssignmentTests.fs.
 val enrichTree: config: FormatConfig -> sourceText: ISourceText -> ast: ParsedInput -> tree: Oak -> Oak
 
-/// Try and insert a cursor position as Trivia inside the Oak
-/// The cursor could either be inside a Node or floating around one.
+/// Record the editor's cursor in the Oak so that CodePrinter can report where it ends up.
+/// When the cursor sits inside a `SingleTextNode`, the node remembers it and the printer reports
+/// the same offset into the printed text. Otherwise a `Cursor` trivia is attached to the smallest
+/// node around it, and the printer reports the position after that node. Mutates `tree` in place.
+/// The end-to-end behaviour is in src/Fantomas.Core.Tests/CursorTests.fs.
 val insertCursor: tree: Oak -> cursor: pos -> Oak

--- a/src/Fantomas.Core/Utils.fsi
+++ b/src/Fantomas.Core/Utils.fsi
@@ -43,4 +43,9 @@ module Async =
 
 [<RequireQualifiedAccess>]
 module Continuation =
+    /// Run a list of continuation-passing computations one after the other and hand their results,
+    /// in order, to `finalContinuation`. This is how the transformer recurses over a list of
+    /// children without growing the stack: a deeply nested expression, such as a long chain of
+    /// infix operators or `elif` branches, would otherwise overflow it. Only worth its cost on the
+    /// few node kinds where the nesting can be deep; plain recursion is used everywhere else.
     val sequence<'a, 'ret> : recursions: (('a -> 'ret) -> 'ret) list -> finalContinuation: ('a list -> 'ret) -> 'ret

--- a/src/Fantomas.Core/Validation.fsi
+++ b/src/Fantomas.Core/Validation.fsi
@@ -2,12 +2,20 @@ module internal Fantomas.Core.Validation
 
 open Fantomas.FCS.Parse
 
+/// The warning numbers Fantomas formats through. Each is something the compiler will complain
+/// about but the parser has fully understood, so the tree is trustworthy: a deprecated construct,
+/// a library-only construct, a reserved keyword used as an identifier, an `@` in an identifier,
+/// and the interfaces-with-static-abstracts preview warning.
+val safeToIgnoreWarnings: Set<int>
+
 /// The diagnostics that make source invalid, rather than only whether any of them do: every error,
-/// and every warning that is not one of the few `safeToIgnoreWarnings` names. Empty when there is
+/// and every warning that is not one of the few `safeToIgnoreWarnings` numbers. Empty when there is
 /// nothing among them Fantomas would refuse.
 val invalidatingDiagnostics: diagnostics: FSharpParserDiagnostic list -> FSharpParserDiagnostic list
 
 val noWarningOrErrorDiagnostics: diagnostics: FSharpParserDiagnostic list -> bool
 
 /// Parse an input string and report what about it, if anything, Fantomas will not accept.
+/// Source with conditional directives is parsed once per define combination, and the first
+/// combination that fails is the one reported. Illustrated in src/Fantomas.Core.Tests/ValidationTests.fs.
 val validateFSharpCode: isSignature: bool -> source: string -> Async<ValidationResult>


### PR DESCRIPTION
This adds doc comments to the signature files of `Fantomas.Core`, points each one at the test file that illustrates it, and adds a small tutorial-style test file for trivia assignment. No changelog entry: nothing user facing changes.

## Why

The signature files are where a reader orients. Someone new to the code base, or an LLM agent starting a fresh session, reads `Context.fsi` before `Context.fs` because it is a tenth of the size and shows the public surface. That works well for finding the entry points. It works badly for understanding them, because a signature carries the shape of a function and nothing else.

Some examples of what the types do not say:

- `mkOak` takes an `ISourceText option`. Nothing says the source is where the spelling of literals comes from, or that `None` re-renders `1_000` from its value.
- `enrichTree` is Oak in, Oak out. Nothing says which node a comment lands on, or that a closing bracket never owns one.
- `mergeMultipleFormatResults` takes a list of results. Nothing says the merge is by line on formatted text, which is the reason a directive has to be printed on a line of its own.
- `+>` looks like function composition. It is not: inside a single-line attempt it stops calling its right-hand side after the first newline.
- `futureNlnCheck` returns a bool. Nothing says it ran the whole subtree to get it.

Each of these is something I had to rebuild from the implementation, every session, before I could make a safe change. The signature gave false confidence: I could read the whole `.fsi`, believe I understood the module, and still be wrong about the one thing that mattered.

## What it buys an agent

An agent works with a budget of attention and no memory between sessions. Every fact it has to rediscover is a cost paid again each time, and a fact it fails to rediscover becomes a wrong edit. With the invariants on the signature:

- **Orientation is one read, not two.** The `.fsi` now tells the agent what a module does and where the tests are that show it. It reads the `.fs` when it has to change it, not to find out what it is.
- **The expensive mistakes are named.** Adding a probe inside a recursive printer, using plain `unindent` after an expression that may end in a comment, moving code across a directive: the comment says why not before the agent tries it.
- **The tests are findable from the code.** `CodePrinterHelperFunctionsTests.fs` was the best explanation of `Context` in the repo and nothing linked to it. The agent found it only when a test failed there. Now every signature points at the file that demonstrates it.
- **Stale names are gone.** The `Mode` field and a test comment named helpers that no longer exist. A stale name in the file the agent trusts most sends it looking for something that is not there.

## What is here

- Doc comments on `Context.fsi`, `Trivia.fsi`, `ASTTransformer.fsi`, `Defines.fsi`, `MultipleDefineCombinations.fsi`, `Selection.fsi`, `Validation.fsi`, `RangeHelpers.fsi`, `Utils.fsi`, `CodeFormatterImpl.fsi` and `CodeFormatter.fsi`. Each describes behaviour, not shape, and links the test file that shows it.
- `safeToIgnoreWarnings` exposed in `Validation.fsi` so the signature states the policy. The set still lives once, in the `.fs`.
- Two tutorial tests in `CodePrinterHelperFunctionsTests.fs`: the `+>` early exit, and how many times a fallback layout prints its expression.
- New `TriviaAssignmentTests.fs`: seven tests that parse a few lines and assert which node holds the comment or blank line.
- The module in `DefinesTests.fs` renamed from `TokenParserTests`.

None of the documented symbols has a doc comment in its implementation file, so there is no second copy to keep in sync. `SyntaxOak.fs` deliberately gets no signature file: it would repeat every type declaration, and the `Node` interface already documents the invariants that matter.
