### PR TITLE
Update the build tooling and packages

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "fsharp-analyzers": {
-      "version": "0.39.0",
+      "version": "0.39.1",
       "commands": [
         "fsharp-analyzers"
       ],

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.103
+FROM mcr.microsoft.com/dotnet/sdk:10.0.400
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.2",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:7c409bf6316ffd85f04fd92fba85a744282639e603417dd4796409866bdb6805",
+      "integrity": "sha256:7c409bf6316ffd85f04fd92fba85a744282639e603417dd4796409866bdb6805"
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,9 @@ fsharp_multi_line_lambda_closing_newline=true
 fsharp_bar_before_discriminated_union_declaration=true
 fsharp_experimental_keep_indent_in_branch=true
 
+[{build.fsx,scripts/**/*.fsx}]
+fsharp_experimental_keep_indent_in_branch=true
+
 [build.fsx]
 fsharp_keep_max_number_of_blank_lines=1
 fsharp_blank_lines_around_nested_multiline_expressions=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,8 @@ dotnet fsi build.fsx -- -p AnalyzeChanged
 
 This analyzes the files the working tree changed, and nothing else. A project is loaded when it
 owns a changed `.fs` or `.fsi`, and is then analyzed for those files alone. A changed `.fsproj`
-asks for the whole project, because what it compiles is no longer what it compiled before.
+asks for the whole project, because what it compiles is no longer what it compiled before. A
+changed `.fsx` is reported on through the `Scripts` target.
 
 Scoping it to the changed files is what makes this quick: analyzing one file of
 `Fantomas.Core.Tests` takes seconds where the whole project takes minutes.
@@ -91,10 +92,14 @@ to act on a run. What comes out is the thing to fix.
 dotnet fsi build.fsx -- -p Analyze
 ```
 
-This analyzes every file of every project. The test projects are the largest of the solution and
-decide how long that takes: the smallest projects report within seconds, `Fantomas.Core.Tests`
-takes a couple of minutes. Run it before opening a pull request, and while working use
-`AnalyzeChanged`, which cannot see a finding your change causes in a file you did not edit.
+This analyzes every file of every project, and the scripts. The test projects are the largest of the
+solution and decide how long that takes: the smallest projects report within seconds, the scripts in
+about four, `Fantomas.Core.Tests` takes a couple of minutes. Run it before opening a pull request,
+and while working use `AnalyzeChanged`, which cannot see a finding your change causes in a file you
+did not edit.
+
+The scripts are a weaker check than the projects, for reasons that are all downstream of the typed
+tree a script gets. [analyzers/AGENTS.md](analyzers/AGENTS.md) has what that costs and why.
 
 Both pipelines analyze each project in its own process, so findings are printed per project as
 that project finishes rather than all at the end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [8.0.0-beta-003] - 2026-09-12
+
+### Changed
+
+- Updated the packages the command line tool is built against: `editorconfig` to `0.18.0`, `Serilog` to `4.4.0`, `Spectre.Console` to `0.57.2` and `System.IO.Abstractions` to `22.2.0`. Only one of these is visible in what Fantomas does: `editorconfig` `0.18.0` scopes its cache of the `.editorconfig` files it has read to the parser that reads them, where it used to share one statically. Fantomas keeps a single parser for the process, so a file is still read once and no more. `Fantomas.Core` asks for the same `FSharp.Core` it always did, so nothing referencing it has to move. [#3468](https://github.com/fsprojects/fantomas/pull/3468)
+
 ## [8.0.0-beta-002] - 2026-09-08
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,15 @@
 <Project>
     <PropertyGroup>
+        <!--
+        Keep FSharp.Core out of the SDK's `library-packs` folder and take it from NuGet like any
+        other package. The SDK ships its own build of FSharp.Core there and adds the folder as a
+        restore source, so an SDK whose bundled version equals the one pinned here wins over
+        nuget.org. That build is not byte for byte the published one, so `packages.lock.json`
+        then records a hash no machine without that SDK can reproduce, and restore fails with
+        NU1403. Pointing the folder at a path that does not exist drops it as a source, because
+        the SDK only adds it `Condition="Exists(...)"`.
+        -->
+        <_FSharpCoreLibraryPacksFolder>$(MSBuildThisFileDirectory)no-library-packs</_FSharpCoreLibraryPacksFolder>
         <!-- Set up version and package release note generation from this changelog. -->
         <ChangelogFile>$(MSBuildThisFileDirectory)CHANGELOG.md</ChangelogFile>
         <!-- Common packaging properties for all packages in this repo -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,15 +1,5 @@
 <Project>
     <PropertyGroup>
-        <!--
-        Keep FSharp.Core out of the SDK's `library-packs` folder and take it from NuGet like any
-        other package. The SDK ships its own build of FSharp.Core there and adds the folder as a
-        restore source, so an SDK whose bundled version equals the one pinned here wins over
-        nuget.org. That build is not byte for byte the published one, so `packages.lock.json`
-        then records a hash no machine without that SDK can reproduce, and restore fails with
-        NU1403. Pointing the folder at a path that does not exist drops it as a source, because
-        the SDK only adds it `Condition="Exists(...)"`.
-        -->
-        <_FSharpCoreLibraryPacksFolder>$(MSBuildThisFileDirectory)no-library-packs</_FSharpCoreLibraryPacksFolder>
         <!-- Set up version and package release note generation from this changelog. -->
         <ChangelogFile>$(MSBuildThisFileDirectory)CHANGELOG.md</ChangelogFile>
         <!-- Common packaging properties for all packages in this repo -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,9 +26,9 @@
         <PackageVersion Include="SemanticVersioning" Version="3.0.0" />
         <PackageVersion Include="Serilog" Version="4.3.1"/>
         <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-        <PackageVersion Include="editorconfig" Version="0.15.0" />
+        <PackageVersion Include="editorconfig" Version="0.18.0" />
         <PackageVersion Include="Ignore" Version="0.2.1" />
-        <PackageVersion Include="System.IO.Abstractions" Version="22.1.0" />
+        <PackageVersion Include="System.IO.Abstractions" Version="22.1.1" />
         <PackageVersion Include="Spectre.Console" Version="0.55.0" />
         <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,19 +4,19 @@
         <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include="FSharp.Core" Version="10.0.100"/>
-        <PackageVersion Include="System.Collections.Immutable" Version="10.0.6" />
-        <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.6" />
+        <PackageVersion Include="FSharp.Core" Version="10.1.401"/>
+        <PackageVersion Include="System.Collections.Immutable" Version="10.0.12" />
+        <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.12" />
         <PackageVersion Include="System.Memory" Version="4.6.3" />
         <PackageVersion Include="System.Runtime" Version="4.3.1" />
-        <PackageVersion Include="FsLexYacc" Version="11.4.1" />
+        <PackageVersion Include="FsLexYacc" Version="12.0.0" />
 
         <!-- Hosts the vendored FSharpEmbedResourceText MSBuild task, see Fantomas.FCS.BuildTasks. -->
         <PackageVersion Include="Microsoft.Build.Framework" Version="18.0.2" />
         <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />
 
         <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.3.3"/>
-        <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.2"/>
+        <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5"/>
 
         <PackageVersion Include="G-Research.FSharp.Analyzers" Version="0.25.0" />
         <PackageVersion Include="Ionide.Analyzers" Version="0.19.0" />
@@ -24,21 +24,21 @@
         <PackageVersion Include="StreamJsonRpc" Version="2.25.29" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageVersion Include="SemanticVersioning" Version="3.0.0" />
-        <PackageVersion Include="Serilog" Version="4.3.1"/>
+        <PackageVersion Include="Serilog" Version="4.4.0"/>
         <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageVersion Include="editorconfig" Version="0.18.0" />
         <PackageVersion Include="Ignore" Version="0.2.1" />
-        <PackageVersion Include="System.IO.Abstractions" Version="22.1.1" />
-        <PackageVersion Include="Spectre.Console" Version="0.55.0" />
+        <PackageVersion Include="System.IO.Abstractions" Version="22.2.0" />
+        <PackageVersion Include="Spectre.Console" Version="0.57.2" />
         <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
 
-        <PackageVersion Include="CliWrap" Version="3.10.0" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
-        <PackageVersion Include="NUnit" Version="4.5.1"/>
-        <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0"/>
-        <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-        <PackageVersion Include="FsCheck" Version="3.3.2" />
+        <PackageVersion Include="CliWrap" Version="3.10.5" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.10.0"/>
+        <PackageVersion Include="NUnit" Version="4.6.1"/>
+        <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0"/>
+        <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
+        <PackageVersion Include="FsCheck" Version="3.4.0" />
         <PackageVersion Include="FsUnit" Version="7.1.1" />
-        <PackageVersion Include="AltCover" Version="9.0.102" />
+        <PackageVersion Include="AltCover" Version="9.0.145" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include="FSharp.Core" Version="10.1.401"/>
+        <PackageVersion Include="FSharp.Core" Version="10.1.203"/>
         <PackageVersion Include="System.Collections.Immutable" Version="10.0.12" />
         <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.12" />
         <PackageVersion Include="System.Memory" Version="4.6.3" />

--- a/analyzers/AGENTS.md
+++ b/analyzers/AGENTS.md
@@ -354,6 +354,62 @@ since SDK 0.38.0, because the tool cannot load an assembly built for another run
 the solution happens to target the same, but the two are pinned for different reasons and only the
 analyzer project moves when the tool does.
 
+## The scripts
+
+`build.fsx` and the scripts beside it are source too, and both `Analyze` pipelines run over them as a
+target of their own, `Scripts`, alongside the projects. `--script` is given the scripts that compile
+on their own, which between them `#load` every other one, so a rule reaches `BuildCommon.fsx`
+through `build.fsx` and `shared.fsx` through the diagnostic scripts.
+
+It is a weaker check than a project gets, and the difference is worth knowing before acting on what
+it says or fails to say. The typed tree the analyzers receive for a script is missing every top level
+bare expression, which in this repository is every `pipeline { }` of `build.fsx` and the command line
+handling at the foot of each diagnostic script. See
+[FSharp.Analyzers.SDK#332](https://github.com/ionide/FSharp.Analyzers.SDK/issues/332).
+
+Three things follow from that, and all three are handled in `BuildAnalyzers.fsx` rather than here:
+
+- **Only the analyzers this repository owns run over the scripts.** `Ionide.Analyzers` and
+  `G-Research.FSharp.Analyzers` walk the typed tree, and walking one with error recovery nodes in it
+  throws out of `FSharpExprConvert` and takes the whole run down. Both packages do it, on every
+  script that has a top level `match`.
+- **`FANTOMAS-OPENS-001` is excluded.** It asks the compiler which opens the file resolves nothing
+  through, and on a script it answers about that same incomplete tree: the opens `build.fsx` uses
+  only inside a `pipeline { }` read as unused. It also brings the run down on any script that
+  references `Fantomas.FCS`, because resolving the members of `System.ReadOnlySpan` needs an
+  assembly no script references.
+- **`--include-files` holds the report to scripts.** A script compilation includes whatever it
+  loads, and `shared.fsx` loads `EditorConfig.fs` and `Suggestion.fs` out of `src/Fantomas`. Those
+  are analyzed properly as part of their own project; reporting on them here would say something
+  else about them, because a script loads the `.fs` alone and the signature file that keeps
+  `FANTOMAS-ANNOTATE-001` and `FANTOMAS-XMLDOC-001` quiet about them is no part of the compilation.
+
+So a clean `Scripts` run covers less ground than a clean project run, and a rule that says nothing
+about a script has not necessarily looked at it.
+
+All three are answered upstream, by two changes that together give a script the same references
+`dotnet fsi` gives it:
+
+- [#333](https://github.com/ionide/FSharp.Analyzers.SDK/pull/333) resolves a script against the SDK
+  reference assemblies rather than the .NET Framework ones, so `FSharp.Core` loads.
+- [#334](https://github.com/ionide/FSharp.Analyzers.SDK/issues/334) is the `fsi` object.
+  `GetProjectOptionsFromScript` did not reference `FSharp.Compiler.Interactive.Settings`, so every
+  script here that reads `fsi.CommandLineArgs` failed to type check on that one name and error
+  recovery took the expressions around it with it.
+
+Built against both, every script of this repository type checks with no errors, both crashes go, and
+the fourteen opens the scripts falsely reported drop to none while `FANTOMAS-OPENS-001` still catches
+a real unused one in a script. Once that is released and `.config/dotnet-tools.json` is bumped, all
+three bullets above can go.
+
+The packaged analyzers then have plenty to say about the scripts, `GRA-INTERPOLATED-001` alone
+accounts for 94 findings, so letting them in is a decision rather than a formality.
+
+The `.editorconfig` turns `fsharp_experimental_keep_indent_in_branch` on for `build.fsx` and
+`scripts/**/*.fsx` as well as for `src` and `analyzers`, so acting on a `FANTOMAS-KEEPINDENT-001`
+finding in a script is not something the formatter undoes. Turning it on changed no formatting: the
+setting holds a body already written that way and never de-indents one itself.
+
 ## Two ways a rule silently does nothing
 
 Both of these produce a clean run rather than an error, so check that a new rule actually fires

--- a/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
+++ b/analyzers/Fantomas.Analyzers.Tests/Fantomas.Analyzers.Tests.fsproj
@@ -29,9 +29,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="10.1.400" />
-    <PackageReference Include="FSharp.Analyzers.SDK.Testing" Version="0.39.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="FSharp.Analyzers.SDK.Testing" Version="0.39.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
   </ItemGroup>
 </Project>

--- a/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
+++ b/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
@@ -12,7 +12,7 @@
     <IsPackable>false</IsPackable>
     <!--
     FSharp.Analyzers.SDK depends on FSharp.Core at exactly 10.1.400, where the repository pins
-    10.0.100 centrally. Under central package management that is NU1109, a hard error, so this
+    10.1.401 centrally. Under central package management that is NU1109, a hard error, so this
     project opts out and carries its versions inline. Keeping them here also puts the SDK version
     next to the analyzers rather than in the product's package list.
     -->

--- a/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
+++ b/analyzers/Fantomas.Analyzers/Fantomas.Analyzers.fsproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Must track the fsharp-analyzers version pinned in .config/dotnet-tools.json. -->
-    <PackageReference Include="FSharp.Analyzers.SDK" Version="0.39.0" />
+    <PackageReference Include="FSharp.Analyzers.SDK" Version="0.39.1" />
     <PackageReference Include="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 </Project>

--- a/build.fsx
+++ b/build.fsx
@@ -496,9 +496,13 @@ pipeline "Analyze" {
     stage "BuildAnalyzers" { run buildLocalAnalyzers }
     stage "Analyze" {
         run (fun ctx ->
-            projectsToAnalyze
-            |> List.map (fun (project: string) -> { Project = project; Files = [] })
-            |> analyzeTargets ctx excludeLocalAdvisory everyFinding)
+            [
+                for project: string in projectsToAnalyze do
+                    Project(project, [])
+
+                Scripts analyzableScripts
+            ]
+            |> analyzeTargets ctx localAdvisoryAnalyzers [] everyFinding)
     }
     runIfOnlySpecified true
 }
@@ -527,11 +531,11 @@ pipeline "AnalyzeChanged" {
 
                 match targetsFor files with
                 | [] ->
-                    printfn "No changed file belongs to a project that is analyzed."
+                    printfn "No changed file is analyzed."
                     return 0
                 | targets ->
                     let! scopes = changedLines ctx
-                    return! analyzeTargets ctx demoteLocalErrors (keepFinding scopes) targets
+                    return! analyzeTargets ctx [] demoteLocalErrors (keepFinding scopes) targets
             })
     }
 

--- a/build.fsx
+++ b/build.fsx
@@ -1,10 +1,9 @@
 #!/usr/bin/env -S dotnet fsi --
 
-#r "nuget: Fun.Build, 1.1.18"
-#r "nuget: CliWrap, 3.6.4"
-#r "nuget: FSharp.Data, 6.3.0"
-#r "nuget: Ionide.KeepAChangelog, 0.1.8"
-#r "nuget: Humanizer.Core, 2.14.1"
+#r "nuget: Fun.Build, 1.2.0"
+#r "nuget: FSharp.Data, 8.2.0"
+#r "nuget: Ionide.KeepAChangelog, 0.2.0"
+#r "nuget: Humanizer.Core, 3.0.10"
 
 // The build is split across these, and they are loaded in dependency order: each expects the ones
 // above it to be in scope and does not load them itself. Loading a file twice would compile it
@@ -18,7 +17,6 @@
 open System
 open System.IO
 open Fun.Build
-open CliWrap
 open BuildCommon
 open BuildScripts
 open BuildAnalyzers
@@ -164,9 +162,9 @@ pipeline "Coverage" {
 pipeline "FormatChanged" {
     workingDir __SOURCE_DIRECTORY__
     stage "Format" {
-        run (fun _ ->
+        run (fun ctx ->
             async {
-                let! files = changedFiles ()
+                let! files = changedFiles ctx
                 let sources: string list =
                     List.filter (hasExtension [ ".fs"; ".fsx"; ".fsi" ]) files
 
@@ -175,27 +173,9 @@ pipeline "FormatChanged" {
                     printfn "No changed F# files to format."
                     return 0
                 | sources ->
-                    let arguments: string =
-                        sources
-                        |> List.map (fun (source: string) -> $"\"{source}\"")
-                        |> String.concat " "
+                    let arguments: string = sources |> List.map quoteArgument |> String.concat " "
 
-                    // CliWrap discards the child's output unless it is given somewhere to put
-                    // it, and what fantomas has to say about the files is the point of the run.
-                    let toConsole: PipeTarget =
-                        PipeTarget.ToDelegate(fun (line: string) -> printfn "%s" line)
-
-                    let! result =
-                        Cli
-                            .Wrap("dotnet")
-                            .WithArguments($"fantomas --json {arguments}")
-                            .WithStandardOutputPipe(toConsole)
-                            .WithStandardErrorPipe(toConsole)
-                            .WithValidation(CommandResultValidation.None)
-                            .ExecuteAsync()
-                            .Task
-                        |> Async.AwaitTask
-
+                    let! result = ctx.RunCommandCaptureAll $"dotnet fantomas --json {arguments}"
                     return result.ExitCode
             })
     }
@@ -206,12 +186,12 @@ pipeline "PushClient" {
     workingDir __SOURCE_DIRECTORY__
     stage "Pack" { run "dotnet pack ./src/Fantomas.Client -c Release --tl" }
     stage "Push" {
-        run (fun _ ->
+        run (fun ctx ->
             async {
                 return!
                     Directory.EnumerateFiles(packagesDir, "Fantomas.Client.*.nupkg", SearchOption.TopDirectoryOnly)
                     |> Seq.tryExactlyOne
-                    |> Option.map pushPackage
+                    |> Option.map (pushPackage ctx)
                     |> Option.defaultValue (
                         async {
                             printfn "Fantomas.Client package was not found."
@@ -380,14 +360,14 @@ pipeline "Release" {
     stage "UnitTests" { run "dotnet test -c Release" }
     stage "Pack" { run "dotnet pack -c Release" }
     stage "Release" {
-        run (fun _ ->
+        run (fun ctx ->
             async {
                 if isDryRun then
                     printfn "[DRY-RUN] Starting release pipeline in dry-run mode"
                 else
                     printfn "Starting release pipeline"
 
-                let currentRelease, lastPublishedDate = getCurrentReleaseAndLastPublishedDate ()
+                let! currentRelease, lastPublishedDate = getCurrentReleaseAndLastPublishedDate ctx
 
                 if Option.isSome currentRelease.PublishedDate then
                     printfn $"Release {currentRelease.Version} already exists on GitHub. Skipping release process."
@@ -409,7 +389,8 @@ pipeline "Release" {
                     printfn $"Found {nugetPackages.Length} packages to push to NuGet:"
                     nugetPackages |> Array.iter (fun pkg -> printfn $"  - {Path.GetFileName(pkg)}")
 
-                    let! nugetExitCodes = nugetPackages |> Array.map pushPackage |> Async.Sequential
+                    let! nugetExitCodes =
+                        nugetPackages |> Array.map (pushPackage ctx) |> Async.Sequential
 
                     let nugetSuccess = nugetExitCodes |> Array.forall (fun code -> code = 0)
                     if nugetSuccess then
@@ -418,7 +399,7 @@ pipeline "Release" {
                         let exitCodesStr = nugetExitCodes |> Array.map string |> String.concat ", "
                         printfn $"Warning: Some NuGet packages failed to push. Exit codes: {exitCodesStr}"
 
-                    let notes = getReleaseNotes currentRelease lastPublishedDate
+                    let! notes = getReleaseNotes ctx currentRelease lastPublishedDate
                     printfn "Release notes that will be used:"
                     printfn "---"
                     printfn "%s" notes
@@ -468,14 +449,7 @@ pipeline "Release" {
                         else
                             printfn $"Creating GitHub release: v{currentRelease.Version}"
                             async {
-                                let! result =
-                                    Cli
-                                        .Wrap("gh")
-                                        .WithArguments(releaseCommand)
-                                        .WithValidation(CommandResultValidation.None)
-                                        .ExecuteAsync()
-                                        .Task
-                                    |> Async.AwaitTask
+                                let! result = ctx.RunCommandCaptureAll $"gh {releaseCommand}"
                                 return result.ExitCode
                             }
 
@@ -506,7 +480,8 @@ pipeline "PublishAlpha" {
                     |> Seq.filter (fun nupkg -> not (nupkg.Contains("Fantomas.Client")))
                     |> Seq.toArray
 
-                let! nugetExitCodes = nugetPackages |> Array.map pushPackage |> Async.Sequential
+                let! nugetExitCodes =
+                    nugetPackages |> Array.map (pushPackage ctx) |> Async.Sequential
 
                 return Seq.sum nugetExitCodes
             })
@@ -520,10 +495,10 @@ pipeline "Analyze" {
     stage "RestoreSolution" { run "dotnet restore --tl" }
     stage "BuildAnalyzers" { run buildLocalAnalyzers }
     stage "Analyze" {
-        run (fun _ ->
+        run (fun ctx ->
             projectsToAnalyze
             |> List.map (fun (project: string) -> { Project = project; Files = [] })
-            |> analyzeTargets excludeLocalAdvisory everyFinding)
+            |> analyzeTargets ctx excludeLocalAdvisory everyFinding)
     }
     runIfOnlySpecified true
 }
@@ -541,9 +516,9 @@ pipeline "AnalyzeChanged" {
     stage "BuildAnalyzers" { run buildLocalAnalyzers }
 
     stage "Analyze" {
-        run (fun _ ->
+        run (fun ctx ->
             async {
-                let! files = changedFiles ()
+                let! files = changedFiles ctx
 
                 // Everything reports and nothing fails. Warning rather than something lower
                 // because these are still findings to act on, and the tool prints every severity
@@ -555,8 +530,8 @@ pipeline "AnalyzeChanged" {
                     printfn "No changed file belongs to a project that is analyzed."
                     return 0
                 | targets ->
-                    let! scopes = changedLines ()
-                    return! analyzeTargets demoteLocalErrors (keepFinding scopes) targets
+                    let! scopes = changedLines ctx
+                    return! analyzeTargets ctx demoteLocalErrors (keepFinding scopes) targets
             })
     }
 

--- a/docs/docs/end-users/Configuration.fsx
+++ b/docs/docs/end-users/Configuration.fsx
@@ -23,6 +23,9 @@ UI might be available depending on the IDE.
 #r "../../../artifacts/bin/Fantomas.FCS/release/Fantomas.FCS.dll"
 #r "../../../artifacts/bin/Fantomas.Core/release/Fantomas.Core.dll"
 #r "../../../artifacts/bin/Fantomas/release/EditorConfig.Core.dll"
+// Needed to resolve the `EditorConfigParser` constructor in `EditorConfig.fs`: referencing the
+// built assemblies rather than the package brings no transitive dependency along.
+#r "../../../artifacts/bin/Fantomas/release/Testably.Abstractions.FileSystem.Interface.dll"
 #load "../../../src/Fantomas/Suggestion.fs"
 #load "../../../src/Fantomas/EditorConfig.fs"
 

--- a/docs/docs/end-users/Recipes.fsx
+++ b/docs/docs/end-users/Recipes.fsx
@@ -22,6 +22,9 @@ Sometimes, it makes sense to tweak a few setting for a subset of your codebase.
 #r "../../../artifacts/bin/Fantomas.FCS/release/Fantomas.FCS.dll"
 #r "../../../artifacts/bin/Fantomas.Core/release/Fantomas.Core.dll"
 #r "../../../artifacts/bin/Fantomas/release/EditorConfig.Core.dll"
+// Needed to resolve the `EditorConfigParser` constructor in `EditorConfig.fs`: referencing the
+// built assemblies rather than the package brings no transitive dependency along.
+#r "../../../artifacts/bin/Fantomas/release/Testably.Abstractions.FileSystem.Interface.dll"
 #load "../../../src/Fantomas/Suggestion.fs"
 #load "../../../src/Fantomas/EditorConfig.fs"
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.400",
     "rollForward": "latestMinor"
   }
 }

--- a/scripts/BuildAnalyzers.fsx
+++ b/scripts/BuildAnalyzers.fsx
@@ -1,5 +1,6 @@
 #r "nuget: Fun.Build, 1.2.0"
 #r "nuget: FSharp.Data, 8.2.0"
+#r "nuget: Humanizer.Core, 3.0.10"
 
 open System
 open System.IO
@@ -8,9 +9,13 @@ open System.Xml.XPath
 open Fun.Build
 open Fun.Build.Internal
 open FSharp.Data
+open Humanizer
 // Loaded by `build.fsx`, after `BuildCommon.fsx`. An error here saying BuildCommon is not defined
 // means this file was run on its own; it is a library, so run a pipeline from build.fsx instead.
 open BuildCommon
+// `runnableScripts` is the set of scripts handed to `--script`: the ones that compile on their own,
+// which between them reach every other script of the repository through `#load`.
+open BuildScripts
 
 // Running the analyzers, and deciding which of their findings a run set out to report.
 //
@@ -42,18 +47,36 @@ let projectsToAnalyze: string list =
     |> Seq.sortByDescending sourceSize
     |> Seq.toList
 
-/// One project to hand to the analyzers, and which of its files to look at.
+/// What one run of the analyzers covers, and which of the files it reaches to report on.
 ///
-/// `Files` holds absolute paths, because that is the only form `--include-files` matches: give it a
-/// path relative to the repository root and it matches nothing, says nothing about it and reports a
-/// clean project. An empty list asks for every file of the project.
-type AnalysisTarget = { Project: string; Files: string list }
+/// A file list holds absolute paths, because that is the only form `--include-files` matches: give
+/// it a path relative to the repository root and it matches nothing, says nothing about it and
+/// reports a clean run.
+type AnalysisTarget =
+    /// One project. An empty file list asks for every file of it.
+    | Project of project: string * files: string list
+    /// The scripts of this repository. Which scripts are compiled is not a choice, `runnableScripts`
+    /// decides that; the file list says which of the files they reach a finding may be about, and is
+    /// never empty. A script compilation includes whatever it `#load`s, and `shared.fsx` loads
+    /// `EditorConfig.fs` and `Suggestion.fs` out of `src/Fantomas`, which belong to that project's
+    /// run: a script loads the `.fs` alone, so the signature file that keeps several of the rules
+    /// quiet about them is no part of the compilation and they report as debt they are not.
+    | Scripts of files: string list
+
+/// Every script a finding may be about: `build.fsx` and everything beside this file. The ones that
+/// are `#load`ed rather than run are here too, because they are compiled as part of whatever loads
+/// them and are as much this repository's source as the rest.
+let analyzableScripts: string list =
+    [
+        repositoryRoot </> "build.fsx"
+        yield! Directory.EnumerateFiles(repositoryRoot </> "scripts", "*.fsx")
+    ]
 
 /// What to analyze for a set of changed files: every project that owns one, along with the files of
-/// its own that changed. A project owns everything under its own folder, which is how every project
-/// of this solution is laid out. The order is the one `projectsToAnalyze` puts them in.
+/// its own that changed, and the scripts among them. The order is the one `projectsToAnalyze` puts
+/// the projects in, with the scripts last because they are the quickest to answer.
 ///
-/// Only compiled sources and project files count. A script, a document or a test data file is not
+/// Only compiled sources, project files and scripts count. A document or a test data file is not
 /// part of any compilation, so changing one leaves the analyzers with nothing new to say.
 ///
 /// A changed project file asks for the whole project: what it compiles is no longer what it
@@ -61,25 +84,30 @@ type AnalysisTarget = { Project: string; Files: string list }
 let targetsFor (files: string list) : AnalysisTarget list =
     let sources: string list = List.filter (hasExtension [ ".fs"; ".fsi" ]) files
     let projectFiles: string list = List.filter (hasExtension [ ".fsproj" ]) files
+    let scripts: string list = List.filter (hasExtension [ ".fsx" ]) files
 
-    projectsToAnalyze
-    |> List.choose (fun (project: string) ->
-        let folder: string = project.Substring(0, project.LastIndexOf '/' + 1)
+    let projects: AnalysisTarget list =
+        projectsToAnalyze
+        |> List.choose (fun (project: string) ->
+            let folder: string = project.Substring(0, project.LastIndexOf '/' + 1)
 
-        let owns (file: string) : bool =
-            file.StartsWith(folder, StringComparison.Ordinal)
+            let owns (file: string) : bool =
+                file.StartsWith(folder, StringComparison.Ordinal)
 
-        if List.exists owns projectFiles then
-            Some { Project = project; Files = [] }
-        else
-            match List.filter owns sources with
-            | [] -> None
-            | owned ->
-                Some
-                    {
-                        Project = project
-                        Files = List.map (fun (file: string) -> repositoryRoot </> file) owned
-                    })
+            if List.exists owns projectFiles then
+                Some(Project(project, []))
+            else
+                match List.filter owns sources with
+                | [] -> None
+                | owned -> Some(Project(project, List.map (fun (file: string) -> repositoryRoot </> file) owned)))
+
+    [
+        yield! projects
+
+        match scripts with
+        | [] -> ()
+        | scripts -> Scripts(List.map (fun (script: string) -> repositoryRoot </> script) scripts)
+    ]
 
 /// Where the analyzer project this repository owns is built to. It is deliberately outside the
 /// solution and does not inherit the root `Directory.Build.props`, so this is an ordinary
@@ -454,12 +482,20 @@ let narrowReport (keep: FindingFilter) (report: string) : unit =
 
         File.WriteAllText(report, narrowed.ToString())
 
-/// Returns the highest exit code of the runs, so a project the analyzers could not process fails
-/// the stage rather than passing for want of findings.
+/// The name a target reports under, which is also the name of the SARIF it writes.
+let private targetName (target: AnalysisTarget) : string =
+    match target with
+    | Scripts _ -> "Scripts"
+    | Project(project, _) -> Path.GetFileNameWithoutExtension project
+
+/// Returns the highest exit code of the runs, so a target the analyzers could not process fails the
+/// stage rather than passing for want of findings.
 ///
-/// `extraArguments` is passed to every invocation, and is how the two pipelines differ.
+/// `excludedAnalyzers` names the analyzers to keep out of every run, and `extraArguments` is passed
+/// to every invocation; the two pipelines differ in both.
 let analyzeTargets
     (ctx: StageContext)
+    (excludedAnalyzers: string list)
     (extraArguments: string list)
     (keep: FindingFilter)
     (targets: AnalysisTarget list)
@@ -472,55 +508,90 @@ let analyzeTargets
 
         Directory.CreateDirectory analysisReportsDir |> ignore
 
-        let names =
-            targets
-            |> List.map (fun (target: AnalysisTarget) -> Path.GetFileNameWithoutExtension target.Project)
-            |> String.concat ", "
+        let names: string = targets |> List.map targetName |> String.concat ", "
 
-        let count: string =
-            match targets.Length with
-            | 1 -> "1 project"
-            | n -> $"{n} projects"
+        let count: string = "target".ToQuantity targets.Length
 
         printfn $"Analyzing {count}: {names}"
 
-        let analyzeProject (target: AnalysisTarget) =
+        let analyzeTarget (target: AnalysisTarget) : Async<string * int> =
             async {
-                let name = Path.GetFileNameWithoutExtension target.Project
+                let name: string = targetName target
                 let report = analysisReportsDir </> $"{name}.sarif"
                 let started = DateTime.UtcNow
 
+                // Only the analyzers this repository owns are run over the scripts. Both packaged
+                // ones walk the typed tree, and the typed tree of a script is not one they survive:
+                // `Ionide.Analyzers` brings the run down with `error recovery at ...` on every
+                // script that loads `shared.fsx`. See
+                // https://github.com/ionide/FSharp.Analyzers.SDK/issues/332
+                let analyzers: string list =
+                    match target with
+                    | Project _ -> analyzers
+                    | Scripts _ -> [ localAnalyzerPath ]
+
+                // `FANTOMAS-OPENS-001` asks the compiler which opens the file resolves nothing
+                // through, and on a script that question goes wrong twice over. It brings the run
+                // down on anything that references `Fantomas.FCS`, because resolving the members of
+                // `System.ReadOnlySpan` needs an assembly the script never references. And where it
+                // does answer, it answers about a typed tree that is missing every top level bare
+                // expression, so the opens `build.fsx` uses only inside a `pipeline { }` read as
+                // unused. Same issue as above.
+                let excludedAnalyzers: string list =
+                    match target with
+                    | Project _ -> excludedAnalyzers
+                    | Scripts _ -> "UnusedOpensAnalyzer" :: excludedAnalyzers
+
                 let arguments: string list =
                     [
-                        // Neither of these is source anybody wrote. The test SDK generates its
-                        // entry point into the compilation from the package cache, and MSBuild
-                        // generates an `AssemblyInfo` per project under `obj`. Both are part of
-                        // what gets type checked, and a finding in either is not a finding about
-                        // this repository. `AssemblyInfo` earns its place here because it opens
-                        // `System` and `System.Reflection` and then writes every attribute out
-                        // fully qualified, so `FANTOMAS-OPENS-001` has two true things to say
-                        // about each of them and nowhere to say them.
-                        "--exclude-files"
-                        "**/Microsoft.NET.Test.Sdk.Program.fs"
-                        "**/*.AssemblyInfo.fs"
                         for analyzer in analyzers do
                             "--analyzers-path"
                             analyzer
-                        // One flag, then every file. Repeating the flag is an error, and the tool
-                        // answers it by printing its help and finding nothing, which reads as a
-                        // clean project.
-                        match target.Files with
+                        // Each of these takes a list of values after a single flag. Repeating the
+                        // flag is an error, and the tool answers it by printing its help and
+                        // finding nothing, which reads as a clean run.
+                        match excludedAnalyzers with
                         | [] -> ()
-                        | files ->
-                            "--include-files"
-                            yield! files
+                        | excluded ->
+                            "--exclude-analyzers"
+                            yield! excluded
                         "--code-root"
                         repositoryRoot
                         "--report"
                         report
                         yield! extraArguments
-                        "--project"
-                        repositoryRoot </> target.Project
+
+                        match target with
+                        | Scripts files ->
+                            // Every script that compiles on its own, which between them reach the
+                            // ones that only ever get `#load`ed. `--include-files` is what keeps
+                            // the report to scripts: a script compilation pulls in whatever it
+                            // loads, sources of `src/Fantomas` included.
+                            "--include-files"
+                            yield! files
+                            "--script"
+                            yield! runnableScripts ()
+                        | Project(project, files) ->
+                            // Neither of these is source anybody wrote. The test SDK generates its
+                            // entry point into the compilation from the package cache, and MSBuild
+                            // generates an `AssemblyInfo` per project under `obj`. Both are part of
+                            // what gets type checked, and a finding in either is not a finding about
+                            // this repository. `AssemblyInfo` earns its place here because it opens
+                            // `System` and `System.Reflection` and then writes every attribute out
+                            // fully qualified, so `FANTOMAS-OPENS-001` has two true things to say
+                            // about each of them and nowhere to say them.
+                            "--exclude-files"
+                            "**/Microsoft.NET.Test.Sdk.Program.fs"
+                            "**/*.AssemblyInfo.fs"
+
+                            match files with
+                            | [] -> ()
+                            | files ->
+                                "--include-files"
+                                yield! files
+
+                            "--project"
+                            repositoryRoot </> project
                     ]
 
                 let command: string = arguments |> List.map quoteArgument |> String.concat " "
@@ -541,19 +612,25 @@ let analyzeTargets
                 // A non-zero exit is worth saying out loud. The tool exits non-zero both for a
                 // finding at error severity and for a run that never happened, and a bare
                 // "no findings" would read the same either way.
-                let summary =
-                    match result.ExitCode, findings with
-                    | 0, 0 -> "no findings"
-                    | 0, 1 -> "1 finding"
-                    | 0, n -> $"{n} findings"
-                    | code, 0 -> $"no findings, exit code {code}"
-                    | code, n -> $"{n} findings, exit code {code}"
+                let counted: string =
+                    if findings = 0 then
+                        "no findings"
+                    else
+                        "finding".ToQuantity findings
 
-                let scope =
-                    match target.Files with
-                    | [] -> ""
-                    | [ _ ] -> " (1 file)"
-                    | files -> $" ({files.Length} files)"
+                let summary: string =
+                    if result.ExitCode = 0 then
+                        counted
+                    else
+                        $"{counted}, exit code {result.ExitCode}"
+
+                // A whole project says nothing about its scope. Anything else names how many
+                // files it was asked about, which for the scripts is always some of them.
+                let scope: string =
+                    match target with
+                    | Project(_, []) -> ""
+                    | Scripts files
+                    | Project(_, files) -> $""" ({"file".ToQuantity files.Length})"""
 
                 printfn $"\n=== {name}{scope}: {summary} in {elapsed.TotalSeconds:F1}s"
                 printf "%s" (narrowOutput keep result.StandardOutput)
@@ -565,13 +642,9 @@ let analyzeTargets
         // Every analyzer process type checks a whole project, so a handful at a time is what keeps
         // the machine busy without the runs starving each other of memory.
         let! results =
-            Async.Parallel(List.map analyzeProject targets, max 2 (Environment.ProcessorCount / 2))
+            Async.Parallel(List.map analyzeTarget targets, max 2 (Environment.ProcessorCount / 2))
 
         mergeSarifReports (results |> Array.map fst |> List.ofArray) (mergedAnalysisReport)
 
         return results |> Array.map snd |> Array.fold max 0
     }
-
-/// Each of these takes a list of values after a single flag. Repeating the flag is an error.
-let excludeLocalAdvisory: string list =
-    "--exclude-analyzers" :: localAdvisoryAnalyzers

--- a/scripts/BuildAnalyzers.fsx
+++ b/scripts/BuildAnalyzers.fsx
@@ -1,12 +1,12 @@
-#r "nuget: CliWrap, 3.6.4"
-#r "nuget: FSharp.Data, 6.3.0"
+#r "nuget: Fun.Build, 1.2.0"
+#r "nuget: FSharp.Data, 8.2.0"
 
 open System
 open System.IO
 open System.Xml.Linq
 open System.Xml.XPath
-open CliWrap
-open CliWrap.Buffered
+open Fun.Build
+open Fun.Build.Internal
 open FSharp.Data
 // Loaded by `build.fsx`, after `BuildCommon.fsx`. An error here saying BuildCommon is not defined
 // means this file was run on its own; it is a library, so run a pipeline from build.fsx instead.
@@ -104,24 +104,21 @@ let buildLocalAnalyzers: string =
 /// Where the analyzers live on disk. The two packages are ordinary package references, so MSBuild
 /// already knows the restored path of each and there is no second place to keep the version in
 /// sync. The third is ours, and is built by the pipeline that is about to use it.
-let analyzerPaths () : Async<string list> =
+let analyzerPaths (ctx: StageContext) : Async<string list> =
     async {
         if not (File.Exists(localAnalyzerPath </> "Fantomas.Analyzers.dll")) then
             failwith
                 $"The local analyzers are not built. Expected an assembly in {localAnalyzerPath}.\nRun `dotnet build analyzers/Fantomas.Analyzers -c Release` first."
 
         let! result =
-            Cli
-                .Wrap("dotnet")
-                .WithArguments(
-                    "msbuild src/Fantomas/Fantomas.fsproj -getProperty:PkgIonide_Analyzers "
-                    + "-getProperty:PkgG-Research_FSharp_Analyzers"
-                )
-                .WithWorkingDirectory(repositoryRoot)
-                .WithValidation(CommandResultValidation.None)
-                .ExecuteBufferedAsync()
-                .Task
-            |> Async.AwaitTask
+            ctx.RunCommandCaptureAll(
+                "dotnet msbuild src/Fantomas/Fantomas.fsproj "
+                + "-getProperty:PkgIonide_Analyzers "
+                + "-getProperty:PkgG-Research_FSharp_Analyzers",
+                workingDir = repositoryRoot,
+                disablePrintCommand = true,
+                disablePrintOutput = true
+            )
 
         if result.ExitCode <> 0 then
             failwith $"Could not resolve the analyzer packages. Run `dotnet restore` first.\n{result.StandardError}"
@@ -461,9 +458,14 @@ let narrowReport (keep: FindingFilter) (report: string) : unit =
 /// the stage rather than passing for want of findings.
 ///
 /// `extraArguments` is passed to every invocation, and is how the two pipelines differ.
-let analyzeTargets (extraArguments: string list) (keep: FindingFilter) (targets: AnalysisTarget list) : Async<int> =
+let analyzeTargets
+    (ctx: StageContext)
+    (extraArguments: string list)
+    (keep: FindingFilter)
+    (targets: AnalysisTarget list)
+    : Async<int> =
     async {
-        let! analyzers = analyzerPaths ()
+        let! analyzers = analyzerPaths ctx
 
         if Directory.Exists analysisReportsDir then
             Directory.Delete(analysisReportsDir, true)
@@ -488,9 +490,8 @@ let analyzeTargets (extraArguments: string list) (keep: FindingFilter) (targets:
                 let report = analysisReportsDir </> $"{name}.sarif"
                 let started = DateTime.UtcNow
 
-                let arguments =
+                let arguments: string list =
                     [
-                        "fsharp-analyzers"
                         // Neither of these is source anybody wrote. The test SDK generates its
                         // entry point into the compilation from the package cache, and MSBuild
                         // generates an `AssemblyInfo` per project under `obj`. Both are part of
@@ -522,15 +523,15 @@ let analyzeTargets (extraArguments: string list) (keep: FindingFilter) (targets:
                         repositoryRoot </> target.Project
                     ]
 
+                let command: string = arguments |> List.map quoteArgument |> String.concat " "
+
                 let! result =
-                    Cli
-                        .Wrap("dotnet")
-                        .WithArguments(arguments)
-                        .WithWorkingDirectory(repositoryRoot)
-                        .WithValidation(CommandResultValidation.None)
-                        .ExecuteBufferedAsync()
-                        .Task
-                    |> Async.AwaitTask
+                    ctx.RunCommandCaptureAll(
+                        $"dotnet fsharp-analyzers {command}",
+                        workingDir = repositoryRoot,
+                        disablePrintCommand = true,
+                        disablePrintOutput = true
+                    )
 
                 narrowReport keep report
 

--- a/scripts/BuildCommon.fsx
+++ b/scripts/BuildCommon.fsx
@@ -1,9 +1,11 @@
-#r "nuget: CliWrap, 3.6.4"
+#r "nuget: Fun.Build, 1.2.0"
 
 open System
 open System.IO
-open CliWrap
-open CliWrap.Buffered
+open Fun.Build
+// `StageContext` is the type every command runs through, and Fun.Build puts it here rather than
+// beside the builders. A pipeline never has to name it; anything a `run` step hands off to does.
+open Fun.Build.Internal
 
 // This file is loaded by `build.fsx`. It defines things and runs nothing, so a direct run would
 // look like a success while doing no work at all. Say so instead.
@@ -59,14 +61,28 @@ let cleanFolders (input: string seq) : Async<unit> =
                 do! deleteDirectory 1 dir
     }
 
-let runGitCommand (arguments: string) =
+/// Run a git command in the repository root and hand back what it said, whatever the exit code was.
+///
+/// Neither the command nor its output is printed: every caller here reads the output rather than
+/// showing it, and a `git status` scrolling past says nothing about the stage that asked for it.
+let runGitCommand (ctx: StageContext) (arguments: string) : Async<int * string * string> =
     async {
         let! result =
-            Cli.Wrap("git").WithArguments(arguments).WithWorkingDirectory(repositoryRoot).ExecuteBufferedAsync().Task
-            |> Async.AwaitTask
+            ctx.RunCommandCaptureAll(
+                $"git {arguments}",
+                workingDir = repositoryRoot,
+                disablePrintCommand = true,
+                disablePrintOutput = true
+            )
 
         return result.ExitCode, result.StandardOutput, result.StandardError
     }
+
+/// Quote one argument of a command line, so a path with a space in it stays a single argument.
+///
+/// Fun.Build takes a command as one string and splits it back apart on whitespace, unless quotes
+/// say otherwise.
+let quoteArgument (argument: string) : string = $"\"{argument}\""
 
 /// The files git reports as changed in the working tree, as paths relative to the repository root.
 ///
@@ -77,10 +93,10 @@ let runGitCommand (arguments: string) =
 /// Untracked files are asked for one by one. Git otherwise reports a new folder as a single entry
 /// and the files inside it are never named, which is exactly the case of a feature that arrives as
 /// a new folder of sources.
-let changedFiles () : Async<string list> =
+let changedFiles (ctx: StageContext) : Async<string list> =
     async {
         let! exitCode, stdout, stdErr =
-            runGitCommand "status --porcelain --untracked-files=all"
+            runGitCommand ctx "status --porcelain --untracked-files=all"
 
         if exitCode <> 0 then
             failwith $"Could not read the git status.\n{stdErr}"
@@ -120,13 +136,13 @@ type ChangedLines =
 /// `git diff HEAD` covers staged and unstaged changes alike, and `-U0` asks for no context lines,
 /// so every hunk header names exactly the lines that differ. An untracked file has no diff to read
 /// and is new in its entirety.
-let changedLines () : Async<Map<string, ChangedLines>> =
+let changedLines (ctx: StageContext) : Async<Map<string, ChangedLines>> =
     async {
-        let! files = changedFiles ()
+        let! files = changedFiles ctx
         // The prefixes are spelled out because `diff.mnemonicPrefix` turns them into `c/` and `w/`,
         // which the header match below would read as no file at all.
         let! exitCode, stdout, stdErr =
-            runGitCommand "diff -U0 --src-prefix=a/ --dst-prefix=b/ HEAD --"
+            runGitCommand ctx "diff -U0 --src-prefix=a/ --dst-prefix=b/ HEAD --"
 
         if exitCode <> 0 then
             failwith $"Could not read the git diff.\n{stdErr}"

--- a/scripts/BuildCompiler.fsx
+++ b/scripts/BuildCompiler.fsx
@@ -1,5 +1,4 @@
-#r "nuget: CliWrap, 3.6.4"
-#r "nuget: FSharp.Data, 6.3.0"
+#r "nuget: FSharp.Data, 8.2.0"
 
 open System.IO
 open System.Xml.Linq

--- a/scripts/BuildRelease.fsx
+++ b/scripts/BuildRelease.fsx
@@ -1,12 +1,12 @@
-#r "nuget: CliWrap, 3.6.4"
-#r "nuget: FSharp.Data, 6.3.0"
-#r "nuget: Ionide.KeepAChangelog, 0.1.8"
-#r "nuget: Humanizer.Core, 2.14.1"
+#r "nuget: Fun.Build, 1.2.0"
+#r "nuget: FSharp.Data, 8.2.0"
+#r "nuget: Ionide.KeepAChangelog, 0.2.0"
+#r "nuget: Humanizer.Core, 3.0.10"
 
 open System
 open System.IO
-open CliWrap
-open CliWrap.Buffered
+open Fun.Build
+open Fun.Build.Internal
 open FSharp.Data
 open Ionide.KeepAChangelog
 open Ionide.KeepAChangelog.Domain
@@ -26,23 +26,21 @@ let isDryRun: bool =
     Array.exists (fun arg -> arg = "--dry-run") args
 
 /// Push a package to NuGet, unless this run was told not to publish.
-let pushPackage nupkg =
+let pushPackage (ctx: StageContext) (nupkg: string) : Async<int> =
     async {
         if isDryRun then
             printfn $"[DRY-RUN] Would push package: {nupkg}"
             return 0
         else
-            let key = Environment.GetEnvironmentVariable("NUGET_KEY")
+            let key: string = Environment.GetEnvironmentVariable "NUGET_KEY"
 
+            // The sensitive variant masks every interpolated value in what it prints, which is
+            // how the key stays out of a CI log. The package path is masked along with it, which
+            // costs nothing: it is the one the stage just picked out of the packages folder.
             let! result =
-                Cli
-                    .Wrap("dotnet")
-                    .WithArguments(
-                        $"nuget push \"{nupkg}\" --api-key \"{key}\" --source https://api.nuget.org/v3/index.json"
-                    )
-                    .ExecuteAsync()
-                    .Task
-                |> Async.AwaitTask
+                ctx.RunSensitiveCommandCaptureAll(
+                    $"dotnet nuget push {quoteArgument nupkg} --api-key {key} --source https://api.nuget.org/v3/index.json"
+                )
 
             return result.ExitCode
     }
@@ -81,262 +79,291 @@ let versionSortKey (v: SemanticVersion) : int * int * int * int * string =
 /// The date the GitHub release for this version was published.
 /// None when GitHub has no release for it, which is what happens for a version that was pushed
 /// to NuGet by hand, like 7.0.6.
-let getPublishedDate (version: string) : string option =
-    let prefixedVersion = $"v{version}"
-    printfn $"Checking if release {prefixedVersion} already exists on GitHub..."
+let getPublishedDate (ctx: StageContext) (version: string) : Async<string option> =
+    async {
+        let prefixedVersion: string = $"v{version}"
+        printfn $"Checking if release {prefixedVersion} already exists on GitHub..."
 
-    let cmdResult =
-        Cli
-            .Wrap("gh")
-            .WithArguments($"release view {prefixedVersion} --json publishedAt -t \"{{{{.publishedAt}}}}\"")
-            .WithValidation(CommandResultValidation.None)
-            .ExecuteBufferedAsync()
-            .Task.Result
+        let! cmdResult =
+            ctx.RunCommandCaptureAll(
+                $"gh release view {prefixedVersion} --json publishedAt -t \"{{{{.publishedAt}}}}\"",
+                disablePrintOutput = true
+            )
 
-    if cmdResult.ExitCode <> 0 then
-        printfn $"Release {prefixedVersion} does not exist yet"
-        None
-    else
-        let output = cmdResult.StandardOutput.Trim()
-        let lastIdx = output.LastIndexOf("Z", StringComparison.Ordinal)
-        let dateStr = output.Substring(0, lastIdx)
-        printfn $"Release {prefixedVersion} already exists, published at: {dateStr}"
-        Some dateStr
+        if cmdResult.ExitCode <> 0 then
+            printfn $"Release {prefixedVersion} does not exist yet"
+            return None
+        else
+            let output: string = cmdResult.StandardOutput.Trim()
+            let lastIdx: int = output.LastIndexOf("Z", StringComparison.Ordinal)
+            let dateStr: string = output.Substring(0, lastIdx)
+            printfn $"Release {prefixedVersion} already exists, published at: {dateStr}"
+            return Some dateStr
+    }
 
-let mkGithubRelease (v: SemanticVersion, d: DateTime, cd: ChangelogData option) : GithubRelease =
+let mkGithubRelease
+    (ctx: StageContext)
+    (v: SemanticVersion, d: DateTime, cd: ChangelogData option)
+    : Async<GithubRelease> =
     match cd with
     | None -> failwith "Each Fantomas release is expected to have at least one section."
     | Some cd ->
-        let version = formatVersion v
 
-        printfn $"Parsing release version: {version} (prerelease: {not (String.IsNullOrEmpty v.Prerelease)})"
+        async {
+            let version = formatVersion v
 
-        let title =
-            let month = d.ToString("MMMM")
-            let day = d.Day.Ordinalize()
-            $"{month} {day} Release"
+            printfn $"Parsing release version: {version} (prerelease: {not (String.IsNullOrEmpty v.Prerelease)})"
 
-        let publishDate = getPublishedDate version
+            let title =
+                let month = d.ToString("MMMM")
+                let day = d.Day.Ordinalize()
+                $"{month} {day} Release"
 
-        let sections =
-            [
-                "Added", cd.Added
-                "Changed", cd.Changed
-                "Fixed", cd.Fixed
-                "Deprecated", cd.Deprecated
-                "Removed", cd.Removed
-                "Security", cd.Security
-                yield! (Map.toList cd.Custom)
-            ]
-            |> List.choose (fun (header, lines) ->
-                if lines.IsEmpty then
-                    None
-                else
-                    lines
-                    |> List.map (fun line -> line.TrimStart())
-                    |> String.concat "\n"
-                    |> sprintf "### %s\n%s" header
-                    |> Some)
-            |> String.concat "\n\n"
+            let! publishDate = getPublishedDate ctx version
 
-        let draft =
-            $"""# {version}
+            let sections =
+                [
+                    "Added", cd.Added
+                    "Changed", cd.Changed
+                    "Fixed", cd.Fixed
+                    "Deprecated", cd.Deprecated
+                    "Removed", cd.Removed
+                    "Security", cd.Security
+                    yield! (Map.toList cd.Custom)
+                ]
+                // Since Ionide.KeepAChangelog 0.2.0 a section arrives as one string rather than as its
+                // lines, so what used to be a trim per line is a trim of each line of that string.
+                |> List.choose (fun (header: string, body: string) ->
+                    let content: string =
+                        body.Split('\n')
+                        |> Array.map (fun (line: string) -> line.TrimStart())
+                        |> String.concat "\n"
+                        |> (fun (text: string) -> text.Trim '\n')
+
+                    if content = String.Empty then
+                        None
+                    else
+                        Some(sprintf "### %s\n%s" header content))
+                |> String.concat "\n\n"
+
+            let draft =
+                $"""# {version}
 
 {sections}"""
 
-        {
-            Version = version
-            Title = title
-            Date = d
-            PublishedDate = publishDate
-            Draft = draft
+            return
+                {
+                    Version = version
+                    Title = title
+                    Date = d
+                    PublishedDate = publishDate
+                    Draft = draft
+                }
         }
 
-let getReleaseNotes (currentRelease: GithubRelease) (lastPublishedDate: string option) : string =
-    let date =
-        match lastPublishedDate with
-        | Some d ->
-            printfn $"Using last release published date for author attribution: {d}"
-            d
-        | None ->
-            // Query GitHub for the most recent published release
-            printfn "No earlier changelog entry is on GitHub, querying GitHub for most recent release..."
+/// The date of the most recent release GitHub knows about, for the contributor query to start from.
+///
+/// Falls back to today whenever GitHub has nothing to say, which narrows the query rather than
+/// widening it: a release with no contributors named is better than one that fails to be cut.
+let private mostRecentReleaseDate (ctx: StageContext) : Async<string> =
+    async {
+        printfn "No earlier changelog entry is on GitHub, querying GitHub for most recent release..."
 
-            let ghReleaseResult =
-                Cli
-                    .Wrap("gh")
-                    .WithArguments("release list --limit 1 --json createdAt")
-                    .WithValidation(CommandResultValidation.None)
-                    .ExecuteBufferedAsync()
-                    .Task.Result
+        let! result =
+            ctx.RunCommandCaptureAll("gh release list --limit 1 --json createdAt", disablePrintOutput = true)
 
-            if
-                ghReleaseResult.ExitCode = 0
-                && not (String.IsNullOrWhiteSpace(ghReleaseResult.StandardOutput.Trim()))
-            then
-                let jsonOutput = ghReleaseResult.StandardOutput.Trim()
-                let jsonValue = FSharp.Data.JsonValue.Parse(jsonOutput)
-                let releases = jsonValue.AsArray()
-
-                if releases.Length > 0 then
-                    match releases.[0].TryGetProperty("createdAt") with
-                    | Some createdAtJson ->
-                        let createdAt = createdAtJson.AsString()
-                        // Parse ISO 8601 date and convert back to string format for the query
-                        let dateTime =
-                            DateTime
-                                .Parse(createdAt, null, System.Globalization.DateTimeStyles.RoundtripKind)
-                                .ToUniversalTime()
-
-                        let ghDate = dateTime.ToString("yyyy-MM-ddTHH:mm:ss")
-                        printfn $"Using most recent GitHub release date for author attribution: {ghDate}"
-                        ghDate
-                    | None ->
-                        let fallbackDate = DateTime.UtcNow.ToString("yyyy-MM-dd")
-                        printfn $"GitHub release missing createdAt, using current date: {fallbackDate}"
-                        fallbackDate
-                else
-                    let fallbackDate = DateTime.UtcNow.ToString("yyyy-MM-dd")
-                    printfn $"No GitHub releases found, using current date: {fallbackDate}"
-                    fallbackDate
-            else
-                let fallbackDate = DateTime.UtcNow.ToString("yyyy-MM-dd")
-                printfn $"Could not query GitHub releases, using current date: {fallbackDate}"
-                fallbackDate
-
-    printfn $"Querying PRs closed after {date} for author attribution..."
-
-    let authorMsg =
-        let queryResult =
-            Cli
-                .Wrap("gh")
-                .WithArguments($"pr list -S \"state:closed base:main closed:>{date}\" --json commits,mergedAt")
-                .WithValidation(CommandResultValidation.None)
-                .ExecuteBufferedAsync()
-                .Task.Result
-
-        if queryResult.ExitCode <> 0 then
-            printfn $"Warning: Failed to query PRs for author attribution (exit code: {queryResult.ExitCode})"
-            String.Empty
+        if result.ExitCode <> 0 || String.IsNullOrWhiteSpace(result.StandardOutput.Trim()) then
+            let fallbackDate: string = DateTime.UtcNow.ToString "yyyy-MM-dd"
+            printfn $"Could not query GitHub releases, using current date: {fallbackDate}"
+            return fallbackDate
         else
-            let jsonOutput = queryResult.StandardOutput.Trim()
 
-            // Parse JSON to filter by mergedAt timestamp
-            let jsonValue = FSharp.Data.JsonValue.Parse(jsonOutput)
-            let prs = jsonValue.AsArray()
+            let releases: JsonValue array =
+                JsonValue.Parse(result.StandardOutput.Trim()).AsArray()
 
-            // Parse the date as ISO 8601 format (GitHub always returns dates in this format: "2025-08-02T10:25:30Z")
-            let cutoffTimestamp =
-                DateTime.Parse(date, null, System.Globalization.DateTimeStyles.RoundtripKind).ToUniversalTime()
+            match Array.tryHead releases |> Option.bind (fun r -> r.TryGetProperty "createdAt") with
+            | None ->
+                let fallbackDate: string = DateTime.UtcNow.ToString "yyyy-MM-dd"
+                printfn $"No GitHub release with a createdAt, using current date: {fallbackDate}"
+                return fallbackDate
+            | Some createdAtJson ->
+                // Parse ISO 8601 date and convert back to string format for the query
+                let dateTime: DateTime =
+                    DateTime
+                        .Parse(createdAtJson.AsString(), null, System.Globalization.DateTimeStyles.RoundtripKind)
+                        .ToUniversalTime()
 
-            printfn $"Filtering PRs merged after: {cutoffTimestamp:O}"
+                let ghDate: string = dateTime.ToString("yyyy-MM-ddTHH:mm:ss")
+                printfn $"Using most recent GitHub release date for author attribution: {ghDate}"
+                return ghDate
+    }
 
-            let authors =
-                prs
-                |> Array.collect (fun (pr: FSharp.Data.JsonValue) ->
-                    let mergedAtOpt =
-                        match pr.TryGetProperty("mergedAt") with
-                        | Some mergedAtJson ->
-                            let mergedAtStr = mergedAtJson.AsString()
+let getReleaseNotes
+    (ctx: StageContext)
+    (currentRelease: GithubRelease)
+    (lastPublishedDate: string option)
+    : Async<string> =
+    async {
+        let! date =
+            match lastPublishedDate with
+            | None -> mostRecentReleaseDate ctx
+            | Some d ->
+                printfn $"Using last release published date for author attribution: {d}"
+                async.Return d
 
-                            match
-                                DateTime.TryParse(mergedAtStr, null, System.Globalization.DateTimeStyles.RoundtripKind)
-                            with
-                            | true, dt -> Some(dt.ToUniversalTime())
-                            | false, _ -> None
-                        | None -> None
+        printfn $"Querying PRs closed after {date} for author attribution..."
 
-                    match mergedAtOpt with
-                    | Some mergedAt when mergedAt > cutoffTimestamp ->
-                        match pr.TryGetProperty("commits") with
-                        | Some commitsJson ->
-                            let commits = commitsJson.AsArray()
+        let! queryResult =
+            ctx.RunCommandCaptureAll(
+                $"gh pr list -S \"state:closed base:main closed:>{date}\" --json commits,mergedAt",
+                disablePrintOutput = true
+            )
 
-                            commits
-                            |> Array.collect (fun (commit: FSharp.Data.JsonValue) ->
-                                match commit.TryGetProperty("authors") with
-                                | Some authorsJson ->
-                                    let commitAuthors = authorsJson.AsArray()
-
-                                    commitAuthors
-                                    |> Array.choose (fun (author: FSharp.Data.JsonValue) ->
-                                        match author.TryGetProperty("login") with
-                                        | Some loginJson ->
-                                            let login = loginJson.AsString()
-                                            // Filter out bots
-                                            if login.EndsWith("[bot]", StringComparison.Ordinal) then
-                                                None
-                                            else
-                                                Some(login)
-                                        | None -> None)
-                                | None -> [||])
-                        | None -> [||]
-                    | _ -> [||])
-                |> Array.distinct
-                |> Array.sort
-
-            printfn $"Found {authors.Length} contributors for this release"
-
-            if authors.Length = 0 then
+        let authorMsg =
+            if queryResult.ExitCode <> 0 then
+                printfn $"Warning: Failed to query PRs for author attribution (exit code: {queryResult.ExitCode})"
                 String.Empty
-            elif authors.Length = 1 then
-                $"Special thanks to @%s{authors.[0]}!"
             else
-                let lastAuthor = Array.last authors
+                let jsonOutput = queryResult.StandardOutput.Trim()
 
-                let otherAuthors =
-                    if authors.Length = 2 then
-                        $"@{authors.[0]}"
-                    else
-                        authors
-                        |> Array.take (authors.Length - 1)
-                        |> Array.map (sprintf "@%s")
-                        |> String.concat ", "
+                // Parse JSON to filter by mergedAt timestamp
+                let jsonValue = FSharp.Data.JsonValue.Parse(jsonOutput)
+                let prs = jsonValue.AsArray()
 
-                $"Special thanks to %s{otherAuthors} and @%s{lastAuthor}!"
+                // Parse the date as ISO 8601 format (GitHub always returns dates in this format: "2025-08-02T10:25:30Z")
+                let cutoffTimestamp =
+                    DateTime.Parse(date, null, System.Globalization.DateTimeStyles.RoundtripKind).ToUniversalTime()
 
-    $"""{currentRelease.Draft}
+                printfn $"Filtering PRs merged after: {cutoffTimestamp:O}"
+
+                let authors =
+                    prs
+                    |> Array.collect (fun (pr: FSharp.Data.JsonValue) ->
+                        let mergedAtOpt =
+                            match pr.TryGetProperty("mergedAt") with
+                            | Some mergedAtJson ->
+                                let mergedAtStr = mergedAtJson.AsString()
+
+                                match
+                                    DateTime.TryParse(
+                                        mergedAtStr,
+                                        null,
+                                        System.Globalization.DateTimeStyles.RoundtripKind
+                                    )
+                                with
+                                | true, dt -> Some(dt.ToUniversalTime())
+                                | false, _ -> None
+                            | None -> None
+
+                        match mergedAtOpt with
+                        | Some mergedAt when mergedAt > cutoffTimestamp ->
+                            match pr.TryGetProperty("commits") with
+                            | Some commitsJson ->
+                                let commits = commitsJson.AsArray()
+
+                                commits
+                                |> Array.collect (fun (commit: FSharp.Data.JsonValue) ->
+                                    match commit.TryGetProperty("authors") with
+                                    | Some authorsJson ->
+                                        let commitAuthors = authorsJson.AsArray()
+
+                                        commitAuthors
+                                        |> Array.choose (fun (author: FSharp.Data.JsonValue) ->
+                                            match author.TryGetProperty("login") with
+                                            | Some loginJson ->
+                                                let login = loginJson.AsString()
+                                                // Filter out bots
+                                                if login.EndsWith("[bot]", StringComparison.Ordinal) then
+                                                    None
+                                                else
+                                                    Some(login)
+                                            | None -> None)
+                                    | None -> [||])
+                            | None -> [||]
+                        | _ -> [||])
+                    |> Array.distinct
+                    |> Array.sort
+
+                printfn $"Found {authors.Length} contributors for this release"
+
+                if authors.Length = 0 then
+                    String.Empty
+                elif authors.Length = 1 then
+                    $"Special thanks to @%s{authors.[0]}!"
+                else
+                    let lastAuthor = Array.last authors
+
+                    let otherAuthors =
+                        if authors.Length = 2 then
+                            $"@{authors.[0]}"
+                        else
+                            authors
+                            |> Array.take (authors.Length - 1)
+                            |> Array.map (sprintf "@%s")
+                            |> String.concat ", "
+
+                    $"Special thanks to %s{otherAuthors} and @%s{lastAuthor}!"
+
+        return
+            $"""{currentRelease.Draft}
 
 {authorMsg}
 
 [https://www.nuget.org/packages/fantomas/{currentRelease.Version}](https://www.nuget.org/packages/fantomas/{currentRelease.Version})
     """
+    }
 
-let getCurrentReleaseAndLastPublishedDate () : GithubRelease * string option =
-    printfn "Parsing CHANGELOG.md to find current and last release..."
-    let changelog = FileInfo(repositoryRoot </> "CHANGELOG.md")
+/// The first of the given versions that GitHub has a release for, along with the date it was
+/// published. `List.tryPick` would say this in a line, but every lookup is a `gh` call, so the walk
+/// is written out to keep it lazy: the answer is nearly always the first one asked about.
+let rec private firstPublished (ctx: StageContext) (versions: string list) : Async<(string * string) option> =
+    async {
+        match versions with
+        | [] -> return None
+        | version :: rest ->
+            let! published = getPublishedDate ctx version
 
-    let changeLogResult =
-        match Parser.parseChangeLog changelog with
-        | Error error -> failwithf "Failed to parse changelog: %A" error
-        | Ok result ->
-            printfn $"Found {result.Releases.Length} releases in changelog"
-            result
+            match published with
+            | Some date -> return Some(version, date)
+            | None -> return! firstPublished ctx rest
+    }
 
-    let releases =
-        changeLogResult.Releases
-        |> List.sortByDescending (fun (v, _, _) -> versionSortKey v)
+let getCurrentReleaseAndLastPublishedDate (ctx: StageContext) : Async<GithubRelease * string option> =
+    async {
+        printfn "Parsing CHANGELOG.md to find current and last release..."
+        let changelog = FileInfo(repositoryRoot </> "CHANGELOG.md")
 
-    match releases with
-    | [] -> failwith "Could not find any release in CHANGELOG.md"
-    | current :: earlierReleases ->
-        let currentRelease = mkGithubRelease current
-        printfn $"Current release: {currentRelease.Version}"
+        let changeLogResult =
+            match Parser.parseChangeLog changelog with
+            | Error error -> failwithf "Failed to parse changelog: %A" error
+            | Ok result ->
+                printfn $"Found {result.Releases.Length} releases in changelog"
+                result
 
-        // The release below the current one does not have to exist on GitHub: 7.0.6 went to
-        // NuGet by hand from the v7.0.6 branch and never got a GitHub release. Walk down the
-        // recent entries until GitHub knows one, its publish date is what the contributor
-        // query is based on. Anything older than that is out of date anyway, getReleaseNotes
-        // then falls back to the most recent release GitHub reports.
-        let lastPublishedRelease =
-            earlierReleases
-            |> List.truncate 5
-            |> List.tryPick (fun (v, _, _) ->
-                let version = formatVersion v
-                getPublishedDate version |> Option.map (fun date -> version, date))
+        let releases =
+            changeLogResult.Releases
+            |> List.sortByDescending (fun (v, _, _) -> versionSortKey v)
 
-        match lastPublishedRelease with
-        | Some(version, date) -> printfn $"Last release on GitHub: {version}, published at {date}"
-        | None -> printfn "None of the recent changelog entries has a GitHub release"
+        match releases with
+        | [] -> return failwith "Could not find any release in CHANGELOG.md"
+        | current :: earlierReleases ->
+            let! currentRelease = mkGithubRelease ctx current
+            printfn $"Current release: {currentRelease.Version}"
 
-        currentRelease, Option.map snd lastPublishedRelease
+            // The release below the current one does not have to exist on GitHub: 7.0.6 went to
+            // NuGet by hand from the v7.0.6 branch and never got a GitHub release. Walk down the
+            // recent entries until GitHub knows one, its publish date is what the contributor
+            // query is based on. Anything older than that is out of date anyway, getReleaseNotes
+            // then falls back to the most recent release GitHub reports.
+            let! lastPublishedRelease =
+                earlierReleases
+                |> List.truncate 5
+                |> List.map (fun (v, _, _) -> formatVersion v)
+                |> firstPublished ctx
+
+            match lastPublishedRelease with
+            | None -> printfn "None of the recent changelog entries has a GitHub release"
+            | Some(version, date) -> printfn $"Last release on GitHub: {version}, published at {date}"
+
+            return currentRelease, Option.map snd lastPublishedRelease
+    }

--- a/scripts/BuildScripts.fsx
+++ b/scripts/BuildScripts.fsx
@@ -1,9 +1,9 @@
-#r "nuget: CliWrap, 3.6.4"
+#r "nuget: Fun.Build, 1.2.0"
 
 open System.IO
 open System.Text.RegularExpressions
-open CliWrap
-open CliWrap.Buffered
+open Fun.Build
+open Fun.Build.Internal
 // Loaded by `build.fsx`, after `BuildCommon.fsx`. An error here saying BuildCommon is not defined
 // means this file was run on its own; it is a library, so run a pipeline from build.fsx instead.
 open BuildCommon
@@ -78,17 +78,15 @@ let runnableDocScripts () : string list =
     |> runnableIn
 
 /// Compile one script and stop short of running it, reporting whatever the compiler said.
-let private typecheckScript (script: string) : Async<string * int * string> =
+let private typecheckScript (ctx: StageContext) (script: string) : Async<string * int * string> =
     async {
         let! result =
-            Cli
-                .Wrap("dotnet")
-                .WithArguments($"fsi --typecheck-only --nologo \"{script}\"")
-                .WithWorkingDirectory(repositoryRoot)
-                .WithValidation(CommandResultValidation.None)
-                .ExecuteBufferedAsync()
-                .Task
-            |> Async.AwaitTask
+            ctx.RunCommandCaptureAll(
+                $"dotnet fsi --typecheck-only --nologo {quoteArgument script}",
+                workingDir = repositoryRoot,
+                disablePrintCommand = true,
+                disablePrintOutput = true
+            )
 
         return script, result.ExitCode, (result.StandardOutput + result.StandardError).Trim()
     }
@@ -96,11 +94,11 @@ let private typecheckScript (script: string) : Async<string * int * string> =
 /// Compile each of the given scripts, and report what the compiler said about any that would not
 /// compile. Writes nothing: no script is run, and the assemblies they reference are built by the
 /// stage before whichever one calls this.
-let private check (scripts: string list) : Async<int> =
+let private check (ctx: StageContext) (scripts: string list) : Async<int> =
     async {
         // One at a time: the compiler output of a script that fails is the point of this, and
         // running them together interleaves it beyond reading.
-        let! results = scripts |> List.map typecheckScript |> Async.Sequential
+        let! results = scripts |> List.map (typecheckScript ctx) |> Async.Sequential
 
         for (script: string), (exitCode: int), (output: string) in results do
             let name: string = Path.GetRelativePath(repositoryRoot, script)
@@ -118,7 +116,7 @@ let private check (scripts: string list) : Async<int> =
     }
 
 /// Compile `build.fsx` and the diagnostic scripts. Needs the debug build.
-let checkScripts _ : Async<int> = check (runnableScripts ())
+let checkScripts (ctx: StageContext) : Async<int> = check ctx (runnableScripts ())
 
 /// Compile the documentation scripts. Needs the release build.
-let checkDocScripts _ : Async<int> = check (runnableDocScripts ())
+let checkDocScripts (ctx: StageContext) : Async<int> = check ctx (runnableDocScripts ())

--- a/scripts/shared.fsx
+++ b/scripts/shared.fsx
@@ -1,6 +1,8 @@
 #r "../artifacts/bin/Fantomas.FCS/debug/Fantomas.FCS.dll"
 #r "../artifacts/bin/Fantomas.Core/debug/Fantomas.Core.dll"
-#r "nuget: editorconfig, 0.15.0"
+// Must match the version `Directory.Packages.props` gives Fantomas: `EditorConfig.fs` is loaded as
+// source below and compiles against whatever this resolves.
+#r "nuget: editorconfig, 0.18.0"
 
 #load "../src/Fantomas/Suggestion.fs"
 #load "../src/Fantomas/EditorConfig.fs"

--- a/src/Fantomas.Benchmarks/packages.lock.json
+++ b/src/Fantomas.Benchmarks/packages.lock.json
@@ -24,7 +24,7 @@
         "type": "Direct",
         "requested": "[10.1.401, )",
         "resolved": "10.1.401",
-        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
+        "contentHash": "/lvOK51KD8IangBYkfDVna3/HrE/r4VUnX3dI01KDspctoYXmind3POeoYkqWKeXHwiKlf6Hc9TxwSnoSCWcjw=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",

--- a/src/Fantomas.Benchmarks/packages.lock.json
+++ b/src/Fantomas.Benchmarks/packages.lock.json
@@ -187,14 +187,14 @@
       "fantomas.core": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )",
+          "FSharp.Core": "[10.0.100, )",
           "Fantomas.FCS": "[1.0.0, )"
         }
       },
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )"
+          "FSharp.Core": "[10.0.100, )"
         }
       }
     }

--- a/src/Fantomas.Benchmarks/packages.lock.json
+++ b/src/Fantomas.Benchmarks/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.1.401, )",
-        "resolved": "10.1.401",
-        "contentHash": "/lvOK51KD8IangBYkfDVna3/HrE/r4VUnX3dI01KDspctoYXmind3POeoYkqWKeXHwiKlf6Hc9TxwSnoSCWcjw=="
+        "requested": "[10.1.203, )",
+        "resolved": "10.1.203",
+        "contentHash": "I2MFk72yHqfgI594gKFigq8PVIso0Mh1ZUgG9R4n8gyYQ4IwpBxmvecfjnKA7iMLdVHYULB70PsLwYW/K76gew=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",

--- a/src/Fantomas.Benchmarks/packages.lock.json
+++ b/src/Fantomas.Benchmarks/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.0.100, )",
-        "resolved": "10.0.100",
-        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
+        "requested": "[10.1.401, )",
+        "resolved": "10.1.401",
+        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
@@ -187,14 +187,14 @@
       "fantomas.core": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )",
+          "FSharp.Core": "[10.1.401, )",
           "Fantomas.FCS": "[1.0.0, )"
         }
       },
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )"
+          "FSharp.Core": "[10.1.401, )"
         }
       }
     }

--- a/src/Fantomas.Client.Tests/packages.lock.json
+++ b/src/Fantomas.Client.Tests/packages.lock.json
@@ -18,7 +18,7 @@
         "type": "Direct",
         "requested": "[10.1.401, )",
         "resolved": "10.1.401",
-        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
+        "contentHash": "/lvOK51KD8IangBYkfDVna3/HrE/r4VUnX3dI01KDspctoYXmind3POeoYkqWKeXHwiKlf6Hc9TxwSnoSCWcjw=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",

--- a/src/Fantomas.Client.Tests/packages.lock.json
+++ b/src/Fantomas.Client.Tests/packages.lock.json
@@ -4,21 +4,21 @@
     "net10.0": {
       "altcover": {
         "type": "Direct",
-        "requested": "[9.0.102, )",
-        "resolved": "9.0.102",
-        "contentHash": "q3Rf5t0M9kXlcO5qhsaAe6NrFSNd5enrhKmF/Ezgmomqw34PbUTbRSYjSDNhS3YGDyUrPTkyPn14EfLDJWztcA=="
+        "requested": "[9.0.145, )",
+        "resolved": "9.0.145",
+        "contentHash": "jVDhMWOTK4CE36yx7iUBx09nBD7Yv8KJzGptCwPPkoy+ibQCE6J+ns1wTMOn8TXz8YJTi8KK9XTKgrCfV6aMgA=="
       },
       "CliWrap": {
         "type": "Direct",
-        "requested": "[3.10.0, )",
-        "resolved": "3.10.0",
-        "contentHash": "Igph39WNImUFqQrpTeBDPafcCnM1u/8IooZHqMRF/5JdV5H78p+AbZkeYY1Nkz1WlbI/Gt2Hq/3rYh55jxRF9Q=="
+        "requested": "[3.10.5, )",
+        "resolved": "3.10.5",
+        "contentHash": "L5SghZThsAVhV8ucwwW5FLMzKj1Ps57JB8DM2bEjpBNTyGi1EDjDO7Mi39Yx1FoXM2fZ1l9j39xqlPsZI1QCJQ=="
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.0.100, )",
-        "resolved": "10.0.100",
-        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
+        "requested": "[10.1.401, )",
+        "resolved": "10.1.401",
+        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
@@ -34,29 +34,29 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.10.0, )",
+        "resolved": "18.10.0",
+        "contentHash": "0CZZ688UBvpQFB9HKo7wrNJNVe+AOM4UtipgwpER3TTM+d2DDM6QyKkIJZTR3mpbn9/zFbZEtAgVIz4SPTjQZQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.10.0",
+          "Microsoft.TestPlatform.TestHost": "18.10.0"
         }
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.5.1, )",
-        "resolved": "4.5.1",
-        "contentHash": "x1sIqU9i0IkxqFayqthzmJs/75jTMbrfNMixj4vtfTi7rRzGbtuY27V+iAhfTY02u5k2qvW3QBGM414OG4q8Lw=="
+        "requested": "[4.6.1, )",
+        "resolved": "4.6.1",
+        "contentHash": "xS4+YaBFUv1r8bcAbjitSfYaRZGfMwUiMdiaRziBXZpKgVxKDSHhjUn0mV5mObHGZRZq6eNa+WFWr3g8grj66A=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "8PMJB8za2u8S0ey/nEtvh9BHjLhv5yzUEMCmA0+VIPLKSeOAZ3TEHWDyAp0+iPQb3jnBH1o8k0PoU2FgzXLRnQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "8ZD+0dIfDHsL4w4Gl/LPxWH0O4ky3hFXqTZjY+ry0ThI3cMVErr9Tjxal5O5wJxGXh50a9qkDEAWVca8KQYCEw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "8.0.2",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.1.0",
-          "Microsoft.Testing.Platform.MSBuild": "2.1.0"
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
         }
       },
       "MessagePack": {
@@ -80,8 +80,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.10.0",
+        "contentHash": "zo1hqV+Nz6FlIwdc+aPfrvGzqfKAPPaZ6OPj1W8C0QQE2xH951AZwTUytL3K7XX8brVBUFd7MhrLDl3CtK3U/A=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -95,57 +95,56 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "5TwgTx2u7k9Al/xbZ18QXq4Hdy2xewkVTI6K3sk+jY2ykqUkIKNuj7rFu3GOV5KnEUkevhw6eZcyZs77STHJIA==",
+        "resolved": "2.3.3",
+        "contentHash": "nY8ceQyPWB9TRE1WE5Oe/sks2e10SxgPv61vBHsFYpgCeDtNwhpMZwmL29GklO3/etTdOsLdrCmNr4zJWaR2fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "D8xmIJYQFJ6D49Rx5/vPrkZZxb338Jkew+eSqZLBfBiWKw4QZKy3i1BOXiLfz0lOmaNErwDz/YWRojCdNl+B9Q==",
+        "resolved": "2.3.3",
+        "contentHash": "dceVNxnfTEjKnrIreLcMfkgrzzBY8kgCCJX5NAv7Lq/6vPlTP4VB5zxKeuYy0yfCoBtWuPkLjUG6qtOBMfpypA==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Extensions.VSTestBridge": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "bNRIEA2YoGr+Y+7LHdA7i1U80+7BAdf4K4Qh4Kx6eKkoBK/NV7QpoMg+GWPP0/eqAFzuUmUOIPVZ87Oo0Vyxmw==",
+        "resolved": "2.3.3",
+        "contentHash": "JLovZjH6K10YiHO/BcidsaSHo/M2DfOe9FDjxjFdV6aoHO6VYTTYlLBNcyLJSo20q5gDTmNvmxYVH39A942aJA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
-          "Microsoft.Testing.Extensions.Telemetry": "2.1.0",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.1.0",
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.3",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.3",
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "aHkjNTGIA+Zbdw6RJgSFrbDrCjO0CgqpElqYcvkRSeUhBv2bKarnvU3ep786U7UqrPlArT/B7VmImRibJD0Zrg=="
+        "resolved": "2.3.3",
+        "contentHash": "ENbH4BQh9riXtOKc25KKITfiGGWhWMBJA7pZuNaF9zxzzSaVkp5AMeZxGQ6sXYaR6xb724NLz985Is6XIYqLSg=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "resolved": "18.10.0",
+        "contentHash": "aXA7DDbnt6MYu3eLBEDksNdl09QxJ/PpMzrFcSxqEOk3RvRGJzhKI5mezVCEOcvveRhjfw/mvn6xVXC/rTaOog=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.10.0",
+        "contentHash": "Spu6C7bgz1PmWN+Y7wS0PfGCw9Kwv5RvJbCwyQaEWjcwpMire+qYMrcZ7qk8agjy6nd0sdHLc3ugCSrGuSbZdw==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.TestPlatform.ObjectModel": "18.10.0"
         }
       },
       "Microsoft.VisualStudio.Threading.Only": {
@@ -188,7 +187,7 @@
       "fantomas.client": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )",
+          "FSharp.Core": "[10.1.401, )",
           "SemanticVersioning": "[3.0.0, )",
           "StreamJsonRpc": "[2.25.29, )"
         }

--- a/src/Fantomas.Client.Tests/packages.lock.json
+++ b/src/Fantomas.Client.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.1.401, )",
-        "resolved": "10.1.401",
-        "contentHash": "/lvOK51KD8IangBYkfDVna3/HrE/r4VUnX3dI01KDspctoYXmind3POeoYkqWKeXHwiKlf6Hc9TxwSnoSCWcjw=="
+        "requested": "[10.1.203, )",
+        "resolved": "10.1.203",
+        "contentHash": "I2MFk72yHqfgI594gKFigq8PVIso0Mh1ZUgG9R4n8gyYQ4IwpBxmvecfjnKA7iMLdVHYULB70PsLwYW/K76gew=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",

--- a/src/Fantomas.Client.Tests/packages.lock.json
+++ b/src/Fantomas.Client.Tests/packages.lock.json
@@ -187,7 +187,7 @@
       "fantomas.client": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )",
+          "FSharp.Core": "[10.0.100, )",
           "SemanticVersioning": "[3.0.0, )",
           "StreamJsonRpc": "[2.25.29, )"
         }

--- a/src/Fantomas.Client/CHANGELOG.md
+++ b/src/Fantomas.Client/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is the changelog for the Fantomas.Client package specifically. It's distinct from that of the overall libraries and command-line tool.
 
+## [0.12.0-beta-003] - 2026-09-12
+
+### Changed
+- `System.Collections.Immutable` and `System.Diagnostics.DiagnosticSource` move to `10.0.12`, a servicing patch of the versions this package already asked for. Nothing else moved: the API, `FSharp.Core`, `StreamJsonRpc` and `SemanticVersioning` are where `0.12.0-beta-002` left them. [#3468](https://github.com/fsprojects/fantomas/pull/3468)
+
 ## [0.12.0-beta-002] - 2026-08-28
 
 ### Added

--- a/src/Fantomas.Client/Fantomas.Client.fsproj
+++ b/src/Fantomas.Client/Fantomas.Client.fsproj
@@ -22,7 +22,11 @@
     <Compile Include="LSPFantomasService.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" />
+    <!--
+    A published library, so its FSharp.Core is the lowest version consumers must have rather than
+    the newest one available. `VersionOverride` holds it below what the rest of the solution uses.
+    -->
+    <PackageReference Include="FSharp.Core" VersionOverride="10.0.100" />
     <PackageReference Include="StreamJsonRpc" />
     <PackageReference Include="SemanticVersioning" />
   </ItemGroup>

--- a/src/Fantomas.Client/packages.lock.json
+++ b/src/Fantomas.Client/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.1.401, )",
-        "resolved": "10.1.401",
-        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
+        "requested": "[10.0.100, )",
+        "resolved": "10.0.100",
+        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",

--- a/src/Fantomas.Client/packages.lock.json
+++ b/src/Fantomas.Client/packages.lock.json
@@ -4,15 +4,15 @@
     ".NETStandard,Version=v2.0": {
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
-        "requested": "[2.0.2, )",
-        "resolved": "2.0.2",
-        "contentHash": "VaHoEN6YHp0jXucxm67vfuRy8zo9ufiKSuaZ4ZudRi8xmWcEFMKxfCsg2nvYNvdISFTURDu+IHqADGh53+Bamw=="
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "8LrlvI1KpjjJ4VGSqZ16yoOCKlQnYS+Y8rYNifNrscmVh5anJcF9E4e0NiDP30BHBMUbkoJ5KdcxoRWM7Pz9Aw=="
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.0.100, )",
-        "resolved": "10.0.100",
-        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
+        "requested": "[10.1.401, )",
+        "resolved": "10.1.401",
+        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
@@ -284,9 +284,9 @@
       },
       "System.Collections.Immutable": {
         "type": "CentralTransitive",
-        "requested": "[10.0.6, )",
-        "resolved": "10.0.6",
-        "contentHash": "g5J8W/ovAraH1IDCvRZlXmpFc2v9yr1caYbVLIye2kzNtsWjJXD6TzV8vNdXni2b7wASoUeY2pnCBHxWrstXGQ==",
+        "requested": "[10.0.12, )",
+        "resolved": "10.0.12",
+        "contentHash": "tRMzrybcwEEaudfpL9ghzfnSjEVVuhKa5sR86q30mYxXJdcKOLSBkpMFm62CGsbB50diPZta73Pxu8DgjGdDbA==",
         "dependencies": {
           "System.Memory": "4.6.3",
           "System.Runtime.CompilerServices.Unsafe": "6.1.2"
@@ -294,9 +294,9 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "CentralTransitive",
-        "requested": "[10.0.6, )",
-        "resolved": "10.0.6",
-        "contentHash": "v/YvmOpq+lv50oxxIDSvZlgiFD2m38DogHTE4MToMEGf6HtgBAmy8gB7Oq0C2pBt+6/bLvUnzLxubWFcvfzTsQ==",
+        "requested": "[10.0.12, )",
+        "resolved": "10.0.12",
+        "contentHash": "CRZTWYO0rzEcJN/6SuN1kMvQOJT7vyHZ64CCkQs0RRWTj7kH2KMkaMalbsbSI/eg5dS5JAQfQFFuuWgn+XRMsQ==",
         "dependencies": {
           "System.Memory": "4.6.3",
           "System.Runtime.CompilerServices.Unsafe": "6.1.2"

--- a/src/Fantomas.Core.Tests/TypeProviderTests.fs
+++ b/src/Fantomas.Core.Tests/TypeProviderTests.fs
@@ -47,12 +47,14 @@ type Graphml = XmlProvider<Schema= @"http://graphml.graphdrawing.org/xmlns/1.0/g
 
 [<Test>]
 let ``should throw FormatException on unparsed input`` () =
-    Assert.Throws<ParseException>(fun () ->
-        formatSourceString
-            """
+    Assert.Throws<ParseException>(
+        System.Action(fun () ->
+            formatSourceString
+                """
     type GeoResults = JsonProvider<Sample= "A" + "GitHub.json" >"""
-            config
-        |> ignore
+                config
+            |> ignore
+        )
     )
     |> ignore
 

--- a/src/Fantomas.Core.Tests/packages.lock.json
+++ b/src/Fantomas.Core.Tests/packages.lock.json
@@ -21,7 +21,7 @@
         "type": "Direct",
         "requested": "[10.1.401, )",
         "resolved": "10.1.401",
-        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
+        "contentHash": "/lvOK51KD8IangBYkfDVna3/HrE/r4VUnX3dI01KDspctoYXmind3POeoYkqWKeXHwiKlf6Hc9TxwSnoSCWcjw=="
       },
       "FsUnit": {
         "type": "Direct",

--- a/src/Fantomas.Core.Tests/packages.lock.json
+++ b/src/Fantomas.Core.Tests/packages.lock.json
@@ -19,9 +19,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.1.401, )",
-        "resolved": "10.1.401",
-        "contentHash": "/lvOK51KD8IangBYkfDVna3/HrE/r4VUnX3dI01KDspctoYXmind3POeoYkqWKeXHwiKlf6Hc9TxwSnoSCWcjw=="
+        "requested": "[10.1.203, )",
+        "resolved": "10.1.203",
+        "contentHash": "I2MFk72yHqfgI594gKFigq8PVIso0Mh1ZUgG9R4n8gyYQ4IwpBxmvecfjnKA7iMLdVHYULB70PsLwYW/K76gew=="
       },
       "FsUnit": {
         "type": "Direct",

--- a/src/Fantomas.Core.Tests/packages.lock.json
+++ b/src/Fantomas.Core.Tests/packages.lock.json
@@ -175,14 +175,14 @@
       "fantomas.core": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )",
+          "FSharp.Core": "[10.0.100, )",
           "Fantomas.FCS": "[1.0.0, )"
         }
       },
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )"
+          "FSharp.Core": "[10.0.100, )"
         }
       }
     }

--- a/src/Fantomas.Core.Tests/packages.lock.json
+++ b/src/Fantomas.Core.Tests/packages.lock.json
@@ -4,24 +4,24 @@
     "net10.0": {
       "altcover": {
         "type": "Direct",
-        "requested": "[9.0.102, )",
-        "resolved": "9.0.102",
-        "contentHash": "q3Rf5t0M9kXlcO5qhsaAe6NrFSNd5enrhKmF/Ezgmomqw34PbUTbRSYjSDNhS3YGDyUrPTkyPn14EfLDJWztcA=="
+        "requested": "[9.0.145, )",
+        "resolved": "9.0.145",
+        "contentHash": "jVDhMWOTK4CE36yx7iUBx09nBD7Yv8KJzGptCwPPkoy+ibQCE6J+ns1wTMOn8TXz8YJTi8KK9XTKgrCfV6aMgA=="
       },
       "FsCheck": {
         "type": "Direct",
-        "requested": "[3.3.2, )",
-        "resolved": "3.3.2",
-        "contentHash": "JlK719ZlP/ofbsN0qXYrfqbe2SCgp4D1BEyJynkzyurMI2JqUkWgZHXgEu0pXVdj35zU/GWsXrGYA68sSdAmHQ==",
+        "requested": "[3.4.0, )",
+        "resolved": "3.4.0",
+        "contentHash": "wkWR1DORrKd46W6MEhmS4muo/0kgrtUV/AGW1ohMWemy7WukcRH8T3JjkDpn/daOHk0yVqf0CBvScU17Ab//PA==",
         "dependencies": {
           "FSharp.Core": "5.0.2"
         }
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.0.100, )",
-        "resolved": "10.0.100",
-        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
+        "requested": "[10.1.401, )",
+        "resolved": "10.1.401",
+        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
       },
       "FsUnit": {
         "type": "Direct",
@@ -47,38 +47,38 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.10.0, )",
+        "resolved": "18.10.0",
+        "contentHash": "0CZZ688UBvpQFB9HKo7wrNJNVe+AOM4UtipgwpER3TTM+d2DDM6QyKkIJZTR3mpbn9/zFbZEtAgVIz4SPTjQZQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.10.0",
+          "Microsoft.TestPlatform.TestHost": "18.10.0"
         }
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.5.1, )",
-        "resolved": "4.5.1",
-        "contentHash": "x1sIqU9i0IkxqFayqthzmJs/75jTMbrfNMixj4vtfTi7rRzGbtuY27V+iAhfTY02u5k2qvW3QBGM414OG4q8Lw=="
+        "requested": "[4.6.1, )",
+        "resolved": "4.6.1",
+        "contentHash": "xS4+YaBFUv1r8bcAbjitSfYaRZGfMwUiMdiaRziBXZpKgVxKDSHhjUn0mV5mObHGZRZq6eNa+WFWr3g8grj66A=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "8PMJB8za2u8S0ey/nEtvh9BHjLhv5yzUEMCmA0+VIPLKSeOAZ3TEHWDyAp0+iPQb3jnBH1o8k0PoU2FgzXLRnQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "8ZD+0dIfDHsL4w4Gl/LPxWH0O4ky3hFXqTZjY+ry0ThI3cMVErr9Tjxal5O5wJxGXh50a9qkDEAWVca8KQYCEw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "8.0.2",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.1.0",
-          "Microsoft.Testing.Platform.MSBuild": "2.1.0"
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
         }
       },
       "System.IO.Abstractions.TestingHelpers": {
         "type": "Direct",
-        "requested": "[22.1.1, )",
-        "resolved": "22.1.1",
-        "contentHash": "/fJ2F9N8Q7ZL7l7TQRcFtgaBdLBOj4+XL8ipc9sZC8tLMjoNBJtuyxMise5utraozm3KDAzPls5iWIcDCwpawQ==",
+        "requested": "[22.2.0, )",
+        "resolved": "22.2.0",
+        "contentHash": "yVy8HIx57CFwf9Z5UMYbrokQtLdwf7f004UiR8XhA70Q3BWlIAYDaOUk7ZhDp3BtIgh739dgJkqGmSN0LUA50Q==",
         "dependencies": {
-          "TestableIO.System.IO.Abstractions.TestingHelpers": "22.1.1"
+          "TestableIO.System.IO.Abstractions.TestingHelpers": "22.2.0"
         }
       },
       "Microsoft.ApplicationInsights": {
@@ -88,8 +88,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.10.0",
+        "contentHash": "zo1hqV+Nz6FlIwdc+aPfrvGzqfKAPPaZ6OPj1W8C0QQE2xH951AZwTUytL3K7XX8brVBUFd7MhrLDl3CtK3U/A=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -98,99 +98,92 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "5TwgTx2u7k9Al/xbZ18QXq4Hdy2xewkVTI6K3sk+jY2ykqUkIKNuj7rFu3GOV5KnEUkevhw6eZcyZs77STHJIA==",
+        "resolved": "2.3.3",
+        "contentHash": "nY8ceQyPWB9TRE1WE5Oe/sks2e10SxgPv61vBHsFYpgCeDtNwhpMZwmL29GklO3/etTdOsLdrCmNr4zJWaR2fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "D8xmIJYQFJ6D49Rx5/vPrkZZxb338Jkew+eSqZLBfBiWKw4QZKy3i1BOXiLfz0lOmaNErwDz/YWRojCdNl+B9Q==",
+        "resolved": "2.3.3",
+        "contentHash": "dceVNxnfTEjKnrIreLcMfkgrzzBY8kgCCJX5NAv7Lq/6vPlTP4VB5zxKeuYy0yfCoBtWuPkLjUG6qtOBMfpypA==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Extensions.VSTestBridge": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "bNRIEA2YoGr+Y+7LHdA7i1U80+7BAdf4K4Qh4Kx6eKkoBK/NV7QpoMg+GWPP0/eqAFzuUmUOIPVZ87Oo0Vyxmw==",
+        "resolved": "2.3.3",
+        "contentHash": "JLovZjH6K10YiHO/BcidsaSHo/M2DfOe9FDjxjFdV6aoHO6VYTTYlLBNcyLJSo20q5gDTmNvmxYVH39A942aJA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
-          "Microsoft.Testing.Extensions.Telemetry": "2.1.0",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.1.0",
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.3",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.3",
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "aHkjNTGIA+Zbdw6RJgSFrbDrCjO0CgqpElqYcvkRSeUhBv2bKarnvU3ep786U7UqrPlArT/B7VmImRibJD0Zrg=="
+        "resolved": "2.3.3",
+        "contentHash": "ENbH4BQh9riXtOKc25KKITfiGGWhWMBJA7pZuNaF9zxzzSaVkp5AMeZxGQ6sXYaR6xb724NLz985Is6XIYqLSg=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "resolved": "18.10.0",
+        "contentHash": "aXA7DDbnt6MYu3eLBEDksNdl09QxJ/PpMzrFcSxqEOk3RvRGJzhKI5mezVCEOcvveRhjfw/mvn6xVXC/rTaOog=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.10.0",
+        "contentHash": "Spu6C7bgz1PmWN+Y7wS0PfGCw9Kwv5RvJbCwyQaEWjcwpMire+qYMrcZ7qk8agjy6nd0sdHLc3ugCSrGuSbZdw==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.TestPlatform.ObjectModel": "18.10.0"
         }
       },
       "TestableIO.System.IO.Abstractions.TestingHelpers": {
         "type": "Transitive",
-        "resolved": "22.1.1",
-        "contentHash": "To7oYx68nrl0tu8duRSO9SyRHrNOVYSYIUlvfqNnoX9X2X9thIdJGmM3W3ZINtT4xqKuSy1Tb4hJK35Umhtfqg==",
+        "resolved": "22.2.0",
+        "contentHash": "mmsYxNRoxsimceoqImCPVf+LuqJJSd8esDQVP5uONDUZ8envfrKen8I+fRtwsoyt+GVrKvf+XiZJgKWns+t9eg==",
         "dependencies": {
-          "TestableIO.System.IO.Abstractions.Wrappers": "22.1.1",
-          "Testably.Abstractions.FileSystem.Interface": "10.1.0"
+          "TestableIO.System.IO.Abstractions.Wrappers": "22.2.0",
+          "Testably.Abstractions.FileSystem.Interface": "10.3.0"
         }
       },
       "TestableIO.System.IO.Abstractions.Wrappers": {
         "type": "Transitive",
-        "resolved": "22.1.1",
-        "contentHash": "J91zmSwuMY75ybtkqAFMC3vDNMkLJ/kiDDLhORITEwTKNhEwEYfxAQGv+f0jGYZg/H0YbnGcx5Ky0FgFJwrrWQ==",
+        "resolved": "22.2.0",
+        "contentHash": "0GW9i46ozm687WGAWsBHWMhLR7l1HmKwhiSU2hQrbFnI5m2YRfqXwqTQNjnOwT8BdbvcGqwMr97/zlnPWa1u1Q==",
         "dependencies": {
-          "Testably.Abstractions.FileSystem.Interface": "10.1.0"
+          "Testably.Abstractions.FileSystem.Interface": "10.3.0"
         }
       },
       "Testably.Abstractions.FileSystem.Interface": {
         "type": "Transitive",
-        "resolved": "10.1.0",
-        "contentHash": "0R+m7DvS2QuDcFOfDGtyGErRrgXOl4/z2tbNLX2RfvlYJjlVcKG+wMIBfZO8vxGtTNwNxffTG4ibFRwd0jkM7w=="
+        "resolved": "10.3.0",
+        "contentHash": "5ebMaoADkzjfW7GnZYKaUebV8XmUn++C/4sKk1PTzCiddEgbSKBq3pW4EWEi70rYJAK0gA1yDWrYFeHq18FvHQ=="
       },
       "fantomas.core": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )",
+          "FSharp.Core": "[10.1.401, )",
           "Fantomas.FCS": "[1.0.0, )"
         }
       },
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )"
+          "FSharp.Core": "[10.1.401, )"
         }
-      },
-      "Newtonsoft.Json": {
-        "type": "CentralTransitive",
-        "requested": "[13.0.4, )",
-        "resolved": "13.0.4",
-        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       }
     }
   }

--- a/src/Fantomas.Core/Fantomas.Core.fsproj
+++ b/src/Fantomas.Core/Fantomas.Core.fsproj
@@ -42,7 +42,11 @@
     <Compile Include="CodeFormatter.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" />
+    <!--
+    A published library, so its FSharp.Core is the lowest version consumers must have rather than
+    the newest one available. `VersionOverride` holds it below what the rest of the solution uses.
+    -->
+    <PackageReference Include="FSharp.Core" VersionOverride="10.0.100" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fantomas.FCS\Fantomas.FCS.fsproj" />

--- a/src/Fantomas.Core/packages.lock.json
+++ b/src/Fantomas.Core/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.1.401, )",
-        "resolved": "10.1.401",
-        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
+        "requested": "[10.0.100, )",
+        "resolved": "10.0.100",
+        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
@@ -69,7 +69,7 @@
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )",
+          "FSharp.Core": "[10.0.100, )",
           "System.Collections.Immutable": "[10.0.12, )",
           "System.Diagnostics.DiagnosticSource": "[10.0.12, )",
           "System.Memory": "[4.6.3, )",

--- a/src/Fantomas.Core/packages.lock.json
+++ b/src/Fantomas.Core/packages.lock.json
@@ -4,15 +4,15 @@
     ".NETStandard,Version=v2.0": {
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
-        "requested": "[2.0.2, )",
-        "resolved": "2.0.2",
-        "contentHash": "VaHoEN6YHp0jXucxm67vfuRy8zo9ufiKSuaZ4ZudRi8xmWcEFMKxfCsg2nvYNvdISFTURDu+IHqADGh53+Bamw=="
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "8LrlvI1KpjjJ4VGSqZ16yoOCKlQnYS+Y8rYNifNrscmVh5anJcF9E4e0NiDP30BHBMUbkoJ5KdcxoRWM7Pz9Aw=="
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.0.100, )",
-        "resolved": "10.0.100",
-        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
+        "requested": "[10.1.401, )",
+        "resolved": "10.1.401",
+        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
@@ -69,18 +69,18 @@
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )",
-          "System.Collections.Immutable": "[10.0.6, )",
-          "System.Diagnostics.DiagnosticSource": "[10.0.6, )",
+          "FSharp.Core": "[10.1.401, )",
+          "System.Collections.Immutable": "[10.0.12, )",
+          "System.Diagnostics.DiagnosticSource": "[10.0.12, )",
           "System.Memory": "[4.6.3, )",
           "System.Runtime": "[4.3.1, )"
         }
       },
       "System.Collections.Immutable": {
         "type": "CentralTransitive",
-        "requested": "[10.0.6, )",
-        "resolved": "10.0.6",
-        "contentHash": "g5J8W/ovAraH1IDCvRZlXmpFc2v9yr1caYbVLIye2kzNtsWjJXD6TzV8vNdXni2b7wASoUeY2pnCBHxWrstXGQ==",
+        "requested": "[10.0.12, )",
+        "resolved": "10.0.12",
+        "contentHash": "tRMzrybcwEEaudfpL9ghzfnSjEVVuhKa5sR86q30mYxXJdcKOLSBkpMFm62CGsbB50diPZta73Pxu8DgjGdDbA==",
         "dependencies": {
           "System.Memory": "4.6.3",
           "System.Runtime.CompilerServices.Unsafe": "6.1.2"
@@ -88,9 +88,9 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "CentralTransitive",
-        "requested": "[10.0.6, )",
-        "resolved": "10.0.6",
-        "contentHash": "v/YvmOpq+lv50oxxIDSvZlgiFD2m38DogHTE4MToMEGf6HtgBAmy8gB7Oq0C2pBt+6/bLvUnzLxubWFcvfzTsQ==",
+        "requested": "[10.0.12, )",
+        "resolved": "10.0.12",
+        "contentHash": "CRZTWYO0rzEcJN/6SuN1kMvQOJT7vyHZ64CCkQs0RRWTj7kH2KMkaMalbsbSI/eg5dS5JAQfQFFuuWgn+XRMsQ==",
         "dependencies": {
           "System.Memory": "4.6.3",
           "System.Runtime.CompilerServices.Unsafe": "6.1.2"

--- a/src/Fantomas.FCS/Fantomas.FCS.fsproj
+++ b/src/Fantomas.FCS/Fantomas.FCS.fsproj
@@ -363,7 +363,11 @@
     <Compile Include="Parse.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" />
+    <!--
+    A published library, so its FSharp.Core is the lowest version consumers must have rather than
+    the newest one available. `VersionOverride` holds it below what the rest of the solution uses.
+    -->
+    <PackageReference Include="FSharp.Core" VersionOverride="10.0.100" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource"  />
     <PackageReference Include="System.Memory" />

--- a/src/Fantomas.FCS/packages.lock.json
+++ b/src/Fantomas.FCS/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.1.401, )",
-        "resolved": "10.1.401",
-        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
+        "requested": "[10.0.100, )",
+        "resolved": "10.0.100",
+        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
       },
       "FsLexYacc": {
         "type": "Direct",

--- a/src/Fantomas.FCS/packages.lock.json
+++ b/src/Fantomas.FCS/packages.lock.json
@@ -4,24 +4,24 @@
     ".NETStandard,Version=v2.0": {
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
-        "requested": "[2.0.2, )",
-        "resolved": "2.0.2",
-        "contentHash": "VaHoEN6YHp0jXucxm67vfuRy8zo9ufiKSuaZ4ZudRi8xmWcEFMKxfCsg2nvYNvdISFTURDu+IHqADGh53+Bamw=="
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "8LrlvI1KpjjJ4VGSqZ16yoOCKlQnYS+Y8rYNifNrscmVh5anJcF9E4e0NiDP30BHBMUbkoJ5KdcxoRWM7Pz9Aw=="
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.0.100, )",
-        "resolved": "10.0.100",
-        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
+        "requested": "[10.1.401, )",
+        "resolved": "10.1.401",
+        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
       },
       "FsLexYacc": {
         "type": "Direct",
-        "requested": "[11.4.1, )",
-        "resolved": "11.4.1",
-        "contentHash": "t77MbPw80ndxR0GGkoFByCl27/oWW5jtLN7S4aYQ21IfoBnskXNdtOlxt7cJw/F9aD2dd8kqCrRbpMuE0cDyaQ==",
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "d191/bl1SugbCDu/wywTUGyyH6B4r5tAyqqjzR5Zs6L9R/DNJHqZrm4V8dVmeHAvBgdDBLnfIg6DNjPHYm0dPA==",
         "dependencies": {
-          "FSharp.Core": "4.6.2",
-          "FsLexYacc.Runtime": "11.4.1"
+          "FSharp.Core": "10.1.400",
+          "FsLexYacc.Runtime": "12.0.0"
         }
       },
       "G-Research.FSharp.Analyzers": {
@@ -53,9 +53,9 @@
       },
       "System.Collections.Immutable": {
         "type": "Direct",
-        "requested": "[10.0.6, )",
-        "resolved": "10.0.6",
-        "contentHash": "g5J8W/ovAraH1IDCvRZlXmpFc2v9yr1caYbVLIye2kzNtsWjJXD6TzV8vNdXni2b7wASoUeY2pnCBHxWrstXGQ==",
+        "requested": "[10.0.12, )",
+        "resolved": "10.0.12",
+        "contentHash": "tRMzrybcwEEaudfpL9ghzfnSjEVVuhKa5sR86q30mYxXJdcKOLSBkpMFm62CGsbB50diPZta73Pxu8DgjGdDbA==",
         "dependencies": {
           "System.Memory": "4.6.3",
           "System.Runtime.CompilerServices.Unsafe": "6.1.2"
@@ -63,9 +63,9 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Direct",
-        "requested": "[10.0.6, )",
-        "resolved": "10.0.6",
-        "contentHash": "v/YvmOpq+lv50oxxIDSvZlgiFD2m38DogHTE4MToMEGf6HtgBAmy8gB7Oq0C2pBt+6/bLvUnzLxubWFcvfzTsQ==",
+        "requested": "[10.0.12, )",
+        "resolved": "10.0.12",
+        "contentHash": "CRZTWYO0rzEcJN/6SuN1kMvQOJT7vyHZ64CCkQs0RRWTj7kH2KMkaMalbsbSI/eg5dS5JAQfQFFuuWgn+XRMsQ==",
         "dependencies": {
           "System.Memory": "4.6.3",
           "System.Runtime.CompilerServices.Unsafe": "6.1.2"
@@ -94,10 +94,10 @@
       },
       "FsLexYacc.Runtime": {
         "type": "Transitive",
-        "resolved": "11.4.1",
-        "contentHash": "BNLDgkJMztlyUgVV2SuECN5nPZK1C70g06r/dMKmyG7BbbLnQjTuCjAjrde0A5PLEKuVobIQAhuS7ljpoDX9aA==",
+        "resolved": "12.0.0",
+        "contentHash": "XIhOFQ8SSq05BrObuwxAXPnDFjiM/AEBom83c1F4/fltd2lX+Hu7+0e4EhNw0Vw4viecZ72MkbHQ9sfG5UOYwA==",
         "dependencies": {
-          "FSharp.Core": "4.6.2"
+          "FSharp.Core": "10.1.400"
         }
       },
       "Microsoft.NETCore.Platforms": {

--- a/src/Fantomas.Tests/EditorConfigurationTests.fs
+++ b/src/Fantomas.Tests/EditorConfigurationTests.fs
@@ -391,9 +391,11 @@ end_of_line = cr
     // exception, because that is the type the CLI matches on to decide what to print. Anything else
     // reports an empty message at normal verbosity.
     let ex =
-        Assert.Throws<FormatException>(fun () ->
-            EditorConfigReport.readConfiguration ignoreProblems fsharpFile.FSharpFile
-            |> ignore
+        Assert.Throws<FormatException>(
+            Action(fun () ->
+                EditorConfigReport.readConfiguration ignoreProblems fsharpFile.FSharpFile
+                |> ignore
+            )
         )
 
     ex.Message

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -4,24 +4,24 @@
     "net10.0": {
       "altcover": {
         "type": "Direct",
-        "requested": "[9.0.102, )",
-        "resolved": "9.0.102",
-        "contentHash": "q3Rf5t0M9kXlcO5qhsaAe6NrFSNd5enrhKmF/Ezgmomqw34PbUTbRSYjSDNhS3YGDyUrPTkyPn14EfLDJWztcA=="
+        "requested": "[9.0.145, )",
+        "resolved": "9.0.145",
+        "contentHash": "jVDhMWOTK4CE36yx7iUBx09nBD7Yv8KJzGptCwPPkoy+ibQCE6J+ns1wTMOn8TXz8YJTi8KK9XTKgrCfV6aMgA=="
       },
       "FsCheck": {
         "type": "Direct",
-        "requested": "[3.3.2, )",
-        "resolved": "3.3.2",
-        "contentHash": "JlK719ZlP/ofbsN0qXYrfqbe2SCgp4D1BEyJynkzyurMI2JqUkWgZHXgEu0pXVdj35zU/GWsXrGYA68sSdAmHQ==",
+        "requested": "[3.4.0, )",
+        "resolved": "3.4.0",
+        "contentHash": "wkWR1DORrKd46W6MEhmS4muo/0kgrtUV/AGW1ohMWemy7WukcRH8T3JjkDpn/daOHk0yVqf0CBvScU17Ab//PA==",
         "dependencies": {
           "FSharp.Core": "5.0.2"
         }
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.0.100, )",
-        "resolved": "10.0.100",
-        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
+        "requested": "[10.1.401, )",
+        "resolved": "10.1.401",
+        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
       },
       "FsUnit": {
         "type": "Direct",
@@ -47,38 +47,38 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.10.0, )",
+        "resolved": "18.10.0",
+        "contentHash": "0CZZ688UBvpQFB9HKo7wrNJNVe+AOM4UtipgwpER3TTM+d2DDM6QyKkIJZTR3mpbn9/zFbZEtAgVIz4SPTjQZQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.10.0",
+          "Microsoft.TestPlatform.TestHost": "18.10.0"
         }
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.5.1, )",
-        "resolved": "4.5.1",
-        "contentHash": "x1sIqU9i0IkxqFayqthzmJs/75jTMbrfNMixj4vtfTi7rRzGbtuY27V+iAhfTY02u5k2qvW3QBGM414OG4q8Lw=="
+        "requested": "[4.6.1, )",
+        "resolved": "4.6.1",
+        "contentHash": "xS4+YaBFUv1r8bcAbjitSfYaRZGfMwUiMdiaRziBXZpKgVxKDSHhjUn0mV5mObHGZRZq6eNa+WFWr3g8grj66A=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "8PMJB8za2u8S0ey/nEtvh9BHjLhv5yzUEMCmA0+VIPLKSeOAZ3TEHWDyAp0+iPQb3jnBH1o8k0PoU2FgzXLRnQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "8ZD+0dIfDHsL4w4Gl/LPxWH0O4ky3hFXqTZjY+ry0ThI3cMVErr9Tjxal5O5wJxGXh50a9qkDEAWVca8KQYCEw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "8.0.2",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.1.0",
-          "Microsoft.Testing.Platform.MSBuild": "2.1.0"
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
         }
       },
       "System.IO.Abstractions.TestingHelpers": {
         "type": "Direct",
-        "requested": "[22.1.1, )",
-        "resolved": "22.1.1",
-        "contentHash": "/fJ2F9N8Q7ZL7l7TQRcFtgaBdLBOj4+XL8ipc9sZC8tLMjoNBJtuyxMise5utraozm3KDAzPls5iWIcDCwpawQ==",
+        "requested": "[22.2.0, )",
+        "resolved": "22.2.0",
+        "contentHash": "yVy8HIx57CFwf9Z5UMYbrokQtLdwf7f004UiR8XhA70Q3BWlIAYDaOUk7ZhDp3BtIgh739dgJkqGmSN0LUA50Q==",
         "dependencies": {
-          "TestableIO.System.IO.Abstractions.TestingHelpers": "22.1.1"
+          "TestableIO.System.IO.Abstractions.TestingHelpers": "22.2.0"
         }
       },
       "MessagePack": {
@@ -102,8 +102,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.10.0",
+        "contentHash": "zo1hqV+Nz6FlIwdc+aPfrvGzqfKAPPaZ6OPj1W8C0QQE2xH951AZwTUytL3K7XX8brVBUFd7MhrLDl3CtK3U/A=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -117,57 +117,56 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "5TwgTx2u7k9Al/xbZ18QXq4Hdy2xewkVTI6K3sk+jY2ykqUkIKNuj7rFu3GOV5KnEUkevhw6eZcyZs77STHJIA==",
+        "resolved": "2.3.3",
+        "contentHash": "nY8ceQyPWB9TRE1WE5Oe/sks2e10SxgPv61vBHsFYpgCeDtNwhpMZwmL29GklO3/etTdOsLdrCmNr4zJWaR2fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "D8xmIJYQFJ6D49Rx5/vPrkZZxb338Jkew+eSqZLBfBiWKw4QZKy3i1BOXiLfz0lOmaNErwDz/YWRojCdNl+B9Q==",
+        "resolved": "2.3.3",
+        "contentHash": "dceVNxnfTEjKnrIreLcMfkgrzzBY8kgCCJX5NAv7Lq/6vPlTP4VB5zxKeuYy0yfCoBtWuPkLjUG6qtOBMfpypA==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Extensions.VSTestBridge": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "bNRIEA2YoGr+Y+7LHdA7i1U80+7BAdf4K4Qh4Kx6eKkoBK/NV7QpoMg+GWPP0/eqAFzuUmUOIPVZ87Oo0Vyxmw==",
+        "resolved": "2.3.3",
+        "contentHash": "JLovZjH6K10YiHO/BcidsaSHo/M2DfOe9FDjxjFdV6aoHO6VYTTYlLBNcyLJSo20q5gDTmNvmxYVH39A942aJA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
-          "Microsoft.Testing.Extensions.Telemetry": "2.1.0",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.1.0",
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.3",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.3",
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "aHkjNTGIA+Zbdw6RJgSFrbDrCjO0CgqpElqYcvkRSeUhBv2bKarnvU3ep786U7UqrPlArT/B7VmImRibJD0Zrg=="
+        "resolved": "2.3.3",
+        "contentHash": "ENbH4BQh9riXtOKc25KKITfiGGWhWMBJA7pZuNaF9zxzzSaVkp5AMeZxGQ6sXYaR6xb724NLz985Is6XIYqLSg=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "resolved": "18.10.0",
+        "contentHash": "aXA7DDbnt6MYu3eLBEDksNdl09QxJ/PpMzrFcSxqEOk3RvRGJzhKI5mezVCEOcvveRhjfw/mvn6xVXC/rTaOog=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.10.0",
+        "contentHash": "Spu6C7bgz1PmWN+Y7wS0PfGCw9Kwv5RvJbCwyQaEWjcwpMire+qYMrcZ7qk8agjy6nd0sdHLc3ugCSrGuSbZdw==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.TestPlatform.ObjectModel": "18.10.0"
         }
       },
       "Microsoft.VisualStudio.Threading.Only": {
@@ -209,58 +208,58 @@
       },
       "Spectre.Console.Ansi": {
         "type": "Transitive",
-        "resolved": "0.55.0",
-        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
+        "resolved": "0.57.2",
+        "contentHash": "Y1+u73shwP+JYHmrkdN6bSt2kaGBEAafhi2nrecczbXdFRey+k7J/WF9YPfcB0rqivv2S8fmif6FSBq9m/AFvw=="
       },
       "TestableIO.System.IO.Abstractions": {
         "type": "Transitive",
-        "resolved": "22.1.1",
-        "contentHash": "EJmXIKfwvJHvSHWP+NjA213avUdofV4SmBx2aWxc3SzPkrHHVKxUMC3fSa/epzk/SVITwuU2EAntgQTvobAqwQ==",
+        "resolved": "22.2.0",
+        "contentHash": "BQPyr0A1s2HvpVTZIyolrZ3ZdPn8DU2tqciaK1oco3pjm76fiKIk75eup4R9reZjNS75M+WJIICOlNX5OFt50g==",
         "dependencies": {
-          "Testably.Abstractions.FileSystem.Interface": "10.1.0"
+          "Testably.Abstractions.FileSystem.Interface": "10.3.0"
         }
       },
       "TestableIO.System.IO.Abstractions.TestingHelpers": {
         "type": "Transitive",
-        "resolved": "22.1.1",
-        "contentHash": "To7oYx68nrl0tu8duRSO9SyRHrNOVYSYIUlvfqNnoX9X2X9thIdJGmM3W3ZINtT4xqKuSy1Tb4hJK35Umhtfqg==",
+        "resolved": "22.2.0",
+        "contentHash": "mmsYxNRoxsimceoqImCPVf+LuqJJSd8esDQVP5uONDUZ8envfrKen8I+fRtwsoyt+GVrKvf+XiZJgKWns+t9eg==",
         "dependencies": {
-          "TestableIO.System.IO.Abstractions.Wrappers": "22.1.1",
-          "Testably.Abstractions.FileSystem.Interface": "10.1.0"
+          "TestableIO.System.IO.Abstractions.Wrappers": "22.2.0",
+          "Testably.Abstractions.FileSystem.Interface": "10.3.0"
         }
       },
       "TestableIO.System.IO.Abstractions.Wrappers": {
         "type": "Transitive",
-        "resolved": "22.1.1",
-        "contentHash": "J91zmSwuMY75ybtkqAFMC3vDNMkLJ/kiDDLhORITEwTKNhEwEYfxAQGv+f0jGYZg/H0YbnGcx5Ky0FgFJwrrWQ==",
+        "resolved": "22.2.0",
+        "contentHash": "0GW9i46ozm687WGAWsBHWMhLR7l1HmKwhiSU2hQrbFnI5m2YRfqXwqTQNjnOwT8BdbvcGqwMr97/zlnPWa1u1Q==",
         "dependencies": {
-          "Testably.Abstractions.FileSystem.Interface": "10.1.0"
+          "Testably.Abstractions.FileSystem.Interface": "10.3.0"
         }
       },
       "Testably.Abstractions.FileSystem.Interface": {
         "type": "Transitive",
-        "resolved": "10.1.0",
-        "contentHash": "0R+m7DvS2QuDcFOfDGtyGErRrgXOl4/z2tbNLX2RfvlYJjlVcKG+wMIBfZO8vxGtTNwNxffTG4ibFRwd0jkM7w=="
+        "resolved": "10.3.0",
+        "contentHash": "5ebMaoADkzjfW7GnZYKaUebV8XmUn++C/4sKk1PTzCiddEgbSKBq3pW4EWEi70rYJAK0gA1yDWrYFeHq18FvHQ=="
       },
       "fantomas": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )",
+          "FSharp.Core": "[10.1.401, )",
           "Fantomas.Client": "[1.0.0, )",
           "Fantomas.Core": "[1.0.0, )",
           "Ignore": "[0.2.1, )",
-          "Serilog": "[4.3.1, )",
+          "Serilog": "[4.4.0, )",
           "Serilog.Sinks.Console": "[6.1.1, )",
-          "Spectre.Console": "[0.55.0, )",
+          "Spectre.Console": "[0.57.2, )",
           "StreamJsonRpc": "[2.25.29, )",
-          "System.IO.Abstractions": "[22.1.1, )",
+          "System.IO.Abstractions": "[22.2.0, )",
           "editorconfig": "[0.18.0, )"
         }
       },
       "fantomas.client": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )",
+          "FSharp.Core": "[10.1.401, )",
           "SemanticVersioning": "[3.0.0, )",
           "StreamJsonRpc": "[2.25.29, )"
         }
@@ -268,14 +267,14 @@
       "fantomas.core": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )",
+          "FSharp.Core": "[10.1.401, )",
           "Fantomas.FCS": "[1.0.0, )"
         }
       },
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )"
+          "FSharp.Core": "[10.1.401, )"
         }
       },
       "editorconfig": {
@@ -307,9 +306,9 @@
       },
       "Serilog": {
         "type": "CentralTransitive",
-        "requested": "[4.3.1, )",
-        "resolved": "4.3.1",
-        "contentHash": "savYe7h5yRlkqBVOwP8cIRDOdqKiPmYCU4W87JH38sBmcKD5EBoXvQIw6bNEvZ/pTe1gsiye3VFCzBsoppGkXQ=="
+        "requested": "[4.4.0, )",
+        "resolved": "4.4.0",
+        "contentHash": "ZC6Le3rr4TVJJjS4KsQAesxeF1EhW9qcZmmG7eP5Y2G3+gTGkJEUXkq4+tZNPtyp05I0wWOxnIjwtxFweJsObw=="
       },
       "Serilog.Sinks.Console": {
         "type": "CentralTransitive",
@@ -322,11 +321,11 @@
       },
       "Spectre.Console": {
         "type": "CentralTransitive",
-        "requested": "[0.55.0, )",
-        "resolved": "0.55.0",
-        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "requested": "[0.57.2, )",
+        "resolved": "0.57.2",
+        "contentHash": "wzsB+P9i6F9G+cFOJxRotCiQWNSzZVAMxi8YMiHlGXXU1JLMXGp7zSSqBMmROZS2bzpK5jk+Saa7Evp8HwqhKg==",
         "dependencies": {
-          "Spectre.Console.Ansi": "0.55.0"
+          "Spectre.Console.Ansi": "0.57.2"
         }
       },
       "StreamJsonRpc": {
@@ -345,12 +344,12 @@
       },
       "System.IO.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[22.1.1, )",
-        "resolved": "22.1.1",
-        "contentHash": "nm4sNhAoN1NyiIVT6MS3EEzNjnir3PC1HE0mKGGUFg6RBW1HmRvWKuRDPkij1etOoQkpyIFmjVGcM6TpBGF3qQ==",
+        "requested": "[22.2.0, )",
+        "resolved": "22.2.0",
+        "contentHash": "fwnNXyIPb7ABPLae6K9YZz0FAkRjb2s/nElRWrg73usMveY/qdOHjKaNvAF7iAfmzTl1W4wa7S/SnmIc4LDvTg==",
         "dependencies": {
-          "TestableIO.System.IO.Abstractions": "22.1.1",
-          "TestableIO.System.IO.Abstractions.Wrappers": "22.1.1"
+          "TestableIO.System.IO.Abstractions": "22.2.0",
+          "TestableIO.System.IO.Abstractions.Wrappers": "22.2.0"
         }
       }
     }

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -21,7 +21,7 @@
         "type": "Direct",
         "requested": "[10.1.401, )",
         "resolved": "10.1.401",
-        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
+        "contentHash": "/lvOK51KD8IangBYkfDVna3/HrE/r4VUnX3dI01KDspctoYXmind3POeoYkqWKeXHwiKlf6Hc9TxwSnoSCWcjw=="
       },
       "FsUnit": {
         "type": "Direct",

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -259,7 +259,7 @@
       "fantomas.client": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )",
+          "FSharp.Core": "[10.0.100, )",
           "SemanticVersioning": "[3.0.0, )",
           "StreamJsonRpc": "[2.25.29, )"
         }
@@ -267,14 +267,14 @@
       "fantomas.core": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )",
+          "FSharp.Core": "[10.0.100, )",
           "Fantomas.FCS": "[1.0.0, )"
         }
       },
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )"
+          "FSharp.Core": "[10.0.100, )"
         }
       },
       "editorconfig": {

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -214,10 +214,10 @@
       },
       "TestableIO.System.IO.Abstractions": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "YQ/IuNE8gP/+yNwQjdqd6DKhB9ADGjosxuY2IMXcQ3729iXa9QRsPlmIBpk73L0s9E2b+MTYhAR/2Spk8REjvA==",
+        "resolved": "22.1.1",
+        "contentHash": "EJmXIKfwvJHvSHWP+NjA213avUdofV4SmBx2aWxc3SzPkrHHVKxUMC3fSa/epzk/SVITwuU2EAntgQTvobAqwQ==",
         "dependencies": {
-          "Testably.Abstractions.FileSystem.Interface": "10.0.0"
+          "Testably.Abstractions.FileSystem.Interface": "10.1.0"
         }
       },
       "TestableIO.System.IO.Abstractions.TestingHelpers": {
@@ -253,8 +253,8 @@
           "Serilog.Sinks.Console": "[6.1.1, )",
           "Spectre.Console": "[0.55.0, )",
           "StreamJsonRpc": "[2.25.29, )",
-          "System.IO.Abstractions": "[22.1.0, )",
-          "editorconfig": "[0.15.0, )"
+          "System.IO.Abstractions": "[22.1.1, )",
+          "editorconfig": "[0.18.0, )"
         }
       },
       "fantomas.client": {
@@ -280,9 +280,12 @@
       },
       "editorconfig": {
         "type": "CentralTransitive",
-        "requested": "[0.15.0, )",
-        "resolved": "0.15.0",
-        "contentHash": "NuUxFbycSCOhl0WzmNZ8ksSMrTHBFzTASkil+IOqXpqTXszokKjy6ihxMdjArGaC+AaLLq4nxfGVFLi6KWyFJg=="
+        "requested": "[0.18.0, )",
+        "resolved": "0.18.0",
+        "contentHash": "VgT9Q0CT0KlgCkYitPRIgtmzaHZ9G8CqjEdY8KeweihFdLdhVgQWJy15BwBjoW2PGRl/uqgnAqhG9bBE9lfU9A==",
+        "dependencies": {
+          "System.IO.Abstractions": "22.1.1"
+        }
       },
       "Ignore": {
         "type": "CentralTransitive",
@@ -342,12 +345,12 @@
       },
       "System.IO.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[22.1.0, )",
-        "resolved": "22.1.0",
-        "contentHash": "+QDwmFWQQ84FIRFkOGLwdhJWgOP2Qm+d73edWavzVvYrQ029jjB7CdT24L/F9QvGThN7uYZW6vLLSpvaUBC2Cw==",
+        "requested": "[22.1.1, )",
+        "resolved": "22.1.1",
+        "contentHash": "nm4sNhAoN1NyiIVT6MS3EEzNjnir3PC1HE0mKGGUFg6RBW1HmRvWKuRDPkij1etOoQkpyIFmjVGcM6TpBGF3qQ==",
         "dependencies": {
-          "TestableIO.System.IO.Abstractions": "22.1.0",
-          "TestableIO.System.IO.Abstractions.Wrappers": "22.1.0"
+          "TestableIO.System.IO.Abstractions": "22.1.1",
+          "TestableIO.System.IO.Abstractions.Wrappers": "22.1.1"
         }
       }
     }

--- a/src/Fantomas.Tests/packages.lock.json
+++ b/src/Fantomas.Tests/packages.lock.json
@@ -19,9 +19,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.1.401, )",
-        "resolved": "10.1.401",
-        "contentHash": "/lvOK51KD8IangBYkfDVna3/HrE/r4VUnX3dI01KDspctoYXmind3POeoYkqWKeXHwiKlf6Hc9TxwSnoSCWcjw=="
+        "requested": "[10.1.203, )",
+        "resolved": "10.1.203",
+        "contentHash": "I2MFk72yHqfgI594gKFigq8PVIso0Mh1ZUgG9R4n8gyYQ4IwpBxmvecfjnKA7iMLdVHYULB70PsLwYW/K76gew=="
       },
       "FsUnit": {
         "type": "Direct",
@@ -244,7 +244,7 @@
       "fantomas": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )",
+          "FSharp.Core": "[10.1.203, )",
           "Fantomas.Client": "[1.0.0, )",
           "Fantomas.Core": "[1.0.0, )",
           "Ignore": "[0.2.1, )",

--- a/src/Fantomas/EditorConfig.fs
+++ b/src/Fantomas/EditorConfig.fs
@@ -261,7 +261,8 @@ let configToEditorConfig (config: FormatConfig) : string =
     |> List.map (fun (setting: string, value: string) -> $"%s{setting}=%s{value}")
     |> String.concat "\n"
 
-let editorConfigParser = EditorConfigParser(EditorConfigFileCache.GetOrCreate)
+/// One parser for the process, and with it one cache of the `.editorconfig` files it has read.
+let editorConfigParser: EditorConfigParser = EditorConfigParser()
 
 /// Where an `.editorconfig` file lives, as one absolute path.
 let editorConfigFilePath (file: IEditorConfigFile) : string =

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -19,9 +19,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.1.401, )",
-        "resolved": "10.1.401",
-        "contentHash": "/lvOK51KD8IangBYkfDVna3/HrE/r4VUnX3dI01KDspctoYXmind3POeoYkqWKeXHwiKlf6Hc9TxwSnoSCWcjw=="
+        "requested": "[10.1.203, )",
+        "resolved": "10.1.203",
+        "contentHash": "I2MFk72yHqfgI594gKFigq8PVIso0Mh1ZUgG9R4n8gyYQ4IwpBxmvecfjnKA7iMLdVHYULB70PsLwYW/K76gew=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -180,7 +180,7 @@
       "fantomas.client": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )",
+          "FSharp.Core": "[10.0.100, )",
           "SemanticVersioning": "[3.0.0, )",
           "StreamJsonRpc": "[2.25.29, )"
         }
@@ -188,14 +188,14 @@
       "fantomas.core": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )",
+          "FSharp.Core": "[10.0.100, )",
           "Fantomas.FCS": "[1.0.0, )"
         }
       },
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.1.401, )"
+          "FSharp.Core": "[10.0.100, )"
         }
       },
       "Newtonsoft.Json": {

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
-        "requested": "[2.0.2, )",
-        "resolved": "2.0.2",
-        "contentHash": "VaHoEN6YHp0jXucxm67vfuRy8zo9ufiKSuaZ4ZudRi8xmWcEFMKxfCsg2nvYNvdISFTURDu+IHqADGh53+Bamw=="
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "8LrlvI1KpjjJ4VGSqZ16yoOCKlQnYS+Y8rYNifNrscmVh5anJcF9E4e0NiDP30BHBMUbkoJ5KdcxoRWM7Pz9Aw=="
       },
       "editorconfig": {
         "type": "Direct",
@@ -19,9 +19,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[10.0.100, )",
-        "resolved": "10.0.100",
-        "contentHash": "c/r6T/HE9MWL0O0OispLtaKhVwDsiYQlLS249LoxSo1HNH/wfc0f5DE4pI6WpTXkCEdeXa66K5f9FmKLr/0cmw=="
+        "requested": "[10.1.401, )",
+        "resolved": "10.1.401",
+        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",
@@ -49,9 +49,9 @@
       },
       "Serilog": {
         "type": "Direct",
-        "requested": "[4.3.1, )",
-        "resolved": "4.3.1",
-        "contentHash": "savYe7h5yRlkqBVOwP8cIRDOdqKiPmYCU4W87JH38sBmcKD5EBoXvQIw6bNEvZ/pTe1gsiye3VFCzBsoppGkXQ=="
+        "requested": "[4.4.0, )",
+        "resolved": "4.4.0",
+        "contentHash": "ZC6Le3rr4TVJJjS4KsQAesxeF1EhW9qcZmmG7eP5Y2G3+gTGkJEUXkq4+tZNPtyp05I0wWOxnIjwtxFweJsObw=="
       },
       "Serilog.Sinks.Console": {
         "type": "Direct",
@@ -64,11 +64,11 @@
       },
       "Spectre.Console": {
         "type": "Direct",
-        "requested": "[0.55.0, )",
-        "resolved": "0.55.0",
-        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "requested": "[0.57.2, )",
+        "resolved": "0.57.2",
+        "contentHash": "wzsB+P9i6F9G+cFOJxRotCiQWNSzZVAMxi8YMiHlGXXU1JLMXGp7zSSqBMmROZS2bzpK5jk+Saa7Evp8HwqhKg==",
         "dependencies": {
-          "Spectre.Console.Ansi": "0.55.0"
+          "Spectre.Console.Ansi": "0.57.2"
         }
       },
       "StreamJsonRpc": {
@@ -87,12 +87,12 @@
       },
       "System.IO.Abstractions": {
         "type": "Direct",
-        "requested": "[22.1.1, )",
-        "resolved": "22.1.1",
-        "contentHash": "nm4sNhAoN1NyiIVT6MS3EEzNjnir3PC1HE0mKGGUFg6RBW1HmRvWKuRDPkij1etOoQkpyIFmjVGcM6TpBGF3qQ==",
+        "requested": "[22.2.0, )",
+        "resolved": "22.2.0",
+        "contentHash": "fwnNXyIPb7ABPLae6K9YZz0FAkRjb2s/nElRWrg73usMveY/qdOHjKaNvAF7iAfmzTl1W4wa7S/SnmIc4LDvTg==",
         "dependencies": {
-          "TestableIO.System.IO.Abstractions": "22.1.1",
-          "TestableIO.System.IO.Abstractions.Wrappers": "22.1.1"
+          "TestableIO.System.IO.Abstractions": "22.2.0",
+          "TestableIO.System.IO.Abstractions.Wrappers": "22.2.0"
         }
       },
       "MessagePack": {
@@ -153,34 +153,34 @@
       },
       "Spectre.Console.Ansi": {
         "type": "Transitive",
-        "resolved": "0.55.0",
-        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
+        "resolved": "0.57.2",
+        "contentHash": "Y1+u73shwP+JYHmrkdN6bSt2kaGBEAafhi2nrecczbXdFRey+k7J/WF9YPfcB0rqivv2S8fmif6FSBq9m/AFvw=="
       },
       "TestableIO.System.IO.Abstractions": {
         "type": "Transitive",
-        "resolved": "22.1.1",
-        "contentHash": "EJmXIKfwvJHvSHWP+NjA213avUdofV4SmBx2aWxc3SzPkrHHVKxUMC3fSa/epzk/SVITwuU2EAntgQTvobAqwQ==",
+        "resolved": "22.2.0",
+        "contentHash": "BQPyr0A1s2HvpVTZIyolrZ3ZdPn8DU2tqciaK1oco3pjm76fiKIk75eup4R9reZjNS75M+WJIICOlNX5OFt50g==",
         "dependencies": {
-          "Testably.Abstractions.FileSystem.Interface": "10.1.0"
+          "Testably.Abstractions.FileSystem.Interface": "10.3.0"
         }
       },
       "TestableIO.System.IO.Abstractions.Wrappers": {
         "type": "Transitive",
-        "resolved": "22.1.1",
-        "contentHash": "J91zmSwuMY75ybtkqAFMC3vDNMkLJ/kiDDLhORITEwTKNhEwEYfxAQGv+f0jGYZg/H0YbnGcx5Ky0FgFJwrrWQ==",
+        "resolved": "22.2.0",
+        "contentHash": "0GW9i46ozm687WGAWsBHWMhLR7l1HmKwhiSU2hQrbFnI5m2YRfqXwqTQNjnOwT8BdbvcGqwMr97/zlnPWa1u1Q==",
         "dependencies": {
-          "Testably.Abstractions.FileSystem.Interface": "10.1.0"
+          "Testably.Abstractions.FileSystem.Interface": "10.3.0"
         }
       },
       "Testably.Abstractions.FileSystem.Interface": {
         "type": "Transitive",
-        "resolved": "10.1.0",
-        "contentHash": "0R+m7DvS2QuDcFOfDGtyGErRrgXOl4/z2tbNLX2RfvlYJjlVcKG+wMIBfZO8vxGtTNwNxffTG4ibFRwd0jkM7w=="
+        "resolved": "10.3.0",
+        "contentHash": "5ebMaoADkzjfW7GnZYKaUebV8XmUn++C/4sKk1PTzCiddEgbSKBq3pW4EWEi70rYJAK0gA1yDWrYFeHq18FvHQ=="
       },
       "fantomas.client": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )",
+          "FSharp.Core": "[10.1.401, )",
           "SemanticVersioning": "[3.0.0, )",
           "StreamJsonRpc": "[2.25.29, )"
         }
@@ -188,14 +188,14 @@
       "fantomas.core": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )",
+          "FSharp.Core": "[10.1.401, )",
           "Fantomas.FCS": "[1.0.0, )"
         }
       },
       "fantomas.fcs": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Core": "[10.0.100, )"
+          "FSharp.Core": "[10.1.401, )"
         }
       },
       "Newtonsoft.Json": {

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -10,9 +10,12 @@
       },
       "editorconfig": {
         "type": "Direct",
-        "requested": "[0.15.0, )",
-        "resolved": "0.15.0",
-        "contentHash": "NuUxFbycSCOhl0WzmNZ8ksSMrTHBFzTASkil+IOqXpqTXszokKjy6ihxMdjArGaC+AaLLq4nxfGVFLi6KWyFJg=="
+        "requested": "[0.18.0, )",
+        "resolved": "0.18.0",
+        "contentHash": "VgT9Q0CT0KlgCkYitPRIgtmzaHZ9G8CqjEdY8KeweihFdLdhVgQWJy15BwBjoW2PGRl/uqgnAqhG9bBE9lfU9A==",
+        "dependencies": {
+          "System.IO.Abstractions": "22.1.1"
+        }
       },
       "FSharp.Core": {
         "type": "Direct",
@@ -84,12 +87,12 @@
       },
       "System.IO.Abstractions": {
         "type": "Direct",
-        "requested": "[22.1.0, )",
-        "resolved": "22.1.0",
-        "contentHash": "+QDwmFWQQ84FIRFkOGLwdhJWgOP2Qm+d73edWavzVvYrQ029jjB7CdT24L/F9QvGThN7uYZW6vLLSpvaUBC2Cw==",
+        "requested": "[22.1.1, )",
+        "resolved": "22.1.1",
+        "contentHash": "nm4sNhAoN1NyiIVT6MS3EEzNjnir3PC1HE0mKGGUFg6RBW1HmRvWKuRDPkij1etOoQkpyIFmjVGcM6TpBGF3qQ==",
         "dependencies": {
-          "TestableIO.System.IO.Abstractions": "22.1.0",
-          "TestableIO.System.IO.Abstractions.Wrappers": "22.1.0"
+          "TestableIO.System.IO.Abstractions": "22.1.1",
+          "TestableIO.System.IO.Abstractions.Wrappers": "22.1.1"
         }
       },
       "MessagePack": {
@@ -155,24 +158,24 @@
       },
       "TestableIO.System.IO.Abstractions": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "YQ/IuNE8gP/+yNwQjdqd6DKhB9ADGjosxuY2IMXcQ3729iXa9QRsPlmIBpk73L0s9E2b+MTYhAR/2Spk8REjvA==",
+        "resolved": "22.1.1",
+        "contentHash": "EJmXIKfwvJHvSHWP+NjA213avUdofV4SmBx2aWxc3SzPkrHHVKxUMC3fSa/epzk/SVITwuU2EAntgQTvobAqwQ==",
         "dependencies": {
-          "Testably.Abstractions.FileSystem.Interface": "10.0.0"
+          "Testably.Abstractions.FileSystem.Interface": "10.1.0"
         }
       },
       "TestableIO.System.IO.Abstractions.Wrappers": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "IsW3jQqIiTN4GwdWFx+dzgRL5XR75UDTFVGuuIackPf2d7eH0KKyrx4wuIoASa1XnS9zhgLP39FKwJq6nbbx1w==",
+        "resolved": "22.1.1",
+        "contentHash": "J91zmSwuMY75ybtkqAFMC3vDNMkLJ/kiDDLhORITEwTKNhEwEYfxAQGv+f0jGYZg/H0YbnGcx5Ky0FgFJwrrWQ==",
         "dependencies": {
-          "Testably.Abstractions.FileSystem.Interface": "10.0.0"
+          "Testably.Abstractions.FileSystem.Interface": "10.1.0"
         }
       },
       "Testably.Abstractions.FileSystem.Interface": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "tZOXFLGjkh8TxgMgKeEcM2HAlz9DwndGl6TFLo6ISHcszFX3FkuPMrtVbmqVjhooWNXrgJ/a9cH9ym5MZL1LAg=="
+        "resolved": "10.1.0",
+        "contentHash": "0R+m7DvS2QuDcFOfDGtyGErRrgXOl4/z2tbNLX2RfvlYJjlVcKG+wMIBfZO8vxGtTNwNxffTG4ibFRwd0jkM7w=="
       },
       "fantomas.client": {
         "type": "Project",

--- a/src/Fantomas/packages.lock.json
+++ b/src/Fantomas/packages.lock.json
@@ -21,7 +21,7 @@
         "type": "Direct",
         "requested": "[10.1.401, )",
         "resolved": "10.1.401",
-        "contentHash": "IGqjL9U8pQl7CaCpFP3f5slZMduE8c7ZBx7HycAQ9dc1tawyniNyw7Fh6L2cShIoQDcaDL+S8/kokhWs8WwnBQ=="
+        "contentHash": "/lvOK51KD8IangBYkfDVna3/HrE/r4VUnX3dI01KDspctoYXmind3POeoYkqWKeXHwiKlf6Hc9TxwSnoSCWcjw=="
       },
       "G-Research.FSharp.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
Build tooling and dependencies. Nothing here changes how Fantomas formats.

- `build.fsx` and the scripts beside it drop CliWrap, using Fun.Build 1.2's `RunCommandCaptureAll` instead. One dependency fewer.
- Both `Analyze` pipelines now run over the scripts as well as the projects. This needs `fsharp-analyzers` 0.39.1, which fixes [#332](https://github.com/ionide/FSharp.Analyzers.SDK/issues/332) and [#334](https://github.com/ionide/FSharp.Analyzers.SDK/issues/334); `analyzers/AGENTS.md` covers what a script run can and cannot see.
- Every package is up to date. Two needed a source change: `editorconfig` 0.18.0, where `EditorConfigFileCache` stopped being static, and NUnit 4.6.1, which added an `Assert.Throws<T>(Action)` overload that left two call sites ambiguous.
- `Fantomas.Core`, `Fantomas.FCS` and `Fantomas.Client` hold their `FSharp.Core` floor at 10.0.100 with `VersionOverride`, so nothing referencing them has to move.

Changelog entries for `8.0.0-beta-003` and `Fantomas.Client` `0.12.0-beta-003`.
