### PR TITLE
Update the analyzers to SDK 0.39.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "fsharp-analyzers": {
-      "version": "0.37.2",
+      "version": "0.39.0",
       "commands": [
         "fsharp-analyzers"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,8 +18,8 @@
         <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.3.3"/>
         <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.2"/>
 
-        <PackageVersion Include="G-Research.FSharp.Analyzers" Version="0.23.0" />
-        <PackageVersion Include="Ionide.Analyzers" Version="0.17.0" />
+        <PackageVersion Include="G-Research.FSharp.Analyzers" Version="0.25.0" />
+        <PackageVersion Include="Ionide.Analyzers" Version="0.19.0" />
 
         <PackageVersion Include="StreamJsonRpc" Version="2.25.29" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/analyzers/AGENTS.md
+++ b/analyzers/AGENTS.md
@@ -349,10 +349,10 @@ walk up, because they cannot restore under the repository's central package mana
 NU1109 rather than a warning. Inheriting the root would also hand them version-less package
 references that only resolve under central package management.
 
-The two projects target different frameworks on purpose. `Fantomas.Analyzers` is `net8.0`, because
-that is what the `fsharp-analyzers` tool loads, and a `net10.0` assembly fails to load when the tool
-runs on the .NET 8 runtime. `Fantomas.Analyzers.Tests` is `net10.0`, like the rest of the solution,
-because nothing loads it as an analyzer.
+`Fantomas.Analyzers` has to target the framework the `fsharp-analyzers` tool runs on, `net10.0`
+since SDK 0.38.0, because the tool cannot load an assembly built for another runtime. The rest of
+the solution happens to target the same, but the two are pinned for different reasons and only the
+analyzer project moves when the tool does.
 
 ## Two ways a rule silently does nothing
 

--- a/analyzers/Directory.Build.props
+++ b/analyzers/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
     <!--
     Deliberately does not import the repository root Directory.Build.props, which stops MSBuild
-    walking any further up. The projects here are build tooling, not product: they target net8.0
-    rather than net10.0, they are never packed, and they cannot restore under the repository's
+    walking any further up. The projects here are build tooling, not product: they are never
+    packed, and they cannot restore under the repository's
     central package management, because FSharp.Analyzers.SDK pins FSharp.Core to a version the
     product does not use. Inheriting the root would also hand them the packaging metadata, the
     lock file settings and the analyzer package references, none of which mean anything here.

--- a/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
+++ b/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!--
-    net10.0, unlike the analyzer project it references, which has to be net8.0 for the tool to load
-    it. Nothing here is loaded by the tool, so this follows global.json instead, which is also the
-    framework the test harness builds its throwaway project for.
+    net10.0, like the rest of the solution. Nothing here is loaded by the tool, so this follows
+    global.json, which is also the framework the test harness builds its throwaway project for.
     -->
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -29,8 +28,8 @@
     <ProjectReference Include="..\Fantomas.Analyzers\Fantomas.Analyzers.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="10.1.201" />
-    <PackageReference Include="FSharp.Analyzers.SDK.Testing" Version="0.37.2" />
+    <PackageReference Include="FSharp.Core" Version="10.1.400" />
+    <PackageReference Include="FSharp.Analyzers.SDK.Testing" Version="0.39.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/analyzers/Fantomas.Analyzers/Common.fs
+++ b/analyzers/Fantomas.Analyzers/Common.fs
@@ -28,6 +28,7 @@ let triviaOf (parsedInput: ParsedInput) : range list * range list =
             | ConditionalDirectiveTrivia.Else range -> range
             | ConditionalDirectiveTrivia.EndIf range -> range
             | ConditionalDirectiveTrivia.If(range = range) -> range
+            | ConditionalDirectiveTrivia.Elif(range = range) -> range
         )
 
     commentRanges, directiveRanges

--- a/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
+++ b/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!--
-    net8.0 is what the fsharp-analyzers tool targets and what Ionide.Analyzers and
-    G-Research.FSharp.Analyzers ship. A net10.0 assembly fails to load when the tool runs on the
-    .NET 8 runtime.
+    net10.0 is what the fsharp-analyzers tool targets since 0.38.0, and what Ionide.Analyzers and
+    G-Research.FSharp.Analyzers ship. The tool only loads an assembly built for the runtime it runs
+    on, so this has to follow the tool.
     -->
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <!-- The SDK only ever looks at files matching *Analyzer*.dll, so the name is load bearing. -->
     <AssemblyName>Fantomas.Analyzers</AssemblyName>
     <RootNamespace>Fantomas.Analyzers</RootNamespace>
     <IsPackable>false</IsPackable>
     <!--
-    FSharp.Analyzers.SDK depends on FSharp.Core at exactly 10.1.201, where the repository pins
+    FSharp.Analyzers.SDK depends on FSharp.Core at exactly 10.1.400, where the repository pins
     10.0.100 centrally. Under central package management that is NU1109, a hard error, so this
     project opts out and carries its versions inline. Keeping them here also puts the SDK version
     next to the analyzers rather than in the product's package list.
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Must track the fsharp-analyzers version pinned in .config/dotnet-tools.json. -->
-    <PackageReference Include="FSharp.Analyzers.SDK" Version="0.37.2" />
-    <PackageReference Include="FSharp.Core" Version="10.1.201" />
+    <PackageReference Include="FSharp.Analyzers.SDK" Version="0.39.0" />
+    <PackageReference Include="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 </Project>

--- a/build.fsx
+++ b/build.fsx
@@ -548,7 +548,7 @@ pipeline "AnalyzeChanged" {
                 // Everything reports and nothing fails. Warning rather than something lower
                 // because these are still findings to act on, and the tool prints every severity
                 // either way; the only thing being given up here is the non-zero exit.
-                let demoteLocalErrors: string list = "--treat-as-warning" :: localErrorRules
+                let demoteLocalErrors: string list = [ "--treat-as-warning"; localRulesPattern ]
 
                 match targetsFor files with
                 | [] ->

--- a/scripts/BuildAnalyzers.fsx
+++ b/scripts/BuildAnalyzers.fsx
@@ -93,7 +93,7 @@ let localAnalyzerPath: string =
     </> "Fantomas.Analyzers"
     </> "bin"
     </> "Release"
-    </> "net8.0"
+    </> "net10.0"
 
 /// The analyzers are in the solution, so `Build` compiles and tests them along with everything
 /// else. The `Analyze` pipelines do not depend on `Build` having run, so they build them again,
@@ -302,12 +302,14 @@ let mergeSarifReports (reports: string list) (target: string) : unit =
 /// Whatever is analyzed here is what `analysis.sarif` holds afterwards, so a run over a couple of
 /// files replaces the report of an earlier run over the solution.
 ///
-/// The local rules that report at error severity, and so fail a run when they fire.
+/// Every local rule, as the pattern the `--treat-as-*` switches take since fsharp-analyzers 0.39.0.
 ///
-/// `AnalyzeChanged` demotes these, because the run you do while working should report everything
-/// and stop for nothing. `Analyze` leaves them alone, so CI is where they bite.
-let localErrorRules: string list =
-    [ "FANTOMAS-PIPEBACK-001"; "FANTOMAS-PRIVATE-001" ]
+/// Two of them report at error severity, and so fail a run when they fire. `AnalyzeChanged` demotes
+/// these, because the run you do while working should report everything and stop for nothing.
+/// `Analyze` leaves them alone, so CI is where they bite. The pattern rather than the two codes,
+/// so that a rule changing severity, or a new one arriving at error, needs no edit here. The others
+/// already report at warning, and a demotion to what they are is a no-op.
+let localRulesPattern: string = "FANTOMAS-*"
 
 /// The local analyzers that are kept out of the full run.
 ///

--- a/scripts/BuildCommon.fsx
+++ b/scripts/BuildCommon.fsx
@@ -123,7 +123,10 @@ type ChangedLines =
 let changedLines () : Async<Map<string, ChangedLines>> =
     async {
         let! files = changedFiles ()
-        let! exitCode, stdout, stdErr = runGitCommand "diff -U0 HEAD --"
+        // The prefixes are spelled out because `diff.mnemonicPrefix` turns them into `c/` and `w/`,
+        // which the header match below would read as no file at all.
+        let! exitCode, stdout, stdErr =
+            runGitCommand "diff -U0 --src-prefix=a/ --dst-prefix=b/ HEAD --"
 
         if exitCode <> 0 then
             failwith $"Could not read the git diff.\n{stdErr}"

--- a/src/Fantomas.Benchmarks/packages.lock.json
+++ b/src/Fantomas.Benchmarks/packages.lock.json
@@ -28,15 +28,15 @@
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
-        "requested": "[0.23.0, )",
-        "resolved": "0.23.0",
-        "contentHash": "OySQ+6afD54e0P4bhGFS7DS7ijVP0tm4MgKw+Qn+JSyr0ObSktOoRGYO2mxUX7wzNuxr/67xO2JkXrkwBWwlnA=="
+        "requested": "[0.25.0, )",
+        "resolved": "0.25.0",
+        "contentHash": "P+u0uXq1PRVD1Wto9j0JrZHJ8JmmSwJM6ogq6mqX849JRrqcsWmgFR3+oRSy4EmrYwtMfCSgp6D+LWe6yAtvSg=="
       },
       "Ionide.Analyzers": {
         "type": "Direct",
-        "requested": "[0.17.0, )",
-        "resolved": "0.17.0",
-        "contentHash": "vTlenH0GbY+MGQHa26EeFaNIf4AfmVa9Jha2DJCTJxFZlYcr11Phi1ngq/Rabpn3Xii/Ri0ZWFqMjI90KgQEMQ=="
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "FBp/etThPSWhbvlM8wLxWtGYWgZ768yYjhwW83y18xZI9VBniG6kFVy4TEleyDkB7QnqfUgVepbT6ryHHFnZEA=="
       },
       "BenchmarkDotNet.Annotations": {
         "type": "Transitive",

--- a/src/Fantomas.Client.Tests/packages.lock.json
+++ b/src/Fantomas.Client.Tests/packages.lock.json
@@ -22,15 +22,15 @@
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
-        "requested": "[0.23.0, )",
-        "resolved": "0.23.0",
-        "contentHash": "OySQ+6afD54e0P4bhGFS7DS7ijVP0tm4MgKw+Qn+JSyr0ObSktOoRGYO2mxUX7wzNuxr/67xO2JkXrkwBWwlnA=="
+        "requested": "[0.25.0, )",
+        "resolved": "0.25.0",
+        "contentHash": "P+u0uXq1PRVD1Wto9j0JrZHJ8JmmSwJM6ogq6mqX849JRrqcsWmgFR3+oRSy4EmrYwtMfCSgp6D+LWe6yAtvSg=="
       },
       "Ionide.Analyzers": {
         "type": "Direct",
-        "requested": "[0.17.0, )",
-        "resolved": "0.17.0",
-        "contentHash": "vTlenH0GbY+MGQHa26EeFaNIf4AfmVa9Jha2DJCTJxFZlYcr11Phi1ngq/Rabpn3Xii/Ri0ZWFqMjI90KgQEMQ=="
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "FBp/etThPSWhbvlM8wLxWtGYWgZ768yYjhwW83y18xZI9VBniG6kFVy4TEleyDkB7QnqfUgVepbT6ryHHFnZEA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",

--- a/src/Fantomas.Client/packages.lock.json
+++ b/src/Fantomas.Client/packages.lock.json
@@ -16,15 +16,15 @@
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
-        "requested": "[0.23.0, )",
-        "resolved": "0.23.0",
-        "contentHash": "OySQ+6afD54e0P4bhGFS7DS7ijVP0tm4MgKw+Qn+JSyr0ObSktOoRGYO2mxUX7wzNuxr/67xO2JkXrkwBWwlnA=="
+        "requested": "[0.25.0, )",
+        "resolved": "0.25.0",
+        "contentHash": "P+u0uXq1PRVD1Wto9j0JrZHJ8JmmSwJM6ogq6mqX849JRrqcsWmgFR3+oRSy4EmrYwtMfCSgp6D+LWe6yAtvSg=="
       },
       "Ionide.Analyzers": {
         "type": "Direct",
-        "requested": "[0.17.0, )",
-        "resolved": "0.17.0",
-        "contentHash": "vTlenH0GbY+MGQHa26EeFaNIf4AfmVa9Jha2DJCTJxFZlYcr11Phi1ngq/Rabpn3Xii/Ri0ZWFqMjI90KgQEMQ=="
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "FBp/etThPSWhbvlM8wLxWtGYWgZ768yYjhwW83y18xZI9VBniG6kFVy4TEleyDkB7QnqfUgVepbT6ryHHFnZEA=="
       },
       "Ionide.KeepAChangelog.Tasks": {
         "type": "Direct",

--- a/src/Fantomas.Core.Tests/FormatAstTests.fs
+++ b/src/Fantomas.Core.Tests/FormatAstTests.fs
@@ -9,7 +9,7 @@ let parseAndFormat sourceCode =
     let ast =
         CodeFormatter.ParseAsync(false, source = sourceCode)
         |> Async.RunSynchronously
-        |> Seq.head
+        |> Array.head
         |> fst
 
     let config =

--- a/src/Fantomas.Core.Tests/packages.lock.json
+++ b/src/Fantomas.Core.Tests/packages.lock.json
@@ -35,15 +35,15 @@
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
-        "requested": "[0.23.0, )",
-        "resolved": "0.23.0",
-        "contentHash": "OySQ+6afD54e0P4bhGFS7DS7ijVP0tm4MgKw+Qn+JSyr0ObSktOoRGYO2mxUX7wzNuxr/67xO2JkXrkwBWwlnA=="
+        "requested": "[0.25.0, )",
+        "resolved": "0.25.0",
+        "contentHash": "P+u0uXq1PRVD1Wto9j0JrZHJ8JmmSwJM6ogq6mqX849JRrqcsWmgFR3+oRSy4EmrYwtMfCSgp6D+LWe6yAtvSg=="
       },
       "Ionide.Analyzers": {
         "type": "Direct",
-        "requested": "[0.17.0, )",
-        "resolved": "0.17.0",
-        "contentHash": "vTlenH0GbY+MGQHa26EeFaNIf4AfmVa9Jha2DJCTJxFZlYcr11Phi1ngq/Rabpn3Xii/Ri0ZWFqMjI90KgQEMQ=="
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "FBp/etThPSWhbvlM8wLxWtGYWgZ768yYjhwW83y18xZI9VBniG6kFVy4TEleyDkB7QnqfUgVepbT6ryHHFnZEA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",

--- a/src/Fantomas.Core/Trivia.fs
+++ b/src/Fantomas.Core/Trivia.fs
@@ -246,7 +246,7 @@ let rec visitLastChildNode (node: Node) : Node =
         if Array.isEmpty node.Children then
             node
         else
-            visitLastChildNode (Seq.last node.Children)
+            visitLastChildNode (Array.last node.Children)
     | _ -> node
 
 let lineCommentAfterSourceCodeToTriviaInstruction (containerNode: Node) (trivia: TriviaNode) : unit =
@@ -369,7 +369,7 @@ let assignTriviaToTriviaInstruction (containerNode: Node) (trivia: TriviaNode) :
 let blockCommentToTriviaInstruction (containerNode: Node) (trivia: TriviaNode) : unit =
     let nodeAfter =
         containerNode.Children
-        |> Seq.tryFind (fun tn ->
+        |> Array.tryFind (fun tn ->
             let range = tn.Range
 
             (range.StartLine > trivia.Range.StartLine)
@@ -379,7 +379,7 @@ let blockCommentToTriviaInstruction (containerNode: Node) (trivia: TriviaNode) :
 
     let nodeBefore =
         containerNode.Children
-        |> Seq.tryFindBack (fun tn ->
+        |> Array.tryFindBack (fun tn ->
             let range = tn.Range
 
             range.EndLine <= trivia.Range.StartLine

--- a/src/Fantomas.Core/packages.lock.json
+++ b/src/Fantomas.Core/packages.lock.json
@@ -16,15 +16,15 @@
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
-        "requested": "[0.23.0, )",
-        "resolved": "0.23.0",
-        "contentHash": "OySQ+6afD54e0P4bhGFS7DS7ijVP0tm4MgKw+Qn+JSyr0ObSktOoRGYO2mxUX7wzNuxr/67xO2JkXrkwBWwlnA=="
+        "requested": "[0.25.0, )",
+        "resolved": "0.25.0",
+        "contentHash": "P+u0uXq1PRVD1Wto9j0JrZHJ8JmmSwJM6ogq6mqX849JRrqcsWmgFR3+oRSy4EmrYwtMfCSgp6D+LWe6yAtvSg=="
       },
       "Ionide.Analyzers": {
         "type": "Direct",
-        "requested": "[0.17.0, )",
-        "resolved": "0.17.0",
-        "contentHash": "vTlenH0GbY+MGQHa26EeFaNIf4AfmVa9Jha2DJCTJxFZlYcr11Phi1ngq/Rabpn3Xii/Ri0ZWFqMjI90KgQEMQ=="
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "FBp/etThPSWhbvlM8wLxWtGYWgZ768yYjhwW83y18xZI9VBniG6kFVy4TEleyDkB7QnqfUgVepbT6ryHHFnZEA=="
       },
       "Ionide.KeepAChangelog.Tasks": {
         "type": "Direct",

--- a/src/Fantomas.FCS/packages.lock.json
+++ b/src/Fantomas.FCS/packages.lock.json
@@ -26,15 +26,15 @@
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
-        "requested": "[0.23.0, )",
-        "resolved": "0.23.0",
-        "contentHash": "OySQ+6afD54e0P4bhGFS7DS7ijVP0tm4MgKw+Qn+JSyr0ObSktOoRGYO2mxUX7wzNuxr/67xO2JkXrkwBWwlnA=="
+        "requested": "[0.25.0, )",
+        "resolved": "0.25.0",
+        "contentHash": "P+u0uXq1PRVD1Wto9j0JrZHJ8JmmSwJM6ogq6mqX849JRrqcsWmgFR3+oRSy4EmrYwtMfCSgp6D+LWe6yAtvSg=="
       },
       "Ionide.Analyzers": {
         "type": "Direct",
-        "requested": "[0.17.0, )",
-        "resolved": "0.17.0",
-        "contentHash": "vTlenH0GbY+MGQHa26EeFaNIf4AfmVa9Jha2DJCTJxFZlYcr11Phi1ngq/Rabpn3Xii/Ri0ZWFqMjI90KgQEMQ=="
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "FBp/etThPSWhbvlM8wLxWtGYWgZ768yYjhwW83y18xZI9VBniG6kFVy4TEleyDkB7QnqfUgVepbT6ryHHFnZEA=="
       },
       "Ionide.KeepAChangelog.Tasks": {
         "type": "Direct",

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -35,15 +35,15 @@
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
-        "requested": "[0.23.0, )",
-        "resolved": "0.23.0",
-        "contentHash": "OySQ+6afD54e0P4bhGFS7DS7ijVP0tm4MgKw+Qn+JSyr0ObSktOoRGYO2mxUX7wzNuxr/67xO2JkXrkwBWwlnA=="
+        "requested": "[0.25.0, )",
+        "resolved": "0.25.0",
+        "contentHash": "P+u0uXq1PRVD1Wto9j0JrZHJ8JmmSwJM6ogq6mqX849JRrqcsWmgFR3+oRSy4EmrYwtMfCSgp6D+LWe6yAtvSg=="
       },
       "Ionide.Analyzers": {
         "type": "Direct",
-        "requested": "[0.17.0, )",
-        "resolved": "0.17.0",
-        "contentHash": "vTlenH0GbY+MGQHa26EeFaNIf4AfmVa9Jha2DJCTJxFZlYcr11Phi1ngq/Rabpn3Xii/Ri0ZWFqMjI90KgQEMQ=="
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "FBp/etThPSWhbvlM8wLxWtGYWgZ768yYjhwW83y18xZI9VBniG6kFVy4TEleyDkB7QnqfUgVepbT6ryHHFnZEA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",

--- a/src/Fantomas/Invocation.fs
+++ b/src/Fantomas/Invocation.fs
@@ -11,11 +11,11 @@ let nameOf (processPath: string option) : string =
     | None -> "fantomas"
     | Some path ->
 
-    match Path.GetFileNameWithoutExtension path with
-    | "" -> "fantomas"
-    | executable ->
+    let executable: string = Path.GetFileNameWithoutExtension path
 
-    if String.Equals(executable, "dotnet", StringComparison.OrdinalIgnoreCase) then
+    if String.IsNullOrEmpty executable then
+        "fantomas"
+    elif String.Equals(executable, "dotnet", StringComparison.OrdinalIgnoreCase) then
         "dotnet fantomas"
     else
         executable

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
-        "requested": "[0.23.0, )",
-        "resolved": "0.23.0",
-        "contentHash": "OySQ+6afD54e0P4bhGFS7DS7ijVP0tm4MgKw+Qn+JSyr0ObSktOoRGYO2mxUX7wzNuxr/67xO2JkXrkwBWwlnA=="
+        "requested": "[0.25.0, )",
+        "resolved": "0.25.0",
+        "contentHash": "P+u0uXq1PRVD1Wto9j0JrZHJ8JmmSwJM6ogq6mqX849JRrqcsWmgFR3+oRSy4EmrYwtMfCSgp6D+LWe6yAtvSg=="
       },
       "Ignore": {
         "type": "Direct",
@@ -34,9 +34,9 @@
       },
       "Ionide.Analyzers": {
         "type": "Direct",
-        "requested": "[0.17.0, )",
-        "resolved": "0.17.0",
-        "contentHash": "vTlenH0GbY+MGQHa26EeFaNIf4AfmVa9Jha2DJCTJxFZlYcr11Phi1ngq/Rabpn3Xii/Ri0ZWFqMjI90KgQEMQ=="
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "FBp/etThPSWhbvlM8wLxWtGYWgZ768yYjhwW83y18xZI9VBniG6kFVy4TEleyDkB7QnqfUgVepbT6ryHHFnZEA=="
       },
       "Ionide.KeepAChangelog.Tasks": {
         "type": "Direct",


### PR DESCRIPTION
fsharp-analyzers 0.37.2 to 0.39.0, Ionide.Analyzers 0.17.0 to 0.19.0 and
G-Research.FSharp.Analyzers 0.23.0 to 0.25.0, which are the releases built
against that SDK. The local analyzer project follows, together with the
testing package.

SDK 0.38.0 moved the tool to .NET 10, so the local analyzer project moves
from net8.0 to net10.0: the tool cannot load an assembly built for another
runtime. Its FSharp.Core pin follows the SDK's exact pin to 10.1.400. The
comments that explained the net8.0 target go with it.

The compiler service under the new SDK added an Elif case to conditional
directive trivia, which the local analyzers now match.

SDK 0.39.0 accepts a trailing wildcard in the --treat-as-* switches. The
changed-files pipeline demoted the two error-severity local codes by
name; it now demotes FANTOMAS-*, so a rule changing severity needs no
edit in the build script. Every local rule reports at warning or error,
so the pattern changes nothing else.

The full run turns up five new warnings, four GRA-VIRTUALCALL-001 and one
IONIDE-005. Neither analyzer changed behaviour; the newer compiler
service exposes array types and empty-string matches differently
(dotnet/fsharp#19923). They are left for a change of their own.